### PR TITLE
chore: move `MarshalDelimited*` functions

### DIFF
--- a/pkg/shares/shares.go
+++ b/pkg/shares/shares.go
@@ -1,10 +1,7 @@
 package shares
 
 import (
-	"encoding/binary"
-
 	"github.com/celestiaorg/nmt/namespace"
-	coretypes "github.com/tendermint/tendermint/types"
 )
 
 // Share contains the raw share data (including namespace ID).
@@ -36,23 +33,4 @@ func (ns NamespacedShares) RawShares() [][]byte {
 		res[i] = nsh.Share
 	}
 	return res
-}
-
-// MarshalDelimitedTx prefixes a transaction with the length of the transaction
-// encoded as a varint.
-func MarshalDelimitedTx(tx coretypes.Tx) ([]byte, error) {
-	lenBuf := make([]byte, binary.MaxVarintLen64)
-	length := uint64(len(tx))
-	n := binary.PutUvarint(lenBuf, length)
-	return append(lenBuf[:n], tx...), nil
-}
-
-// MarshalDelimitedMessage marshals the raw share data (excluding the namespace)
-// of this message and prefixes it with the length of the message encoded as a
-// varint.
-func MarshalDelimitedMessage(msg coretypes.Message) ([]byte, error) {
-	lenBuf := make([]byte, binary.MaxVarintLen64)
-	length := uint64(len(msg.Data))
-	n := binary.PutUvarint(lenBuf, length)
-	return append(lenBuf[:n], msg.Data...), nil
 }

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -2,6 +2,7 @@ package shares
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
@@ -184,6 +185,15 @@ func TailPaddingShares(n int) NamespacedShares {
 		}
 	}
 	return shares
+}
+
+// MarshalDelimitedTx prefixes a transaction with the length of the transaction
+// encoded as a varint.
+func MarshalDelimitedTx(tx coretypes.Tx) ([]byte, error) {
+	lenBuf := make([]byte, binary.MaxVarintLen64)
+	length := uint64(len(tx))
+	n := binary.PutUvarint(lenBuf, length)
+	return append(lenBuf[:n], tx...), nil
 }
 
 func namespacedPaddedShares(ns []byte, count int) NamespacedShares {

--- a/pkg/shares/split_sparse_shares.go
+++ b/pkg/shares/split_sparse_shares.go
@@ -1,6 +1,7 @@
 package shares
 
 import (
+	"encoding/binary"
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
@@ -110,6 +111,16 @@ func AppendToShares(shares []NamespacedShare, nid namespace.ID, rawData []byte) 
 		shares = append(shares, splitMessage(rawData, nid)...)
 	}
 	return shares
+}
+
+// MarshalDelimitedMessage marshals the raw share data (excluding the namespace)
+// of this message and prefixes it with the length of the message encoded as a
+// varint.
+func MarshalDelimitedMessage(msg coretypes.Message) ([]byte, error) {
+	lenBuf := make([]byte, binary.MaxVarintLen64)
+	length := uint64(len(msg.Data))
+	n := binary.PutUvarint(lenBuf, length)
+	return append(lenBuf[:n], msg.Data...), nil
 }
 
 // splitMessage breaks the data in a message into the minimum number of


### PR DESCRIPTION
Move `MarshalDelimited*` functions to the files in which they are used. Previously they were located in the top level `shares.go` which makes it non-obvious that `MarshalDelimitedTx` is only applicable to compact shares whereas `MarshalDelimitedMessage` is only applicable to sparse shares.