### PR TITLE
chore: move malleated transaction decoder to the encoding package

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -240,7 +240,7 @@ func New(
 	cdc := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
 
-	bApp := baseapp.NewBaseApp(Name, logger, db, MalleatedTxDecoder(encodingConfig.TxConfig.TxDecoder()), baseAppOptions...)
+	bApp := baseapp.NewBaseApp(Name, logger, db, encoding.MalleatedTxDecoder(encodingConfig.TxConfig.TxDecoder()), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)
 	bApp.SetVersion(version.Version)
 	bApp.SetInterfaceRegistry(interfaceRegistry)

--- a/app/encoding/malleated_tx_decoder.go
+++ b/app/encoding/malleated_tx_decoder.go
@@ -1,4 +1,4 @@
-package app
+package encoding
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -10,6 +10,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 
+	"github.com/celestiaorg/celestia-app/app/encoding"
 	shares "github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/x/payment/types"
 )
@@ -30,7 +31,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 	// also see https://github.com/celestiaorg/celestia-app/issues/226
 	commitmentCounter := 0
 	for _, rawTx := range req.BlockData.Txs {
-		tx, err := MalleatedTxDecoder(app.txConfig.TxDecoder())(rawTx)
+		tx, err := encoding.MalleatedTxDecoder(app.txConfig.TxDecoder())(rawTx)
 		if err != nil {
 			continue
 		}

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -80,7 +80,7 @@ func TestPrepareProposal(t *testing.T) {
 		if err != nil {
 			require.NoError(t, err)
 		}
-		dec := app.MalleatedTxDecoder(encCfg.TxConfig.TxDecoder())
+		dec := encoding.MalleatedTxDecoder(encCfg.TxConfig.TxDecoder())
 		for _, tx := range res.BlockData.Txs {
 			sTx, err := dec(tx)
 			require.NoError(t, err)


### PR DESCRIPTION
I don't think it makes sense that we are keeping the custom decoder in the app package, since it is strictly related to encoding. 

Moved this in the non-interactive defaults feature branch, but it should probably be its own PR.