### PR TITLE
fix!: pass the baseapp msg service router

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -187,7 +187,6 @@ type App struct {
 	appCodec          codec.Codec
 	interfaceRegistry types.InterfaceRegistry
 	txConfig          client.TxConfig
-	msgSvcRouter      *baseapp.MsgServiceRouter
 
 	invCheckPeriod uint
 
@@ -268,7 +267,6 @@ func New(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
-		msgSvcRouter:      bApp.MsgServiceRouter(),
 	}
 
 	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
@@ -363,7 +361,7 @@ func New(
 
 	app.GovKeeper = govkeeper.NewKeeper(
 		appCodec, keys[govtypes.StoreKey], app.GetSubspace(govtypes.ModuleName), app.AccountKeeper, app.BankKeeper,
-		&stakingKeeper, govRouter, app.msgSvcRouter, govConfig,
+		&stakingKeeper, govRouter, bApp.MsgServiceRouter(), govConfig,
 	)
 
 	app.BlobKeeper = *blobmodulekeeper.NewKeeper(

--- a/app/app.go
+++ b/app/app.go
@@ -268,6 +268,7 @@ func New(
 		keys:              keys,
 		tkeys:             tkeys,
 		memKeys:           memKeys,
+		msgSvcRouter:      bApp.MsgServiceRouter(),
 	}
 
 	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])


### PR DESCRIPTION
## Overview

as noticed by @cmwaters, we accidentally removed setting the app's msg service router. This is why this functionality was present in v0.6.0, but not in v0.10.0. The only usage of the msg service router is for the gov keeper, so it doesn't have an effect on other modules. 

this fix is tested in a followup PR #1160 

closes #1158 