### PR TITLE
fix: markdown lint links

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,11 @@ rm -r ~/.celestia-app/config
 celestia-appd tx payment payForData [hexNamespace] [hexMessage] [flags]
 ```
 
+<!-- markdown-link-check-disable -->
+<!-- markdown-link encounters an HTTP 503 on this link even though it works. -->
+<!-- See https://github.com/celestiaorg/celestia-app/actions/runs/3296219513/jobs/5439416229#step:4:185 -->
 See <https://docs.celestia.org/category/celestia-app> for more information
+<!-- markdown-link-check-enable -->
 
 ## Contributing
 

--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-To accommodate the requirements of the [Quantum Gravity Bridge](https://github.com/celestiaorg/quantum-gravity-bridge/blob/master/ethereum/solidity/src/QuantumGravityBridge.sol), We will need to add support for `ValSet`s, i.e. Validator Sets, which reflect the current state of the bridge validators.
+To accommodate the requirements of the [Quantum Gravity Bridge](https://github.com/celestiaorg/quantum-gravity-bridge/blob/76efeca0be1a17d32ef633c0fdbd3c8f5e4cc53f/src/QuantumGravityBridge.sol), We will need to add support for `ValSet`s, i.e. Validator Sets, which reflect the current state of the bridge validators.
 
 ## Decision
 

--- a/docs/architecture/adr-003-qgb-data-commitments.md
+++ b/docs/architecture/adr-003-qgb-data-commitments.md
@@ -2,7 +2,7 @@
 
 ## Context
 
-To accommodate the requirements of the [Quantum Gravity Bridge](https://github.com/celestiaorg/quantum-gravity-bridge/blob/master/ethereum/solidity/src/QuantumGravityBridge.sol), We will need to add support for `DataCommitment`s messages, i.e. commitments generated over a set of blocks to attest their existence.
+To accommodate the requirements of the [Quantum Gravity Bridge](https://github.com/celestiaorg/quantum-gravity-bridge/blob/76efeca0be1a17d32ef633c0fdbd3c8f5e4cc53f/src/QuantumGravityBridge.sol), We will need to add support for `DataCommitment`s messages, i.e. commitments generated over a set of blocks to attest their existence.
 
 ## Decision
 

--- a/docs/architecture/adr-005-qgb-reduce-state-usage.md
+++ b/docs/architecture/adr-005-qgb-reduce-state-usage.md
@@ -63,7 +63,7 @@ We will need to decide on two things:
 ## Detailed Design
 
 The proposed design consists of keeping the same transaction types we currently have : the `MsgValsetConfirm` defined in [here](https://github.com/celestiaorg/celestia-app/blob/a965914b8a467f0384b17d9a8a0bb1ac62f384db/proto/qgb/msgs.proto#L24-L49), and the `MsgDataCommitmentConfirm` defined in [here](
-https://github.com/celestiaorg/celestia-app/blob/a965914b8a467f0384b17d9a8a0bb1ac62f384db/proto/qgb/msgs.proto#L55-L76). However, remove  all the message server checks defined in the [msg_server.go](https://github.com/celestiaorg/celestia-app/blob/qgb-integration/x/qgb/keeper/msg_server.go) :
+https://github.com/celestiaorg/celestia-app/blob/a965914b8a467f0384b17d9a8a0bb1ac62f384db/proto/qgb/msgs.proto#L55-L76). However, remove  all the message server checks defined in the [msg_server.go](https://github.com/celestiaorg/celestia-app/blob/9867b653b2a253ba01cb7889e2dbfa6c9ff67909/x/qgb/keeper/msg_server.go) :
 
 ```go
 // ValsetConfirm handles MsgValsetConfirm.


### PR DESCRIPTION
The markdown lint links CI workflow is [failing](https://github.com/celestiaorg/celestia-app/actions/runs/3296219513/jobs/5439416229). This PR fixes links by updating links to use permalinks.

See https://github.com/celestiaorg/celestia-app/pull/902#issuecomment-1287007498