### PR TITLE
Adds querier stop method

### DIFF
--- a/x/qgb/orchestrator/deploy_command.go
+++ b/x/qgb/orchestrator/deploy_command.go
@@ -77,6 +77,7 @@ func DeployCmd() *cobra.Command {
 				tx.Hash(),
 				addr.Hex(),
 			)
+			querier.Stop()
 			return nil
 		},
 	}

--- a/x/qgb/orchestrator/querier.go
+++ b/x/qgb/orchestrator/querier.go
@@ -78,6 +78,19 @@ func NewQuerier(qgbRPCAddr, tendermintRPC string, logger tmlog.Logger) (*querier
 	}, nil
 }
 
+
+// TODO add the other stop methods for other clients
+func (q *querier) Stop() {
+	err := q.qgbRPC.Close()
+	if err != nil {
+		q.logger.Error(err.Error())
+	}
+	err = q.tendermintRPC.Stop()
+	if err != nil {
+		q.logger.Error(err.Error())
+	}
+}
+
 func (q *querier) QueryDataCommitments(
 	ctx context.Context,
 	commit string,


### PR DESCRIPTION
Small PR that adds a stop method to the `Querier` and adds a TODO so that when we implement the new design, we don't forget about them.