### PR TITLE
chore!(testnode): return errors in cleanup functions and wait for cleanup

### DIFF
--- a/testutil/testnode/full_node.go
+++ b/testutil/testnode/full_node.go
@@ -176,7 +176,7 @@ func DefaultGenesisState(fundedAccounts ...string) (map[string]json.RawMessage, 
 // using test friendly defaults. These defaults include fast block times and
 // funded accounts. The returned client.Context has a keyring with all of the
 // funded keys stored in it.
-func DefaultNetwork(t *testing.T, blockTime time.Duration) (cleanup func(), accounts []string, cctx Context) {
+func DefaultNetwork(t *testing.T, blockTime time.Duration) (cleanup func() error, accounts []string, cctx Context) {
 	// we create an arbitrary number of funded accounts
 	accounts = make([]string, 300)
 	for i := 0; i < 300; i++ {
@@ -198,8 +198,12 @@ func DefaultNetwork(t *testing.T, blockTime time.Duration) (cleanup func(), acco
 	cctx, cleanupGRPC, err := StartGRPCServer(app, DefaultAppConfig(), cctx)
 	require.NoError(t, err)
 
-	return func() {
-		stopNode()
-		cleanupGRPC()
+	return func() error {
+		err := stopNode()
+		if err != nil {
+			return err
+		}
+		return cleanupGRPC()
+
 	}, accounts, cctx
 }

--- a/testutil/testnode/full_node.go
+++ b/testutil/testnode/full_node.go
@@ -204,6 +204,5 @@ func DefaultNetwork(t *testing.T, blockTime time.Duration) (cleanup func() error
 			return err
 		}
 		return cleanupGRPC()
-
 	}, accounts, cctx
 }

--- a/testutil/testnode/full_node_test.go
+++ b/testutil/testnode/full_node_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-app/testutil"
 	"github.com/celestiaorg/celestia-app/testutil/namespace"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -18,7 +19,7 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	cleanups []func()
+	cleanups []func() error
 	accounts []string
 	cctx     Context
 }
@@ -56,7 +57,8 @@ func (s *IntegrationTestSuite) SetupSuite() {
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.T().Log("tearing down integration test suite")
 	for _, c := range s.cleanups {
-		c()
+		err := c()
+		require.NoError(s.T(), err)
 	}
 }
 

--- a/testutil/testnode/rpc_client.go
+++ b/testutil/testnode/rpc_client.go
@@ -37,6 +37,7 @@ func StartNode(tmNode *node.Node, cctx Context) (Context, func() error, error) {
 		if err != nil {
 			return err
 		}
+		tmNode.Wait()
 		return nil
 	}
 

--- a/testutil/testnode/rpc_client.go
+++ b/testutil/testnode/rpc_client.go
@@ -33,10 +33,6 @@ func StartNode(tmNode *node.Node, cctx Context) (Context, func() error, error) {
 		if err != nil {
 			return err
 		}
-		err = coreClient.Stop()
-		if err != nil {
-			return err
-		}
 		tmNode.Wait()
 		return nil
 	}

--- a/testutil/testnode/rpc_client.go
+++ b/testutil/testnode/rpc_client.go
@@ -17,9 +17,9 @@ import (
 // rpc is returned via the client.Context. The function returned should be
 // called during cleanup to teardown the node, core client, along with canceling
 // the internal context.Context in the returned Context.
-func StartNode(tmNode *node.Node, cctx Context) (Context, func(), error) {
+func StartNode(tmNode *node.Node, cctx Context) (Context, func() error, error) {
 	if err := tmNode.Start(); err != nil {
-		return cctx, func() {}, err
+		return cctx, func() error { return nil }, err
 	}
 
 	coreClient := local.New(tmNode)
@@ -27,10 +27,17 @@ func StartNode(tmNode *node.Node, cctx Context) (Context, func(), error) {
 	cctx.Context = cctx.WithClient(coreClient)
 	goCtx, cancel := context.WithCancel(context.Background())
 	cctx.rootCtx = goCtx
-	cleanup := func() {
-		_ = tmNode.Stop()
-		_ = coreClient.Stop()
+	cleanup := func() error {
 		cancel()
+		err := tmNode.Stop()
+		if err != nil {
+			return err
+		}
+		err = coreClient.Stop()
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 
 	return cctx, cleanup, nil
@@ -39,7 +46,8 @@ func StartNode(tmNode *node.Node, cctx Context) (Context, func(), error) {
 // StartGRPCServer starts the grpc server using the provided application and
 // config. A grpc client connection to that server is also added to the client
 // context. The returned function should be used to shutdown the server.
-func StartGRPCServer(app srvtypes.Application, appCfg *srvconfig.Config, cctx Context) (Context, func(), error) {
+func StartGRPCServer(app srvtypes.Application, appCfg *srvconfig.Config, cctx Context) (Context, func() error, error) {
+	emptycleanup := func() error { return nil }
 	// Add the tx service in the gRPC router.
 	app.RegisterTxService(cctx.Context)
 
@@ -48,18 +56,21 @@ func StartGRPCServer(app srvtypes.Application, appCfg *srvconfig.Config, cctx Co
 
 	grpcSrv, err := srvgrpc.StartGRPCServer(cctx.Context, app, appCfg.GRPC)
 	if err != nil {
-		return Context{}, func() {}, err
+		return Context{}, emptycleanup, err
 	}
 
 	nodeGRPCAddr := strings.Replace(appCfg.GRPC.Address, "0.0.0.0", "localhost", 1)
 	conn, err := grpc.Dial(nodeGRPCAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
-		return Context{}, func() {}, err
+		return Context{}, emptycleanup, err
 	}
 
 	cctx.Context = cctx.WithGRPCClient(conn)
 
-	return cctx, grpcSrv.Stop, nil
+	return cctx, func() error {
+		grpcSrv.Stop()
+		return nil
+	}, nil
 }
 
 // DefaultAppConfig wraps the default config described in the server


### PR DESCRIPTION
## Overview

@renaynay found that we weren't actually waiting for the tendermint node to shutdown during cleanup. This might be causing an issue when running multiple different nodes in CI (not locally). We also were not returning errors for the cleanup functions, which could be silencing useful errors. 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
