### PR TITLE
feat: return `bytesOfPadding`

### DIFF
--- a/pkg/shares/parse_sparse_shares.go
+++ b/pkg/shares/parse_sparse_shares.go
@@ -92,7 +92,7 @@ func ParseDelimiter(input []byte) (inputWithoutLengthDelimiter []byte, dataLengt
 		l = len(input)
 	}
 
-	delimiter := zeroPadIfNecessary(input[:l], binary.MaxVarintLen64)
+	delimiter, _ := zeroPadIfNecessary(input[:l], binary.MaxVarintLen64)
 
 	// read the length of the data
 	r := bytes.NewBuffer(delimiter)
@@ -112,15 +112,15 @@ func ParseDelimiter(input []byte) (inputWithoutLengthDelimiter []byte, dataLengt
 // zeroPadIfNecessary pads the share with trailing zero bytes if the provided
 // share has fewer bytes than width. Returns the share unmodified if the
 // len(share) is greater than or equal to width.
-func zeroPadIfNecessary(share []byte, width int) []byte {
+func zeroPadIfNecessary(share []byte, width int) (padded []byte, bytesOfPadding int) {
 	oldLen := len(share)
 	if oldLen >= width {
-		return share
+		return share, 0
 	}
 
 	missingBytes := width - oldLen
 	padByte := []byte{0}
 	padding := bytes.Repeat(padByte, missingBytes)
 	share = append(share, padding...)
-	return share
+	return share, missingBytes
 }

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -176,19 +176,24 @@ func Test_zeroPadIfNecessary(t *testing.T) {
 		width int
 	}
 	tests := []struct {
-		name string
-		args args
-		want []byte
+		name               string
+		args               args
+		wantPadded         []byte
+		wantBytesOfPadding int
 	}{
-		{"pad", args{[]byte{1, 2, 3}, 6}, []byte{1, 2, 3, 0, 0, 0}},
-		{"not necessary (equal to shareSize)", args{[]byte{1, 2, 3}, 3}, []byte{1, 2, 3}},
-		{"not necessary (greater shareSize)", args{[]byte{1, 2, 3}, 2}, []byte{1, 2, 3}},
+		{"pad", args{[]byte{1, 2, 3}, 6}, []byte{1, 2, 3, 0, 0, 0}, 3},
+		{"not necessary (equal to shareSize)", args{[]byte{1, 2, 3}, 3}, []byte{1, 2, 3}, 0},
+		{"not necessary (greater shareSize)", args{[]byte{1, 2, 3}, 2}, []byte{1, 2, 3}, 0},
 	}
 	for _, tt := range tests {
 		tt := tt // stupid scopelint :-/
 		t.Run(tt.name, func(t *testing.T) {
-			if got := zeroPadIfNecessary(tt.args.share, tt.args.width); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("zeroPadIfNecessary() = %v, want %v", got, tt.want)
+			gotPadded, gotBytesOfPadding := zeroPadIfNecessary(tt.args.share, tt.args.width)
+			if !reflect.DeepEqual(gotPadded, tt.wantPadded) {
+				t.Errorf("zeroPadIfNecessary gotPadded %v, wantPadded %v", gotPadded, tt.wantPadded)
+			}
+			if gotBytesOfPadding != tt.wantBytesOfPadding {
+				t.Errorf("zeroPadIfNecessary gotBytesOfPadding %v, wantBytesOfPadding %v", gotBytesOfPadding, tt.wantBytesOfPadding)
 			}
 		})
 	}

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -132,7 +132,7 @@ func (css *CompactShareSplitter) stackPending() {
 func (css *CompactShareSplitter) Export() NamespacedShares {
 	// add the pending share to the current shares before returning
 	if len(css.pendingShare.Share) > appconsts.NamespaceSize+appconsts.ShareInfoBytes {
-		css.pendingShare.Share = zeroPadIfNecessary(css.pendingShare.Share, appconsts.ShareSize)
+		css.pendingShare.Share, _ = zeroPadIfNecessary(css.pendingShare.Share, appconsts.ShareSize)
 		css.shares = append(css.shares, css.pendingShare)
 	}
 	// force the last share to have a reserve byte of zero

--- a/pkg/shares/split_sparse_shares.go
+++ b/pkg/shares/split_sparse_shares.go
@@ -104,7 +104,7 @@ func AppendToShares(shares []NamespacedShare, nid namespace.ID, rawData []byte) 
 			byte(infoByte)),
 			rawData...,
 		)
-		paddedShare := zeroPadIfNecessary(rawShare, appconsts.ShareSize)
+		paddedShare, _ := zeroPadIfNecessary(rawShare, appconsts.ShareSize)
 		share := NamespacedShare{paddedShare, nid}
 		shares = append(shares, share)
 	} else { // len(rawData) > MsgShareSize
@@ -151,7 +151,7 @@ func splitMessage(rawData []byte, nid namespace.ID) NamespacedShares {
 			byte(infoByte)),
 			rawData[:shareSizeOrLen]...,
 		)
-		paddedShare := zeroPadIfNecessary(rawShare, appconsts.ShareSize)
+		paddedShare, _ := zeroPadIfNecessary(rawShare, appconsts.ShareSize)
 		share := NamespacedShare{paddedShare, nid}
 		shares = append(shares, share)
 		rawData = rawData[shareSizeOrLen:]


### PR DESCRIPTION
Spun out of https://github.com/celestiaorg/celestia-app/pull/781

In https://github.com/celestiaorg/celestia-app/pull/781 , there is a need to calculate the total data length written to a compact share splitter so that a varint of this data length can be written to the first share. It becomes easier to perform this calculation if the utility function `zeroPadIfNecessary` returns the `bytesOfPadding` because the export command can subtract the `bytesOfPadding` from the number of bytes used by all shares in the compact share splitter.

Without this change, it may be possible to calculate the # of bytes written by summing the # of bytes written to shares and the number of bytes in the pending share _prior_ to adding padding to the pending share but this option includes more edge cases.