### PR TITLE
chore!: unexport merge

### DIFF
--- a/pkg/shares/share_merging.go
+++ b/pkg/shares/share_merging.go
@@ -12,8 +12,8 @@ import (
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
-// Merge extracts block data from an extended data square.
-func Merge(eds *rsmt2d.ExtendedDataSquare) (coretypes.Data, error) {
+// merge extracts block data from an extended data square.
+func merge(eds *rsmt2d.ExtendedDataSquare) (coretypes.Data, error) {
 	squareSize := eds.Width() / 2
 
 	// sort block data shares by namespace

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -209,7 +209,7 @@ func TestMerge(t *testing.T) {
 				t.Error(err)
 			}
 
-			res, err := Merge(eds)
+			res, err := merge(eds)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/840

Reduce the public API of the shares package by unexporting `Merge`. This function doesn't appear invoked by celestia-node ([search](https://github.com/celestiaorg/celestia-node/search?q=Merge)) so it doesn't seem necessary to export.
