### PR TITLE
Update docker-build workflow to fix version tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -52,7 +52,7 @@ jobs:
           # yamllint disable
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.full }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.tag_version.outputs.full }}
           # yamllint enable
           file: Dockerfile
 


### PR DESCRIPTION
Currently the docker-build workflow attempts to tag releases with 
```
...${{ steps.version.outputs.full }}
```
but the correct string is
```
...${{ steps.tag_version.outputs.full }}
``` 
to match the previous step id of `tag_version`