### PR TITLE
Move tendermint consensus config overrides

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/app/encoding"
@@ -81,6 +82,8 @@ func NewRootCmd() *cobra.Command {
 			tmCfg.Mempool.TTLNumBlocks = 10
 			tmCfg.Mempool.MaxTxBytes = 2 * 1024 * 1024 // 2 MiB
 			tmCfg.Mempool.Version = "v1"               // prioritized mempool
+			tmCfg.Consensus.TimeoutCommit = time.Second * 25
+			tmCfg.Consensus.SkipTimeoutCommit = false
 
 			customAppTemplate, customAppConfig := initAppConfig()
 			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmCfg)


### PR DESCRIPTION
Addresses https://github.com/celestiaorg/celestia-app/issues/669#issuecomment-1315796678 by copying the consensus config overrides from celestiaorg/cosmos-sdk.

This PR should be merged in parallel with https://github.com/celestiaorg/cosmos-sdk/pull/284
