### PR TITLE
chore!: Test std modules

### DIFF
--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestStandardSDKIntegrationTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in unit-tests or race-detector mode.")
+	}
 	suite.Run(t, new(StandardSDKIntegrationTestSuite))
 }
 
@@ -43,12 +46,7 @@ type StandardSDKIntegrationTestSuite struct {
 
 func (s *StandardSDKIntegrationTestSuite) SetupSuite() {
 	t := s.T()
-	if testing.Short() {
-		t.Skip("skipping test in unit-tests or race-detector mode.")
-	}
-
 	t.Log("setting up integration test suite")
-
 	cleanup, accounts, cctx := testnode.DefaultNetwork(t, time.Millisecond*400)
 	s.cleanup = cleanup
 	s.accounts = accounts
@@ -91,8 +89,6 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 			},
 		},
 		{
-			// demonstrate that a send transactions use different amounts of gas
-			// depending on the number of funds
 			name: "send 1,000,000 TIA",
 			msgFunc: func() (msg sdk.Msg, signer string) {
 				account1, account2 := s.unusedAccount(), s.unusedAccount()

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/celestiaorg/celestia-app/testutil/testnode"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
@@ -132,7 +131,7 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 					pv.PrivKey.PubKey(),
 					sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000)),
 					stakingtypes.NewDescription("taco tuesday", "my keybase", "www.celestia.org", "ping @celestiaorg on twitter", "fake validator"),
-					stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(6, 02), sdk.NewDecWithPrec(12, 02), sdk.NewDecWithPrec(1, 02)),
+					stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(6, 0o2), sdk.NewDecWithPrec(12, 0o2), sdk.NewDecWithPrec(1, 0o2)),
 					sdk.NewInt(1000000),
 					valopAccAddr,
 					evmAddr,
@@ -195,7 +194,6 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 		require.NoError(t, err)
 		assert.Equal(t, abci.CodeTypeOK, res.TxResult.Code, tt.name)
 	}
