### PR TITLE
chore: Enable prealloc linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,4 @@ linters:
     - gofumpt
     - misspell
     - revive
+    - prealloc

--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -151,7 +151,7 @@ func rawShareCount(txs []*parsedTx, evd core.EvidenceList) (txShares, evdShares 
 		namespace []byte
 	}
 
-	var msgSummaries []msgSummary
+	var msgSummaries []msgSummary //nolint:prealloc
 
 	// we use bytes instead of shares for tx and evd as they are encoded
 	// contiguously in the square, unlike msgs where each of which is assigned their


### PR DESCRIPTION
Enable `prealloc` linter in `.golangci.yml

- [X] Tested: working with `golangci-lint v1.47.2`

Closes #676 