### PR TITLE
chore: resolve local lint issues

### DIFF
--- a/app/export.go
+++ b/app/export.go
@@ -44,9 +44,9 @@ func (app *App) ExportAppStateAndValidators(
 	}, err
 }
 
-// prepare for fresh start at zero height
-// NOTE zero height genesis is a temporary feature which will be deprecated
-//      in favour of export at a block height
+// prepForZeroHeightGenesis preps for fresh start at zero height. Zero height
+// genesis is a temporary feature which will be deprecated in favour of export
+// at a block height.
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 

--- a/pkg/inclusion/paths.go
+++ b/pkg/inclusion/paths.go
@@ -47,6 +47,7 @@ func calculateCommitPaths(squareSize, start, msgShareLen int) []path {
 // genSubTreeRootPath calculates the path to a given subtree root of a node, given the
 // depth and position of the node. note: the root of the tree is depth 0.
 // The following nolint can be removed after this function is used.
+//
 //nolint:unused,deadcode
 func genSubTreeRootPath(depth int, pos uint) []WalkInstruction {
 	path := make([]WalkInstruction, depth)
@@ -63,15 +64,16 @@ func genSubTreeRootPath(depth int, pos uint) []WalkInstruction {
 }
 
 // coord identifies a tree node using the depth and position
-// Depth       Position
-// 0              0
-//               / \
-//              /   \
-// 1           0     1
-//            /\     /\
-// 2         0  1   2  3
-//          /\  /\ /\  /\
-// 3       0 1 2 3 4 5 6 7
+//
+//	Depth       Position
+//	0              0
+//	              / \
+//	             /   \
+//	1           0     1
+//	           /\     /\
+//	2         0  1   2  3
+//	         /\  /\ /\  /\
+//	3       0 1 2 3 4 5 6 7
 type coord struct {
 	// depth is the typical depth of a tree, 0 being the root
 	depth int

--- a/x/payment/keeper/keeper.go
+++ b/x/payment/keeper/keeper.go
@@ -28,7 +28,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 	return ctx.Logger().With("module", fmt.Sprintf("x/%s", types.ModuleName))
 }
 
-//  MsgPayForData moves a user's coins to the module address and burns them.
+// MsgPayForData moves a user's coins to the module address and burns them.
 func (k Keeper) PayForData(goCtx context.Context, msg *types.MsgPayForData) (*types.MsgPayForDataResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 


### PR DESCRIPTION
Resolve the following issues observed on `make lint`

```
--> Running linter
pkg/inclusion/paths.go:49: File is not `gofumpt`-ed (gofumpt)
// The following nolint can be removed after this function is used.
pkg/inclusion/paths.go:68: File is not `gofumpt`-ed (gofumpt)
//               / \
//              /   \
pkg/inclusion/paths.go:71: File is not `gofumpt`-ed (gofumpt)
//            /\     /\
x/payment/keeper/keeper.go:31: File is not `gofumpt`-ed (gofumpt)
//  MsgPayForData moves a user's coins to the module address and burns them.
app/export.go:49: File is not `gofumpt`-ed (gofumpt)
//      in favour of export at a block height
make: *** [lint] Error 1
```

These lines haven't been modified recently. It's not clear to me why these issues haven't been flagged by lint on CI. 