### PR TITLE
chore: rename SignShareCommitments -> SignShareCommitment

### DIFF
--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -271,7 +271,7 @@ func generateSignedWirePayForDataTxs(clientCtx client.Context, txConfig client.T
 			return nil, err
 		}
 
-		err = msg.SignShareCommitments(signer, opts...)
+		err = msg.SignShareCommitment(signer, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -171,7 +171,7 @@ func generateSignedWirePayForData(t *testing.T, ns, message []byte, signer *type
 		t.Error(err)
 	}
 
-	err = msg.SignShareCommitments(signer, options...)
+	err = msg.SignShareCommitment(signer, options...)
 	if err != nil {
 		t.Error(err)
 	}

--- a/app/test_util.go
+++ b/app/test_util.go
@@ -142,7 +142,7 @@ func generateSignedWirePayForData(t *testing.T, ns, message []byte, signer *type
 		t.Error(err)
 	}
 
-	err = msg.SignShareCommitments(signer, options...)
+	err = msg.SignShareCommitment(signer, options...)
 	if err != nil {
 		t.Error(err)
 	}

--- a/testutil/payment/testutil.go
+++ b/testutil/payment/testutil.go
@@ -117,7 +117,7 @@ func generateSignedWirePayForData(t *testing.T, ns, message []byte, signer *type
 		t.Error(err)
 	}
 
-	err = msg.SignShareCommitments(signer, options...)
+	err = msg.SignShareCommitment(signer, options...)
 	if err != nil {
 		t.Error(err)
 	}

--- a/x/payment/client/cli/wirepayfordata.go
+++ b/x/payment/client/cli/wirepayfordata.go
@@ -79,7 +79,7 @@ func CmdWirePayForData() *cobra.Command {
 			}
 
 			// sign the  MsgPayForData's ShareCommitments
-			err = pfdMsg.SignShareCommitments(
+			err = pfdMsg.SignShareCommitment(
 				signer,
 				types.SetGasLimit(gasSetting.Gas),
 				types.SetFeeAmount(parsedFees),

--- a/x/payment/payfordata.go
+++ b/x/payment/payfordata.go
@@ -71,7 +71,7 @@ func BuildPayForData(
 
 	// generate the signatures for each `MsgPayForData` using the `KeyringSigner`,
 	// then set the gas limit for the tx
-	err = wpfd.SignShareCommitments(signer, opts...)
+	err = wpfd.SignShareCommitment(signer, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/x/payment/types/payfordata_test.go
+++ b/x/payment/types/payfordata_test.go
@@ -147,7 +147,7 @@ func TestSignMalleatedTxs(t *testing.T) {
 	for _, tt := range tests {
 		wpfd, err := NewWirePayForData(tt.ns, tt.msg)
 		require.NoError(t, err, tt.name)
-		err = wpfd.SignShareCommitments(signer, tt.options...)
+		err = wpfd.SignShareCommitment(signer, tt.options...)
 		// there should be no error
 		assert.NoError(t, err)
 		// the signature should exist
@@ -280,7 +280,7 @@ func validWirePayForData(t *testing.T) *MsgWirePayForData {
 
 	signer := generateKeyringSigner(t)
 
-	err = msg.SignShareCommitments(signer)
+	err = msg.SignShareCommitment(signer)
 	if err != nil {
 		panic(err)
 	}
@@ -296,7 +296,7 @@ func validMsgPayForData(t *testing.T) *MsgPayForData {
 	wpfd, err := NewWirePayForData(ns, msg)
 	assert.NoError(t, err)
 
-	err = wpfd.SignShareCommitments(signer)
+	err = wpfd.SignShareCommitment(signer)
 	assert.NoError(t, err)
 
 	_, spfd, _, err := ProcessWirePayForData(wpfd)

--- a/x/payment/types/wirepayfordata.go
+++ b/x/payment/types/wirepayfordata.go
@@ -47,9 +47,9 @@ func NewWirePayForData(namespace, message []byte) (*MsgWirePayForData, error) {
 	return out, nil
 }
 
-// SignShareCommitments creates and signs MsgPayForDatas for each square size configured in the MsgWirePayForData
-// to complete each shares commitment.
-func (msg *MsgWirePayForData) SignShareCommitments(signer *KeyringSigner, options ...TxBuilderOption) error {
+// SignShareCommitment creates and signs the message share commitment associated
+// with a MsgWirePayForData.
+func (msg *MsgWirePayForData) SignShareCommitment(signer *KeyringSigner, options ...TxBuilderOption) error {
 	addr, err := signer.GetSignerInfo().GetAddress()
 	if err != nil {
 		return err

--- a/x/payment/types/wirepayfordata_test.go
+++ b/x/payment/types/wirepayfordata_test.go
@@ -184,7 +184,7 @@ func TestProcessWirePayForData(t *testing.T) {
 	for _, tt := range tests {
 		wpfd, err := NewWirePayForData(tt.namespace, tt.msg)
 		require.NoError(t, err, tt.name)
-		err = wpfd.SignShareCommitments(signer)
+		err = wpfd.SignShareCommitment(signer)
 		assert.NoError(t, err)
 
 		wpfd = tt.modify(wpfd)


### PR DESCRIPTION
If ADR 008 is adopted, only one message share commitment is signed so this PR renames a plural function to be singular. This is a follow-up to https://github.com/celestiaorg/celestia-app/pull/937 and could've been included in that PR.

Note: targets feature branch