### PR TITLE
Throw errors if messages try to use `ParitySharesNamespaceID` or `TailPaddingNamespaceID`

### DIFF
--- a/x/payment/types/errors.go
+++ b/x/payment/types/errors.go
@@ -14,4 +14,6 @@ var (
 	ErrCommittedSquareSizeNotPowOf2   = sdkerrors.Register(ModuleName, 11114, "committed to invalid square size: must be power of two")
 	ErrCalculateCommit                = sdkerrors.Register(ModuleName, 11115, "unexpected error calculating commit for share")
 	ErrInvalidShareCommit             = sdkerrors.Register(ModuleName, 11116, "invalid commit for share")
+	ErrParitySharesNamespace          = sdkerrors.Register(ModuleName, 11117, "cannot use parity shares namespace ID")
+	ErrTailPaddingNamespace           = sdkerrors.Register(ModuleName, 11118, "cannot use tail padding namespace ID")
 )

--- a/x/payment/types/payfordata.go
+++ b/x/payment/types/payfordata.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"fmt"
 	"math/bits"
@@ -50,6 +51,19 @@ func (msg *MsgPayForData) ValidateBasic() error {
 		return err
 	}
 
+	// ensure that ParitySharesNamespaceID is not used
+	if bytes.Compare(msg.GetMessageNamespaceId(), consts.ParitySharesNamespaceID) == 0 {
+		return ErrParitySharesNamespace
+	}
+
+	// ensure that TailPaddingNamespaceID is not used
+	if bytes.Compare(msg.GetMessageNamespaceId(), consts.TailPaddingNamespaceID) == 0 {
+		return ErrTailPaddingNamespace
+	}
+
+	// TODO: why doesn't this function throw an error if NamespaceID is lower
+	// than the max reserved namespace ID?
+	// https://github.com/celestiaorg/celestia-app/blob/master/x/payment/types/wirepayfordata.go#L108-L111=
 	return nil
 }
 

--- a/x/payment/types/payfordata.go
+++ b/x/payment/types/payfordata.go
@@ -52,12 +52,12 @@ func (msg *MsgPayForData) ValidateBasic() error {
 	}
 
 	// ensure that ParitySharesNamespaceID is not used
-	if bytes.Compare(msg.GetMessageNamespaceId(), consts.ParitySharesNamespaceID) == 0 {
+	if bytes.Equal(msg.GetMessageNamespaceId(), consts.ParitySharesNamespaceID) {
 		return ErrParitySharesNamespace
 	}
 
 	// ensure that TailPaddingNamespaceID is not used
-	if bytes.Compare(msg.GetMessageNamespaceId(), consts.TailPaddingNamespaceID) == 0 {
+	if bytes.Equal(msg.GetMessageNamespaceId(), consts.TailPaddingNamespaceID) {
 		return ErrTailPaddingNamespace
 	}
 

--- a/x/payment/types/payfordata.go
+++ b/x/payment/types/payfordata.go
@@ -61,9 +61,6 @@ func (msg *MsgPayForData) ValidateBasic() error {
 		return ErrTailPaddingNamespace
 	}
 
-	// TODO: why doesn't this function throw an error if NamespaceID is lower
-	// than the max reserved namespace ID?
-	// https://github.com/celestiaorg/celestia-app/blob/master/x/payment/types/wirepayfordata.go#L108-L111=
 	return nil
 }
 

--- a/x/payment/types/payfordata_test.go
+++ b/x/payment/types/payfordata_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	sdkerrors "github.com/cosmos/cosmos-sdk/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -312,6 +313,55 @@ func TestProcessMessage(t *testing.T) {
 	}
 }
 
