### PR TITLE
chore: update to go 1.18

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: "Build"
         run: "make build"
       - name: Set up QEMU
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: "Build"
         run: "make build"
       - name: Set up QEMU

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,6 @@ jobs:
             go.sum
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.47.2
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17.1
+          go-version: 1.18
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6.1.0
         with:
@@ -26,7 +26,7 @@ jobs:
       - uses: golangci/golangci-lint-action@v3.2.0
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.42.1
+          version: v1.47.2
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - run: make build
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - name: Install runsim
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v6.1.0
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v6.1.0
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v6.1.0
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - uses: technote-space/get-diff-action@v6.1.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Create release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - name: Display go version
         run: go version
       - name: install tparse
@@ -38,7 +38,7 @@ jobs:
   #     - uses: actions/checkout@v3
   #     - uses: actions/setup-go@v3
   #       with:
-  #         go-version: 1.17
+  #         go-version: 1.18
   #     - name: Display go version
   #       run: go version
   #     - uses: technote-space/get-diff-action@v6.1.0
@@ -91,7 +91,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: technote-space/get-diff-action@v6.1.0
         with:
           PATTERNS: |
@@ -169,7 +169,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: 1.17
+          go-version: 1.18
       - uses: technote-space/get-diff-action@v6.1.0
         with:
           PATTERNS: |
@@ -235,7 +235,7 @@ jobs:
   #     - uses: actions/checkout@v3
   #     - uses: actions/setup-go@v3
   #       with:
-  #         go-version: 1.17
+  #         go-version: 1.18
   #     - uses: technote-space/get-diff-action@v6.1.0
   #       id: git_diff
   #       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # stage 1 Generate celestia-appd Binary
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 RUN apk update && apk --no-cache add make gcc git musl-dev
 COPY . /celestia-app
 WORKDIR /celestia-app

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BUILD_FLAGS := -ldflags '$(ldflags)'
 all: install
 
 mod:
-	@go mod tidy -compat=1.17
+	@go mod tidy -compat=1.18
 
 pre-build:
 	@echo "Fetching latest tags"
@@ -34,7 +34,7 @@ build: mod
 	@mkdir -p build/
 	@go build -o build/ ./cmd/celestia-appd
 	@packr2 clean
-	@go mod tidy -compat=1.17
+	@go mod tidy -compat=1.18
 
 install: go.sum
 		@echo "--> Installing celestia-appd"

--- a/contrib/Dockerfile.test
+++ b/contrib/Dockerfile.test
@@ -2,7 +2,7 @@
 # > docker build -t celestia-app .
 # > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.celestia-appd:/root/.celestia-appd -v ~/.celestia-appcli:/root/.celestia-appcli celestia-app celestia-appd init
 # > docker run -it -p 46657:46657 -p 46656:46656 -v ~/.celestia-appd:/root/.celestia-appd -v ~/.celestia-appcli:/root/.celestia-appcli celestia-app celestia-appd start
-FROM golang:1.15-alpine AS build-env
+FROM golang:1.18-alpine AS build-env
 
 # Set up dependencies
 ENV PACKAGES curl make git libc-dev bash gcc linux-headers eudev-dev python3

--- a/docker/Dockerfile_ephemeral
+++ b/docker/Dockerfile_ephemeral
@@ -1,5 +1,5 @@
 # stage 1 Generate celestia-appd Binary
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine as builder
 
 RUN apk update && \
     apk upgrade && \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/celestia-app
 
-go 1.17
+go 1.18
 
 require (
 	github.com/celestiaorg/nmt v0.10.0


### PR DESCRIPTION
## Description

This PR updates this repo to use go 1.18. It also requires an update to golangci-linter in order for that to keep working. 

closes #572 
unblocks #472 
