### PR TITLE
fix: remove debug printf statement

### DIFF
--- a/pkg/prove/proof.go
+++ b/pkg/prove/proof.go
@@ -2,7 +2,6 @@ package prove
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/shares"
@@ -109,7 +108,6 @@ func txSharePosition(txs types.Txs, txIndex uint64) (startSharePos, endSharePos 
 
 	startSharePos = txShareIndex(prevTxTotalLen)
 	endSharePos = txShareIndex(endOfCurrentTxLen)
-	fmt.Printf("prevTxTotalLen: %d, endOfCurrentTxLen: %d, startSharePos: %d, endSharePos %d, currentTxTotalLen %d\n", prevTxTotalLen, endOfCurrentTxLen, startSharePos, endSharePos, currentTxTotalLen)
 	return startSharePos, endSharePos, nil
 }
 


### PR DESCRIPTION
This printf statement was accidentally introduced in https://github.com/celestiaorg/celestia-app/pull/781

It should be removed to avoid log spam when developers run `make test`