### PR TITLE
go get -> go install

### DIFF
--- a/.github/workflows/release-sims.yml
+++ b/.github/workflows/release-sims.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: install runsim
         run: |
-          export GO111MODULE="on" && go get github.com/cosmos/tools/cmd/runsim@v1.0.0
+          export GO111MODULE="on" && go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v2.1.7
         with:
           path: ~/go/bin

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Display go version
         run: go version
       - name: Install runsim
-        run: export GO111MODULE="on" && go get github.com/cosmos/tools/cmd/runsim@v1.0.0
+        run: export GO111MODULE="on" && go install github.com/cosmos/tools/cmd/runsim@v1.0.0
       - uses: actions/cache@v2.1.7
         with:
           path: ~/go/bin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: go version
       - name: install tparse
         run: |
-          export GO111MODULE="on" && go get github.com/mfridman/tparse@v0.8.3
+          export GO111MODULE="on" && go install github.com/mfridman/tparse@v0.8.3
       - uses: actions/cache@v2.1.7
         with:
           path: ~/go/bin

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ frontend/.cache
 secret.yml
 build
 coverage.txt
+tools-stamp

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ pre-build:
 	@git fetch --tags
 
 build: mod
-	@go install github.com/gobuffalo/packr/v2/packr2
+	@go install github.com/gobuffalo/packr/v2/packr2@latest
 	@cd ./cmd/celestia-appd && packr2
 	@mkdir -p build/
 	@go build -o build/ ./cmd/celestia-appd

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ pre-build:
 	@git fetch --tags
 
 build: mod
-	@go install -u github.com/gobuffalo/packr/v2/packr2
+	@go install github.com/gobuffalo/packr/v2/packr2
 	@cd ./cmd/celestia-appd && packr2
 	@mkdir -p build/
 	@go build -o build/ ./cmd/celestia-appd

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ pre-build:
 	@git fetch --tags
 
 build: mod
-	@go get -u github.com/gobuffalo/packr/v2/packr2
+	@go install -u github.com/gobuffalo/packr/v2/packr2
 	@cd ./cmd/celestia-appd && packr2
 	@mkdir -p build/
 	@go build -o build/ ./cmd/celestia-appd

--- a/contrib/devtools/Makefile
+++ b/contrib/devtools/Makefile
@@ -64,15 +64,11 @@ tools: tools-stamp
 tools-stamp: $(RUNSIM)
 	touch $@
 
-# Install the runsim binary with a temporary workaround of entering an outside
-# directory as the "go get" command ignores the -mod option and will polute the
-# go.{mod, sum} files.
-# 
-# ref: https://github.com/golang/go/issues/30515
+# Install the runsim binary.
 runsim: $(RUNSIM)
 $(RUNSIM):
 	@echo "Installing runsim..."
-	@(cd /tmp && go get github.com/cosmos/tools/cmd/runsim@v1.0.0)
+	@(go install github.com/cosmos/tools/cmd/runsim@v1.0.0)
 
 protoc:
 	@echo "Installing protoc compiler..."

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -8,7 +8,7 @@ protoc_gen_gocosmos() {
     return 1
   fi
 
-  go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
+  go install github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
 }
 
 protoc_gen_gocosmos

--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -8,7 +8,7 @@ protoc_gen_gocosmos() {
     return 1
   fi
 
-  go install github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
+  go get github.com/regen-network/cosmos-proto/protoc-gen-gocosmos@latest 2>/dev/null
 }
 
 protoc_gen_gocosmos


### PR DESCRIPTION
`go get` for binaries was deprecated in 1.17 and removed in 1.18 in favor of `go install`. https://go.dev/doc/go-get-install-deprecation