### PR TITLE
fix: invalidate reserved namespace ids in ValidateBasic

### DIFF
--- a/x/payment/types/payfordata.go
+++ b/x/payment/types/payfordata.go
@@ -38,13 +38,8 @@ func (msg *MsgPayForData) Type() string {
 // ValidateBasic fullfills the sdk.Msg interface by performing stateless
 // validity checks on the msg that also don't require having the actual message
 func (msg *MsgPayForData) ValidateBasic() error {
-	// ensure that the namespace id is of length == NamespaceIDSize
-	if nsLen := len(msg.GetMessageNamespaceId()); nsLen != NamespaceIDSize {
-		return fmt.Errorf(
-			"invalid namespace length: got %d wanted %d",
-			nsLen,
-			NamespaceIDSize,
-		)
+	if err := ValidateMessageNamespaceID(msg.GetMessageNamespaceId()); err != nil {
+		return err
 	}
 
 	_, err := sdk.AccAddressFromBech32(msg.Signer)

--- a/x/payment/types/payfordata_test.go
+++ b/x/payment/types/payfordata_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	sdkerrors "cosmossdk.io/errors"
+	"github.com/celestiaorg/nmt/namespace"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -332,6 +333,22 @@ func TestValidateBasic(t *testing.T) {
 	tailPaddingMsg := validMsgPayForData(t)
 	tailPaddingMsg.MessageNamespaceId = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFE}
 
+	// MsgPayForData that uses transaction namespace id
+	txNamespaceMsg := validMsgPayForData(t)
+	txNamespaceMsg.MessageNamespaceId = namespace.ID{0, 0, 0, 0, 0, 0, 0, 1}
+
+	// MsgPayForData that uses intermediateStateRoots namespace id
+	intermediateStateRootsNamespaceMsg := validMsgPayForData(t)
+	intermediateStateRootsNamespaceMsg.MessageNamespaceId = namespace.ID{0, 0, 0, 0, 0, 0, 0, 2}
+
+	// MsgPayForData that uses evidence namespace id
+	evidenceNamespaceMsg := validMsgPayForData(t)
+	evidenceNamespaceMsg.MessageNamespaceId = namespace.ID{0, 0, 0, 0, 0, 0, 0, 3}
+
+	// MsgPayForData that uses the max reserved namespace id
+	maxReservedNamespaceMsg := validMsgPayForData(t)
+	maxReservedNamespaceMsg.MessageNamespaceId = namespace.ID{0, 0, 0, 0, 0, 0, 0, 255}
+
 	tests := []test{
 		{
 			name:    "valid msg",
@@ -347,6 +364,26 @@ func TestValidateBasic(t *testing.T) {
 			name:    "tail padding namespace id",
 			msg:     tailPaddingMsg,
 			wantErr: ErrTailPaddingNamespace,
+		},
+		{
+			name:    "transaction namspace namespace id",
+			msg:     txNamespaceMsg,
+			wantErr: ErrReservedNamespace,
+		},
+		{
+			name:    "intermediate state root namespace id",
+			msg:     intermediateStateRootsNamespaceMsg,
+			wantErr: ErrReservedNamespace,
+		},
+		{
+			name:    "evidence namspace namespace id",
+			msg:     evidenceNamespaceMsg,
+			wantErr: ErrReservedNamespace,
+		},
+		{
+			name:    "max reserved namespace id",
+			msg:     maxReservedNamespaceMsg,
+			wantErr: ErrReservedNamespace,
 		},
 	}
 


### PR DESCRIPTION
Closes https://github.com/informalsystems/audit-celestia/issues/2