### PR TITLE
chore: rename gas descriptor to use `blob` instead of `data`

### DIFF
--- a/x/blob/keeper/keeper.go
+++ b/x/blob/keeper/keeper.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	payForBlobGasDescriptor = "pay for data"
+	payForBlobGasDescriptor = "pay for blob"
 
 	// GasPerBlobByte is the amount of gas to charge per byte of message data.
 	// TODO: extract GasPerBlobByte as a parameter to this module.


### PR DESCRIPTION
As title