### PR TITLE
chore: remove redundant check

### DIFF
--- a/x/payment/types/wirepayfordata.go
+++ b/x/payment/types/wirepayfordata.go
@@ -145,10 +145,6 @@ func (msg *MsgWirePayForData) ValidateAllSquareSizesCommitedTo() error {
 	allSquareSizes := AllSquareSizes(int(msg.MessageSize))
 	committedSquareSizes := msg.committedSquareSizes()
 
-	if len(allSquareSizes) != len(committedSquareSizes) {
-		return ErrInvalidShareCommitments.Wrapf("length of all square sizes: %v must equal length of committed square sizes: %v", len(allSquareSizes), len(committedSquareSizes))
-	}
-
 	if !isEqual(allSquareSizes, committedSquareSizes) {
 		return ErrInvalidShareCommitments.Wrapf("all square sizes: %v, committed square sizes: %v", allSquareSizes, committedSquareSizes)
 	}


### PR DESCRIPTION
The check on this [line](https://github.com/celestiaorg/celestia-app/blob/e088d61fcb6579b4bc797deefd2ceff7601aa079/x/payment/types/wirepayfordata.go#L148) is redundant as it's done [here](https://github.com/celestiaorg/celestia-app/blob/e088d61fcb6579b4bc797deefd2ceff7601aa079/x/payment/types/wirepayfordata.go#L160).

Originally discovered by @mpoke in https://github.com/informalsystems/audit-celestia/issues/6#issuecomment-1272940401