### PR TITLE
feat: add shares inclusion proofs 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -486,6 +486,7 @@ func New(
 	)
 
 	app.QueryRouter().AddRoute(prove.TxInclusionQueryPath, prove.QueryTxInclusionProof)
+	app.QueryRouter().AddRoute(prove.ShareInclusionQueryPath, prove.QueryShareInclusionProof)
 
 	app.mm.RegisterInvariants(&app.CrisisKeeper)
 	app.mm.RegisterRoutes(app.Router(), app.QueryRouter(), encodingConfig.Amino)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/celestiaorg/celestia-app
 go 1.18
 
 require (
-	github.com/celestiaorg/nmt v0.10.0
+	github.com/celestiaorg/nmt v0.11.0
 	github.com/celestiaorg/quantum-gravity-bridge v1.2.0
 	github.com/cosmos/cosmos-sdk v0.44.3
 	github.com/ethereum/go-ethereum v1.10.26
@@ -204,5 +204,5 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.1.7-0.20210622111912-ef00f8ac3d76
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.4.0-sdk-v0.46.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint v0.34.20 => github.com/celestiaorg/celestia-core v1.8.0-tm-v0.34.20
+	github.com/tendermint/tendermint v0.34.20 => github.com/sweexordious/celestia-core v0.34.14-celestia.0.20221118223755-1c5061fe2b14
 )

--- a/go.sum
+++ b/go.sum
@@ -227,14 +227,12 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3k
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.8.0-tm-v0.34.20 h1:D1KxHZp8xGksmmYMUNlgMcEq2dnXyGQzU6XBWm7vlh0=
-github.com/celestiaorg/celestia-core v1.8.0-tm-v0.34.20/go.mod h1:2ze96HI7+bV0RxY/EMEInsVJAgYO7sQ1DOt4MnFU/No=
 github.com/celestiaorg/cosmos-sdk v1.4.0-sdk-v0.46.0 h1:65gnQ92mfz+9XNVTHeVwMp+SZuBqmToEnz8+WdDRmQ8=
 github.com/celestiaorg/cosmos-sdk v1.4.0-sdk-v0.46.0/go.mod h1:ByQ2rOrZs7s2OnPfeaiTMC8IOlcrT195xIRPgevydCI=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
-github.com/celestiaorg/nmt v0.10.0 h1:HLfVWvpagHz5+uiE0QSjzv350wLhhnybNmrxq9NHLKc=
-github.com/celestiaorg/nmt v0.10.0/go.mod h1:3bqzTj8xKj0DgQUpOgZzoxvtNkC3MS/hTbQ6dn8SIa0=
+github.com/celestiaorg/nmt v0.11.0 h1:iqTaNwnVzM3njBmPklpHzb3A4Xy/JKahoclRPbAzxNc=
+github.com/celestiaorg/nmt v0.11.0/go.mod h1:NN3W8EEoospv8EHCw50DDNWwPLpJkFHoEFiqCEcNCH4=
 github.com/celestiaorg/quantum-gravity-bridge v1.2.0 h1:l/LEEUP+x8MhhXB8rrWkyUVFZgQj1Ur/TAwUpnyLK38=
 github.com/celestiaorg/quantum-gravity-bridge v1.2.0/go.mod h1:6WOajINTDEUXpSj5UZzod16UZ96ZVB/rFNKyM+Mt1gI=
 github.com/celestiaorg/rsmt2d v0.7.0 h1:r8fybOWhE2/VJ2XEJ6BncnYTSlLYx2c7dQDUD+5hBqg=
@@ -698,7 +696,6 @@ github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.1-0.20200604201612-c04b05f3adfa/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=
@@ -1311,6 +1308,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/subosito/gotenv v1.4.0 h1:yAzM1+SmVcz5R4tXGsNMu1jUl2aOJXoiWUCEwwnGrvs=
 github.com/subosito/gotenv v1.4.0/go.mod h1:mZd6rFysKEcUhUHXJk0C/08wAgyDBFuwEYL7vWWGaGo=
+github.com/sweexordious/celestia-core v0.34.14-celestia.0.20221118223755-1c5061fe2b14 h1:yeSDyzVZ9mv4BWcwx6mYMQkpGuW9ClQqmVO0vpAqoKU=
+github.com/sweexordious/celestia-core v0.34.14-celestia.0.20221118223755-1c5061fe2b14/go.mod h1:2ze96HI7+bV0RxY/EMEInsVJAgYO7sQ1DOt4MnFU/No=
 github.com/syndtr/gocapability v0.0.0-20170704070218-db04d3cc01c8/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20180916011248-d98352740cb2/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=

