### PR TITLE
feat: Add store, indexer, extractor and loader to QGB

### DIFF
--- a/x/qgb/orchestrator/confirm_store.go
+++ b/x/qgb/orchestrator/confirm_store.go
@@ -1,0 +1,131 @@
+package orchestrator
+
+import (
+	"fmt"
+	"github.com/celestiaorg/celestia-app/x/qgb/types"
+	"sync"
+)
+
+// ConfirmStoreI is a store interface for data commitment confirms and valset confirms.
+type ConfirmStoreI interface {
+	AddDataCommitmentConfirm(confirm types.MsgDataCommitmentConfirm) error
+	GetDataCommitmentConfirms(nonce uint64) ([]types.MsgDataCommitmentConfirm, error)
+	GetDataCommitmentConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgDataCommitmentConfirm, error)
+	GetDataCommitmentConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgDataCommitmentConfirm, error)
+	AddValsetConfirm(confirm types.MsgValsetConfirm) error
+	GetValsetConfirms(nonce uint64) ([]types.MsgValsetConfirm, error)
+	GetValsetConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgValsetConfirm, error)
+	GetValsetConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgValsetConfirm, error)
+}
+
+// ConfirmStore is simple in memory store for data commitment confirms and valset confirms.
+// To be used with the InMemoryIndexer.
+type ConfirmStore struct {
+	mutex                  *sync.Mutex
+	DataCommitmentConfirms map[uint64][]types.MsgDataCommitmentConfirm
+	ValsetConfirms         map[uint64][]types.MsgValsetConfirm
+}
+
+var _ ConfirmStoreI = &ConfirmStore{}
+
+func NewConfirmStore() *ConfirmStore {
+	return &ConfirmStore{
+		DataCommitmentConfirms: make(map[uint64][]types.MsgDataCommitmentConfirm),
+		ValsetConfirms:         make(map[uint64][]types.MsgValsetConfirm),
+		mutex:                  &sync.Mutex{},
+	}
+}
+
+func (store ConfirmStore) AddDataCommitmentConfirm(confirm types.MsgDataCommitmentConfirm) error {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	store.DataCommitmentConfirms[confirm.Nonce] = append(store.DataCommitmentConfirms[confirm.Nonce], confirm)
+	return nil
+}
+
+func (store ConfirmStore) GetDataCommitmentConfirms(nonce uint64) ([]types.MsgDataCommitmentConfirm, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	confirms, ok := store.DataCommitmentConfirms[nonce]
+	if !ok {
+		return nil, fmt.Errorf("not existant")
+	}
+	return confirms, nil
+}
+
+func (store ConfirmStore) GetDataCommitmentConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgDataCommitmentConfirm, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	confirms, ok := store.DataCommitmentConfirms[nonce]
+	if !ok {
+		return types.MsgDataCommitmentConfirm{}, fmt.Errorf("not existent")
+	}
+	for _, confirm := range confirms {
+		if confirm.ValidatorAddress == orch {
+			return confirm, nil
+		}
+	}
+	return types.MsgDataCommitmentConfirm{}, fmt.Errorf("not existent")
+}
+
+func (store ConfirmStore) GetDataCommitmentConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgDataCommitmentConfirm, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	confirms, ok := store.DataCommitmentConfirms[nonce]
+	if !ok {
+		return types.MsgDataCommitmentConfirm{}, fmt.Errorf("not existent")
+	}
+	for _, confirm := range confirms {
+		if confirm.EthAddress == ethAddr {
+			return confirm, nil
+		}
+	}
+	return types.MsgDataCommitmentConfirm{}, fmt.Errorf("not existent")
+}
+
+func (store ConfirmStore) AddValsetConfirm(confirm types.MsgValsetConfirm) error {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	store.ValsetConfirms[confirm.Nonce] = append(store.ValsetConfirms[confirm.Nonce], confirm)
+	return nil
+}
+
+func (store ConfirmStore) GetValsetConfirms(nonce uint64) ([]types.MsgValsetConfirm, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	confirms, ok := store.ValsetConfirms[nonce]
+	if !ok {
+		return nil, fmt.Errorf("not existant")
+	}
+	return confirms, nil
+}
+
+func (store ConfirmStore) GetValsetConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgValsetConfirm, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	confirms, ok := store.ValsetConfirms[nonce]
+	if !ok {
+		return types.MsgValsetConfirm{}, fmt.Errorf("not existent")
+	}
+	for _, confirm := range confirms {
+		if confirm.Orchestrator == orch {
+			return confirm, nil
+		}
+	}
+	return types.MsgValsetConfirm{}, fmt.Errorf("not existent")
+}
+
+func (store ConfirmStore) GetValsetConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgValsetConfirm, error) {
+	store.mutex.Lock()
+	defer store.mutex.Unlock()
+	confirms, ok := store.ValsetConfirms[nonce]
+	if !ok {
+		return types.MsgValsetConfirm{}, fmt.Errorf("not existent")
+	}
+	for _, confirm := range confirms {
+		if confirm.EthAddress == ethAddr {
+			return confirm, nil
+		}
+	}
+	return types.MsgValsetConfirm{}, fmt.Errorf("not existent")
+}

