### PR TITLE
Deduct fees for PayForData transactions 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -341,7 +341,6 @@ func New(
 
 	app.PaymentKeeper = *paymentmodulekeeper.NewKeeper(
 		appCodec,
-		app.BankKeeper,
 		keys[paymentmoduletypes.StoreKey],
 		keys[paymentmoduletypes.MemStoreKey],
 	)

--- a/x/payment/keeper/gas_test.go
+++ b/x/payment/keeper/gas_test.go
@@ -1,0 +1,27 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/x/payment/types"
+	"github.com/cosmos/cosmos-sdk/simapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestPayForDataGas(t *testing.T) {
+	app := simapp.Setup(false)
+	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
+	k := Keeper{}
+
+	messageSize := uint64(100)
+
+	msg := types.MsgPayForData{
+		MessageSize: messageSize,
+	}
+
+	_, err := k.PayForData(sdk.WrapSDKContext(ctx), &msg)
+	require.NoError(t, err)
+	require.Equal(t, messageSize, ctx.GasMeter().GasConsumed())
+}

--- a/x/payment/keeper/keeper.go
+++ b/x/payment/keeper/keeper.go
@@ -11,20 +11,20 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+const payForDataGasDescriptor = "pay for data"
+
 // Keeper handles all the state changes for the celestia-app module.
 type Keeper struct {
 	cdc      codec.BinaryCodec
 	storeKey sdk.StoreKey
 	memKey   sdk.StoreKey
-	bank     BankKeeper
 }
 
-func NewKeeper(cdc codec.BinaryCodec, bank BankKeeper, storeKey, memKey sdk.StoreKey) *Keeper {
+func NewKeeper(cdc codec.BinaryCodec, storeKey, memKey sdk.StoreKey) *Keeper {
 	return &Keeper{
 		cdc:      cdc,
 		storeKey: storeKey,
 		memKey:   memKey,
-		bank:     bank,
 	}
 }
 
@@ -35,15 +35,12 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 //  MsgPayForData moves a user's coins to the module address and burns them.
 func (k Keeper) PayForData(goCtx context.Context, msg *types.MsgPayForData) (*types.MsgPayForDataResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	ctx.GasMeter().ConsumeGas(msg.MessageSize, payForDataGasDescriptor)
+
 	ctx.EventManager().EmitEvent(
 		types.NewPayForDataEvent(sdk.AccAddress(msg.Signer).String(), msg.GetMessageSize()),
 	)
 
 	return &types.MsgPayForDataResponse{}, nil
-}
-
-// BankKeeper restricts the funtionality of the bank keeper used in the payment keeper
-type BankKeeper interface {
-	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
-	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 }


### PR DESCRIPTION
## Description

This PR consumes gas for PayForData transactions. This should work, as it's a fairly standard operation, but it would be nice to have more integration testing. When attempting to add this to the cli integration test, I encountered #379. We might want to wait until that bug is fixed just to be sure.

closes #48 
