### PR TITLE
fix: compact share `Count`

### DIFF
--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -92,14 +92,8 @@ func calculateCompactShareCount(txs []*parsedTx, evd core.EvidenceList, squareSi
 			panic(err)
 		}
 	}
-	txCount, available := txSplitter.Count()
-	if appconsts.CompactShareContentSize-available > 0 {
-		txCount++
-	}
-	evdCount, available := evdSplitter.Count()
-	if appconsts.CompactShareContentSize-available > 0 {
-		evdCount++
-	}
+	txCount := txSplitter.Count()
+	evdCount := evdSplitter.Count()
 	return txCount + evdCount
 }
 

--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -92,9 +92,7 @@ func calculateCompactShareCount(txs []*parsedTx, evd core.EvidenceList, squareSi
 			panic(err)
 		}
 	}
-	txCount := txSplitter.Count()
-	evdCount := evdSplitter.Count()
-	return txCount + evdCount
+	return txSplitter.Count() + evdSplitter.Count()
 }
 
 // estimateSquareSize uses the provided block data to estimate the square size

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -153,15 +153,13 @@ func (css *CompactShareSplitter) Export() NamespacedShares {
 	return css.shares
 }
 
-// Count returns the current number of shares that will be made if exporting and
-// the number of availableBytes in the last pending share.
-func (css *CompactShareSplitter) Count() (count, availableBytes int) {
+// Count returns the current number of shares that will be made if exporting.
+func (css *CompactShareSplitter) Count() (shareCount int) {
 	if len(css.pendingShare.Share) > appconsts.NamespaceSize+appconsts.ShareInfoBytes {
-		return len(css.shares), 0
+		// pending share is non-empty, so we must add one to the count
+		return len(css.shares) + 1
 	}
-	//  this doesn't account for the size of the reserved byte
-	availableBytes = appconsts.CompactShareContentSize - (len(css.pendingShare.Share) - appconsts.NamespaceSize - appconsts.ShareInfoBytes)
-	return len(css.shares), availableBytes
+	return len(css.shares)
 }
 
 var tailPaddingInfo, _ = NewInfoReservedByte(appconsts.ShareVersion, false)

--- a/pkg/shares/split_compact_shares_test.go
+++ b/pkg/shares/split_compact_shares_test.go
@@ -1,0 +1,33 @@
+package shares
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	coretypes "github.com/tendermint/tendermint/types"
+)
+
+func TestCount(t *testing.T) {
+	type testCase struct {
+		transactions   []coretypes.Tx
+		wantShareCount int
+	}
+	testCases := []testCase{
+		{transactions: []coretypes.Tx{}, wantShareCount: 0},
+		{transactions: []coretypes.Tx{[]byte{0}}, wantShareCount: 1},
+		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, 100)}, wantShareCount: 1},
+		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, appconsts.CompactShareContentSize+1)}, wantShareCount: 2},
+		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, appconsts.CompactShareContentSize*2+1)}, wantShareCount: 3},
+	}
+	for _, tc := range testCases {
+		css := NewCompactShareSplitter(appconsts.TxNamespaceID, appconsts.ShareVersion)
+		for _, transaction := range tc.transactions {
+			css.WriteTx(transaction)
+		}
+		got := css.Count()
+		if got != tc.wantShareCount {
+			t.Errorf("count got %d want %d", got, tc.wantShareCount)
+		}
+	}
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/777

I choose to fix the implementation to match the doc comment because it seems like a leaky abstraction for this function to also return the # of available bytes in the pending share. By removing the second return value, the compact share `Count` more closely matches the sparse share [`Count`](https://github.com/rootulp/celestia-app/blob/5eab874a214861a5de9af2a662c9bcbe352c5608/pkg/shares/split_sparse_shares.go#L87-L90) function signature.