### PR TITLE
fix(pkg/da): ensure DAH.hash is always calculated during ValidateBasic

### DIFF
--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -150,7 +150,7 @@ func (dah *DataAvailabilityHeader) ValidateBasic() error {
 			len(dah.ColumnRoots),
 		)
 	}
-	if err := validateHash(dah.hash); err != nil {
+	if err := validateHash(dah.Hash()); err != nil {
 		return fmt.Errorf("wrong hash: %v", err)
 	}
 


### PR DESCRIPTION
This is useful for headers downloaded from the network. Each such header goes through validation during which the hash should be calculated. Otherwise, the hash is calcualated at much later point, which is prone to races. In celestia-node we observed such races when the DAH.Hahs is read from multiple routines, where both end up calculating the hash and setting the it to the cache value making the race detector complain. Such precompute fixes this.