### PR TITLE
docs: delete all contents of `~/.celestia-app`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ celestia-appd --help
 ### Create your own single node devnet
 
 ```sh
-# WARNING: this deletes config from previous local devnets
-rm -r ~/.celestia-app/config
+# WARNING: this deletes config, data, and keyrings from previous local devnets
+rm -r ~/.celestia-app
 
 # Start a single node devnet
 ./scripts/single-node.sh


### PR DESCRIPTION
I encountered an error:

```
$ celestia-appd tx payment payForData 0101010101010101 0101010101010101 --from validator --keyring-backend test
Error: rpc error: code = NotFound desc = rpc error: code = NotFound desc = account celestia10etmzwghs0rcffu6dzs4wdw6wrumgcu2u3wl67 not found: key not found
```

because I failed to delete the `~/.celestia-app/keyring-test` from a previous devnet. After deleting it, I was able to successfully submit a PFD. This change updates the docs to suggest deleting the entire `~/.celestia-app` directory prior to running the single node script.