### PR TITLE
chore: add lint and fmt Makefile tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,11 @@ proto-format:
 build-docker:
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/Dockerfile .
 
+lint:
+	@echo "--> Running linter"
+	@golangci-lint run
+	@markdownlint --config .markdownlint.yaml '**/*.md'
+.PHONY: lint
 
 ###############################################################################
 ###                           Tests & Simulation                            ###

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,12 @@ proto-format:
 build-docker:
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/Dockerfile .
 
+fmt:
+	@go mod tidy -compat=1.17
+	@golangci-lint run --fix
+	@markdownlint --fix --quiet --config .markdownlint.yaml .
+.PHONY: fmt
+
 lint:
 	@echo "--> Running linter"
 	@golangci-lint run

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ build-docker:
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/Dockerfile .
 
 fmt:
-	@go mod tidy -compat=1.17
 	@golangci-lint run --fix
 	@markdownlint --fix --quiet --config .markdownlint.yaml .
 .PHONY: fmt

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ See <https://docs.celestia.org/category/celestia-app> for more information
 
 ## Contributing
 
+### Tools
+
+1. Install [golangci-lint](https://golangci-lint.run/usage/install/)
+1. Install [markdownlint](https://github.com/DavidAnson/markdownlint)
+
 ### Helpful Commands
 
 ```sh
@@ -49,6 +54,9 @@ make build
 
 # Run tests
 make test
+
+# Run linters (this assumes golangci-lint and markdownlint are installed)
+make lint
 ```
 
 ## Careers

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ make build
 # Run tests
 make test
 
-# Run linters (this assumes golangci-lint and markdownlint are installed)
-make lint
+# Format code with linters (this assumes golangci-lint and markdownlint are installed)
+make fmt
 ```
 
 ## Careers


### PR DESCRIPTION
Inspired by https://github.com/celestiaorg/celestia-node/blob/main/Makefile#L61-L74

## Testing

I intentionally introduced a markdownlint violation
```
$ make lint
--> Running linter
WARN [linters context] structcheck is disabled because of go1.18. You can track the evolution of the go1.18 support by following the https://github.com/golangci/golangci-lint/issues/2649.
README.md:62 MD025/single-title/single-h1 Multiple top-level headings in the same document [Context: "# Carrers"]
make: *** [lint] Error 1
```