### PR TITLE
Change P2P Network version and overide configs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -158,5 +158,5 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0.0.20220527192417-2ee3a5ee36ad // v1.1.1-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint v0.35.4 => github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4
+	github.com/tendermint/tendermint v0.35.4 => github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4.0.20220528043755-b39d395a9592 // v1.2.2-tm-v0.35.4
 )

--- a/go.mod
+++ b/go.mod
@@ -156,7 +156,7 @@ require (
 
 replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0.0.20220527192417-2ee3a5ee36ad // v1.1.1-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint v0.35.4 => github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4
 )

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4 h1:b+S47xLUVfmRAr+Wi6MH0b5HX6AqZUHxQRVioG851ys=
 github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4/go.mod h1:qfSLGgzbnzEVXNMv80VxzXH3yAJHT/u6IlpNHJk0/aQ=
-github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0 h1:C0FRN6YDoAVtmIE92mXJErBcrscC+ic+fuX+tXk8KvM=
-github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0/go.mod h1:GqLQYM+p8fKlafrn3cRAJgonJBPvSV6h5BUSnuInyvk=
+github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0.0.20220527192417-2ee3a5ee36ad h1:IA+nbjeWU61/AJW8UyKakT8IbCm/sKSx3pTlIJLX+fQ=
+github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0.0.20220527192417-2ee3a5ee36ad/go.mod h1:GqLQYM+p8fKlafrn3cRAJgonJBPvSV6h5BUSnuInyvk=
 github.com/celestiaorg/go-leopard v0.1.0 h1:28z2EkvKJIez5J9CEaiiUEC+OxalRLtTGJJ1oScfE1g=
 github.com/celestiaorg/go-leopard v0.1.0/go.mod h1:NtO/rjlB8dw2aq7jr06vZFKGvryQcTDXaNHelmPNOAM=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/btcsuite/snappy-go v1.0.0/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4 h1:b+S47xLUVfmRAr+Wi6MH0b5HX6AqZUHxQRVioG851ys=
-github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4/go.mod h1:qfSLGgzbnzEVXNMv80VxzXH3yAJHT/u6IlpNHJk0/aQ=
+github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4.0.20220528043755-b39d395a9592 h1:HJi3IdUxeNjW79sjNFR7fG/i+z4XeQs37q6J9C3o5ac=
+github.com/celestiaorg/celestia-core v1.2.2-tm-v0.35.4.0.20220528043755-b39d395a9592/go.mod h1:qfSLGgzbnzEVXNMv80VxzXH3yAJHT/u6IlpNHJk0/aQ=
 github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0.0.20220527192417-2ee3a5ee36ad h1:IA+nbjeWU61/AJW8UyKakT8IbCm/sKSx3pTlIJLX+fQ=
 github.com/celestiaorg/cosmos-sdk v1.1.1-sdk-v0.46.0.0.20220527192417-2ee3a5ee36ad/go.mod h1:GqLQYM+p8fKlafrn3cRAJgonJBPvSV6h5BUSnuInyvk=
 github.com/celestiaorg/go-leopard v0.1.0 h1:28z2EkvKJIez5J9CEaiiUEC+OxalRLtTGJJ1oScfE1g=


### PR DESCRIPTION
## Description

This PR bumps celestia-core to use an incremented network version. :exclamation:  IMPORTANT :exclamation: : this will sever the p2p handshake between nodes that use an older binary. It also intercepts the configs and forces `timeout-commit = 25s` and `use-legacy = true`, along with changing those defaults.

NOTE: we still need to test that this actually works.

closes: #XXXX