-
 }
 
 func getAddress(account string, kr keyring.Keyring) sdk.AccAddress {
@@ -208,16 +206,4 @@ func getAddress(account string, kr keyring.Keyring) sdk.AccAddress {
 		panic(err)
 	}
 	return addr
-}
-
-func getPubKey(account string, kr keyring.Keyring) cryptotypes.PubKey {
-	rec, err := kr.Key(account)
-	if err != nil {
-		panic(err)
-	}
-	pub, err := rec.GetPubKey()
-	if err != nil {
-		panic(err)
-	}
-	return pub
 }

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -1,0 +1,227 @@
+package app_test
+
+import (
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/testutil/testnode"
+	"github.com/cosmos/cosmos-sdk/crypto/hd"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	"github.com/cosmos/cosmos-sdk/testutil/mock"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	oldgov "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func TestStandardSDKIntegrationTestSuite(t *testing.T) {
+	suite.Run(t, new(StandardSDKIntegrationTestSuite))
+}
+
+type StandardSDKIntegrationTestSuite struct {
+	suite.Suite
+
+	cleanup  func() error
+	accounts []string
+	cctx     testnode.Context
+	ecfg     encoding.Config
+
+	mut            sync.Mutex
+	accountCounter int
+}
+
+func (s *StandardSDKIntegrationTestSuite) SetupSuite() {
+	t := s.T()
+	if testing.Short() {
+		t.Skip("skipping test in unit-tests or race-detector mode.")
+	}
+
+	t.Log("setting up integration test suite")
+
+	cleanup, accounts, cctx := testnode.DefaultNetwork(t, time.Millisecond*400)
+	s.cleanup = cleanup
+	s.accounts = accounts
+	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	s.cctx = cctx
+}
+
+func (s *StandardSDKIntegrationTestSuite) TearDownSuite() {
+	t := s.T()
+	t.Log("tearing down integration test suite")
+	require.NoError(t, s.cleanup())
+}
+
+func (s *StandardSDKIntegrationTestSuite) unusedAccount() string {
+	s.mut.Lock()
+	acc := s.accounts[s.accountCounter]
+	s.accountCounter++
+	s.mut.Unlock()
+	return acc
+}
+
+func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
+	t := s.T()
+	type test struct {
+		name    string
+		msgFunc func() (msg sdk.Msg, signer string)
+		hash    string
+	}
+	tests := []test{
+		{
+			name: "send 1 utia",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				account1, account2 := s.unusedAccount(), s.unusedAccount()
+				msgSend := banktypes.NewMsgSend(
+					getAddress(account1, s.cctx.Keyring),
+					getAddress(account2, s.cctx.Keyring),
+					sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1))),
+				)
+				return msgSend, account1
+			},
+		},
+		{
+			// demonstrate that a send transactions use different amounts of gas
+			// depending on the number of funds
+			name: "send 1,000,000 TIA",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				account1, account2 := s.unusedAccount(), s.unusedAccount()
+				msgSend := banktypes.NewMsgSend(
+					getAddress(account1, s.cctx.Keyring),
+					getAddress(account2, s.cctx.Keyring),
+					sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000000000))),
+				)
+				return msgSend, account1
+			},
+		},
+		{
+			name: "delegate 1 TIA",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				valopAddr := sdk.ValAddress(getAddress("validator", s.cctx.Keyring))
+				account1 := s.unusedAccount()
+				account1Addr := getAddress(account1, s.cctx.Keyring)
+				msg = stakingtypes.NewMsgDelegate(account1Addr, valopAddr, sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000)))
+				return msg, account1
+			},
+		},
+		{
+			name: "undelegate 1 TIA",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				valAccAddr := getAddress("validator", s.cctx.Keyring)
+				valopAddr := sdk.ValAddress(valAccAddr)
+				msg = stakingtypes.NewMsgUndelegate(valAccAddr, valopAddr, sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000)))
+				return msg, "validator"
+			},
+		},
+		{
+			name: "create validator",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				pv := mock.NewPV()
+				account := s.unusedAccount()
+				valopAccAddr := getAddress(account, s.cctx.Keyring)
+				valopAddr := sdk.ValAddress(valopAccAddr)
+				evmAddr := common.BigToAddress(big.NewInt(420))
+				msg, err := stakingtypes.NewMsgCreateValidator(
+					valopAddr,
+					pv.PrivKey.PubKey(),
+					sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000)),
+					stakingtypes.NewDescription("taco tuesday", "my keybase", "www.celestia.org", "ping @celestiaorg on twitter", "fake validator"),
+					stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(6, 02), sdk.NewDecWithPrec(12, 02), sdk.NewDecWithPrec(1, 02)),
+					sdk.NewInt(1000000),
+					valopAccAddr,
+					evmAddr,
+				)
+				require.NoError(t, err)
+				return msg, account
+			},
+		},
+		{
+			name: "create vesting account",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				vestAccName := "vesting"
+				_, _, err := s.cctx.Keyring.NewMnemonic(vestAccName, keyring.English, "", "", hd.Secp256k1)
+				require.NoError(t, err)
+				sendAcc := s.unusedAccount()
+				sendingAccAddr := getAddress(sendAcc, s.cctx.Keyring)
+				vestAccAddr := getAddress(vestAccName, s.cctx.Keyring)
+				msg = vestingtypes.NewMsgCreateVestingAccount(
+					sendingAccAddr,
+					vestAccAddr,
+					sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000))),
+					10000, true,
+				)
+				return msg, sendAcc
+			},
+		},
+		{
+			name: "create legacy governance proposal",
+			msgFunc: func() (msg sdk.Msg, signer string) {
+				account := s.unusedAccount()
+				content, ok := oldgov.ContentFromProposalType("title", "description", "text")
+				require.True(t, ok)
+				addr := getAddress(account, s.cctx.Keyring)
+				msg, err := oldgov.NewMsgSubmitProposal(
+					content,
+					sdk.NewCoins(
+						sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000000))),
+					addr,
+				)
+				require.NoError(t, err)
+				return msg, account
+			},
+		},
+	}
+
+	// sign and submit the transactions
+	for i, tt := range tests {
+		msg, signer := tt.msgFunc()
+		res, err := testnode.SignAndBroadcastTx(s.ecfg, s.cctx.Context, signer, msg)
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Equal(t, abci.CodeTypeOK, res.Code)
+		tests[i].hash = res.TxHash
+	}
+
+	require.NoError(s.T(), s.cctx.WaitForNextBlock())
+
+	for _, tt := range tests {
+		res, err := queryTx(s.cctx.Context, tt.hash, false)
+		require.NoError(t, err)
+		assert.Equal(t, abci.CodeTypeOK, res.TxResult.Code, tt.name)
+	}
+
+}
+
+func getAddress(account string, kr keyring.Keyring) sdk.AccAddress {
+	rec, err := kr.Key(account)
+	if err != nil {
+		panic(err)
+	}
+	addr, err := rec.GetAddress()
+	if err != nil {
+		panic(err)
+	}
+	return addr
+}
+
+func getPubKey(account string, kr keyring.Keyring) cryptotypes.PubKey {
+	rec, err := kr.Key(account)
+	if err != nil {
+		panic(err)
+	}
+	pub, err := rec.GetPubKey()
+	if err != nil {
+		panic(err)
+	}
+	return pub
+}

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestStandardSDKIntegrationTestSuite(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skipping test in unit-tests or race-detector mode.")
+		t.Skip("skipping SDK integration test in short mode.")
 	}
 	suite.Run(t, new(StandardSDKIntegrationTestSuite))
 }

