### PR TITLE
chore: rename master to main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,10 +18,10 @@ Before we can merge this PR, please make sure that all the following items have 
 checked off. If any of the checklist items are not applicable, please leave them but
 write a little note why.
 
-- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
+- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
 - [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
-- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
-- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
+- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules/structure.md).
+- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
 - [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
 - [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
 - [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: backport patches to v0.5.x branch
     conditions:
-      - base=master
+      - base=main
       - label=S:backport-to-v0.5.x
     actions:
       backport:
@@ -9,7 +9,7 @@ pull_request_rules:
           - v0.5.x
   - name: backport patches to v0.6.x branch
     conditions:
-      - base=master
+      - base=main
       - label=S:backport-to-v0.6.x
     actions:
       backport:

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,15 +3,15 @@ name: "docker-build"
 on:
   push:
     branches:
-      - "master"
+      - "main"
   workflow_dispatch:
 
 jobs:
   docker-build:
     runs-on: "ubuntu-latest"
     permissions:
-      contents: write 
-      packages: write 
+      contents: write
+      packages: write
     steps:
       - name: "Checkout source code"
         uses: "actions/checkout@v3"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,12 @@
 name: Lint
 # Lint runs golangci-lint over the entire cosmos-sdk repository
-# This workflow is run on every pull request and push to master
+# This workflow is run on every pull request and push to main
 # The `golangci` will pass without running if no *.{go, mod, sum} files have been changed.
 on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 jobs:
   golangci:
     name: golangci-lint

--- a/.github/workflows/sims.yml
+++ b/.github/workflows/sims.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   cleanup-runs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
 name: Tests / Code Coverage
 #  Tests / Code Coverage workflow runs unit tests and uploads a code coverage report
-#  This workflow is run on pushes to master & every Pull Requests where a .go, .mod, .sum have been changed
+#  This workflow is run on pushes to main & every Pull Requests where a .go, .mod, .sum have been changed
 on:
   pull_request:
   push:
     branches:
-      - master
+      - main
 jobs:
   cleanup-runs:
     runs-on: ubuntu-latest
@@ -251,4 +251,3 @@ jobs:
   #       run: |
   #         ./contrib/localnet_liveness.sh 100 5 50 localhost
   #       if: env.GIT_DIFF
-

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/celestiaorg/celestia-app)](https://goreportcard.com/report/github.com/celestiaorg/celestia-app)
 [![Lint](https://github.com/celestiaorg/celestia-app/actions/workflows/lint.yml/badge.svg)](https://github.com/celestiaorg/celestia-app/actions/workflows/lint.yml)
 [![Tests / Code Coverage](https://github.com/celestiaorg/celestia-app/actions/workflows/test.yml/badge.svg)](https://github.com/celestiaorg/celestia-app/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/celestiaorg/celestia-app/branch/master/graph/badge.svg?token=CWGA4RLDS9)](https://codecov.io/gh/celestiaorg/celestia-app)
+[![codecov](https://codecov.io/gh/celestiaorg/celestia-app/branch/main/graph/badge.svg?token=CWGA4RLDS9)](https://codecov.io/gh/celestiaorg/celestia-app)
 
 **celestia-app** is a blockchain application built using Cosmos SDK and [celestia-core](https://github.com/celestiaorg/celestia-core) in place of Tendermint.
 


### PR DESCRIPTION
## Description

Partially addresses https://github.com/celestiaorg/celestia-app/issues/564 but blocked on a repo admin renaming `master` to `main` in Github UI