### PR TITLE
fix: update default `timeout_commit` when running `sed` on genesis in `single-node.sh` script

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -21,7 +21,7 @@ celestia-appd collect-gentxs
 
 # Set proper defaults and change ports
 sed -i 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ~/.celestia-app/config/config.toml
-sed -i 's/timeout_commit = "5s"/timeout_commit = "1s"/g' ~/.celestia-app/config/config.toml
+sed -i 's/timeout_commit = "25s"/timeout_commit = "1s"/g' ~/.celestia-app/config/config.toml
 sed -i 's/timeout_propose = "3s"/timeout_propose = "1s"/g' ~/.celestia-app/config/config.toml
 sed -i 's/index_all_keys = false/index_all_keys = true/g' ~/.celestia-app/config/config.toml
 sed -i 's/mode = "full"/mode = "validator"/g' ~/.celestia-app/config/config.toml


### PR DESCRIPTION
the default is `25s` now instead of `5s`