### PR TITLE
temporary fix for proto-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test:
 	@go test -mod=readonly $(PACKAGES)
 
 proto-gen:
-	$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/sdk-proto-gen sh ./scripts/protocgen.sh
+	$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/sdk-proto-gen:v0.2 sh ./scripts/protocgen.sh
 
 proto-lint:
 	@$(DOCKER_BUF) lint --error-format=json


### PR DESCRIPTION
Update the Makefile to use tendermintdev/sdk-proto-gen version v0.2 to temporarily fix the broken script.

Closes: https://github.com/celestiaorg/celestia-app/issues/340