### PR TITLE
chore: un-export namespaced padded share bytes

### DIFF
--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -1,8 +1,6 @@
 package appconsts
 
 import (
-	"bytes"
-
 	"github.com/celestiaorg/nmt"
 	"github.com/celestiaorg/nmt/namespace"
 	"github.com/celestiaorg/rsmt2d"
@@ -104,12 +102,6 @@ var (
 
 	// DataCommitmentBlocksLimit is the limit to the number of blocks we can generate a data commitment for.
 	DataCommitmentBlocksLimit = consts.DataCommitmentBlocksLimit
-
-	// NameSpacedPaddedShareBytes are the raw bytes that are used in the contents
-	// of a NameSpacedPaddedShare. A NameSpacedPaddedShare follows a blob so
-	// that the next blob starts at an index that conforms to non-interactive
-	// defaults.
-	NameSpacedPaddedShareBytes = bytes.Repeat([]byte{0}, FirstSparseShareContentSize)
 
 	// SupportedShareVersions is a list of supported share versions.
 	SupportedShareVersions = []uint8{ShareVersionZero}

--- a/pkg/shares/split_sparse_shares.go
+++ b/pkg/shares/split_sparse_shares.go
@@ -1,6 +1,7 @@
 package shares
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
 
@@ -157,6 +158,12 @@ func namespacedPaddedShares(ns namespace.ID, count int) []Share {
 	return shares
 }
 
+// namespacedPaddedShareBytes are the raw bytes that are used in the contents
+// of a namespacedPaddedShare. A namespacedPaddedShare follows a blob so
+// that the next blob starts at an index that conforms to non-interactive
+// defaults.
+var namespacedPaddedShareBytes = bytes.Repeat([]byte{0}, appconsts.FirstSparseShareContentSize)
+
 func namespacedPaddedShare(ns namespace.ID) Share {
 	infoByte, err := NewInfoByte(appconsts.ShareVersionZero, true)
 	if err != nil {
@@ -170,6 +177,6 @@ func namespacedPaddedShare(ns namespace.ID) Share {
 	share = append(share, ns...)
 	share = append(share, byte(infoByte))
 	share = append(share, sequenceLen...)
-	share = append(share, appconsts.NameSpacedPaddedShareBytes...)
+	share = append(share, namespacedPaddedShareBytes...)
 	return share
 }


### PR DESCRIPTION
This constant is an implementation detail and shouldn't be exported from celestia-app