### PR TITLE
.github: fix permissions issue on pr review request on forks

### DIFF
--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -1,7 +1,12 @@
 name: Housekeeping
 
 on:
-  pull_request:
+  # pull_request_target is used to allow forks write permissions when running
+  # this workflow. With the pull_request trigger, forks do not have any write
+  # access for security reasons, however write access is needed in order to
+  # request reviews. Since this workflow is simply requesting reviewers, it is
+  # safe to allow forks write access. 
+  pull_request_target:
 
 jobs:
   pr-assignment:

--- a/.github/workflows/housekeeping.yml
+++ b/.github/workflows/housekeeping.yml
@@ -5,7 +5,7 @@ on:
   # this workflow. With the pull_request trigger, forks do not have any write
   # access for security reasons, however write access is needed in order to
   # request reviews. Since this workflow is simply requesting reviewers, it is
-  # safe to allow forks write access. 
+  # safe to allow forks write access.
   pull_request_target:
 
 jobs:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
The housingkeeping workflow was failing due to forks not having write access during workflow runs. This is for security reasons. However there are many non-security critical tasks that require write access, such as requesting reviewers or making comments on a PR. For these, the `pull_request_target` trigger can be used, as it allows write access to forks for the select workflows. 

I tested this on a personal github org and it worked for both native branches and forks. 

**NOTE**:  the reason the workflow is not running on this PR is because of the chicken and egg issue of updating workflows, in that the update needs to be on main in order for it to run. 

Closes https://github.com/celestiaorg/.github/issues/19

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