+func TestValidateBasic(t *testing.T) {
+	type test struct {
+		name    string
+		msg     *MsgPayForData
+		wantErr *sdkerrors.Error
+	}
+
+	validMsg := validMsgPayForData(t)
+
+	// MsgPayForData that uses parity shares namespace id
+	paritySharesMsg := validMsgPayForData(t)
+	paritySharesMsg.MessageNamespaceId = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+
+	// MsgPayForData that uses tail padding namespace id
+	tailPaddingMsg := validMsgPayForData(t)
+	tailPaddingMsg.MessageNamespaceId = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE}
+
+	tests := []test{
+		{
+			name:    "valid msg",
+			msg:     validMsg,
+			wantErr: nil,
+		},
+		{
+			name:    "parity shares namespace id",
+			msg:     paritySharesMsg,
+			wantErr: ErrParitySharesNamespace,
+		},
+		{
+			name:    "tail padding namespace id",
+			msg:     tailPaddingMsg,
+			wantErr: ErrTailPaddingNamespace,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.msg.ValidateBasic()
+			if tt.wantErr != nil {
+				assert.Contains(t, err.Error(), tt.wantErr.Error())
+				space, code, log := sdkerrors.ABCIInfo(err, false)
+				assert.Equal(t, tt.wantErr.Codespace(), space)
+				assert.Equal(t, tt.wantErr.ABCICode(), code)
+				t.Log(log)
+			}
+		})
+	}
+}
+
 // totalMsgSize subtracts the delimiter size from the desired total size. this
 // is useful for testing for messages that occupy exactly so many shares.
 func totalMsgSize(size int) int {
@@ -335,4 +385,23 @@ func validWirePayForData(t *testing.T) *MsgWirePayForData {
 		panic(err)
 	}
 	return msg
+}
+
+func validMsgPayForData(t *testing.T) *MsgPayForData {
+	kb := generateKeyring(t, "test")
+	signer := NewKeyringSigner(kb, "test", "chain-id")
+	ns := []byte{1, 1, 1, 1, 1, 1, 1, 2}
+	msg := bytes.Repeat([]byte{2}, totalMsgSize(consts.MsgShareSize*15))
+	ss := uint64(4)
+
+	wpfd, err := NewWirePayForData(ns, msg, ss)
+	assert.NoError(t, err)
+
+	err = wpfd.SignShareCommitments(signer)
+	assert.NoError(t, err)
+
+	_, spfd, _, err := ProcessWirePayForData(wpfd, ss)
+	require.NoError(t, err)
+
+	return spfd
 }

--- a/x/payment/types/wirepayfordata.go
+++ b/x/payment/types/wirepayfordata.go
@@ -111,12 +111,12 @@ func (msg *MsgWirePayForData) ValidateBasic() error {
 	}
 
 	// ensure that ParitySharesNamespaceID is not used
-	if bytes.Compare(msg.GetMessageNameSpaceId(), consts.ParitySharesNamespaceID) == 0 {
+	if bytes.Equal(msg.GetMessageNameSpaceId(), consts.ParitySharesNamespaceID) {
 		return ErrParitySharesNamespace
 	}
 
 	// ensure that TailPaddingNamespaceID is not used
-	if bytes.Compare(msg.GetMessageNameSpaceId(), consts.TailPaddingNamespaceID) == 0 {
+	if bytes.Equal(msg.GetMessageNameSpaceId(), consts.TailPaddingNamespaceID) {
 		return ErrTailPaddingNamespace
 	}
 

--- a/x/payment/types/wirepayfordata.go
+++ b/x/payment/types/wirepayfordata.go
@@ -110,6 +110,16 @@ func (msg *MsgWirePayForData) ValidateBasic() error {
 		return ErrReservedNamespace.Wrapf("got namespace: %x, want: > %x", msg.GetMessageNameSpaceId(), consts.MaxReservedNamespace)
 	}
 
+	// ensure that ParitySharesNamespaceID is not used
+	if bytes.Compare(msg.GetMessageNameSpaceId(), consts.ParitySharesNamespaceID) == 0 {
+		return ErrParitySharesNamespace
+	}
+
+	// ensure that TailPaddingNamespaceID is not used
+	if bytes.Compare(msg.GetMessageNameSpaceId(), consts.TailPaddingNamespaceID) == 0 {
+		return ErrTailPaddingNamespace
+	}
+
 	for idx, commit := range msg.MessageShareCommitment {
 		// check that each commit is valid
 		if !powerOf2(commit.K) {

--- a/x/payment/types/wirepayfordata_test.go
+++ b/x/payment/types/wirepayfordata_test.go
@@ -25,6 +25,14 @@ func TestWirePayForData_ValidateBasic(t *testing.T) {
 	reservedMsg := validWirePayForData(t)
 	reservedMsg.MessageNameSpaceId = []byte{0, 0, 0, 0, 0, 0, 0, 100}
 
+	// pfd that uses parity shares namespace id
+	paritySharesMsg := validWirePayForData(t)
+	paritySharesMsg.MessageNameSpaceId = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+
+	// pfd that uses parity shares namespace id
+	tailPaddingMsg := validWirePayForData(t)
+	tailPaddingMsg.MessageNameSpaceId = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE}
+
 	// pfd that has a wrong msg size
 	invalidDeclaredMsgSizeMsg := validWirePayForData(t)
 	invalidDeclaredMsgSizeMsg.MessageSize = 999
@@ -76,6 +84,16 @@ func TestWirePayForData_ValidateBasic(t *testing.T) {
 			name:    "wrong but valid square size",
 			msg:     badSquareSizeMsg,
 			wantErr: ErrInvalidShareCommit,
+		},
+		{
+			name:    "parity shares namespace id",
+			msg:     paritySharesMsg,
+			wantErr: ErrParitySharesNamespace,
+		},
+		{
+			name:    "tail padding namespace id",
+			msg:     tailPaddingMsg,
+			wantErr: ErrTailPaddingNamespace,
 		},
 	}
 


### PR DESCRIPTION
## Description

Resolves https://github.com/celestiaorg/celestia-app/issues/312