### PR TITLE
fix: ParseShares failed to append last sequence

### DIFF
--- a/pkg/shares/share_merging_test.go
+++ b/pkg/shares/share_merging_test.go
@@ -122,7 +122,7 @@ func TestParseShares(t *testing.T) {
 			if tt.expectErr && err == nil {
 				t.Errorf("ParseShares() error %v, expectErr %v", err, tt.expectErr)
 			}
-			if reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("ParseShares() got %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
After correcting an error in unit tests:

```diff
-			if reflect.DeepEqual(got, tt.want) {
+			if !reflect.DeepEqual(got, tt.want) {
```

unit tests surfaced an error with the current `ParseShares` implementation. The last currentSequence wasn't appended to the result prior to returning.