### PR TITLE
chore!(testnode): return errors in cleanup functions and wait for cleanup (#1051)

### DIFF
--- a/testutil/testnode/full_node_test.go
+++ b/testutil/testnode/full_node_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-app/testutil"
 	"github.com/celestiaorg/celestia-app/testutil/namespace"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -17,7 +18,7 @@ import (
 type IntegrationTestSuite struct {
 	suite.Suite
 
-	cleanups []func()
+	cleanups []func() error
 	accounts []string
 	cctx     Context
 }
@@ -52,7 +53,8 @@ func (s *IntegrationTestSuite) SetupSuite() {
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.T().Log("tearing down integration test suite")
 	for _, c := range s.cleanups {
-		c()
+		err := c()
+		require.NoError(s.T(), err)
 	}
 }
 


### PR DESCRIPTION
cherry picking this testing change into the v0.10.0 release as its only testing releated, and then celestia-node can use it
…
@renaynay found that we weren't actually waiting for the tendermint node to shutdown during cleanup. This might be causing an issue when running multiple different nodes in CI (not locally). We also were not returning errors for the cleanup functions, which could be silencing useful errors.

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
