### PR TITLE
chore: rename data length to sequence length

### DIFF
--- a/docs/architecture/adr-007-universal-share-prefix.md
+++ b/docs/architecture/adr-007-universal-share-prefix.md
@@ -114,7 +114,7 @@ Types
 Logic
 
 1. Account for the new `InfoByte` in all share splitting and merging code.
-1. Encode a total data length varint into the first compact share of a sequence.
+1. Encode a total sequence length varint into the first compact share of a sequence.
 1. Introduce a new `ParseShares` API that can accept any type of share (compact or sparse).
 1. Introduce new block validity rules:
     1. All shares contain a share version that belongs to a list of supported versions (initially this list contains version `0`)

--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -114,24 +114,24 @@ var (
 	// defaults.
 	NameSpacedPaddedShareBytes = bytes.Repeat([]byte{0}, SparseShareContentSize)
 
-	// FirstCompactShareDataLengthBytes is the number of bytes reserved for the total
-	// data length that is stored in the first compact share of a reserved
-	// namespace. This value is the maximum number of bytes required to store
-	// the data length of a block that only contains compact shares of one type.
-	// For example, if a block contains only evidence then it could contain:
-	// MaxSquareSize * MaxSquareSize * ShareSize bytes of evidence.
+	// FirstCompactShareSequenceLengthBytes is the number of bytes reserved for the total
+	// sequence length that is stored in the first compact share of a sequence. This
+	// value is the maximum number of bytes required to store the sequence
+	// length of a block that only contains shares of one type. For example, if
+	// a block contains only evidence then it could contain: MaxSquareSize *
+	// MaxSquareSize * ShareSize bytes of evidence.
 	//
 	// Assuming MaxSquareSize is 128 and ShareSize is 256, this is 4194304 bytes
 	// of evidence. It takes 4 bytes to store a varint of 4194304.
 	//
 	// https://go.dev/play/p/MynwcDHQ_me
-	FirstCompactShareDataLengthBytes = numberOfBytesVarint(MaxSquareSize * MaxSquareSize * ShareSize)
+	FirstCompactShareSequenceLengthBytes = numberOfBytesVarint(MaxSquareSize * MaxSquareSize * ShareSize)
 
 	// FirstCompactShareContentSize is the number of bytes usable for data in
 	// the first compact share of a reserved namespace. This type of share
 	// contains less space for data than a ContinuationCompactShare because the
-	// first compact share includes a total data length varint.
-	FirstCompactShareContentSize = ContinuationCompactShareContentSize - FirstCompactShareDataLengthBytes
+	// first compact share includes a total sequence length varint.
+	FirstCompactShareContentSize = ContinuationCompactShareContentSize - FirstCompactShareSequenceLengthBytes
 
 	// SupportedShareVersions is a list of supported share versions.
 	SupportedShareVersions = []uint8{ShareVersion}

--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -231,8 +231,8 @@ func TestTxShareIndex(t *testing.T) {
 func stripCompactShares(compactShares []shares.Share, start uint64, end uint64) (result []byte) {
 	for i := start; i <= end; i++ {
 		if i == 0 {
-			// the first compact share includes a total data length varint
-			result = append(result, compactShares[i][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareDataLengthBytes+appconsts.CompactShareReservedBytes:]...)
+			// the first compact share includes a total sequence length varint
+			result = append(result, compactShares[i][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareSequenceLengthBytes+appconsts.CompactShareReservedBytes:]...)
 		} else {
 			result = append(result, compactShares[i][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.CompactShareReservedBytes:]...)
 		}

--- a/pkg/shares/parse_compact_shares.go
+++ b/pkg/shares/parse_compact_shares.go
@@ -59,7 +59,7 @@ func (ss *shareStack) resolve() ([][]byte, error) {
 	if !infoByte.IsMessageStart() {
 		return nil, errors.New("first share is not a message start")
 	}
-	err = ss.peel(ss.shares[0][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareDataLengthBytes+appconsts.CompactShareReservedBytes:], true)
+	err = ss.peel(ss.shares[0][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareSequenceLengthBytes+appconsts.CompactShareReservedBytes:], true)
 	return ss.data, err
 }
 

--- a/pkg/shares/shares.go
+++ b/pkg/shares/shares.go
@@ -43,7 +43,7 @@ func (s Share) MessageLength() (uint64, error) {
 	if !infoByte.IsMessageStart() {
 		return 0, nil
 	}
-	if s.isCompactShare() || len(s) < appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareDataLengthBytes {
+	if s.isCompactShare() || len(s) < appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareSequenceLengthBytes {
 		panic(fmt.Sprintf("compact share %s is too short to contain message length", s))
 	}
 	reader := bytes.NewReader(s[appconsts.NamespaceSize+appconsts.ShareInfoBytes:])

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -28,7 +28,7 @@ func NewCompactShareSplitter(ns namespace.ID, version uint8) *CompactShareSplitt
 	if err != nil {
 		panic(err)
 	}
-	placeholderDataLength := make([]byte, appconsts.FirstCompactShareDataLengthBytes)
+	placeholderDataLength := make([]byte, appconsts.FirstCompactShareSequenceLengthBytes)
 	placeholderReservedBytes := make([]byte, appconsts.CompactShareReservedBytes)
 
 	pendingShare = append(pendingShare, ns...)
@@ -136,9 +136,9 @@ func (css *CompactShareSplitter) dataLengthVarint(bytesOfPadding int) []byte {
 	}
 
 	// declare and initialize the data length
-	dataLengthVarint := make([]byte, appconsts.FirstCompactShareDataLengthBytes)
+	dataLengthVarint := make([]byte, appconsts.FirstCompactShareSequenceLengthBytes)
 	binary.PutUvarint(dataLengthVarint, css.dataLength(bytesOfPadding))
-	zeroPadIfNecessary(dataLengthVarint, appconsts.FirstCompactShareDataLengthBytes)
+	zeroPadIfNecessary(dataLengthVarint, appconsts.FirstCompactShareSequenceLengthBytes)
 
 	return dataLengthVarint
 }
@@ -150,7 +150,7 @@ func (css *CompactShareSplitter) writeDataLengthVarintToFirstShare(dataLengthVar
 
 	// write the data length varint to the first share
 	firstShare := css.shares[0]
-	for i := 0; i < appconsts.FirstCompactShareDataLengthBytes; i++ {
+	for i := 0; i < appconsts.FirstCompactShareSequenceLengthBytes; i++ {
 		firstShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes+i] = dataLengthVarint[i]
 	}
 
@@ -173,7 +173,7 @@ func (css *CompactShareSplitter) maybeWriteReservedByteToPendingShare() {
 
 	// write the location of next unit to the reserved byte of the pending share
 	if css.isPendingShareTheFirstShare() {
-		css.pendingShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareDataLengthBytes : appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareContentSize+appconsts.CompactShareReservedBytes][0] = byte(locationOfNextUnit)
+		css.pendingShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareSequenceLengthBytes : appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareContentSize+appconsts.CompactShareReservedBytes][0] = byte(locationOfNextUnit)
 	} else {
 		css.pendingShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes : appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.CompactShareReservedBytes][0] = byte(locationOfNextUnit)
 	}
@@ -184,7 +184,7 @@ func (css *CompactShareSplitter) isEmptyReservedByte() bool {
 	var reservedByte byte
 
 	if css.isPendingShareTheFirstShare() {
-		reservedByte = css.pendingShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareDataLengthBytes : appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareContentSize+appconsts.CompactShareReservedBytes][0]
+		reservedByte = css.pendingShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareSequenceLengthBytes : appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareContentSize+appconsts.CompactShareReservedBytes][0]
 	} else {
 		reservedByte = css.pendingShare[appconsts.NamespaceSize+appconsts.ShareInfoBytes : appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.CompactShareReservedBytes][0]
 	}
@@ -213,7 +213,7 @@ func (css *CompactShareSplitter) dataLength(bytesOfPadding int) uint64 {
 // isEmptyPendingShare returns true if the pending share is empty, false otherwise.
 func (css *CompactShareSplitter) isEmptyPendingShare() bool {
 	if css.isPendingShareTheFirstShare() {
-		return len(css.pendingShare) == appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareDataLengthBytes+appconsts.CompactShareReservedBytes
+		return len(css.pendingShare) == appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.FirstCompactShareSequenceLengthBytes+appconsts.CompactShareReservedBytes
 	}
 	return len(css.pendingShare) == appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.CompactShareReservedBytes
 }


### PR DESCRIPTION
Motivaiton: "sequence length" is more precise than "data length"