### PR TITLE
ci: markdown link checker config

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,3 @@
+{
+    "retryOn429": true
+}


### PR DESCRIPTION
celestia-app is observing several false positives on the markdown lint link checker. See https://github.com/celestiaorg/celestia-app/actions/runs/3586356956/jobs/6035453041#step:4:318

this PR attempts to mitigate by configuring markdown lint link checker to retry when an HTTP 429 is observed. See https://github.com/gaurav-nelson/github-action-markdown-link-check#too-many-requests