### PR TITLE
feat: implement parser for data commitment/valset confirm messages

### DIFF
--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -1,0 +1,93 @@
+package orchestrator
+
+import (
+	"fmt"
+	"github.com/celestiaorg/celestia-app/app"
+	qgbtypes "github.com/celestiaorg/celestia-app/x/qgb/types"
+	sdkcodec "github.com/cosmos/cosmos-sdk/codec"
+	sdkcodectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/std"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
+	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
+	"github.com/gogo/protobuf/proto"
+	coretypes "github.com/tendermint/tendermint/types"
+)
+
+var _ QGBParserI = QGBParser{}
+
+type QGBParserI interface {
+	IsDataCommitmentConfirm(msg sdktypes.Msg) (bool, error)
+	ParseDataCommitmentConfirm(msg sdktypes.Msg) (qgbtypes.MsgDataCommitmentConfirm, error)
+	IsValsetConfirm(msg sdktypes.Msg) (bool, error)
+	ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error)
+	ParseCoreTx(tx coretypes.Tx) (sdktx.Tx, error)
+	ParseSdkTx(any *sdkcodectypes.Any) (sdktypes.Msg, error)
+}
+
+type QGBParser struct {
+	codec sdkcodec.Codec
+}
+
+func NewQGBParser(codec sdkcodec.Codec) *QGBParser {
+	return &QGBParser{codec: codec}
+}
+
+func (parser QGBParser) IsValsetConfirm(msg sdktypes.Msg) (bool, error) {
+	switch msg.(type) {
+	case *qgbtypes.MsgValsetConfirm:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (parser QGBParser) IsDataCommitmentConfirm(msg sdktypes.Msg) (bool, error) {
+	switch msg.(type) {
+	case *qgbtypes.MsgDataCommitmentConfirm:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func (parser QGBParser) ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error) {
+	vs, ok := msg.(*qgbtypes.MsgValsetConfirm)
+	if !ok {
+		return qgbtypes.MsgValsetConfirm{}, fmt.Errorf("not good")
+	}
+	return *vs, nil
+}
+
+func (parser QGBParser) ParseDataCommitmentConfirm(msg sdktypes.Msg) (qgbtypes.MsgDataCommitmentConfirm, error) {
+	dcc, ok := msg.(*qgbtypes.MsgDataCommitmentConfirm)
+	if !ok {
+		return qgbtypes.MsgDataCommitmentConfirm{}, fmt.Errorf("not good")
+	}
+	return *dcc, nil
+}
+
+func (parser QGBParser) ParseCoreTx(tx coretypes.Tx) (sdktx.Tx, error) {
+	var sdkTx sdktx.Tx
+	err := proto.Unmarshal(tx, &sdkTx)
+	if err != nil {
+		return sdktx.Tx{}, fmt.Errorf("error while unmarshalling core transaction: %s", err)
+	}
+	return sdkTx, nil
+}
+
+func (parser QGBParser) ParseSdkTx(any *sdkcodectypes.Any) (sdktypes.Msg, error) {
+	var stdMsg sdktypes.Msg
+	err := parser.codec.UnpackAny(any, &stdMsg)
+	if err != nil {
+		return nil, fmt.Errorf("error while unpacking message: %s", err)
+	}
+	return stdMsg, nil
+}
+
+func MakeDefaultAppCodec() sdkcodec.Codec {
+	interfaceRegistry := sdkcodectypes.NewInterfaceRegistry()
+	std.RegisterInterfaces(interfaceRegistry)
+	app.ModuleBasics.RegisterInterfaces(interfaceRegistry)
+	qgbtypes.RegisterInterfaces(interfaceRegistry)
+	return sdkcodec.NewProtoCodec(interfaceRegistry)
+}

--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -16,6 +16,7 @@ import (
 
 var _ QGBParserI = QGBParser{}
 
+// FIXME remove this interface after writing tests and see if it is needed or not
 type QGBParserI interface {
 	ParseDataCommitmentConfirm(msg sdktypes.Msg) (qgbtypes.MsgDataCommitmentConfirm, error)
 	ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error)

--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -54,7 +54,8 @@ func (parser QGBParser) IsDataCommitmentConfirm(msg sdktypes.Msg) (bool, error) 
 func (parser QGBParser) ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error) {
 	vs, ok := msg.(*qgbtypes.MsgValsetConfirm)
 	if !ok {
-		return qgbtypes.MsgValsetConfirm{}, fmt.Errorf("not good")
+		return qgbtypes.MsgValsetConfirm{},
+			fmt.Errorf("unable to cast sdk message to msg valset confirm")
 	}
 	return *vs, nil
 }
@@ -62,7 +63,8 @@ func (parser QGBParser) ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValset
 func (parser QGBParser) ParseDataCommitmentConfirm(msg sdktypes.Msg) (qgbtypes.MsgDataCommitmentConfirm, error) {
 	dcc, ok := msg.(*qgbtypes.MsgDataCommitmentConfirm)
 	if !ok {
-		return qgbtypes.MsgDataCommitmentConfirm{}, fmt.Errorf("not good")
+		return qgbtypes.MsgDataCommitmentConfirm{},
+			fmt.Errorf("unable to cast sdk message to msg data commitment confirm")
 	}
 	return *dcc, nil
 }

--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"fmt"
+
 	"github.com/celestiaorg/celestia-app/app"
 	qgbtypes "github.com/celestiaorg/celestia-app/x/qgb/types"
 	sdkcodec "github.com/cosmos/cosmos-sdk/codec"

--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -17,9 +17,7 @@ import (
 var _ QGBParserI = QGBParser{}
 
 type QGBParserI interface {
-	IsDataCommitmentConfirm(msg sdktypes.Msg) (bool, error)
 	ParseDataCommitmentConfirm(msg sdktypes.Msg) (qgbtypes.MsgDataCommitmentConfirm, error)
-	IsValsetConfirm(msg sdktypes.Msg) (bool, error)
 	ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error)
 	ParseCoreTx(tx coretypes.Tx) (sdktx.Tx, error)
 	ParseSdkTx(any *sdkcodectypes.Any) (sdktypes.Msg, error)
@@ -31,24 +29,6 @@ type QGBParser struct {
 
 func NewQGBParser(codec sdkcodec.Codec) *QGBParser {
 	return &QGBParser{codec: codec}
-}
-
-func (parser QGBParser) IsValsetConfirm(msg sdktypes.Msg) (bool, error) {
-	switch msg.(type) {
-	case *qgbtypes.MsgValsetConfirm:
-		return true, nil
-	default:
-		return false, nil
-	}
-}
-
-func (parser QGBParser) IsDataCommitmentConfirm(msg sdktypes.Msg) (bool, error) {
-	switch msg.(type) {
-	case *qgbtypes.MsgDataCommitmentConfirm:
-		return true, nil
-	default:
-		return false, nil
-	}
 }
 
 func (parser QGBParser) ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error) {

--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -3,11 +3,9 @@ package orchestrator
 import (
 	"fmt"
 
-	"github.com/celestiaorg/celestia-app/app"
 	qgbtypes "github.com/celestiaorg/celestia-app/x/qgb/types"
 	sdkcodec "github.com/cosmos/cosmos-sdk/codec"
 	sdkcodectypes "github.com/cosmos/cosmos-sdk/codec/types"
-	"github.com/cosmos/cosmos-sdk/std"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/gogo/protobuf/proto"
@@ -66,12 +64,4 @@ func (parser QGBParser) ParseSdkMsg(any *sdkcodectypes.Any) (sdktypes.Msg, error
 		return nil, fmt.Errorf("error while unpacking message: %s", err)
 	}
 	return stdMsg, nil
-}
-
-func MakeDefaultAppCodec() sdkcodec.Codec {
-	interfaceRegistry := sdkcodectypes.NewInterfaceRegistry()
-	std.RegisterInterfaces(interfaceRegistry)
-	app.ModuleBasics.RegisterInterfaces(interfaceRegistry)
-	qgbtypes.RegisterInterfaces(interfaceRegistry)
-	return sdkcodec.NewProtoCodec(interfaceRegistry)
 }

--- a/x/qgb/orchestrator/parser.go
+++ b/x/qgb/orchestrator/parser.go
@@ -20,7 +20,7 @@ type QGBParserI interface {
 	ParseDataCommitmentConfirm(msg sdktypes.Msg) (qgbtypes.MsgDataCommitmentConfirm, error)
 	ParseValsetConfirm(msg sdktypes.Msg) (qgbtypes.MsgValsetConfirm, error)
 	ParseCoreTx(tx coretypes.Tx) (sdktx.Tx, error)
-	ParseSdkTx(any *sdkcodectypes.Any) (sdktypes.Msg, error)
+	ParseSdkMsg(any *sdkcodectypes.Any) (sdktypes.Msg, error)
 }
 
 type QGBParser struct {
@@ -58,7 +58,7 @@ func (parser QGBParser) ParseCoreTx(tx coretypes.Tx) (sdktx.Tx, error) {
 	return sdkTx, nil
 }
 
-func (parser QGBParser) ParseSdkTx(any *sdkcodectypes.Any) (sdktypes.Msg, error) {
+func (parser QGBParser) ParseSdkMsg(any *sdkcodectypes.Any) (sdktypes.Msg, error) {
 	var stdMsg sdktypes.Msg
 	err := parser.codec.UnpackAny(any, &stdMsg)
 	if err != nil {


### PR DESCRIPTION
Implements a parser for tendermint and sdk messages for the QGB transactions.
Adds to: https://github.com/celestiaorg/celestia-app/issues/684