### PR TITLE
refactor: optimize blob shares used

### DIFF
--- a/pkg/shares/utils.go
+++ b/pkg/shares/utils.go
@@ -31,6 +31,13 @@ func BlobSharesUsed(blobSize int) int {
 	return shareCount
 }
 
+func BlobSharesUsedOptimized(blobSize int) int {
+	// add the delimiter to the blob size
+	blobSize = DelimLen(uint64(blobSize)) + blobSize
+	shareCount := 1 + ((blobSize - 1) / appconsts.SparseShareContentSize)
+	return shareCount
+}
+
 func BlobShareCountsFromBlobs(blobs []core.Blob) []int {
 	e := make([]int, len(blobs))
 	for i, blob := range blobs {

--- a/pkg/shares/utils_test.go
+++ b/pkg/shares/utils_test.go
@@ -24,6 +24,44 @@ func FuzzBlobSharesUsed(f *testing.F) {
 	})
 }
 
+func FuzzBlobSharesUsedOptimized(f *testing.F) {
+	f.Add(1)
+	f.Fuzz(func(t *testing.T, a int) {
+		if a < 1 {
+			t.Skip()
+		}
+		ml := BlobSharesUsedOptimized(a)
+		blob := testfactory.GenerateRandomBlob(a)
+		rawShares, err := SplitBlobs(0, nil, []types.Blob{blob}, false)
+		require.NoError(t, err)
+		require.Equal(t, len(rawShares), ml)
+	})
+}
+
+func FuzzBlobSharesEquality(f *testing.F) {
+	f.Add(1)
+	f.Fuzz(func(t *testing.T, a int) {
+		if a < 1 {
+			t.Skip()
+		}
+		original := BlobSharesUsed(a)
+		optimized := BlobSharesUsedOptimized(a)
+		require.Equal(t, original, optimized)
+	})
+}
+
+func BenchmarkBlobSharesUsed(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		BlobSharesUsed(123456789)
+	}
+}
+
+func BenchmarkBlobSharesUsedOptimized(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		BlobSharesUsedOptimized(123456789)
+	}
+}
+
 func Test_zeroPadIfNecessary(t *testing.T) {
 	type args struct {
 		share []byte


### PR DESCRIPTION
Closes https://github.com/informalsystems/audit-celestia/issues/11

```bash
$ go test -bench=.
goos: darwin
goarch: arm64
pkg: github.com/celestiaorg/celestia-app/pkg/shares
BenchmarkBlobSharesUsed-10             	480383745	         2.488 ns/op
BenchmarkBlobSharesUsedOptimized-10    	482551569	         2.493 ns/op
PASS
ok  	github.com/celestiaorg/celestia-app/pkg/shares	3.648s
```