### PR TITLE
feat: use `private` chain ID for single node

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o nounset
 
-CHAINID="test"
+CHAINID="private"
 
 # Build genesis file incl account for passed address
 coins="1000000000000000utia"


### PR DESCRIPTION
If you try connecting a local celestia-node instance to celestia-app that is running via this script, it fails with:

```error
$ celestia bridge init --p2p.network "test"
Error: invalid network specified: test
```

Ref:
https://github.com/celestiaorg/celestia-node/blob/52048ce466d58c1688ba48de0a2656b27306634d/nodebuilder/p2p/network.go#L12-L19
