### PR TITLE
Register the legacy amino codec

### DIFF
--- a/app/encoding/encoding.go
+++ b/app/encoding/encoding.go
@@ -22,6 +22,7 @@ type EncodingConfig struct {
 // MakeEncodingConfig creates an encoding config for the app.
 func MakeEncodingConfig(regs ...InterfaceRegister) EncodingConfig {
 	amino := codec.NewLegacyAmino()
+	std.RegisterLegacyAminoCodec(amino)
 	interfaceRegistry := codectypes.NewInterfaceRegistry()
 	std.RegisterInterfaces(interfaceRegistry)
 	for _, reg := range regs {


### PR DESCRIPTION
## Description

We weren't registering the legacy amino codec, which stops us from being able to unmarshal some things from tendermint in some sub commands of our cli.

closes: #XXXX