### PR TITLE
chore: switch default keyring backend

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -151,12 +151,16 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig encoding.Config) {
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, NewAppServer, createAppAndExport, addModuleInitFlags)
 
+	// set the default keyring backend to `file`
+	keybase := keys.Commands(app.DefaultNodeHome)
+	keybase.Flag(flags.FlagKeyringBackend).DefValue = "file"
+
 	// add keybase, auxiliary RPC, query, and tx child commands
 	rootCmd.AddCommand(
 		rpc.StatusCommand(),
 		queryCommand(),
 		txCommand(),
-		keys.Commands(app.DefaultNodeHome),
+		keybase,
 	)
 }
 


### PR DESCRIPTION
- [x] closes https://github.com/celestiaorg/celestia-app/issues/405
- [x] manually test that default value is switched