### PR TITLE
ci: check protobuf generated code

### DIFF
--- a/.github/workflows/proto.yml
+++ b/.github/workflows/proto.yml
@@ -1,5 +1,5 @@
 name: Protobuf
-# Protobuf runs buf (https://buf.build/) lint and check-breakage
+# Protobuf runs buf (https://buf.build/) lint and generate
 # This workflow is only run when a .proto file has been changed
 on:
   pull_request:
@@ -18,8 +18,20 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - name: proto-gen
-        run: make proto-gen
+      - name: "Check protobuf generated code matches committed code"
+        run: |
+          set -euo pipefail
+
+          make proto-gen
+
+          if ! git diff --stat --exit-code ; then
+            echo ">> ERROR:"
+            echo ">>"
+            echo ">> Protobuf generated code requires update (either tools or .proto files may have changed)."
+            echo ">> Ensure your tools are up-to-date, re-run 'make proto-gen' and update this PR."
+            echo ">>"
+            exit 1
+          fi
   # add this back when we start using versioning
   # breakage:
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Resolves https://github.com/celestiaorg/celestia-app/issues/560

## Testing

Sample PR fails when a field was added to `tx.proto` but the corresponding generated file `x/payment/types/tx.pb.go` was not committed. See https://github.com/rootulp/celestia-app/runs/7506797210?check_suite_focus=true#step%3A3%3A68=

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
