### PR TITLE
gitignore `__debug_bin`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,5 @@ coverage.txt
 .idea
 .vscode
 tools-stamp
-.vscode
+__debug_bin
 profile.out


### PR DESCRIPTION
Add `__debug_bin` to gitignore because this file is generated when you run tests in Debug mode inside VSCode.