### PR TITLE
docs: update "How is the `MessageShareCommitment` generated?"

### DIFF
--- a/x/payment/spec/docs.md
+++ b/x/payment/spec/docs.md
@@ -20,7 +20,7 @@ When a PayForData message is processed, it consumes gas based on the message siz
 
 ## Messages
 
-- [`MsgWirePayForData`](https://github.com/celestiaorg/celestia-app/blob/b4c8ebdf35db200a9b99d295a13de01110802af4/x/payment/types/tx.pb.go#L32-L40) is created and signed by the user but it never ends up on-chain. Instead, it is "malleated" into it's component parts: data and a `MsgPayForData` message.
+- [`MsgWirePayForData`](https://github.com/celestiaorg/celestia-app/blob/b4c8ebdf35db200a9b99d295a13de01110802af4/x/payment/types/tx.pb.go#L32-L40) is created and signed by the user but it never ends up on-chain. Instead, it is "malleated" into its component parts: data and a `MsgPayForData` message.
 - [`MsgPayForData`](https://github.com/celestiaorg/celestia-app/blob/b4c8ebdf35db200a9b99d295a13de01110802af4/x/payment/types/tx.pb.go#L208-L216) is one output of the malleation process. It contains metadata from the original `MsgWirePayForData` but not the associated data.
 
 ## Events

--- a/x/payment/spec/docs.md
+++ b/x/payment/spec/docs.md
@@ -10,7 +10,7 @@ The payment module enables users to pay for arbitrary data to be published to th
 
 After the `MsgWirePayForData` transaction is submitted to the network, a block producer malleates their transaction into a `MsgPayForData` which doesn't include their data (a.k.a message). Both components get included in the data square in different namespaces: the `MsgPayForData` gets included in the transaction namespace and the associated data gets included in the namespace the user specified in the original `MsgWirePayForData`. Further reading: [Message Block Layout](https://github.com/celestiaorg/celestia-specs/blob/master/src/rationale/message_block_layout.md)
 
-After a block has been created, the user can verify that their data was included in a block via a message inclusion proof. A message inclusion proof the `MessageShareCommitment` in the original `MsgWirePayForData` and subtree roots of the block's data square to proove to the user that the shares that compose their original data do in fact exist in a particular block.
+After a block has been created, the user can verify that their data was included in a block via a message inclusion proof. A message inclusion proof uses the `MessageShareCommitment` in the original `MsgWirePayForData` and subtree roots of the block's data square to prove to the user that the shares that compose their original data do in fact exist in a particular block.
 
 ## State
 

--- a/x/payment/spec/docs.md
+++ b/x/payment/spec/docs.md
@@ -5,7 +5,7 @@
 The payment module enables users to pay for arbitrary data to be published to the Celestia blockchain. Users create a single `MsgWirePayForData` transaction that is composed of:
 
 1. `Message`: the data they wish to publish
-2. `MessageNameSpaceId`: the namespace they wish to publish to
+2. `MessageNamespaceId`: the namespace they wish to publish to
 3. `MessageShareCommitment`: a signature and a commitment over their data when encoded into shares
 
 After the `MsgWirePayForData` transaction is submitted to the network, a block producer malleates their transaction into a `MsgPayForData` which doesn't include their data (a.k.a message). Both components get included in the data square in different namespaces: the `MsgPayForData` gets included in the transaction namespace and the associated data gets included in the namespace the user specified in the original `MsgWirePayForData`. Further reading: [Message Block Layout](https://github.com/celestiaorg/celestia-specs/blob/master/src/rationale/message_block_layout.md)


### PR DESCRIPTION
Update payment docs to account for how message share commitment is generated post ADR 008.

Note: targets feature branch