### PR TITLE
chore!: rename `SubmitPayForData` => `SubmitWirePayForData`

### DIFF
--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -219,7 +219,7 @@ func (s *IntegrationTestSuite) TestSubmitWirePayForData() {
 	for _, tc := range tests {
 		s.Run(tc.name, func() {
 			signer := types.NewKeyringSigner(s.kr, s.accounts[0], val.ClientCtx.ChainID)
-			res, err := payment.SubmitPayForData(context.TODO(), signer, val.ClientCtx.GRPCClient, tc.ns, tc.message, 10000000, tc.opts...)
+			res, err := payment.SubmitWirePayForData(context.TODO(), signer, val.ClientCtx.GRPCClient, tc.ns, tc.message, 10000000, tc.opts...)
 			require.NoError(err)
 			require.NotNil(res)
 			assert.Equal(abci.CodeTypeOK, res.Code)

--- a/testutil/testnode/node_interaction_api.go
+++ b/testutil/testnode/node_interaction_api.go
@@ -113,7 +113,7 @@ func (c *Context) PostData(account, broadcastMode string, ns, msg []byte) (*sdk.
 	signer.SetSequence(seq)
 
 	// create a random msg per row
-	pfd, err := payment.BuildPayForData(
+	wpfd, err := payment.BuildWirePayForData(
 		c.rootCtx,
 		signer,
 		c.GRPCClient,
@@ -125,7 +125,7 @@ func (c *Context) PostData(account, broadcastMode string, ns, msg []byte) (*sdk.
 		return nil, err
 	}
 
-	signed, err := payment.SignPayForData(signer, pfd, opts...)
+	signed, err := payment.SignWirePayForData(signer, wpfd, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

Previously, there were functions named `*PayForData` that actually dealt with `WirePayForData`s. Since a PayForData != WirePayForData, I found the previous naming confusing. This change renames functions to more accurately reflect the types they deal with.

This change is breaking because `SubmitPayForData` is part of the public API and is used by celestia-node.