### PR TITLE
chore: rename `height` to `treeSizes` in Merkle mountain range

### DIFF
--- a/x/payment/types/payfordata_test.go
+++ b/x/payment/types/payfordata_test.go
@@ -13,30 +13,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMountainRange(t *testing.T) {
+func Test_merkleMountainRangeHeights(t *testing.T) {
 	type test struct {
-		l, squareSize uint64
-		expected      []uint64
+		totalSize  uint64
+		squareSize uint64
+		expected   []uint64
 	}
 	tests := []test{
 		{
-			l:          11,
+			totalSize:  11,
 			squareSize: 4,
 			expected:   []uint64{4, 4, 2, 1},
 		},
 		{
-			l:          2,
+			totalSize:  2,
 			squareSize: 64,
 			expected:   []uint64{2},
 		},
-		{ // should this test throw an error? we
-			l:          64,
+		{
+			totalSize:  64,
 			squareSize: 8,
 			expected:   []uint64{8, 8, 8, 8, 8, 8, 8, 8},
 		},
+		// Height
+		// 3              x                               x
+		//              /    \                         /    \
+		//             /      \                       /      \
+		//            /        \                     /        \
+		//           /          \                   /          \
+		// 2        x            x                 x            x
+		//        /   \        /   \             /   \        /   \
+		// 1     x     x      x     x           x     x      x     x         x
+		//      / \   / \    / \   / \         / \   / \    / \   / \      /   \
+		// 0   0   1 2   3  4   5 6   7       8   9 10  11 12 13 14  15   16   17    18
+		{
+			totalSize:  19,
+			squareSize: 8,
+			expected:   []uint64{8, 8, 2, 1},
+		},
 	}
 	for _, tt := range tests {
-		res := powerOf2MountainRange(tt.l, tt.squareSize)
+		res := merkleMountainRangeSizes(tt.totalSize, tt.squareSize)
 		assert.Equal(t, tt.expected, res)
 	}
 }


### PR DESCRIPTION
This PR is a pure refactor that renames `heights` => `treeSizes` because the previous name was slightly misleading. This function doesn't return the heights of the trees in the Merkle mountain range, it returns the number of leaves in each tree. For example, for the unit test that was added:

``` golang
			totalSize:  19,
			squareSize: 8,
			expected:   []uint64{8, 8, 2, 1},
```

the Merkle mountain range looks like

```ascii
		// Height
		// 3              x                               x
		//              /    \                         /    \
		//             /      \                       /      \
		//            /        \                     /        \
		//           /          \                   /          \
		// 2        x            x                 x            x
		//        /   \        /   \             /   \        /   \
		// 1     x     x      x     x           x     x      x     x         x
		//      / \   / \    / \   / \         / \   / \    / \   / \      /   \
		// 0   0   1 2   3  4   5 6   7       8   9 10  11 12 13 14  15   16   17    18

```

and if this function returned the heights, then expected would be:

```diff
-expected:   []uint64{8, 8, 2, 1},
+expected:   []uint64{3, 3, 1, 0},
```

but it actually returns `{8, 8, 2, 1}` (the number of leaf nodes in each tree). The remaining renames are optional but may aid clarity if we adopt the rename proposed above