### PR TITLE
chore: make `test-short`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ test:
 test-short:
 	@echo "--> Running unit tests in short mode"
 	@go test -mod=readonly ./... -short
-.PHONY: test
+.PHONY: test-short
 
 test-all: test-race test-cover
 

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,11 @@ test:
 	@go test -mod=readonly ./...
 .PHONY: test
 
+test-short:
+	@echo "--> Running unit tests in short mode"
+	@go test -mod=readonly ./... -short
+.PHONY: test
+
 test-all: test-race test-cover
 
 test-race:

--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -52,11 +52,10 @@ func NewIntegrationTestSuite(cfg cosmosnet.Config) *IntegrationTestSuite {
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
-	s.T().Log("setting up integration test suite")
-
 	if testing.Short() {
-		s.T().Skip("skipping test in unit-tests mode.")
+		s.T().Skip("skipping block size integration test in short mode.")
 	}
+	s.T().Log("setting up integration test suite")
 
 	numAccounts := 100
 	s.accounts = make([]string, numAccounts)

--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -21,6 +21,9 @@ import (
 // fuzzing limited types, instead we create blocks our selves using random
 // transction.
 func TestPrepareProposalConsistency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping TestPrepareProposalConsistency in short mode.")
+	}
 	encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	testApp, _ := testutil.SetupTestAppWithGenesisValSet()
 	timer := time.After(time.Minute * 1)

--- a/testutil/testnode/full_node_test.go
+++ b/testutil/testnode/full_node_test.go
@@ -26,7 +26,7 @@ type IntegrationTestSuite struct {
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	if testing.Short() {
-		s.T().Skip("skipping test in unit-tests or race-detector mode.")
+		s.T().Skip("skipping full node integration test in short mode.")
 	}
 
 	s.T().Log("setting up integration test suite")

--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -39,6 +39,9 @@ func NewIntegrationTestSuite(cfg cosmosnet.Config) *IntegrationTestSuite {
 }
 
 func (s *IntegrationTestSuite) SetupSuite() {
+	if testing.Short() {
+		s.T().Skip("skipping integration test in short mode.")
+	}
 	s.T().Log("setting up integration test suite")
 
 	net := network.New(s.T(), s.cfg, username)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1025

Add the Makefile command `test-short` which runs unit tests in `-short` mode. On my machine, `make test-short` completes in ~15 seconds
