### PR TITLE
chore: move `ParseDelimiter`

### DIFF
--- a/pkg/shares/compact_shares_test.go
+++ b/pkg/shares/compact_shares_test.go
@@ -30,22 +30,6 @@ func TestCompactShareWriter(t *testing.T) {
 	assert.Equal(t, txs, resTxs)
 }
 
-func Test_parseDelimiter(t *testing.T) {
-	for i := uint64(0); i < 100; i++ {
-		tx := generateRandomTransaction(1, int(i))[0]
-		input, err := MarshalDelimitedTx(tx)
-		if err != nil {
-			panic(err)
-		}
-		res, txLen, err := ParseDelimiter(input)
-		if err != nil {
-			panic(err)
-		}
-		assert.Equal(t, i, txLen)
-		assert.Equal(t, []byte(tx), res)
-	}
-}
-
 func TestFuzz_processCompactShares(t *testing.T) {
 	t.Skip()
 	// run random shares through processCompactShares for a minute

--- a/pkg/shares/parse_sparse_shares.go
+++ b/pkg/shares/parse_sparse_shares.go
@@ -2,7 +2,6 @@ package shares
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	coretypes "github.com/tendermint/tendermint/types"
@@ -89,35 +88,4 @@ func parseSparseShares(rawShares [][]byte, supportedShareVersions []uint8) ([]co
 		}
 	}
 	return msgs, nil
-}
-
-// ParseDelimiter finds and returns the length delimiter of the share provided
-// while also removing the delimiter bytes from the input. ParseDelimiter
-// applies to both compact and sparse shares. Input should not contain the
-// namespace ID or info byte of a share.
-func ParseDelimiter(input []byte) (inputWithoutLengthDelimiter []byte, dataLength uint64, err error) {
-	if len(input) == 0 {
-		return input, 0, nil
-	}
-
-	l := binary.MaxVarintLen64
-	if len(input) < binary.MaxVarintLen64 {
-		l = len(input)
-	}
-
-	delimiter, _ := zeroPadIfNecessary(input[:l], binary.MaxVarintLen64)
-
-	// read the length of the data
-	r := bytes.NewBuffer(delimiter)
-	dataLen, err := binary.ReadUvarint(r)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	// calculate the number of bytes used by the delimiter
-	lenBuf := make([]byte, binary.MaxVarintLen64)
-	n := binary.PutUvarint(lenBuf, dataLen)
-
-	// return the input without the length delimiter
-	return input[n:], dataLen, nil
 }

--- a/pkg/shares/utils.go
+++ b/pkg/shares/utils.go
@@ -93,3 +93,34 @@ func zeroPadIfNecessary(share []byte, width int) (padded []byte, bytesOfPadding 
 	share = append(share, padding...)
 	return share, missingBytes
 }
+
+// ParseDelimiter finds and returns the length delimiter of the share provided
+// while also removing the delimiter bytes from the input. ParseDelimiter
+// applies to both compact and sparse shares. Input should not contain the
+// namespace ID or info byte of a share.
+func ParseDelimiter(input []byte) (inputWithoutLengthDelimiter []byte, dataLength uint64, err error) {
+	if len(input) == 0 {
+		return input, 0, nil
+	}
+
+	l := binary.MaxVarintLen64
+	if len(input) < binary.MaxVarintLen64 {
+		l = len(input)
+	}
+
+	delimiter, _ := zeroPadIfNecessary(input[:l], binary.MaxVarintLen64)
+
+	// read the length of the data
+	r := bytes.NewBuffer(delimiter)
+	dataLen, err := binary.ReadUvarint(r)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// calculate the number of bytes used by the delimiter
+	lenBuf := make([]byte, binary.MaxVarintLen64)
+	n := binary.PutUvarint(lenBuf, dataLen)
+
+	// return the input without the length delimiter
+	return input[n:], dataLen, nil
+}

--- a/pkg/shares/utils_test.go
+++ b/pkg/shares/utils_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/types"
 )
@@ -48,5 +49,21 @@ func Test_zeroPadIfNecessary(t *testing.T) {
 				t.Errorf("zeroPadIfNecessary gotBytesOfPadding %v, wantBytesOfPadding %v", gotBytesOfPadding, tt.wantBytesOfPadding)
 			}
 		})
+	}
+}
+
+func TestParseDelimiter(t *testing.T) {
+	for i := uint64(0); i < 100; i++ {
+		tx := generateRandomTransaction(1, int(i))[0]
+		input, err := MarshalDelimitedTx(tx)
+		if err != nil {
+			panic(err)
+		}
+		res, txLen, err := ParseDelimiter(input)
+		if err != nil {
+			panic(err)
+		}
+		assert.Equal(t, i, txLen)
+		assert.Equal(t, []byte(tx), res)
 	}
 }


### PR DESCRIPTION
Move `ParseDelimiter` from `parse_sparse_shares` to `utils.go` because it is used when parsing sparse and compact shares