--- a/x/qgb/orchestrator/confirm_store.go
+++ b/x/qgb/orchestrator/confirm_store.go
@@ -2,8 +2,9 @@ package orchestrator
 
 import (
 	"fmt"
-	"github.com/celestiaorg/celestia-app/x/qgb/types"
 	"sync"
+
+	"github.com/celestiaorg/celestia-app/x/qgb/types"
 )
 
 // ConfirmStoreI is a store interface for data commitment confirms and valset confirms.

--- a/x/qgb/orchestrator/confirm_store.go
+++ b/x/qgb/orchestrator/confirm_store.go
@@ -62,6 +62,8 @@ func (store ConfirmStore) GetDataCommitmentConfirmByOrchestratorAddress(nonce ui
 		return types.MsgDataCommitmentConfirm{}, fmt.Errorf("not existent")
 	}
 	for _, confirm := range confirms {
+                // TODO investigate the case where a malicious orchestrator signs two attestations with the same nonce
+                // when we have slashing and how we want to handle that on the DB side.
 		if confirm.ValidatorAddress == orch {
 			return confirm, nil
 		}

--- a/x/qgb/orchestrator/confirm_store.go
+++ b/x/qgb/orchestrator/confirm_store.go
@@ -19,7 +19,7 @@ type ConfirmStoreI interface {
 	GetValsetConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgValsetConfirm, error)
 }
 
