### PR TITLE
chore: initial `CODEOWNERS` file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,16 @@
 # CODEOWNERS: <https://help.github.com/articles/about-codeowners/>
 
-# Everything goes through the following "global owners" by default
-# Unless a later match takes precedence, these three will be
-# requested for review when someone opens a PR
-# Note that the last matching pattern takes precedence, so
-# global owners are only requested if there isn't a more specific
-# codeowner specified below. For this reason, the global codeowners
-# are often repeated in package-level definitions
+# Everything goes through the following "global owners" by default. Unless a later
+# match takes precedence, the "global owners" will be requested for review when
+# someone opens a PR. Note that the last matching pattern takes precedence, so
+# global owners are only requested if there isn't a more specific codeowner
+# specified below. For this reason, the global owners are often repeated in
+# directory-level definitions.
 
+# global owners
 * @evan-forbes
 
-docs/ @liamsi @adlerjohn @MSevey
+# directory owners
+docs @liamsi @adlerjohn @MSevey
 x/qgb @SweeXordious
 pkg/shares @rootulp

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# CODEOWNERS: <https://help.github.com/articles/about-codeowners/>
+
+# Everything goes through the following "global owners" by default
+# Unless a later match takes precedence, these three will be
+# requested for review when someone opens a PR
+# Note that the last matching pattern takes precedence, so
+# global owners are only requested if there isn't a more specific
+# codeowner specified below. For this reason, the global codeowners
+# are often repeated in package-level definitions
+
+* @evan-forbes
+
+docs/ @liamsi @adlerjohn @MSevey
+x/qgb @SweeXordious
+pkg/shares @rootulp


### PR DESCRIPTION
Inspired by https://github.com/celestiaorg/celestia-core/blob/v0.34.x-celestia/.github/CODEOWNERS
Prerequisite to https://github.com/celestiaorg/celestia-app/issues/807 but doesn't close it. #807 can be tackled on the `specs-staging` branch after this PR merges to `main` because the `specs/` directory doesn't exist on `main`.

