### PR TITLE
Remove doc comment on SparseShare vs CompactShare

### DIFF
--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -25,9 +25,6 @@ const (
 	// ShareVersion is the current version of the share format
 	ShareVersion = uint8(0)
 
-	// See https://github.com/celestiaorg/celestia-app/pull/660#discussion_r958603307
-	// for the motivation behind `CompactShare` and `SparseShare` terminology.
-
 	// CompactShareReservedBytes is the number of bytes reserved for the location of
 	// the first unit (transaction, ISR, evidence) in a compact share.
 	CompactShareReservedBytes = 1


### PR DESCRIPTION
ADR007 merged and the share package has a README (soon to be godoc package comment) so this doc comment no longer seems necessary