### PR TITLE
chore: define `OriginalSquareSize` inside `generateRandomBlockData`

### DIFF
--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -224,7 +224,6 @@ func TestMerge(t *testing.T) {
 				tc.msgCount,
 				tc.maxSize,
 			)
-			data.OriginalSquareSize = appconsts.MaxSquareSize
 
 			rawShares, err := Split(data)
 			require.NoError(t, err)
@@ -279,7 +278,7 @@ func generateRandomBlockData(txCount, evdCount, msgCount, maxSize int) (data cor
 	data.Txs = generateRandomlySizedCompactShares(txCount, maxSize)
 	data.Evidence = generateIdenticalEvidence(evdCount)
 	data.Messages = generateRandomlySizedMessages(msgCount, maxSize)
-	data.OriginalSquareSize = 16
+	data.OriginalSquareSize = appconsts.MaxSquareSize
 	return data
 }
 

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -275,12 +275,12 @@ func TestFuzz_Merge(t *testing.T) {
 }
 
 // generateRandomBlockData returns randomly generated block data for testing purposes
-func generateRandomBlockData(txCount, evdCount, msgCount, maxSize int) coretypes.Data {
-	var out coretypes.Data
-	out.Txs = generateRandomlySizedCompactShares(txCount, maxSize)
-	out.Evidence = generateIdenticalEvidence(evdCount)
-	out.Messages = generateRandomlySizedMessages(msgCount, maxSize)
-	return out
+func generateRandomBlockData(txCount, evdCount, msgCount, maxSize int) (data coretypes.Data) {
+	data.Txs = generateRandomlySizedCompactShares(txCount, maxSize)
+	data.Evidence = generateIdenticalEvidence(evdCount)
+	data.Messages = generateRandomlySizedMessages(msgCount, maxSize)
+	data.OriginalSquareSize = 16
+	return data
 }
 
 func generateRandomlySizedCompactShares(count, max int) coretypes.Txs {


### PR DESCRIPTION
Spun out of https://github.com/celestiaorg/celestia-app/pull/691

## Motivation
While iterating on the `TestMerge` test, I encountered an unexpected error
```
            	            	square size is not a power of two: 0
```

because I failed to declare the square size on the data returned from `generateRandomBlockData`. I moved a variable definition to avoid this scenario.

Very minor improvement. Can be closed if not helpful.