-// ConfirmStore is simple in memory store for data commitment confirms and valset confirms.
+// ConfirmStore is a simple in memory store for data commitment confirms and valset confirms.
 // To be used with the InMemoryIndexer.
 type ConfirmStore struct {
 	mutex                  *sync.Mutex

--- a/x/qgb/orchestrator/confirm_store.go
+++ b/x/qgb/orchestrator/confirm_store.go
@@ -62,8 +62,8 @@ func (store ConfirmStore) GetDataCommitmentConfirmByOrchestratorAddress(nonce ui
 		return types.MsgDataCommitmentConfirm{}, fmt.Errorf("not existent")
 	}
 	for _, confirm := range confirms {
-                // TODO investigate the case where a malicious orchestrator signs two attestations with the same nonce
-                // when we have slashing and how we want to handle that on the DB side.
+		// TODO investigate the case where a malicious orchestrator signs two attestations with the same nonce
+		// when we have slashing and how we want to handle that on the DB side.
 		if confirm.ValidatorAddress == orch {
 			return confirm, nil
 		}

--- a/x/qgb/orchestrator/confirm_store.go
+++ b/x/qgb/orchestrator/confirm_store.go
@@ -48,7 +48,7 @@ func (store ConfirmStore) GetDataCommitmentConfirms(nonce uint64) ([]types.MsgDa
 	defer store.mutex.Unlock()
 	confirms, ok := store.DataCommitmentConfirms[nonce]
 	if !ok {
-		return nil, fmt.Errorf("not existant")
+		return nil, fmt.Errorf("not existent")
 	}
 	return confirms, nil
 }
@@ -95,7 +95,7 @@ func (store ConfirmStore) GetValsetConfirms(nonce uint64) ([]types.MsgValsetConf
 	defer store.mutex.Unlock()
 	confirms, ok := store.ValsetConfirms[nonce]
 	if !ok {
-		return nil, fmt.Errorf("not existant")
+		return nil, fmt.Errorf("not existent")
 	}
 	return confirms, nil
 }

--- a/x/qgb/orchestrator/indexer.go
+++ b/x/qgb/orchestrator/indexer.go
@@ -1,0 +1,41 @@
+package orchestrator
+
+import (
+	"github.com/celestiaorg/celestia-app/x/qgb/types"
+)
+
+type IndexerI interface {
+	Start() error
+	Stop() error
+	AddDataCommitmentConfirm(confirm types.MsgDataCommitmentConfirm) error
+	AddValsetConfirm(confirm types.MsgValsetConfirm) error
+	//Remove() error ?
+}
+
+var _ IndexerI = &InMemoryIndexer{}
+
+type InMemoryIndexer struct {
+	Store *ConfirmStore
+}
+
+func NewInMemoryIndexer(store *ConfirmStore) *InMemoryIndexer {
+	return &InMemoryIndexer{
+		Store: store,
+	}
+}
+
+func (indexer InMemoryIndexer) Start() error {
+	return nil
+}
+
+func (indexer InMemoryIndexer) Stop() error {
+	return nil
+}
+
+func (indexer InMemoryIndexer) AddDataCommitmentConfirm(confirm types.MsgDataCommitmentConfirm) error {
+	return indexer.Store.AddDataCommitmentConfirm(confirm)
+}
+
+func (indexer InMemoryIndexer) AddValsetConfirm(confirm types.MsgValsetConfirm) error {
+	return indexer.Store.AddValsetConfirm(confirm)
+}

--- a/x/qgb/orchestrator/indexer.go
+++ b/x/qgb/orchestrator/indexer.go
@@ -9,7 +9,7 @@ type IndexerI interface {
 	Stop() error
 	AddDataCommitmentConfirm(confirm types.MsgDataCommitmentConfirm) error
 	AddValsetConfirm(confirm types.MsgValsetConfirm) error
-	//Remove() error ?
+	// Remove() error ?
 }
 
 var _ IndexerI = &InMemoryIndexer{}

--- a/x/qgb/orchestrator/loader.go
+++ b/x/qgb/orchestrator/loader.go
@@ -1,0 +1,56 @@
+package orchestrator
+
+import "github.com/celestiaorg/celestia-app/x/qgb/types"
+
+type LoaderI interface {
+	Start() error
+	Stop() error
+	GetDataCommitmentConfirms(nonce uint64) ([]types.MsgDataCommitmentConfirm, error)
+	GetDataCommitmentConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgDataCommitmentConfirm, error)
+	GetDataCommitmentConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgDataCommitmentConfirm, error)
+	GetValsetConfirms(nonce uint64) ([]types.MsgValsetConfirm, error)
+	GetValsetConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgValsetConfirm, error)
+	GetValsetConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgValsetConfirm, error)
+}
+
+type InMemoryLoader struct {
+	store ConfirmStore
+}
+
+var _ LoaderI = &InMemoryLoader{}
+
+func NewInMemoryLoader(store ConfirmStore) *InMemoryLoader {
+	return &InMemoryLoader{store: store}
+}
+
+func (loader InMemoryLoader) Start() error {
+	return nil
+}
+
+func (loader InMemoryLoader) Stop() error {
+	return nil
+}
+
+func (loader InMemoryLoader) GetDataCommitmentConfirms(nonce uint64) ([]types.MsgDataCommitmentConfirm, error) {
+	return loader.store.GetDataCommitmentConfirms(nonce)
+}
+
+func (loader InMemoryLoader) GetDataCommitmentConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgDataCommitmentConfirm, error) {
+	return loader.store.GetDataCommitmentConfirmByOrchestratorAddress(nonce, orch)
+}
+
+func (loader InMemoryLoader) GetDataCommitmentConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgDataCommitmentConfirm, error) {
+	return loader.store.GetDataCommitmentConfirmByEthereumAddress(nonce, ethAddr)
+}
+
+func (loader InMemoryLoader) GetValsetConfirms(nonce uint64) ([]types.MsgValsetConfirm, error) {
+	return loader.store.GetValsetConfirms(nonce)
+}
+
+func (loader InMemoryLoader) GetValsetConfirmByEthereumAddress(nonce uint64, ethAddr string) (types.MsgValsetConfirm, error) {
+	return loader.store.GetValsetConfirmByEthereumAddress(nonce, ethAddr)
+}
+
+func (loader InMemoryLoader) GetValsetConfirmByOrchestratorAddress(nonce uint64, orch string) (types.MsgValsetConfirm, error) {
+	return loader.store.GetValsetConfirmByOrchestratorAddress(nonce, orch)
+}


### PR DESCRIPTION
Adds a basic implementation for an in memory store, a transactions' parser, an indexer, an extractor and a loader to QGB.
This stuff is still not used, other subsequent PRs will make use of them. This is just trying to have smaller PRs instead of a giant, big one containing the whole new design.

Adds to https://github.com/celestiaorg/celestia-app/issues/684