### PR TITLE
chore!(shares): remove the ability to merge and split evidence shares

### DIFF
--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -67,7 +67,6 @@ func prune(txConf client.TxConfig, txs []*parsedTx, currentShareCount, squareSiz
 // calculateCompactShareCount calculates the exact number of compact shares used.
 func calculateCompactShareCount(txs []*parsedTx, evd core.EvidenceList, squareSize int) int {
 	txSplitter := shares.NewCompactShareSplitter(appconsts.TxNamespaceID, appconsts.ShareVersionZero)
-	evdSplitter := shares.NewCompactShareSplitter(appconsts.EvidenceNamespaceID, appconsts.ShareVersionZero)
 	var err error
 	msgSharesCursor := len(txs)
 	for _, tx := range txs {
@@ -82,17 +81,7 @@ func calculateCompactShareCount(txs []*parsedTx, evd core.EvidenceList, squareSi
 		}
 		txSplitter.WriteTx(rawTx)
 	}
-	for _, e := range evd.Evidence {
-		evidence, err := coretypes.EvidenceFromProto(&e)
-		if err != nil {
-			panic(err)
-		}
-		err = evdSplitter.WriteEvidence(evidence)
-		if err != nil {
-			panic(err)
-		}
-	}
-	return txSplitter.Count() + evdSplitter.Count()
+	return txSplitter.Count()
 }
 
 // estimateSquareSize uses the provided block data to estimate the square size

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -118,12 +118,11 @@ func TestPrepareMessagesWithReservedNamespaces(t *testing.T) {
 	}
 
 	tests := []test{
-		{"transaction namespace id for message", appconsts.TxNamespaceID, 0},
-		{"evidence namespace id for message", appconsts.EvidenceNamespaceID, 0},
-		{"tail padding namespace id for message", appconsts.TailPaddingNamespaceID, 0},
-		{"parity shares namespace id for message", appconsts.ParitySharesNamespaceID, 0},
-		{"reserved namespace id for message", namespace.ID{0, 0, 0, 0, 0, 0, 0, 200}, 0},
-		{"valid namespace id for message", namespace.ID{3, 3, 2, 2, 2, 1, 1, 1}, 1},
+		{"transaction namespace", appconsts.TxNamespaceID, 0},
+		{"tail padding namespace", appconsts.TailPaddingNamespaceID, 0},
+		{"parity shares namespace", appconsts.ParitySharesNamespaceID, 0},
+		{"other reserved namespace", namespace.ID{0, 0, 0, 0, 0, 0, 0, 200}, 0},
+		{"valid namespace", namespace.ID{3, 3, 2, 2, 2, 1, 1, 1}, 1},
 	}
 
 	for _, tt := range tests {

--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -80,9 +80,6 @@ var (
 	// TODO(liamsi): code commented out but kept intentionally.
 	// IntermediateStateRootsNamespaceID = namespace.ID{0, 0, 0, 0, 0, 0, 0, 2}
 
-	// EvidenceNamespaceID is the namespace reserved for evidence
-	EvidenceNamespaceID = namespace.ID{0, 0, 0, 0, 0, 0, 0, 3}
-
 	// MaxReservedNamespace is the lexicographically largest namespace that is
 	// reserved for protocol use. It is derived from NAMESPACE_ID_MAX_RESERVED
 	// https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/consensus.md#constants

--- a/pkg/prove/proof.go
+++ b/pkg/prove/proof.go
@@ -164,16 +164,6 @@ func genOrigRowShares(data types.Data, startRow, endRow uint64) []shares.Share {
 		return rawShares[startPos:wantLen]
 	}
 
-	evdShares, err := shares.SplitEvidence(data.Evidence.Evidence)
-	if err != nil {
-		panic(err)
-	}
-
-	rawShares = append(rawShares, evdShares...)
-	if uint64(len(rawShares)) >= wantLen {
-		return rawShares[startPos:wantLen]
-	}
-
 	for _, blob := range data.Blobs {
 		msgShares, err := shares.SplitMessages(0, nil, []types.Blob{blob}, false)
 		if err != nil {

--- a/pkg/shares/share_merging.go
+++ b/pkg/shares/share_merging.go
@@ -19,7 +19,6 @@ func merge(eds *rsmt2d.ExtendedDataSquare) (coretypes.Data, error) {
 	// sort block data shares by namespace
 	var (
 		sortedTxShares  [][]byte
-		sortedEvdShares [][]byte
 		sortedMsgShares [][]byte
 	)
 
@@ -34,9 +33,6 @@ func merge(eds *rsmt2d.ExtendedDataSquare) (coretypes.Data, error) {
 			switch {
 			case bytes.Equal(appconsts.TxNamespaceID, nid):
 				sortedTxShares = append(sortedTxShares, share)
-
-			case bytes.Equal(appconsts.EvidenceNamespaceID, nid):
-				sortedEvdShares = append(sortedEvdShares, share)
 
 			case bytes.Equal(appconsts.TailPaddingNamespaceID, nid):
 				continue
@@ -58,11 +54,6 @@ func merge(eds *rsmt2d.ExtendedDataSquare) (coretypes.Data, error) {
 		return coretypes.Data{}, err
 	}
 
-	evd, err := ParseEvd(sortedEvdShares)
-	if err != nil {
-		return coretypes.Data{}, err
-	}
-
 	msgs, err := ParseMsgs(sortedMsgShares)
 	if err != nil {
 		return coretypes.Data{}, err
@@ -70,7 +61,6 @@ func merge(eds *rsmt2d.ExtendedDataSquare) (coretypes.Data, error) {
 
 	return coretypes.Data{
 		Txs:        txs,
-		Evidence:   evd,
 		Blobs:      msgs,
 		SquareSize: uint64(squareSize),
 	}, nil

--- a/pkg/shares/shares.go
+++ b/pkg/shares/shares.go
@@ -52,7 +52,7 @@ func (s Share) SequenceLength() (uint64, error) {
 
 // isCompactShare returns true if this share is a compact share.
 func (s Share) isCompactShare() bool {
-	return s.NamespaceID().Equal(appconsts.TxNamespaceID) || s.NamespaceID().Equal(appconsts.EvidenceNamespaceID)
+	return s.NamespaceID().Equal(appconsts.TxNamespaceID)
 }
 
 func ToBytes(shares []Share) (bytes [][]byte) {


### PR DESCRIPTION
follow to the recent removal of evidence namespace id and the ability to parse shares

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
