### PR TITLE
chore: add v0.7.x, v0.8.x, and v0.9.x to mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,4 @@
 pull_request_rules:
-  - name: backport patches to v0.5.x branch
-    conditions:
-      - base=main
-      - label=S:backport-to-v0.5.x
-    actions:
-      backport:
-        branches:
-          - v0.5.x
   - name: backport patches to v0.6.x branch
     conditions:
       - base=main
@@ -15,3 +7,27 @@ pull_request_rules:
       backport:
         branches:
           - v0.6.x
+  - name: backport patches to v0.7.x branch
+    conditions:
+      - base=main
+      - label=S:backport-to-v0.7.x
+    actions:
+      backport:
+        branches:
+          - v0.7.x
+  - name: backport patches to v0.8.x branch
+    conditions:
+      - base=main
+      - label=S:backport-to-v0.8.x
+    actions:
+      backport:
+        branches:
+          - v0.8.x
+  - name: backport patches to v0.9.x branch
+    conditions:
+      - base=main
+      - label=S:backport-to-v0.9.x
+    actions:
+      backport:
+        branches:
+          - v0.9.x


### PR DESCRIPTION
## Description

adds a few upcoming release branches to mergify. Note that we haven't created v0.8 or v0.9 branches yet, and shouldn't until later.