### PR TITLE
x/payment/pfd.go: Add canonical `PFD` constructor/signer/submittor methods

### DIFF
--- a/x/payment/pfd.go
+++ b/x/payment/pfd.go
@@ -1,0 +1,97 @@
+package payment
+
+import (
+	"context"
+	"google.golang.org/grpc"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdk_tx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+
+	"github.com/celestiaorg/celestia-app/x/payment/types"
+	"github.com/celestiaorg/nmt/namespace"
+)
+
+var (
+	// shareSizes includes all the possible share sizes of the given data
+	// that the signer must sign over.
+	shareSizes = []uint64{16, 32, 64, 128}
+)
+
+// SubmitPayForData constructs, signs and synchronously submits a PayForData
+// transaction, returning a sdk.TxResponse upon submission.
+func SubmitPayForData(
+	ctx context.Context,
+	signer *types.KeyringSigner,
+	conn *grpc.ClientConn,
+	nID namespace.ID,
+	data []byte,
+	gasLim uint64,
+) (*sdk.TxResponse, error) {
+	pfd, err := BuildPayForData(ctx, signer, conn, nID, data, gasLim)
+	if err != nil {
+		return nil, err
+	}
+
+	signed, err := SignPayForData(signer, pfd, types.SetGasLimit(gasLim))
+	if err != nil {
+		return nil, err
+	}
+
+	rawTx, err := signer.EncodeTx(signed)
+	if err != nil {
+		return nil, err
+	}
+
+	txResp, err := types.BroadcastTx(ctx, conn, sdk_tx.BroadcastMode_BROADCAST_MODE_BLOCK, rawTx)
+	if err != nil {
+		return nil, err
+	}
+	return txResp.TxResponse, nil
+}
+
+// BuildPayForData constructs a PayForData transaction.
+func BuildPayForData(
+	ctx context.Context,
+	signer *types.KeyringSigner,
+	conn *grpc.ClientConn,
+	nID namespace.ID,
+	message []byte,
+	gasLim uint64,
+) (*types.MsgWirePayForData, error) {
+	// create the raw WirePayForMessage transaction
+	wpfd, err := types.NewWirePayForData(nID, message, shareSizes...)
+	if err != nil {
+		return nil, err
+	}
+
+	// query for account information necessary to sign a valid tx
+	err = signer.QueryAccountNumber(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+
+	// generate the signatures for each `MsgPayForMessage` using the `KeyringSigner`,
+	// then set the gas limit for the tx
+	gasLimOption := types.SetGasLimit(gasLim)
+	err = wpfd.SignShareCommitments(signer, gasLimOption)
+	if err != nil {
+		return nil, err
+	}
+
+	return wpfd, nil
+}
+
+// SignPayForData signs a PayForData transaction.
+func SignPayForData(
+	signer *types.KeyringSigner,
+	pfd *types.MsgWirePayForData,
+	gasLimOption types.TxBuilderOption,
+) (signing.Tx, error) {
+	// Build and sign the final `WirePayForMessage` tx that now contains the signatures
+	// for potential `MsgPayForMessage`s
+	return signer.BuildSignedTx(
+		gasLimOption(signer.NewTxBuilder()),
+		pfd,
+	)
+}


### PR DESCRIPTION
This PR adds 3 methods: 

* `BuildPayForData`
* `SignPayForData`
* `SubmitPayForData`

Celestia-node (and other repos depending on this message type) should import these methods from app.

Once this PR is merged, I will close https://github.com/celestiaorg/celestia-node/pull/619 and reopen a PR that updates the celestia-app dep to the latest celestia-app release and uses these methods under the hood.