### PR TITLE
chore!: revert PR (#859) `CLS` back to `TIA`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,20 @@ node            |  |                               |  |
 ```sh
 # Print help message
 celestia-appd --help
-```
 
-### Create your own single node devnet
-
-```sh
-# WARNING: this deletes config, data, and keyrings from previous local devnets
-rm -r ~/.celestia-app
-
-# Start a single node devnet
-./scripts/single-node.sh
+# Create your own single node devnet
+celestia-appd init test --chain-id test
+celestia-appd keys add user1
+celestia-appd add-genesis-account <address from above command> 10000000utia,1000token
+celestia-appd gentx user1 1000000utia --chain-id test
+celestia-appd collect-gentxs
+celestia-appd start
 
 # Post data to the local devnet
 celestia-appd tx payment payForData [hexNamespace] [hexMessage] [flags]
 ```
 
-<!-- markdown-link-check-disable -->
-<!-- markdown-link encounters an HTTP 503 on this link even though it works. -->
-<!-- See https://github.com/celestiaorg/celestia-app/actions/runs/3296219513/jobs/5439416229#step:4:185 -->
 See <https://docs.celestia.org/category/celestia-app> for more information
-<!-- markdown-link-check-enable -->
 
 ## Contributing
 

--- a/app/app.go
+++ b/app/app.go
@@ -92,11 +92,11 @@ const (
 	AccountAddressPrefix = "celestia"
 	Name                 = "celestia-app"
 	// BondDenom defines the native staking token denomination.
-	BondDenom = "ucls"
+	BondDenom = "utia"
 	// BondDenomAlias defines an alias for BondDenom.
-	BondDenomAlias = "microcls"
-	// DisplayDenom defines the name, symbol, and display value of the Celestia token.
-	DisplayDenom = "CLS"
+	BondDenomAlias = "microtia"
+	// DisplayDenom defines the name, symbol, and display value of the celes token.
+	DisplayDenom = "TIA"
 )
 
 // These constants are derived from the above variables.

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -29,7 +29,7 @@ import (
 func TestIntegrationTestSuite(t *testing.T) {
 	cfg := network.DefaultConfig()
 	cfg.EnableTMLogging = false
-	cfg.MinGasPrices = "0ucls"
+	cfg.MinGasPrices = "0utia"
 	cfg.NumValidators = 1
 	cfg.TimeoutCommit = time.Millisecond * 400
 	suite.Run(t, NewIntegrationTestSuite(cfg))

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -5,12 +5,12 @@ set -o errexit -o nounset
 CHAINID="test"
 
 # Build genesis file incl account for passed address
-coins="1000000000000000ucls"
-celestia-appd init $CHAINID --chain-id $CHAINID
+coins="1000000000000000utia"
+celestia-appd init $CHAINID --chain-id $CHAINID 
 celestia-appd keys add validator --keyring-backend="test"
 # this won't work because the some proto types are decalared twice and the logs output to stdout (dependency hell involving iavl)
 celestia-appd add-genesis-account $(celestia-appd keys show validator -a --keyring-backend="test") $coins
-celestia-appd gentx validator 5000000000ucls \
+celestia-appd gentx validator 5000000000utia \
   --keyring-backend="test" \
   --chain-id $CHAINID \
   --orchestrator-address $(celestia-appd keys show validator -a --keyring-backend="test") \

--- a/testutil/test_app.go
+++ b/testutil/test_app.go
@@ -115,7 +115,7 @@ func SetupTestAppWithGenesisValSet(t *testing.T) *app.App {
 }
 
 // AddGenesisAccount mimics the cli addGenesisAccount command, providing an
-// account with an allocation of "token" and app.BondDenom tokens in the genesis
+// account with an allocation of to "token" and "tia" tokens in the genesis
 // state
 func AddGenesisAccount(addr sdk.AccAddress, appState app.GenesisState, cdc codec.Codec) (map[string]json.RawMessage, error) {
 	// create concrete account type based on input parameters

--- a/x/payment/types/builder_options.go
+++ b/x/payment/types/builder_options.go
@@ -65,7 +65,7 @@ func InheritTxConfig(builder sdkclient.TxBuilder, tx authsigning.Tx) sdkclient.T
 		builder.SetGasLimit(gas)
 	}
 
-	if feeAmmount := tx.GetFee(); !feeAmmount.AmountOf("ucls").Equal(sdk.NewInt(0)) {
+	if feeAmmount := tx.GetFee(); !feeAmmount.AmountOf("utia").Equal(sdk.NewInt(0)) {
 		builder.SetFeeAmount(tx.GetFee())
 	}
 

--- a/x/payment/types/payfordata_test.go
+++ b/x/payment/types/payfordata_test.go
@@ -143,7 +143,7 @@ func TestSignMalleatedTxs(t *testing.T) {
 			ss:   []uint64{4, 8, 16, 64},
 			options: []TxBuilderOption{
 				SetGasLimit(123456789),
-				SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ucls", sdk.NewInt(987654321)))),
+				SetFeeAmount(sdk.NewCoins(sdk.NewCoin("utia", sdk.NewInt(987654321)))),
 			},
 		},
 		{
@@ -153,7 +153,7 @@ func TestSignMalleatedTxs(t *testing.T) {
 			ss:   AllSquareSizes(50000),
 			options: []TxBuilderOption{
 				SetGasLimit(123456789),
-				SetFeeAmount(sdk.NewCoins(sdk.NewCoin("ucls", sdk.NewInt(987654321)))),
+				SetFeeAmount(sdk.NewCoins(sdk.NewCoin("utia", sdk.NewInt(987654321)))),
 			},
 		},
 	}


### PR DESCRIPTION
This reverts commit 3598fe28772ed1ad55a0bc0b76d222828d35960f.

As we have agreed during the onsite - we want to stick with TIA ticker instead of CLS