### PR TITLE
Refactor to use a single transaction builder

### DIFF
--- a/app/abci_test.go
+++ b/app/abci_test.go
@@ -241,7 +241,7 @@ func generateSignedWirePayForMessage(t *testing.T, k uint64, ns, message []byte,
 		t.Error(err)
 	}
 
-	err = msg.SignShareCommitments(signer, signer.NewTxBuilder())
+	err = msg.SignShareCommitments(signer)
 	if err != nil {
 		t.Error(err)
 	}

--- a/x/payment/client/cli/wirepayformessage.go
+++ b/x/payment/client/cli/wirepayformessage.go
@@ -57,6 +57,7 @@ func CmdWirePayForMessage() *cobra.Command {
 				return err
 			}
 
+			// use the keyring to programmatically sign multiple PayForMessage txs
 			signer := types.NewKeyringSigner(clientCtx.Keyring, accName, clientCtx.ChainID)
 
 			signer.SetAccountNumber(account.GetAccountNumber())
@@ -82,13 +83,12 @@ func CmdWirePayForMessage() *cobra.Command {
 				return err
 			}
 
-			// get the gas price and such and add it to the tx builder that is used to create the signed share commitments
-			builder := signer.NewTxBuilder()
-			builder.SetGasLimit(gasSetting.Gas)
-			builder.SetFeeAmount(parsedFees)
-
 			// sign the  MsgPayForMessage's ShareCommitments
-			err = pfmMsg.SignShareCommitments(signer, builder)
+			err = pfmMsg.SignShareCommitments(
+				signer,
+				types.SetGasLimit(gasSetting.Gas),
+				types.SetFeeAmount(parsedFees),
+			)
 			if err != nil {
 				return err
 			}

--- a/x/payment/types/builder_options.go
+++ b/x/payment/types/builder_options.go
@@ -1,0 +1,22 @@
+package types
+
+import (
+	sdkclient "github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+type TxBuilderOption func(builder sdkclient.TxBuilder) sdkclient.TxBuilder
+
+func SetGasLimit(limit uint64) TxBuilderOption {
+	return func(builder sdkclient.TxBuilder) sdkclient.TxBuilder {
+		builder.SetGasLimit(limit)
+		return builder
+	}
+}
+
+func SetFeeAmount(fees sdk.Coins) TxBuilderOption {
+	return func(builder sdkclient.TxBuilder) sdkclient.TxBuilder {
+		builder.SetFeeAmount(fees)
+		return builder
+	}
+}

--- a/x/payment/types/wirepayformessage.go
+++ b/x/payment/types/wirepayformessage.go
@@ -41,10 +41,16 @@ func NewWirePayForMessage(namespace, message []byte, sizes ...uint64) (*MsgWireP
 
 // SignShareCommitments creates and signs MsgPayForMessages for each square size configured in the MsgWirePayForMessage
 // to complete each shares commitment.
-func (msg *MsgWirePayForMessage) SignShareCommitments(signer *KeyringSigner, builder sdkclient.TxBuilder) error {
+func (msg *MsgWirePayForMessage) SignShareCommitments(signer *KeyringSigner, options ...TxBuilderOption) error {
 	msg.Signer = signer.GetSignerInfo().GetAddress().String()
 	// create an entire MsgPayForMessage and signing over it, including the signature in each commitment
 	for i, commit := range msg.MessageShareCommitment {
+		builder := signer.NewTxBuilder()
+
+		for _, option := range options {
+			builder = option(builder)
+		}
+
 		sig, err := msg.createPayForMessageSignature(signer, builder, commit.K)
 		if err != nil {
 			return err


### PR DESCRIPTION
## Description

still needs some debugging, but this refactors how sdkclient.TxBuilders are used so that we create a new one for each commitment.

closes: #144 