### PR TITLE
chore: prefer appconsts for # of reserved bytes

### DIFF
--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -57,10 +57,11 @@ func (css *CompactShareSplitter) WriteEvidence(evd coretypes.Evidence) error {
 
 // WriteBytes adds the delimited data to the underlying compact shares.
 func (css *CompactShareSplitter) WriteBytes(rawData []byte) {
-	// if this is the first time writing to a pending share, we must add the
-	// reserved bytes
+	// if this is the first time writing to a pending share, we must add a
+	// placeholder for the reserved bytes
 	if len(css.pendingShare.Share) == appconsts.NamespaceSize+appconsts.ShareInfoBytes {
-		css.pendingShare.Share = append(css.pendingShare.Share, 0)
+		reservedBytesPlaceholder := make([]byte, appconsts.CompactShareReservedBytes)
+		css.pendingShare.Share = append(css.pendingShare.Share, reservedBytesPlaceholder...)
 	}
 
 	txCursor := len(rawData)

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -88,16 +88,19 @@ func (css *CompactShareSplitter) WriteBytes(rawData []byte) {
 
 		// add the share reserved bytes to the new pending share
 		pendingCursor := len(rawData) + appconsts.NamespaceSize + appconsts.ShareInfoBytes + appconsts.CompactShareReservedBytes
-		var reservedByte byte
+		reservedBytes := make([]byte, appconsts.CompactShareReservedBytes)
 		if pendingCursor >= appconsts.ShareSize {
 			// the share reserve byte is zero when some compactly written
 			// data takes up the entire share
-			reservedByte = byte(0)
+			for i := range reservedBytes {
+				reservedBytes[i] = byte(0)
+			}
 		} else {
-			reservedByte = byte(pendingCursor)
+			// TODO this must be changed when share size is increased to 512
+			reservedBytes[0] = byte(pendingCursor)
 		}
 
-		css.pendingShare.Share = append(css.pendingShare.Share, reservedByte)
+		css.pendingShare.Share = append(css.pendingShare.Share, reservedBytes...)
 	}
 
 	// if the share is exactly the correct size, then append to shares

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -57,11 +57,11 @@ func (css *CompactShareSplitter) WriteEvidence(evd coretypes.Evidence) error {
 
 // WriteBytes adds the delimited data to the underlying compact shares.
 func (css *CompactShareSplitter) WriteBytes(rawData []byte) {
-	// if this is the first time writing to a pending share, we must add a
-	// placeholder for the reserved bytes
+	// if this is the first time writing to a pending share, we must add the
+	// reserved bytes
 	if len(css.pendingShare.Share) == appconsts.NamespaceSize+appconsts.ShareInfoBytes {
-		reservedBytesPlaceholder := make([]byte, appconsts.CompactShareReservedBytes)
-		css.pendingShare.Share = append(css.pendingShare.Share, reservedBytesPlaceholder...)
+		reservedBytes := make([]byte, appconsts.CompactShareReservedBytes)
+		css.pendingShare.Share = append(css.pendingShare.Share, reservedBytes...)
 	}
 
 	txCursor := len(rawData)


### PR DESCRIPTION
## Motivation

We will increase the # of reserved bytes from 1 to 2 when we do https://github.com/celestiaorg/celestia-app/issues/711. The current implementation hardcodes only 1 reserved byte rather than relying on `appconsts.CompactShareReservedBytes`.