### PR TITLE
chore: remove Makefile `PACKAGES`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 #!/usr/bin/make -f
 
-PACKAGES=$(shell go list ./... | grep -v '/simulation')
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 DOCKER := $(shell which docker)
@@ -45,7 +44,7 @@ go.sum: mod
 		GO111MODULE=on go mod verify
 
 test:
-	@go test -mod=readonly $(PACKAGES)
+	@go test -mod=readonly ./...
 .PHONY: test
 
 proto-gen:


### PR DESCRIPTION
I noticed that we no longer need a Makefile `PACKAGES` variable because this repo doesn't contain a `/simulation` directory. We removed sims from workflows in https://github.com/celestiaorg/celestia-app/pull/697 but there wasn't a `/simulation` directory then either.

This makes the `make test` command easier to copy + paste (if for instance you want to add a trailing `-count=1` flag to disable the cache)

Note: cosmos-sdk uses PACKAGE variables [here](https://github.com/cosmos/cosmos-sdk/blob/main/Makefile#L3-L4) but celestia-app doesn't appear to need this extra complexity 