### PR TITLE
feat: Implement and install new ABCI Query for transaction inclusion proofs 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -78,6 +78,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/pkg/prove"
 	paymentmodule "github.com/celestiaorg/celestia-app/x/payment"
 	paymentmodulekeeper "github.com/celestiaorg/celestia-app/x/payment/keeper"
 	paymentmoduletypes "github.com/celestiaorg/celestia-app/x/payment/types"
@@ -476,6 +477,9 @@ func New(
 		paramstypes.ModuleName,
 		upgradetypes.ModuleName,
 	)
+
+	// add a custom quer
+	app.QueryRouter().AddRoute(prove.QueryPath, prove.Querier)
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)

--- a/app/app.go
+++ b/app/app.go
@@ -478,8 +478,7 @@ func New(
 		upgradetypes.ModuleName,
 	)
 
-	// add a custom quer
-	app.QueryRouter().AddRoute(prove.QueryPath, prove.Querier)
+	app.QueryRouter().AddRoute(prove.TxInclusionQueryPath, prove.QueryTxInclusionProof)
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)

--- a/app/split_shares.go
+++ b/app/split_shares.go
@@ -113,8 +113,8 @@ func SplitShares(txConf client.TxConfig, squareSize uint64, data *core.Data) ([]
 // that message and their corresponding txs get written to the square
 // atomically.
 type shareSplitter struct {
-	txWriter  *coretypes.ContiguousShareWriter
-	msgWriter *coretypes.MessageShareWriter
+	txWriter  *shares.ContiguousShareSplitter
+	msgWriter *shares.MessageShareSplitter
 
 	// Since evidence will always be included in a block, we do not need to
 	// generate these share lazily. Therefore instead of a ContiguousShareWriter
@@ -143,8 +143,8 @@ func newShareSplitter(txConf client.TxConfig, squareSize uint64, data *core.Data
 		panic(err)
 	}
 
-	sqwr.txWriter = coretypes.NewContiguousShareWriter(consts.TxNamespaceID)
-	sqwr.msgWriter = coretypes.NewMessageShareWriter()
+	sqwr.txWriter = shares.NewContiguousShareSplitter(consts.TxNamespaceID)
+	sqwr.msgWriter = shares.NewMessageShareSplitter()
 
 	return &sqwr
 }
@@ -152,7 +152,7 @@ func newShareSplitter(txConf client.TxConfig, squareSize uint64, data *core.Data
 // writeTx marshals the tx and lazily writes it to the square. Returns true if
 // the write was successful, false if there was not enough room in the square.
 func (sqwr *shareSplitter) writeTx(tx []byte) (ok bool, err error) {
-	delimTx, err := coretypes.Tx(tx).MarshalDelimited()
+	delimTx, err := shares.MarshalDelimitedTx(tx)
 	if err != nil {
 		return false, err
 	}
@@ -161,7 +161,7 @@ func (sqwr *shareSplitter) writeTx(tx []byte) (ok bool, err error) {
 		return false, nil
 	}
 
-	sqwr.txWriter.Write(delimTx)
+	sqwr.txWriter.WriteBytes(delimTx)
 	return true, nil
 }
 
@@ -205,12 +205,12 @@ func (sqwr *shareSplitter) writeMalleatedTx(
 		return false, nil, nil, nil
 	}
 
-	delimTx, err := wrappedTx.MarshalDelimited()
+	delimTx, err := shares.MarshalDelimitedTx(wrappedTx)
 	if err != nil {
 		return false, nil, nil, err
 	}
 
-	sqwr.txWriter.Write(delimTx)
+	sqwr.txWriter.WriteBytes(delimTx)
 	sqwr.msgWriter.Write(coretypes.Message{
 		NamespaceID: coreMsg.NamespaceId,
 		Data:        coreMsg.Data,
@@ -256,33 +256,36 @@ func (sqwr *shareSplitter) export() [][]byte {
 	if availableBytes < consts.TxShareSize {
 		count++
 	}
-	shares := make([][]byte, sqwr.maxShareCount)
+	rawShares := make([][]byte, sqwr.maxShareCount)
 
 	txShares := sqwr.txWriter.Export().RawShares()
 	txShareCount := len(txShares)
-	copy(shares, txShares)
+	copy(rawShares, txShares)
 
 	evdShareCount := len(sqwr.evdShares)
 	for i, evdShare := range sqwr.evdShares {
-		shares[i+txShareCount] = evdShare
+		rawShares[i+txShareCount] = evdShare
 	}
 
 	msgShares := sqwr.msgWriter.Export()
+	sort.SliceStable(msgShares, func(i, j int) bool {
+		return msgShares[i].ID.Less(msgShares[j].ID)
+	})
 	msgShareCount := len(msgShares)
 	for i, msgShare := range msgShares {
-		shares[i+txShareCount+evdShareCount] = msgShare.Share
+		rawShares[i+txShareCount+evdShareCount] = msgShare.Share
 	}
 
-	tailShares := coretypes.TailPaddingShares(sqwr.maxShareCount - count).RawShares()
+	tailShares := shares.TailPaddingShares(sqwr.maxShareCount - count).RawShares()
 
 	for i, tShare := range tailShares {
 		d := i + txShareCount + evdShareCount + msgShareCount
-		shares[d] = tShare
+		rawShares[d] = tShare
 	}
 
-	if len(shares[0]) == 0 {
-		shares = coretypes.TailPaddingShares(consts.MinSharecount).RawShares()
+	if len(rawShares[0]) == 0 {
+		rawShares = shares.TailPaddingShares(consts.MinSharecount).RawShares()
 	}
 
-	return shares
+	return rawShares
 }

--- a/app/split_shares.go
+++ b/app/split_shares.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
-	"github.com/tendermint/tendermint/pkg/consts"
 	core "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 
@@ -144,7 +143,7 @@ func newShareSplitter(txConf client.TxConfig, squareSize uint64, data *core.Data
 		panic(err)
 	}
 
-	sqwr.txWriter = shares.NewCompactShareSplitter(consts.TxNamespaceID)
+	sqwr.txWriter = shares.NewCompactShareSplitter(appconsts.TxNamespaceID)
 	sqwr.msgWriter = shares.NewSparseShareSplitter()
 
 	return &sqwr

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -127,8 +127,6 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 
 			heights := make(map[int64]int)
 			for _, hash := range hashes {
-				// TODO: once we are able to query txs that span more than two
-				// shares, we should switch to proving txs existence in the block
 				resp, err := queryTx(val.ClientCtx, hash, true)
 				assert.NoError(err)
 				assert.Equal(abci.CodeTypeOK, resp.TxResult.Code)

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -129,7 +129,7 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 			for _, hash := range hashes {
 				// TODO: once we are able to query txs that span more than two
 				// shares, we should switch to proving txs existence in the block
-				resp, err := queryWithOutProof(val.ClientCtx, hash)
+				resp, err := queryTx(val.ClientCtx, hash, true)
 				assert.NoError(err)
 				assert.Equal(abci.CodeTypeOK, resp.TxResult.Code)
 				if resp.TxResult.Code == abci.CodeTypeOK {
@@ -298,7 +298,7 @@ func randomValidNamespace() namespace.ID {
 	}
 }
 
-func queryWithOutProof(clientCtx client.Context, hashHexStr string) (*rpctypes.ResultTx, error) {
+func queryTx(clientCtx client.Context, hashHexStr string, prove bool) (*rpctypes.ResultTx, error) {
 	hash, err := hex.DecodeString(hashHexStr)
 	if err != nil {
 		return nil, err
@@ -309,5 +309,5 @@ func queryWithOutProof(clientCtx client.Context, hashHexStr string) (*rpctypes.R
 		return nil, err
 	}
 
-	return node.Tx(context.Background(), hash, false)
+	return node.Tx(context.Background(), hash, prove)
 }

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -135,6 +135,7 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 				if resp.TxResult.Code == abci.CodeTypeOK {
 					heights[resp.Height]++
 				}
+				require.True(resp.Proof.VerifyProof())
 			}
 
 			require.Greater(len(heights), 0)

--- a/go.mod
+++ b/go.mod
@@ -160,5 +160,5 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.2.0-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.3.5-tm-v0.34.20
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.4.0-tm-v0.34.20.0.20220914173119-7ea6dc789096
 )

--- a/go.mod
+++ b/go.mod
@@ -160,5 +160,5 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.2.0-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.4.0-tm-v0.34.20.0.20220914173119-7ea6dc789096
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.5.0-tm-v0.34.20
 )

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.3.5-tm-v0.34.20 h1:Z66gewBIJIQ5T72v2ktu4FMA/sgDE4ok4y9DvfnCUUE=
-github.com/celestiaorg/celestia-core v1.3.5-tm-v0.34.20/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
+github.com/celestiaorg/celestia-core v1.4.0-tm-v0.34.20.0.20220914173119-7ea6dc789096 h1:+Djf/4xXb+OHKG/9ikhwOodsNCauIEXvZkWlK9FFmWo=
+github.com/celestiaorg/celestia-core v1.4.0-tm-v0.34.20.0.20220914173119-7ea6dc789096/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
 github.com/celestiaorg/cosmos-sdk v1.2.0-sdk-v0.46.0 h1:A1F7L/09uGClsU+kmugMy47Ezv4ll0uxNRNdaGa37T8=
 github.com/celestiaorg/cosmos-sdk v1.2.0-sdk-v0.46.0/go.mod h1:OXRC0p460CFKl77uQZWY/8p5uZmDrNum7BmVZDupq0Q=
 github.com/celestiaorg/go-leopard v0.1.0 h1:28z2EkvKJIez5J9CEaiiUEC+OxalRLtTGJJ1oScfE1g=

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.4.0-tm-v0.34.20.0.20220914173119-7ea6dc789096 h1:+Djf/4xXb+OHKG/9ikhwOodsNCauIEXvZkWlK9FFmWo=
-github.com/celestiaorg/celestia-core v1.4.0-tm-v0.34.20.0.20220914173119-7ea6dc789096/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
+github.com/celestiaorg/celestia-core v1.5.0-tm-v0.34.20 h1:BqlcOQqL2UqdDTcdCtrOLXDlmwxIA8DiKiY79oahxkQ=
+github.com/celestiaorg/celestia-core v1.5.0-tm-v0.34.20/go.mod h1:f4R8qNJrP1CDH0SNwj4jA3NymBLQM4lNdx6Ijmfllbw=
 github.com/celestiaorg/cosmos-sdk v1.2.0-sdk-v0.46.0 h1:A1F7L/09uGClsU+kmugMy47Ezv4ll0uxNRNdaGa37T8=
 github.com/celestiaorg/cosmos-sdk v1.2.0-sdk-v0.46.0/go.mod h1:OXRC0p460CFKl77uQZWY/8p5uZmDrNum7BmVZDupq0Q=
 github.com/celestiaorg/go-leopard v0.1.0 h1:28z2EkvKJIez5J9CEaiiUEC+OxalRLtTGJJ1oScfE1g=

--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -6,11 +6,11 @@ import (
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	daproto "github.com/celestiaorg/celestia-app/proto/da"
 	"github.com/celestiaorg/rsmt2d"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	"github.com/tendermint/tendermint/crypto/tmhash"
-	"github.com/tendermint/tendermint/pkg/wrapper"
 )
 
 const (

--- a/pkg/prove/proof.go
+++ b/pkg/prove/proof.go
@@ -16,7 +16,7 @@ import (
 // TxInclusion uses the provided block data to progressively generate rows
 // of a data square, and then using those shares to creates nmt inclusion proofs
 // It is possible that a transaction spans more than one row. In that case, we
-// have to return two proofs.
+// have to return more than one proofs.
 func TxInclusion(codec rsmt2d.Codec, data types.Data, txIndex uint64) (types.TxProof, error) {
 	// calculate the index of the shares that contain the tx
 	startPos, endPos, err := txSharePosition(data.Txs, txIndex)

--- a/pkg/prove/proof.go
+++ b/pkg/prove/proof.go
@@ -3,8 +3,8 @@ package prove
 import (
 	"encoding/binary"
 	"errors"
-	"fmt"
 
+	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/pkg/wrapper"
 	"github.com/celestiaorg/rsmt2d"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
@@ -150,36 +150,40 @@ func genOrigRowShares(data types.Data, startRow, endRow uint64) [][]byte {
 	wantLen := (endRow + 1) * data.OriginalSquareSize
 	startPos := startRow * data.OriginalSquareSize
 
-	shares := data.Txs.SplitIntoShares()
+	rawShares := shares.SplitTxs(data.Txs)
 	// return if we have enough shares
-	if uint64(len(shares)) >= wantLen {
-		return shares[startPos:wantLen].RawShares()
+	if uint64(len(rawShares)) >= wantLen {
+		return rawShares[startPos:wantLen]
 	}
 
-	evdShares := data.Evidence.SplitIntoShares()
+	evdShares, err := shares.SplitEvidence(data.Evidence.Evidence)
+	if err != nil {
+		panic(err)
+	}
 
-	shares = append(shares, evdShares...)
-	if uint64(len(shares)) >= wantLen {
-		return shares[startPos:wantLen].RawShares()
+	rawShares = append(rawShares, evdShares...)
+	if uint64(len(rawShares)) >= wantLen {
+		return rawShares[startPos:wantLen]
 	}
 
 	for _, m := range data.Messages.MessagesList {
-		rawData, err := m.MarshalDelimited()
+		msgShares, err := shares.SplitMessages(nil, []types.Message{m})
 		if err != nil {
-			panic(fmt.Sprintf("app accepted a Message that can not be encoded %#v", m))
+			panic(err)
 		}
-		shares = types.AppendToShares(shares, m.NamespaceID, rawData)
+
+		rawShares = append(rawShares, msgShares...)
 
 		// return if we have enough shares
-		if uint64(len(shares)) >= wantLen {
-			return shares[startPos:wantLen].RawShares()
+		if uint64(len(rawShares)) >= wantLen {
+			return rawShares[startPos:wantLen]
 		}
 	}
 
-	tailShares := types.TailPaddingShares(int(wantLen) - len(shares))
-	shares = append(shares, tailShares...)
+	tailShares := shares.TailPaddingShares(int(wantLen) - len(rawShares))
+	rawShares = append(rawShares, tailShares.RawShares()...)
 
-	return shares[startPos:wantLen].RawShares()
+	return rawShares[startPos:wantLen]
 }
 
 // splitIntoRows splits shares into rows of a particular square size

--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
-	"github.com/tendermint/tendermint/pkg/da"
 	"github.com/tendermint/tendermint/types"
 )
 

--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"math/rand"
-	"sort"
 	"strings"
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/pkg/shares"
+	"github.com/celestiaorg/nmt/namespace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -115,7 +116,7 @@ func TestTxSharePosition(t *testing.T) {
 			positions[i] = startEndPoints{start: start, end: end}
 		}
 
-		shares := tt.txs.SplitIntoShares().RawShares()
+		shares := shares.SplitTxs(tt.txs)
 
 		for i, pos := range positions {
 			if pos.start == pos.end {
@@ -153,8 +154,8 @@ func Test_genRowShares(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	allShares, _, _ := typicalBlockData.ComputeShares(squareSize)
-	rawShares := allShares.RawShares()
+	rawShares, err := shares.Split(typicalBlockData)
+	require.NoError(t, err)
 
 	eds, err := da.ExtendShares(squareSize, rawShares)
 	require.NoError(t, err)
@@ -178,20 +179,19 @@ func Test_genOrigRowShares(t *testing.T) {
 		OriginalSquareSize: squareSize,
 	}
 
-	allShares, _, err := typicalBlockData.ComputeShares(squareSize)
+	rawShares, err := shares.Split(typicalBlockData)
 	require.NoError(t, err)
-	rawShares := allShares.RawShares()
 
 	genShares := genOrigRowShares(typicalBlockData, 0, 15)
 
-	require.Equal(t, len(allShares), len(genShares))
+	require.Equal(t, len(rawShares), len(genShares))
 	assert.Equal(t, rawShares, genShares)
 }
 
 func joinByteSlices(s ...[]byte) string {
 	out := make([]string, len(s))
 	for i, sl := range s {
-		sl, _, _ := types.ParseDelimiter(sl)
+		sl, _, _ := shares.ParseDelimiter(sl)
 		out[i] = string(sl[consts.NamespaceSize:])
 	}
 	return strings.Join(out, "")
@@ -239,43 +239,18 @@ func generateRandomlySizedMessages(count, maxMsgSize int) types.Messages {
 }
 
 func generateRandomMessage(size int) types.Message {
-	share := generateRandomNamespacedShares(1, size)[0]
 	msg := types.Message{
-		NamespaceID: share.NamespaceID(),
-		Data:        share.Data(),
+		NamespaceID: randomValidNamespace(),
+		Data:        tmrand.Bytes(size),
 	}
 	return msg
 }
 
-func generateRandomNamespacedShares(count, msgSize int) types.NamespacedShares {
-	shares := generateRandNamespacedRawData(uint32(count), consts.NamespaceSize, uint32(msgSize))
-	msgs := make([]types.Message, count)
-	for i, s := range shares {
-		msgs[i] = types.Message{
-			Data:        s[consts.NamespaceSize:],
-			NamespaceID: s[:consts.NamespaceSize],
+func randomValidNamespace() namespace.ID {
+	for {
+		s := tmrand.Bytes(8)
+		if bytes.Compare(s, consts.MaxReservedNamespace) > 0 {
+			return s
 		}
 	}
-	return types.Messages{MessagesList: msgs}.SplitIntoShares()
-}
-
-func generateRandNamespacedRawData(total, nidSize, leafSize uint32) [][]byte {
-	data := make([][]byte, total)
-	for i := uint32(0); i < total; i++ {
-		nid := make([]byte, nidSize)
-		rand.Read(nid)
-		data[i] = nid
-	}
-	sortByteArrays(data)
-	for i := uint32(0); i < total; i++ {
-		d := make([]byte, leafSize)
-		rand.Read(d)
-		data[i] = append(data[i], d...)
-	}
-
-	return data
-}
-
-func sortByteArrays(src [][]byte) {
-	sort.Slice(src, func(i, j int) bool { return bytes.Compare(src[i], src[j]) < 0 })
 }

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -19,7 +19,7 @@ const TxInclusionQueryPath = "txInclusionProof"
 // proof (tmproto.TxProof) are returned.
 //
 // example path for proving the third transaction in that block:
-// custom/tx-inclusion-proof/3
+// custom/txInclusionProof/3
 func QueryTxInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
 	// parse the index from the path
 	if len(path) != 1 {

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-const QueryPath = "tx-inclusion-proof"
+const TxInclusionQueryPath = "tx-inclusion-proof"
 
 // Querier defines the logic performed when the ABCI client using the Query
 // method with the custom prove.QueryPath. The index of the transaction being
@@ -20,7 +20,7 @@ const QueryPath = "tx-inclusion-proof"
 //
 // example path for proving the third transaction in that block:
 // custom/tx-inclusion-proof/3
-func Querier(_ sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
+func QueryTxInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
 	// parse the index from the path
 	if len(path) != 1 {
 		return nil, fmt.Errorf("unexpected query path length %d", len(path))

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -23,7 +23,7 @@ const TxInclusionQueryPath = "txInclusionProof"
 func QueryTxInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
 	// parse the index from the path
 	if len(path) != 1 {
-		return nil, fmt.Errorf("unexpected query path length %d", len(path))
+		return nil, fmt.Errorf("expected query path length: 1 actual: %d ", len(path))
 	}
 	index, err := strconv.ParseInt(path[0], 10, 64)
 	if err != nil {

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -1,0 +1,56 @@
+package prove
+
+import (
+	"fmt"
+	"strconv"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+	"github.com/tendermint/tendermint/pkg/consts"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	"github.com/tendermint/tendermint/types"
+)
+
+const QueryPath = "tx-inclusion-proof"
+
+// Querier defines the logic performed when the ABCI client using the Query
+// method with the custom prove.QueryPath. The index of the transaction being
+// proved must be appended to the path. The marshalled bytes of the transction
+// proof (tmproto.TxProof) are returned.
+//
+// example path for proving the third transaction in that block:
+// custom/tx-inclusion-proof/3
+func Querier(_ sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
+	// parse the index from the path
+	if len(path) != 1 {
+		return nil, fmt.Errorf("unexpected query path length %d", len(path))
+	}
+	index, err := strconv.ParseInt(path[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal the block data that is passed from the ABCI client
+	pbb := new(tmproto.Block)
+	err = pbb.Unmarshal(req.Data)
+	if err != nil {
+		return nil, fmt.Errorf("error reading block: %w", err)
+	}
+	data, err := types.DataFromProto(&pbb.Data)
+	if err != nil {
+		panic(fmt.Errorf("error from proto block: %w", err))
+	}
+
+	// create and marshal the tx inclusion proof, which we return in the form of []byte
+	txProof, err := TxInclusion(consts.DefaultCodec(), data, uint64(index))
+	if err != nil {
+		return nil, err
+	}
+	pTxProof := txProof.ToProto()
+	rawTxProof, err := pTxProof.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return rawTxProof, nil
+}

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/pkg/consts"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )
@@ -42,7 +42,7 @@ func QueryTxInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) 
 	}
 
 	// create and marshal the tx inclusion proof, which we return in the form of []byte
-	txProof, err := TxInclusion(consts.DefaultCodec(), data, uint64(index))
+	txProof, err := TxInclusion(appconsts.DefaultCodec(), data, uint64(index))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -15,7 +15,7 @@ const TxInclusionQueryPath = "txInclusionProof"
 
 // Querier defines the logic performed when the ABCI client using the Query
 // method with the custom prove.QueryPath. The index of the transaction being
-// proved must be appended to the path. The marshalled bytes of the transction
+// proved must be appended to the path. The marshalled bytes of the transaction
 // proof (tmproto.TxProof) are returned.
 //
 // example path for proving the third transaction in that block:

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -11,7 +11,7 @@ import (
 	"github.com/tendermint/tendermint/types"
 )
 
-const TxInclusionQueryPath = "tx-inclusion-proof"
+const TxInclusionQueryPath = "txInclusionProof"
 
 // Querier defines the logic performed when the ABCI client using the Query
 // method with the custom prove.QueryPath. The index of the transaction being

--- a/pkg/shares/contiguous_shares_test.go
+++ b/pkg/shares/contiguous_shares_test.go
@@ -18,7 +18,7 @@ func TestContigShareWriter(t *testing.T) {
 	w := NewContiguousShareSplitter(consts.TxNamespaceID)
 	txs := generateRandomContiguousShares(33, 200)
 	for _, tx := range txs {
-		rawTx, _ := tx.MarshalDelimited()
+		rawTx, _ := MarshalDelimitedTx(tx)
 		w.WriteBytes(rawTx)
 	}
 	resShares := w.Export()
@@ -32,7 +32,7 @@ func TestContigShareWriter(t *testing.T) {
 func Test_parseDelimiter(t *testing.T) {
 	for i := uint64(0); i < 100; i++ {
 		tx := generateRandomContiguousShares(1, int(i))[0]
-		input, err := tx.MarshalDelimited()
+		input, err := MarshalDelimitedTx(tx)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -224,10 +224,10 @@ func TestMerge(t *testing.T) {
 				tc.msgCount,
 				tc.maxSize,
 			)
+			data.OriginalSquareSize = consts.MaxSquareSize
 
-			shares, _, err := data.ComputeShares(0)
+			rawShares, err := Split(data)
 			require.NoError(t, err)
-			rawShares := shares.RawShares()
 
 			eds, err := rsmt2d.ComputeExtendedDataSquare(rawShares, consts.DefaultCodec(), rsmt2d.NewDefaultTree)
 			if err != nil {

--- a/pkg/shares/split_contiguous_shares.go
+++ b/pkg/shares/split_contiguous_shares.go
@@ -28,7 +28,7 @@ func NewContiguousShareSplitter(ns namespace.ID) *ContiguousShareSplitter {
 }
 
 func (csw *ContiguousShareSplitter) WriteTx(tx coretypes.Tx) {
-	rawData, err := tx.MarshalDelimited()
+	rawData, err := MarshalDelimitedTx(tx)
 	if err != nil {
 		panic(fmt.Sprintf("included Tx in mem-pool that can not be encoded %v", tx))
 	}

--- a/pkg/shares/split_message_shares.go
+++ b/pkg/shares/split_message_shares.go
@@ -22,7 +22,7 @@ func NewMessageShareSplitter() *MessageShareSplitter {
 
 // Write adds the delimited data to the underlying messages shares.
 func (msw *MessageShareSplitter) Write(msg coretypes.Message) {
-	rawMsg, err := msg.MarshalDelimited()
+	rawMsg, err := MarshalDelimitedMessage(msg)
 	if err != nil {
 		panic(fmt.Sprintf("app accepted a Message that can not be encoded %#v", msg))
 	}


### PR DESCRIPTION
This PR introduces a new custom ABCI query that generates the ABCI inclusion proof for a transaction of a specific index. 

Note that this PR does not fix the tx inclusion proof logic to follow the non-interactive defaults, as we haven't merged those yet. It does however alter the integration test to require that transactions include proofs, so we are testing the new ABCI query method.

blocked by https://github.com/celestiaorg/celestia-core/pull/859
closes #698 