### PR TITLE
chore: rename to `ContinuationCompactShareContentSize`

### DIFF
--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -34,9 +34,9 @@ func prune(txConf client.TxConfig, txs []*parsedTx, currentShareCount, squareSiz
 	// inorder to tally total contiguous shares removed
 	adjustContigCursor := func(l int) {
 		contigBytesCursor += l + shares.DelimLen(uint64(l))
-		if contigBytesCursor >= appconsts.CompactShareContentSize {
-			removedContiguousShares += (contigBytesCursor / appconsts.CompactShareContentSize)
-			contigBytesCursor = contigBytesCursor % appconsts.CompactShareContentSize
+		if contigBytesCursor >= appconsts.ContinuationCompactShareContentSize {
+			removedContiguousShares += (contigBytesCursor / appconsts.ContinuationCompactShareContentSize)
+			contigBytesCursor = contigBytesCursor % appconsts.ContinuationCompactShareContentSize
 		}
 	}
 
@@ -175,7 +175,7 @@ func rawShareCount(txs []*parsedTx, evd core.EvidenceList) (txShares, evdShares 
 		msgSummaries = append(msgSummaries, msgSummary{shares.MsgSharesUsed(int(pTx.msg.MessageSize)), pTx.msg.MessageNamespaceId})
 	}
 
-	txShares = txBytes / appconsts.CompactShareContentSize
+	txShares = txBytes / appconsts.ContinuationCompactShareContentSize
 	if txBytes > 0 {
 		txShares++ // add one to round up
 	}
@@ -194,7 +194,7 @@ func rawShareCount(txs []*parsedTx, evd core.EvidenceList) (txShares, evdShares 
 		evdBytes += e.Size() + shares.DelimLen(uint64(e.Size()))
 	}
 
-	evdShares = evdBytes / appconsts.CompactShareContentSize
+	evdShares = evdBytes / appconsts.ContinuationCompactShareContentSize
 	if evdBytes > 0 {
 		evdShares++ // add one to round up
 	}

--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -31,9 +31,11 @@ const (
 	// the first unit (transaction, ISR, evidence) in a compact share.
 	CompactShareReservedBytes = 1
 
-	// CompactShareContentSize is the number of bytes usable for data in a compact
-	// (i.e. transactions, ISRs, evidence) share.
-	CompactShareContentSize = ShareSize - NamespaceSize - ShareInfoBytes - CompactShareReservedBytes
+	// ContinuationCompactShareContentSize is the number of bytes usable for
+	// data in a continuation compact share. A continuation share is any
+	// share in a reserved namespace that isn't the first share in that
+	// namespace.
+	ContinuationCompactShareContentSize = ShareSize - NamespaceSize - ShareInfoBytes - CompactShareReservedBytes
 
 	// SparseShareContentSize is the number of bytes usable for data in a sparse (i.e.
 	// message) share.

--- a/pkg/prove/proof.go
+++ b/pkg/prove/proof.go
@@ -105,8 +105,8 @@ func txSharePosition(txs types.Txs, txIndex uint64) (startSharePos, endSharePos 
 
 	txLen := len(txs[txIndex])
 
-	startSharePos = uint64((totalLen) / appconsts.CompactShareContentSize)
-	endSharePos = uint64((totalLen + txLen + shares.DelimLen(uint64(txLen))) / appconsts.CompactShareContentSize)
+	startSharePos = uint64((totalLen) / appconsts.ContinuationCompactShareContentSize)
+	endSharePos = uint64((totalLen + txLen + shares.DelimLen(uint64(txLen))) / appconsts.ContinuationCompactShareContentSize)
 
 	return startSharePos, endSharePos, nil
 }

--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -28,7 +28,7 @@ func TestTxInclusion(t *testing.T) {
 	overlappingRowsBlockData := types.Data{
 		Txs: types.ToTxs(
 			[][]byte{
-				tmrand.Bytes(appconsts.CompactShareContentSize*overlappingSquareSize + 1),
+				tmrand.Bytes(appconsts.ContinuationCompactShareContentSize*overlappingSquareSize + 1),
 				tmrand.Bytes(10000),
 			},
 		),
@@ -37,7 +37,7 @@ func TestTxInclusion(t *testing.T) {
 	overlappingRowsBlockDataWithMessages := types.Data{
 		Txs: types.ToTxs(
 			[][]byte{
-				tmrand.Bytes(appconsts.CompactShareContentSize*overlappingSquareSize + 1),
+				tmrand.Bytes(appconsts.ContinuationCompactShareContentSize*overlappingSquareSize + 1),
 				tmrand.Bytes(10000),
 			},
 		),

--- a/pkg/shares/compact_shares_test.go
+++ b/pkg/shares/compact_shares_test.go
@@ -65,7 +65,7 @@ func Test_processCompactShares(t *testing.T) {
 	// share, accounting for namespace id and the length delimiter prepended to
 	// each tx. Note that the length delimiter can be 1 to 10 bytes (varint) but
 	// this test assumes it is 1 byte.
-	const exactTxShareSize = appconsts.CompactShareContentSize - 1
+	const exactTxShareSize = appconsts.ContinuationCompactShareContentSize - 1
 
 	type test struct {
 		name    string
@@ -76,10 +76,10 @@ func Test_processCompactShares(t *testing.T) {
 	// each test is ran twice, once using txSize as an exact size, and again
 	// using it as a cap for randomly sized txs
 	tests := []test{
-		{"single small tx", appconsts.CompactShareContentSize / 8, 1},
-		{"many small txs", appconsts.CompactShareContentSize / 8, 10},
-		{"single big tx", appconsts.CompactShareContentSize * 4, 1},
-		{"many big txs", appconsts.CompactShareContentSize * 4, 10},
+		{"single small tx", appconsts.ContinuationCompactShareContentSize / 8, 1},
+		{"many small txs", appconsts.ContinuationCompactShareContentSize / 8, 10},
+		{"single big tx", appconsts.ContinuationCompactShareContentSize * 4, 1},
+		{"many big txs", appconsts.ContinuationCompactShareContentSize * 4, 10},
 		{"single exact size tx", exactTxShareSize, 1},
 		{"many exact size txs", exactTxShareSize, 10},
 	}
@@ -125,7 +125,7 @@ func Test_processCompactShares(t *testing.T) {
 
 func TestCompactShareContainsInfoByte(t *testing.T) {
 	css := NewCompactShareSplitter(appconsts.TxNamespaceID, appconsts.ShareVersion)
-	txs := generateRandomTransaction(1, appconsts.CompactShareContentSize/4)
+	txs := generateRandomTransaction(1, appconsts.ContinuationCompactShareContentSize/4)
 
 	for _, tx := range txs {
 		css.WriteTx(tx)
@@ -145,7 +145,7 @@ func TestCompactShareContainsInfoByte(t *testing.T) {
 
 func TestContiguousCompactShareContainsInfoByte(t *testing.T) {
 	css := NewCompactShareSplitter(appconsts.TxNamespaceID, appconsts.ShareVersion)
-	txs := generateRandomTransaction(1, appconsts.CompactShareContentSize*4)
+	txs := generateRandomTransaction(1, appconsts.ContinuationCompactShareContentSize*4)
 
 	for _, tx := range txs {
 		css.WriteTx(tx)
@@ -164,7 +164,7 @@ func TestContiguousCompactShareContainsInfoByte(t *testing.T) {
 }
 
 func Test_parseCompactSharesReturnsErrForShareWithStartIndicatorFalse(t *testing.T) {
-	txs := generateRandomTransaction(2, appconsts.CompactShareContentSize*4)
+	txs := generateRandomTransaction(2, appconsts.ContinuationCompactShareContentSize*4)
 	shares := SplitTxs(txs)
 	_, err := parseCompactShares(shares[1:]) // the second share has the message start indicator set to false
 	assert.Error(t, err)

--- a/pkg/shares/split_compact_shares_test.go
+++ b/pkg/shares/split_compact_shares_test.go
@@ -17,8 +17,8 @@ func TestCount(t *testing.T) {
 		{transactions: []coretypes.Tx{}, wantShareCount: 0},
 		{transactions: []coretypes.Tx{[]byte{0}}, wantShareCount: 1},
 		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, 100)}, wantShareCount: 1},
-		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, appconsts.CompactShareContentSize+1)}, wantShareCount: 2},
-		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, appconsts.CompactShareContentSize*2+1)}, wantShareCount: 3},
+		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, appconsts.ContinuationCompactShareContentSize+1)}, wantShareCount: 2},
+		{transactions: []coretypes.Tx{bytes.Repeat([]byte{0}, appconsts.ContinuationCompactShareContentSize*2+1)}, wantShareCount: 3},
 	}
 	for _, tc := range testCases {
 		css := NewCompactShareSplitter(appconsts.TxNamespaceID, appconsts.ShareVersion)


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/725

Rename `CompactShareContentSize` to `ContinuationCompactShareContentSize` because we will soon introduce a new appconst for `FirstCompactShareContentSize`.