--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -200,7 +200,7 @@ func TestShareInclusion(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			actualNID, err := ParseNamespaceID(rawShares, tt.startingShare, tt.endingShare)
+			actualNID, err := parseNamespaceID(rawShares, tt.startingShare, tt.endingShare)
 			if !tt.shouldPass {
 				require.Error(t, err)
 				return

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -96,7 +96,7 @@ func QueryShareInclusionProof(_ sdk.Context, path []string, req abci.RequestQuer
 		return nil, err
 	}
 
-	nID, err := ParseNamespaceID(rawShares, beginShare, endShare)
+	nID, err := parseNamespaceID(rawShares, beginShare, endShare)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,8 @@ func QueryShareInclusionProof(_ sdk.Context, path []string, req abci.RequestQuer
 	return rawTxProof, nil
 }
 
-func ParseNamespaceID(rawShares []shares.Share, startShare int64, endingShare int64) (namespace.ID, error) {
+// parseNamespaceID validates the shares range and returns their namespace ID.
+func parseNamespaceID(rawShares []shares.Share, startShare int64, endingShare int64) (namespace.ID, error) {
 	if startShare < 0 {
 		return nil, fmt.Errorf("start share %d should be positive", startShare)
 	}

--- a/pkg/prove/querier.go
+++ b/pkg/prove/querier.go
@@ -1,8 +1,12 @@
 package prove
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
+
+	"github.com/celestiaorg/celestia-app/pkg/shares"
+	"github.com/celestiaorg/nmt/namespace"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -53,4 +57,87 @@ func QueryTxInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) 
 	}
 
 	return rawTxProof, nil
+}
+
+const ShareInclusionQueryPath = "shareInclusionProof"
+
+// QueryShareInclusionProof defines the logic performed when querying for the inclusion
+// of a set of shares to the data root.
+// the shares range should be appended to the path.
+// example path for proving the set of shares [3, 5]:
+// custom/shareInclusionProof/3/5
+func QueryShareInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) ([]byte, error) {
+	// parse the shares range from the path
+	if len(path) != 2 {
+		return nil, fmt.Errorf("expected query path length: 2 actual: %d ", len(path))
+	}
+	beginShare, err := strconv.ParseInt(path[0], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	endShare, err := strconv.ParseInt(path[1], 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal the block data that is passed from the ABCI client
+	pbb := new(tmproto.Block)
+	err = pbb.Unmarshal(req.Data)
+	if err != nil {
+		return nil, fmt.Errorf("error reading block: %w", err)
+	}
+	data, err := types.DataFromProto(&pbb.Data)
+	if err != nil {
+		panic(fmt.Errorf("error from proto block: %w", err))
+	}
+
+	rawShares, err := shares.Split(data, true)
+	if err != nil {
+		return nil, err
+	}
+
+	nID, err := ParseNamespaceID(rawShares, beginShare, endShare)
+	if err != nil {
+		return nil, err
+	}
+
+	// create and marshal the shares inclusion proof, which we return in the form of []byte
+	txProof, err := SharesInclusion(appconsts.DefaultCodec(), rawShares, data.SquareSize, nID, uint64(beginShare), uint64(endShare))
+	if err != nil {
+		return nil, err
+	}
+	pTxProof := txProof.ToProto()
+	rawTxProof, err := pTxProof.Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	return rawTxProof, nil
+}
+
+func ParseNamespaceID(rawShares []shares.Share, startShare int64, endingShare int64) (namespace.ID, error) {
+	if startShare < 0 {
+		return nil, fmt.Errorf("start share %d should be positive", startShare)
+	}
+
+	if endingShare < 0 {
+		return nil, fmt.Errorf("ending share %d should be positive", endingShare)
+	}
+
+	if endingShare < startShare {
+		return nil, fmt.Errorf("ending share %d should be higher than starting share %d", endingShare, startShare)
+	}
+
+	if endingShare >= int64(len(rawShares)) {
+		return nil, fmt.Errorf("ending share %d is higher than block shares %d", endingShare, len(rawShares))
+	}
+
+	nID := rawShares[startShare].NamespaceID()
+
+	for i, n := range rawShares[startShare:endingShare] {
+		if !bytes.Equal(nID, n.NamespaceID()) {
+			return nil, fmt.Errorf("shares range contain different namespaces: %d, %d %d", nID, n.NamespaceID(), i)
+		}
+	}
+	return nID, nil
 }


### PR DESCRIPTION
Adds support for shares inclusion proofs. 
Depends on https://github.com/celestiaorg/celestia-core/pull/878
