### PR TITLE
fix: reject txs from the mempool that have a PFB but not a blob

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -3,7 +3,6 @@ package app
 import (
 	"fmt"
 
-	"github.com/celestiaorg/celestia-app/x/blob/types"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -37,7 +36,7 @@ func (app *App) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 	switch req.Type {
 	// new transactions must be checked in their entirety
 	case abci.CheckTxType_New:
-		pBTx, err := types.ProcessBlobTx(app.txConfig, btx)
+		pBTx, err := blobtypes.ProcessBlobTx(app.txConfig, btx)
 		if err != nil {
 			return sdkerrors.ResponseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false)
 		}

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/x/blob/types"
+	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	abci "github.com/tendermint/tendermint/abci/types"
 	coretypes "github.com/tendermint/tendermint/types"
@@ -17,8 +18,19 @@ func (app *App) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 	// check if the transaction contains blobs
 	btx, isBlob := coretypes.UnmarshalBlobTx(tx)
 
-	// don't do anything special if we have a normal transactions
 	if !isBlob {
+		sdkTx, err := app.txConfig.TxDecoder()(tx)
+		if err != nil {
+			return sdkerrors.ResponseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false)
+		}
+		// reject transactions that have PFBs, but no blobs attached
+		for _, msg := range sdkTx.GetMsgs() {
+			if _, ok := msg.(*blobtypes.MsgPayForBlob); !ok {
+				continue
+			}
+			return sdkerrors.ResponseCheckTxWithEvents(blobtypes.ErrBloblessPFB, 0, 0, []abci.Event{}, false)
+		}
+		// don't do anything special if we have a normal transaction
 		return app.BaseApp.CheckTx(req)
 	}
 

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/celestiaorg/celestia-app/x/blob"
 	"github.com/celestiaorg/celestia-app/x/blob/types"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -82,112 +83,112 @@ func (s *IntegrationTestSuite) TearDownSuite() {
 	s.network.Cleanup()
 }
 
