### PR TITLE
hardcode share index to 0 when calculating compact share count

### DIFF
--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -72,12 +72,12 @@ func calculateCompactShareCount(txs []*parsedTx, evd core.EvidenceList, squareSi
 	for _, tx := range txs {
 		rawTx := tx.rawTx
 		if tx.malleatedTx != nil {
-			// HACKHACK: hardcode the shareIndex to 0 because we can't
-			// accurately determine the shareIndex of the message associated
-			// with this transaction without first writing the transaction and
-			// evidence shares.
-			shareIndex := uint32(0)
-			rawTx, err = coretypes.WrapMalleatedTx(tx.originalHash(), shareIndex, tx.malleatedTx)
+			// HACKHACK: hardcode the shareIndex to the maxShareIndex because we
+			// can't accurately determine the shareIndex of the message
+			// associated with this transaction without first writing the
+			// transaction and evidence shares.
+			maxShareIndex := uint32(appconsts.MaxSquareSize*appconsts.MaxSquareSize - 1)
+			rawTx, err = coretypes.WrapMalleatedTx(tx.originalHash(), maxShareIndex, tx.malleatedTx)
 			if err != nil {
 				panic(err)
 			}

--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -69,16 +69,18 @@ func calculateCompactShareCount(txs []*parsedTx, evd core.EvidenceList, squareSi
 	txSplitter := shares.NewCompactShareSplitter(appconsts.TxNamespaceID, appconsts.ShareVersion)
 	evdSplitter := shares.NewCompactShareSplitter(appconsts.EvidenceNamespaceID, appconsts.ShareVersion)
 	var err error
-	msgSharesCursor := len(txs)
 	for _, tx := range txs {
 		rawTx := tx.rawTx
 		if tx.malleatedTx != nil {
-			rawTx, err = coretypes.WrapMalleatedTx(tx.originalHash(), uint32(msgSharesCursor), tx.malleatedTx)
+			// HACKHACK: hardcode the shareIndex to 0 because we can't
+			// accurately determine the shareIndex of the message associated
+			// with this transaction without first writing the transaction and
+			// evidence shares.
+			shareIndex := uint32(0)
+			rawTx, err = coretypes.WrapMalleatedTx(tx.originalHash(), shareIndex, tx.malleatedTx)
 			if err != nil {
 				panic(err)
 			}
-			used, _ := shares.MsgSharesUsedNonInteractiveDefaults(msgSharesCursor, squareSize, tx.msg.Size())
-			msgSharesCursor += used
 		}
 		txSplitter.WriteTx(rawTx)
 	}


### PR DESCRIPTION
Closes: https://github.com/informalsystems/audit-celestia/issues/25

FWIW this PR becomes unnecessary if we adopt ADR 008 because then we can likely delete square size estimation (WIP [commit](https://github.com/celestiaorg/celestia-app/commit/c0cf6af3ab715dd514bdf1958dd6f3e1dfcf7549)). I'm on the fence about merging this PR because I don't have full confidence this works in all circumstances. Unit tests pass but I'm concerned about edge cases.