### PR TITLE
docs: update how commitments are generated

### DIFF
--- a/x/payment/spec/docs.md
+++ b/x/payment/spec/docs.md
@@ -158,13 +158,6 @@ if err != nil {
 
 ### How the commitments are generated
 
-1. create the final version of the message by adding the length delimiter, the namespace, and then the message together into a single string of bytes
-
-   ```python
-   finalMessage = [length delimiter] + [namespace] + [message]
-   ```
-
-2. chunk the finalMessage into shares of size `appconsts.ShareSize`
-3. pad until number of shares is a power of two
-4. create the commitment by aranging the shares into a merkle mountain range
-5. create a merkle root of the subtree roots
+1. Split the message into shares of `appconsts.ShareSize`
+1. Arrange the shares into a Merkle mountain range where each tree in the mountain range has a maximum size of `squareSize`
+1. Take the roots of the trees in the Merkle mountain range and create a new Merkle tree. The message share commitment is the Markle root of this Merkle tree.


### PR DESCRIPTION
The previous docs were outdated because they describe a historical version of the message share layout.