### PR TITLE
feat!: use MultiShareCommitments instead of a single ShareCommitment

### DIFF
--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -107,7 +107,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 				}
 			}
 
-			commitment, err := inclusion.GetCommit(cacher, dah, int(wrappedTx.ShareIndex), shares.SparseSharesNeeded(pfb.BlobSize))
+			commitment, err := inclusion.GetMultiCommit(cacher, dah, []uint32{wrappedTx.ShareIndex}, []uint32{pfb.BlobSize})
 			if err != nil {
 				logInvalidPropBlockError(app.Logger(), req.Header, "commitment not found", err)
 				return abci.ResponseProcessProposal{

--- a/pkg/inclusion/get_commit.go
+++ b/pkg/inclusion/get_commit.go
@@ -4,8 +4,25 @@ import (
 	"errors"
 
 	"github.com/celestiaorg/celestia-app/pkg/da"
+	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/tendermint/tendermint/crypto/merkle"
 )
+
+func GetMultiCommit(cacher *EDSSubTreeRootCacher, dah da.DataAvailabilityHeader, startIndexes, lengths []uint32) ([]byte, error) {
+	shareCounts := make([]int, len(lengths))
+	for i := range lengths {
+		shareCounts[i] = shares.SparseSharesNeeded(uint32(lengths[i]))
+	}
+	commitments := make([][]byte, len(startIndexes))
+	for i := range startIndexes {
+		commitment, err := GetCommit(cacher, dah, int(startIndexes[i]), shareCounts[i])
+		if err != nil {
+			return nil, err
+		}
+		commitments[i] = commitment
+	}
+	return merkle.HashFromByteSlices(commitments), nil
+}
 
 func GetCommit(cacher *EDSSubTreeRootCacher, dah da.DataAvailabilityHeader, start, blobShareLen int) ([]byte, error) {
 	squareSize := len(dah.RowsRoots) / 2

--- a/x/blob/types/blob_tx.go
+++ b/x/blob/types/blob_tx.go
@@ -96,7 +96,11 @@ func ProcessBlobTx(txcfg client.TxEncodingConfig, bTx tmproto.BlobTx) (Processed
 		}
 
 		// verify that the commitment of the blob matches that of the PFB
-		calculatedCommit, err := CreateCommitment(pfb.NamespaceId, blob, appconsts.ShareVersionZero)
+		calculatedCommit, err := CreateMultiShareCommitment(
+			[][]byte{pfb.NamespaceId},
+			[][]byte{blob},
+			[]uint32{uint32(appconsts.ShareVersionZero)},
+		)
 		if err != nil {
 			return ProcessedBlobTx{}, ErrCalculateCommit
 		}


### PR DESCRIPTION
## Overview

part of #388, and split apart from #1154

this PR uses a new mechanism to generate the share commit that can create a commitment over multiple blobs. We don't yet support multiple blobs per PFB, so this is currently effectively hashing the normal share commitment.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