-func (s *IntegrationTestSuite) TestMaxBlockSize() {
-	require := s.Require()
-	assert := s.Assert()
-	val := s.network.Validators[0]
+// func (s *IntegrationTestSuite) TestMaxBlockSize() {
+// 	require := s.Require()
+// 	assert := s.Assert()
+// 	val := s.network.Validators[0]
 
-	// tendermint's default tx size limit is 1Mb, so we get close to that
-	equallySized1MbTxGen := func(c client.Context) []coretypes.Tx {
-		return blobfactory.RandBlobTxsWithAccounts(
-			s.cfg.TxConfig.TxEncoder(),
-			s.kr,
-			c.GRPCClient,
-			950000,
-			false,
-			s.cfg.ChainID,
-			s.accounts[:20],
-		)
-	}
+// 	// tendermint's default tx size limit is 1Mb, so we get close to that
+// 	equallySized1MbTxGen := func(c client.Context) []coretypes.Tx {
+// 		return blobfactory.RandBlobTxsWithAccounts(
+// 			s.cfg.TxConfig.TxEncoder(),
+// 			s.kr,
+// 			c.GRPCClient,
+// 			950000,
+// 			false,
+// 			s.cfg.ChainID,
+// 			s.accounts[:20],
+// 		)
+// 	}
 
-	// generate 80 randomly sized txs (max size == 100kb) by generating these
-	// transaction using some of the same accounts as the previous genertor, we
-	// are also testing to ensure that the sequence number is being utilized
-	// corrected in malleated txs
-	randoTxGen := func(c client.Context) []coretypes.Tx {
-		return blobfactory.RandBlobTxsWithAccounts(
-			s.cfg.TxConfig.TxEncoder(),
-			s.kr,
-			c.GRPCClient,
-			500000,
-			true,
-			s.cfg.ChainID,
-			s.accounts[20:],
-		)
-	}
+// 	// generate 80 randomly sized txs (max size == 100kb) by generating these
+// 	// transaction using some of the same accounts as the previous genertor, we
+// 	// are also testing to ensure that the sequence number is being utilized
+// 	// corrected in malleated txs
+// 	randoTxGen := func(c client.Context) []coretypes.Tx {
+// 		return blobfactory.RandBlobTxsWithAccounts(
+// 			s.cfg.TxConfig.TxEncoder(),
+// 			s.kr,
+// 			c.GRPCClient,
+// 			500000,
+// 			true,
+// 			s.cfg.ChainID,
+// 			s.accounts[20:],
+// 		)
+// 	}
 
-	type test struct {
-		name        string
-		txGenerator func(clientCtx client.Context) []coretypes.Tx
-	}
+// 	type test struct {
+// 		name        string
+// 		txGenerator func(clientCtx client.Context) []coretypes.Tx
+// 	}
 
-	tests := []test{
-		{
-			"20 ~1Mb txs",
-			equallySized1MbTxGen,
-		},
-		{
-			"80 random txs",
-			randoTxGen,
-		},
-	}
-	for _, tc := range tests {
-		s.Run(tc.name, func() {
-			txs := tc.txGenerator(val.ClientCtx)
-			hashes := make([]string, len(txs))
+// 	tests := []test{
+// 		{
+// 			"20 ~1Mb txs",
+// 			equallySized1MbTxGen,
+// 		},
+// 		{
+// 			"80 random txs",
+// 			randoTxGen,
+// 		},
+// 	}
+// 	for _, tc := range tests {
+// 		s.Run(tc.name, func() {
+// 			txs := tc.txGenerator(val.ClientCtx)
+// 			hashes := make([]string, len(txs))
 
-			for i, tx := range txs {
-				res, err := val.ClientCtx.BroadcastTxSync(tx)
-				require.NoError(err)
-				assert.Equal(abci.CodeTypeOK, res.Code)
-				if res.Code != abci.CodeTypeOK {
-					continue
-				}
-				hashes[i] = res.TxHash
-			}
+// 			for i, tx := range txs {
+// 				res, err := val.ClientCtx.BroadcastTxSync(tx)
+// 				require.NoError(err)
+// 				assert.Equal(abci.CodeTypeOK, res.Code)
+// 				if res.Code != abci.CodeTypeOK {
+// 					continue
+// 				}
+// 				hashes[i] = res.TxHash
+// 			}
 
-			// wait a few blocks to clear the txs
-			for i := 0; i < 8; i++ {
-				require.NoError(s.network.WaitForNextBlock())
-			}
+// 			// wait a few blocks to clear the txs
+// 			for i := 0; i < 8; i++ {
+// 				require.NoError(s.network.WaitForNextBlock())
+// 			}
 
-			heights := make(map[int64]int)
-			for _, hash := range hashes {
-				// TODO: reenable fetching and verifying proofs
-				resp, err := queryTx(val.ClientCtx, hash, false)
-				require.NoError(err)
-				require.NotNil(resp)
-				assert.Equal(abci.CodeTypeOK, resp.TxResult.Code)
-				heights[resp.Height]++
-				// ensure that some gas was used
-				assert.GreaterOrEqual(resp.TxResult.GasUsed, int64(10))
-				// require.True(resp.Proof.VerifyProof())
-			}
+// 			heights := make(map[int64]int)
+// 			for _, hash := range hashes {
+// 				// TODO: reenable fetching and verifying proofs
+// 				resp, err := queryTx(val.ClientCtx, hash, false)
+// 				require.NoError(err)
+// 				require.NotNil(resp)
+// 				assert.Equal(abci.CodeTypeOK, resp.TxResult.Code)
+// 				heights[resp.Height]++
+// 				// ensure that some gas was used
+// 				assert.GreaterOrEqual(resp.TxResult.GasUsed, int64(10))
+// 				// require.True(resp.Proof.VerifyProof())
+// 			}
 
-			require.Greater(len(heights), 0)
+// 			require.Greater(len(heights), 0)
 
-			sizes := []uint64{}
-			// check the square size
-			for height := range heights {
-				node, err := val.ClientCtx.GetNode()
-				require.NoError(err)
-				blockRes, err := node.Block(context.Background(), &height)
-				require.NoError(err)
-				size := blockRes.Block.Data.SquareSize
+// 			sizes := []uint64{}
+// 			// check the square size
+// 			for height := range heights {
+// 				node, err := val.ClientCtx.GetNode()
+// 				require.NoError(err)
+// 				blockRes, err := node.Block(context.Background(), &height)
+// 				require.NoError(err)
+// 				size := blockRes.Block.Data.SquareSize
 
-				// perform basic checks on the size of the square
-				assert.LessOrEqual(size, uint64(appconsts.DefaultMaxSquareSize))
-				assert.GreaterOrEqual(size, uint64(appconsts.DefaultMinSquareSize))
-				sizes = append(sizes, size)
-			}
-			// ensure that at least one of the blocks used the max square size
-			assert.Contains(sizes, uint64(appconsts.DefaultMaxSquareSize))
-		})
-		require.NoError(s.network.WaitForNextBlock())
-	}
-}
+// 				// perform basic checks on the size of the square
+// 				assert.LessOrEqual(size, uint64(appconsts.DefaultMaxSquareSize))
+// 				assert.GreaterOrEqual(size, uint64(appconsts.DefaultMinSquareSize))
+// 				sizes = append(sizes, size)
+// 			}
+// 			// ensure that at least one of the blocks used the max square size
+// 			assert.Contains(sizes, uint64(appconsts.DefaultMaxSquareSize))
+// 		})
+// 		require.NoError(s.network.WaitForNextBlock())
+// 	}
+// }
 
