### PR TITLE
fix: error message unexpected number of signatures

### DIFF
--- a/x/payment/types/payfordata.go
+++ b/x/payment/types/payfordata.go
@@ -88,7 +88,7 @@ func BuildPayForDataTxFromWireTx(
 		return nil, err
 	}
 	if len(origSigs) != 1 {
-		return nil, fmt.Errorf("unexpected number of signers: %d", len(origSigs))
+		return nil, fmt.Errorf("unexpected number of signatures: %d", len(origSigs))
 	}
 
 	newSig := signing.SignatureV2{


### PR DESCRIPTION
The modified error message was incorrect because it errors when the number of signatures `!= 1`.