### PR TITLE
Add a package-specific documentation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ make fmt
 make proto-gen
 ```
 
+### Package-specific documentation
+
+- [Shares](https://pkg.go.dev/github.com/celestiaorg/celestia-app/pkg/shares)
+
 ## Careers
 
 We are hiring Go engineers! Join us in building the future of blockchain scaling and interoperability. [Apply here](https://jobs.lever.co/celestia).


### PR DESCRIPTION
Inspired by https://github.com/celestiaorg/celestia-node#package-specific-documentation

Addresses https://github.com/celestiaorg/celestia-app/pull/842#pullrequestreview-1139027323

We can keep the share docs in Godoc form or move them back to README.md form because both will render in https://pkg.go.dev/github.com/celestiaorg/celestia-app/pkg/shares