### PR TITLE
fix: Update Dockerfiles and fix CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # stage 1 Generate celestia-appd Binary
 FROM golang:1.18-alpine as builder
-RUN apk update && apk --no-cache add make gcc git musl-dev
+RUN apk update && apk --no-cache add make gcc musl-dev
 COPY . /celestia-app
 WORKDIR /celestia-app
 RUN make build

--- a/docker/Dockerfile_ephemeral
+++ b/docker/Dockerfile_ephemeral
@@ -3,7 +3,7 @@ FROM golang:1.18-alpine as builder
 
 RUN apk update && \
     apk upgrade && \
-    apk --no-cache add make
+    apk --no-cache add make gcc musl-dev
 
 ENV HOME /celestia-app
 


### PR DESCRIPTION
Currently, the CI is failing because of not found `gcc` and standard C libraries when building the ephemeral cluster docker image. This PR fixes that.
Also, removes unnecessary `git` install.