### PR TITLE
chore: refactor NewRootCmd into separate pkg

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -1,4 +1,4 @@
-package main
+package cmd
 
 import (
 	"fmt"
@@ -36,6 +36,8 @@ import (
 	dbm "github.com/tendermint/tm-db"
 )
 
+const EnvPrefix = "CELESTIA"
+
 // NewRootCmd creates a new root command for celestia-appd. It is called once in the
 // main function.
 func NewRootCmd() *cobra.Command {
@@ -56,7 +58,7 @@ func NewRootCmd() *cobra.Command {
 		WithAccountRetriever(types.AccountRetriever{}).
 		WithBroadcastMode(flags.BroadcastBlock).
 		WithHomeDir(app.DefaultNodeHome).
-		WithViper(envPrefix)
+		WithViper(EnvPrefix)
 
 	rootCmd := &cobra.Command{
 		Use:   "celestia-appd",

--- a/cmd/celestia-appd/main.go
+++ b/cmd/celestia-appd/main.go
@@ -4,14 +4,14 @@ import (
 	"os"
 
 	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/cmd/celestia-appd/cmd"
+
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 )
 
-const envPrefix = "CELESTIA"
-
 func main() {
-	rootCmd := NewRootCmd()
-	if err := svrcmd.Execute(rootCmd, envPrefix, app.DefaultNodeHome); err != nil {
+	rootCmd := cmd.NewRootCmd()
+	if err := svrcmd.Execute(rootCmd, cmd.EnvPrefix, app.DefaultNodeHome); err != nil {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Move NewRootCmd into separate pkg so it can be used externally.

closes: #525 (@Bidon15 should confirm if that actually closes it)
removes the necessity of copypasta in https://github.com/celestiaorg/test-infra/pull/27

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