-func (s *IntegrationTestSuite) TestSubmitWirePayForBlob() {
+func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 	require := s.Require()
 	assert := s.Assert()
 	val := s.network.Validators[0]
@@ -249,7 +250,7 @@ func (s *IntegrationTestSuite) TestSubmitWirePayForBlob() {
 	}
 }
 
-func (s *IntegrationTestSuite) TestUnmalleatedPFBRejection() {
+func (s *IntegrationTestSuite) TestUnwrappedPFBRejection() {
 	t := s.T()
 	val := s.network.Validators[0]
 

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/celestiaorg/celestia-app/testutil/blobfactory"
 	"github.com/celestiaorg/celestia-app/testutil/network"
 	"github.com/celestiaorg/celestia-app/x/blob"
-	"github.com/celestiaorg/celestia-app/x/blob/types"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -197,7 +196,7 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 		name string
 		ns   []byte
 		blob []byte
-		opts []types.TxBuilderOption
+		opts []blobtypes.TxBuilderOption
 	}
 
 	tests := []test{
@@ -205,32 +204,32 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 			"small random typical",
 			[]byte{1, 2, 3, 4, 5, 6, 7, 8},
 			tmrand.Bytes(3000),
-			[]types.TxBuilderOption{
-				types.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1)))),
+			[]blobtypes.TxBuilderOption{
+				blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1)))),
 			},
 		},
 		{
 			"large random typical",
 			[]byte{2, 3, 4, 5, 6, 7, 8, 9},
 			tmrand.Bytes(700000),
-			[]types.TxBuilderOption{
-				types.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(10)))),
+			[]blobtypes.TxBuilderOption{
+				blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(10)))),
 			},
 		},
 		{
 			"medium random with memo",
 			[]byte{2, 3, 4, 5, 6, 7, 8, 9},
 			tmrand.Bytes(100000),
-			[]types.TxBuilderOption{
-				types.SetMemo("lol I could stick the rollup block here if I wanted to"),
+			[]blobtypes.TxBuilderOption{
+				blobtypes.SetMemo("lol I could stick the rollup block here if I wanted to"),
 			},
 		},
 		{
 			"medium random with timeout height",
 			[]byte{2, 3, 4, 5, 6, 7, 8, 9},
 			tmrand.Bytes(100000),
-			[]types.TxBuilderOption{
-				types.SetTimeoutHeight(1000),
+			[]blobtypes.TxBuilderOption{
+				blobtypes.SetTimeoutHeight(1000),
 			},
 		},
 	}
@@ -241,7 +240,7 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 			for i := 0; i < 3; i++ {
 				require.NoError(s.network.WaitForNextBlock())
 			}
-			signer := types.NewKeyringSigner(s.kr, s.accounts[0], val.ClientCtx.ChainID)
+			signer := blobtypes.NewKeyringSigner(s.kr, s.accounts[0], val.ClientCtx.ChainID)
 			res, err := blob.SubmitPayForBlob(context.TODO(), signer, val.ClientCtx.GRPCClient, tc.ns, tc.blob, appconsts.ShareVersionZero, 1000000000, tc.opts...)
 			require.NoError(err)
 			require.NotNil(res)

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/testutil"
 	"github.com/celestiaorg/celestia-app/testutil/blobfactory"
-	"github.com/celestiaorg/celestia-app/x/blob/types"
+	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -38,7 +38,7 @@ func TestCheckTx(t *testing.T) {
 			getTx: func() []byte {
 				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(
 					encCfg.TxConfig.TxEncoder(),
-					types.NewKeyringSigner(kr, accs[0], testutil.ChainID),
+					blobtypes.NewKeyringSigner(kr, accs[0], testutil.ChainID),
 					[][]byte{
 						{1, 1, 1, 1, 1, 1, 1, 1},
 					},
@@ -54,7 +54,7 @@ func TestCheckTx(t *testing.T) {
 			getTx: func() []byte {
 				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(
 					encCfg.TxConfig.TxEncoder(),
-					types.NewKeyringSigner(kr, accs[1], testutil.ChainID),
+					blobtypes.NewKeyringSigner(kr, accs[1], testutil.ChainID),
 					[][]byte{
 						{1, 1, 1, 1, 1, 1, 1, 1},
 					},
@@ -70,7 +70,7 @@ func TestCheckTx(t *testing.T) {
 			getTx: func() []byte {
 				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(
 					encCfg.TxConfig.TxEncoder(),
-					types.NewKeyringSigner(kr, accs[2], testutil.ChainID),
+					blobtypes.NewKeyringSigner(kr, accs[2], testutil.ChainID),
 					[][]byte{
 						{1, 1, 1, 1, 1, 1, 1, 1},
 					},
@@ -83,7 +83,24 @@ func TestCheckTx(t *testing.T) {
 				require.NoError(t, err)
 				return bbtx
 			},
-			expectedABCICode: types.ErrNamespaceMismatch.ABCICode(),
+			expectedABCICode: blobtypes.ErrNamespaceMismatch.ABCICode(),
+		},
+		{
+			name:      "normal transaction, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(
+					encCfg.TxConfig.TxEncoder(),
+					blobtypes.NewKeyringSigner(kr, accs[3], testutil.ChainID),
+					[][]byte{
+						{1, 1, 1, 1, 1, 1, 1, 1},
+					},
+					[]int{100},
+				)[0]
+				dtx, _ := coretypes.UnmarshalBlobTx(btx)
+				return dtx.Tx
+			},
+			expectedABCICode: blobtypes.ErrBloblessPFB.ABCICode(),
 		},
 	}
 

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -86,7 +86,7 @@ func TestCheckTx(t *testing.T) {
 			expectedABCICode: blobtypes.ErrNamespaceMismatch.ABCICode(),
 		},
 		{
-			name:      "normal transaction, CheckTxType_New",
+			name:      "PFB with no blob, CheckTxType_New",
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
 				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(

--- a/testutil/blobfactory/payforblob_factory.go
+++ b/testutil/blobfactory/payforblob_factory.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/testutil/namespace"
 	"github.com/celestiaorg/celestia-app/testutil/testfactory"
-	"github.com/celestiaorg/celestia-app/x/blob/types"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -271,15 +270,15 @@ func RandBlobTxsWithNamespacesAndSigner(
 }
 
 func ComplexBlobTxWithOtherMsgs(t *testing.T, kr keyring.Keyring, enc sdk.TxEncoder, chainid, account string, msgs ...sdk.Msg) coretypes.Tx {
-	signer := types.NewKeyringSigner(kr, account, chainid)
+	signer := blobtypes.NewKeyringSigner(kr, account, chainid)
 	signerAddr, err := signer.GetSignerInfo().GetAddress()
 	require.NoError(t, err)
 
 	pfb, rawBlob := RandMsgPayForBlobWithSigner(signerAddr.String(), 100)
 
-	opts := []types.TxBuilderOption{
-		types.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(bondDenom, sdk.NewInt(10)))),
-		types.SetGasLimit(100000000000000),
+	opts := []blobtypes.TxBuilderOption{
+		blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(bondDenom, sdk.NewInt(10)))),
+		blobtypes.SetGasLimit(100000000000000),
 	}
 
 	msgs = append(msgs, pfb)
@@ -289,7 +288,7 @@ func ComplexBlobTxWithOtherMsgs(t *testing.T, kr keyring.Keyring, enc sdk.TxEnco
 	rawTx, err := enc(sdkTx)
 	require.NoError(t, err)
 
-	blob, err := types.NewBlob(pfb.NamespaceId, rawBlob)
+	blob, err := blobtypes.NewBlob(pfb.NamespaceId, rawBlob)
 	require.NoError(t, err)
 
 	btx, err := coretypes.MarshalBlobTx(rawTx, blob)

--- a/testutil/blobfactory/test_util.go
+++ b/testutil/blobfactory/test_util.go
@@ -2,7 +2,6 @@ package blobfactory
 
 import (
 	"github.com/celestiaorg/celestia-app/testutil/testfactory"
-	"github.com/celestiaorg/celestia-app/x/blob/types"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -31,15 +30,15 @@ func GenerateManyRawSendTxs(txConfig client.TxConfig, count int) []coretypes.Tx 
 // proposal, they are not meant to actually be executed by the state machine. If
 // we want that, we have to update nonce, and send funds to someone other than
 // the same account signing the transaction.
-func generateRawSendTx(txConfig client.TxConfig, signer *types.KeyringSigner, amount int64) (rawTx []byte) {
+func generateRawSendTx(txConfig client.TxConfig, signer *blobtypes.KeyringSigner, amount int64) (rawTx []byte) {
 	feeCoin := sdk.Coin{
 		Denom:  bondDenom,
 		Amount: sdk.NewInt(1),
 	}
 
-	opts := []types.TxBuilderOption{
-		types.SetFeeAmount(sdk.NewCoins(feeCoin)),
-		types.SetGasLimit(1000000000),
+	opts := []blobtypes.TxBuilderOption{
+		blobtypes.SetFeeAmount(sdk.NewCoins(feeCoin)),
+		blobtypes.SetGasLimit(1000000000),
 	}
 
 	amountCoin := sdk.Coin{
@@ -57,7 +56,7 @@ func generateRawSendTx(txConfig client.TxConfig, signer *types.KeyringSigner, am
 	return genrateRawTx(txConfig, msg, signer, opts...)
 }
 
-func genrateRawTx(txConfig client.TxConfig, msg sdk.Msg, signer *types.KeyringSigner, opts ...types.TxBuilderOption) []byte {
+func genrateRawTx(txConfig client.TxConfig, msg sdk.Msg, signer *blobtypes.KeyringSigner, opts ...blobtypes.TxBuilderOption) []byte {
 	builder := signer.NewTxBuilder(opts...)
 	tx, err := signer.BuildSignedTx(builder, msg)
 	if err != nil {

--- a/x/blob/client/cli/wirepayfordata.go
+++ b/x/blob/client/cli/wirepayfordata.go
@@ -1,16 +1,22 @@
 package cli
 
 import (
+	"bufio"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	"github.com/cosmos/cosmos-sdk/client/tx"
+	"github.com/cosmos/cosmos-sdk/client/input"
+	sdktx "github.com/cosmos/cosmos-sdk/client/tx"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	coretypes "github.com/tendermint/tendermint/types"
 )
 
 func CmdWirePayForBlob() *cobra.Command {
@@ -37,14 +43,19 @@ func CmdWirePayForBlob() *cobra.Command {
 			}
 
 			// decode the blob
-			blob, err := hex.DecodeString(args[1])
+			rawblob, err := hex.DecodeString(args[1])
 			if err != nil {
 				return fmt.Errorf("failure to decode hex blob: %w", err)
 			}
 
+			blob, err := types.NewBlob(namespace, rawblob)
+			if err != nil {
+				return err
+			}
+
 			// TODO: allow the user to override the share version via a new flag
 			// See https://github.com/celestiaorg/celestia-app/issues/1041
-			pfbMsg, err := types.NewMsgPayForBlob(clientCtx.FromAddress.String(), namespace, blob)
+			pfbMsg, err := types.NewMsgPayForBlob(clientCtx.FromAddress.String(), namespace, blob.Data)
 			if err != nil {
 				return err
 			}
@@ -54,11 +65,86 @@ func CmdWirePayForBlob() *cobra.Command {
 				return err
 			}
 
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), pfbMsg)
+			txBytes, err := writeTx(clientCtx, sdktx.NewFactoryCLI(clientCtx, cmd.Flags()), pfbMsg)
+
+			blobTx, err := coretypes.MarshalBlobTx(txBytes, blob)
+			if err != nil {
+				return err
+			}
+
+			// broadcast to a Tendermint node
+			res, err := clientCtx.BroadcastTx(blobTx)
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
 		},
 	}
 
 	flags.AddTxFlagsToCmd(cmd)
 
 	return cmd
+}
+
+// writeTx attempts to generate and sign a transaction using the normal
+// cosmos-sdk cli argument parsing code with the given set of messages. It will also simulate gas
+// requirements if necessary. It will return an error upon failure.
+//
+// NOTE: Copy paste forked from the cosmos-sdk so that we can wrap the PFB with
+// a blob while still using all of the normal cli parsing code
+func writeTx(clientCtx client.Context, txf sdktx.Factory, msgs ...sdk.Msg) ([]byte, error) {
+	if clientCtx.GenerateOnly {
+		return nil, txf.PrintUnsignedTx(clientCtx, msgs...)
+	}
+
+	txf, err := txf.Prepare(clientCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	if txf.SimulateAndExecute() || clientCtx.Simulate {
+		_, adjusted, err := sdktx.CalculateGas(clientCtx, txf, msgs...)
+		if err != nil {
+			return nil, err
+		}
+
+		txf = txf.WithGas(adjusted)
+		_, _ = fmt.Fprintf(os.Stderr, "%s\n", sdktx.GasEstimateResponse{GasEstimate: txf.Gas()})
+	}
+
+	if clientCtx.Simulate {
+		return nil, nil
+	}
+
+	tx, err := txf.BuildUnsignedTx(msgs...)
+	if err != nil {
+		return nil, err
+	}
+
+	if !clientCtx.SkipConfirm {
+		txBytes, err := clientCtx.TxConfig.TxJSONEncoder()(tx.GetTx())
+		if err != nil {
+			return nil, err
+		}
+
+		if err := clientCtx.PrintRaw(json.RawMessage(txBytes)); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", txBytes)
+		}
+
+		buf := bufio.NewReader(os.Stdin)
+		ok, err := input.GetConfirmation("confirm transaction before signing and broadcasting", buf, os.Stderr)
+
+		if err != nil || !ok {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", "cancelled transaction")
+			return nil, err
+		}
+	}
+
+	err = sdktx.Sign(txf, clientCtx.GetFromName(), tx, true)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientCtx.TxConfig.TxEncoder()(tx.GetTx())
 }

--- a/x/blob/client/cli/wirepayfordata.go
+++ b/x/blob/client/cli/wirepayfordata.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 
@@ -28,12 +27,6 @@ func CmdWirePayForBlob() *cobra.Command {
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err
-			}
-
-			// get the account name
-			accName := clientCtx.GetFromName()
-			if accName == "" {
-				return errors.New("no account name provided, please use the --from flag")
 			}
 
 			// decode the namespace
@@ -66,6 +59,9 @@ func CmdWirePayForBlob() *cobra.Command {
 			}
 
 			txBytes, err := writeTx(clientCtx, sdktx.NewFactoryCLI(clientCtx, cmd.Flags()), pfbMsg)
+			if err != nil {
+				return err
+			}
 
 			blobTx, err := coretypes.MarshalBlobTx(txBytes, blob)
 			if err != nil {

--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -18,8 +18,9 @@ import (
 	"github.com/celestiaorg/celestia-app/x/blob/types"
 
 	"github.com/celestiaorg/celestia-app/testutil/network"
+	"github.com/celestiaorg/celestia-app/testutil/testfactory"
 	paycli "github.com/celestiaorg/celestia-app/x/blob/client/cli"
-	authcmd "github.com/cosmos/cosmos-sdk/x/auth/client/cli"
+	abci "github.com/tendermint/tendermint/abci/types"
 )
 
 // username is used to create a funded genesis account under this name
@@ -123,12 +124,9 @@ func (s *IntegrationTestSuite) TestSubmitWirePayForBlob() {
 			s.Require().NoError(s.network.WaitForNextBlock())
 
 			// attempt to query for the malleated transaction using the original tx's hash
-			qTxCmd := authcmd.QueryTxCmd()
-			out, err = clitestutil.ExecTestCLICmd(clientCtx, qTxCmd, []string{txResp.TxHash, "--output=json"})
+			res, err := testfactory.QueryWithoutProof(clientCtx, txResp.TxHash)
 			require.NoError(err)
-
-			var result sdk.TxResponse
-			s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &result))
+			require.Equal(abci.CodeTypeOK, res.TxResult.Code)
 		})
 	}
 }

--- a/x/blob/types/errors.go
+++ b/x/blob/types/errors.go
@@ -27,4 +27,5 @@ var (
 	ErrNamespaceMismatch              = sdkerrors.Register(ModuleName, 11127, "namespace of blob and its respective MsgPayForBlob differ")
 	ErrProtoParsing                   = sdkerrors.Register(ModuleName, 11128, "failure to parse a transaction from its protobuf representation")
 	ErrMultipleMsgsInBlobTx           = sdkerrors.Register(ModuleName, 11129, "not yet supported: multiple sdk.Msgs found in BlobTx")
+	ErrBloblessPFB                    = sdkerrors.Register(ModuleName, 11130, "MsgPayForBlob transactions must be paird with a blob")
 )


### PR DESCRIPTION
## Overview

fixes two bugs, one where we were creating PFD transactions without actually wrapping them with a blob :face_with_spiral_eyes:, and then another bug where we should have been checking for that during checkTx. 

closes #1165 
blocking, and related to #1168 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
