### PR TITLE
fix: propagate share version

### DIFF
--- a/pkg/shares/parse_sparse_shares.go
+++ b/pkg/shares/parse_sparse_shares.go
@@ -67,6 +67,8 @@ func parseSparseShares(rawShares [][]byte, supportedShareVersions []uint8) ([]co
 			currentMsg = coretypes.Blob{
 				NamespaceID: nid,
 				Data:        nextMsgChunk,
+				// TODO: add the share version to the blob
+				// https://github.com/celestiaorg/celestia-app/issues/1053
 			}
 			// the current share contains the entire msg so we save it and
 			// progress

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -161,8 +161,9 @@ func generateRandomlySizedBlobs(count, maxBlobSize int) []coretypes.Blob {
 // generateRandomBlob returns a random blob of the given size (in bytes)
 func generateRandomBlob(size int) coretypes.Blob {
 	blob := coretypes.Blob{
-		NamespaceID: tmrand.Bytes(appconsts.NamespaceSize),
-		Data:        tmrand.Bytes(size),
+		NamespaceID:  tmrand.Bytes(appconsts.NamespaceSize),
+		Data:         tmrand.Bytes(size),
+		ShareVersion: appconsts.ShareVersionZero,
 	}
 	return blob
 }

--- a/x/blob/types/errors.go
+++ b/x/blob/types/errors.go
@@ -20,4 +20,5 @@ var (
 	ErrEvidenceNamespace              = sdkerrors.Register(ModuleName, 11120, "cannot use evidence namespace ID")
 	ErrEmptyShareCommitment           = sdkerrors.Register(ModuleName, 11121, "empty share commitment")
 	ErrInvalidShareCommitments        = sdkerrors.Register(ModuleName, 11122, "invalid share commitments: all relevant square sizes must be committed to")
+	ErrUnsupportedShareVersion        = sdkerrors.Register(ModuleName, 11123, "unsupported share version")
 )


### PR DESCRIPTION
Follow up to https://github.com/celestiaorg/celestia-app/pull/1028 where I didn't propagate the new struct field `ShareVersion` to all instances of `coretypes.Blob`. 

Unfortunately Go isn't exhaustive on specifying struct fields so I wasn't made aware of this miss until working on an unrelated change. Open to ideas on how to have higher confidence all instances have been addressed. [The non_exhaustive attribute](https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute) makes me think Rust structs are exhaustive by default.