### PR TITLE
fix: use build flags when running make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ build: mod
 	@go install github.com/gobuffalo/packr/v2/packr2@latest
 	@cd ./cmd/celestia-appd && packr2
 	@mkdir -p build/
-	@go build -o build/ ./cmd/celestia-appd
+	@go build $(BUILD_FLAGS) -o build/ ./cmd/celestia-appd
 	@packr2 clean
 	@go mod tidy -compat=1.18
 
@@ -85,6 +85,3 @@ benchmark:
 test-cover:
 	@export VERSION=$(VERSION); bash -x contrib/test_cover.sh
 .PHONY: test-cover
-
-
-


### PR DESCRIPTION
## Description

Closes https://github.com/celestiaorg/celestia-app/issues/581

The `$(BUILD_FLAGS)` contain the version:
https://github.com/celestiaorg/celestia-app/blob/5148c709f06357331d0d1a88884080aec55025f4/Makefile#L13-L20

## Testing
```shell
make build
$ ./build/celestia-appd version
0.6.0-11-gcfa991a
```
 