--- a/testutil/testnode/sign.go
+++ b/testutil/testnode/sign.go
@@ -23,7 +23,7 @@ func SignAndBroadcastTx(encCfg encoding.Config, c client.Context, account string
 		)),
 	}
 
-	// use the key for accounts[i] to create a singer used for a single PFB
+	// use the key for accounts[i] to create a signer used for a single PFB
 	signer := types.NewKeyringSigner(c.Keyring, account, c.ChainID)
 
 	signer.SetEncodingConfig(encCfg)

--- a/testutil/testnode/sign.go
+++ b/testutil/testnode/sign.go
@@ -1,0 +1,56 @@
+package testnode
+
+import (
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/x/blob/types"
+	"github.com/cosmos/cosmos-sdk/client"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+const (
+	veryLargeGasLim uint64 = appconsts.MaxShareCount * appconsts.ShareSize * 10
+)
+
+// SignAndBroadcastTx signs a transaction using the provided account and keyring
+// inside the client.Context, then broadcasts it synchronously.
+func SignAndBroadcastTx(encCfg encoding.Config, c client.Context, account string, msg ...sdk.Msg) (res *sdk.TxResponse, err error) {
+	opts := []types.TxBuilderOption{
+		types.SetGasLimit(veryLargeGasLim),
+		types.SetFeeAmount(sdk.NewCoins(
+			sdk.NewCoin(app.BondDenom, sdk.NewInt(1)),
+		)),
+	}
+
+	// use the key for accounts[i] to create a singer used for a single PFB
+	signer := types.NewKeyringSigner(c.Keyring, account, c.ChainID)
+
+	signer.SetEncodingConfig(encCfg)
+
+	rec := signer.GetSignerInfo()
+	addr, err := rec.GetAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	acc, seq, err := c.AccountRetriever.GetAccountNumberSequence(c, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	signer.SetAccountNumber(acc)
+	signer.SetSequence(seq)
+
+	tx, err := signer.BuildSignedTx(signer.NewTxBuilder(opts...), msg...)
+	if err != nil {
+		return nil, err
+	}
+
+	rawTx, err := encCfg.TxConfig.TxEncoder()(tx)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.BroadcastTxSync(rawTx)
+}

--- a/x/blob/types/builder.go
+++ b/x/blob/types/builder.go
@@ -202,6 +202,12 @@ func (k *KeyringSigner) SetKeyringAccName(name string) {
 	k.keyringAccName = name
 }
 
+// SetEncodingConfig manually overides the encoding config of the underlying
+// signer
+func (k *KeyringSigner) SetEncodingConfig(encCfg encoding.Config) {
+	k.encCfg = encCfg
+}
+
 // GetSignerInfo returns the signer info for the KeyringSigner's account. panics
 // if the account in KeyringSigner does not exist.
 func (k *KeyringSigner) GetSignerInfo() *keyring.Record {


### PR DESCRIPTION
## Overview

Adds a smoke test for some of the std cosmos-sdk modules. This test does not test that the state was changed as expected, only that the msgs included in the transactions were applied successfully. 

blocked by #1159, as the test for submitting a governance proposal currently fails until that is merged

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
