### PR TITLE
chore!: refactor NewMsgPayForBlob to accept blobs

### DIFF
--- a/app/test/block_size_test.go
+++ b/app/test/block_size_test.go
@@ -191,42 +191,43 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 	assert := s.Assert()
 	val := s.network.Validators[0]
 
+	mustNewBlob := func(ns, data []byte) *blobtypes.Blob {
+		b, err := blobtypes.NewBlob(ns, data)
+		require.NoError(err)
+		return b
+	}
+
 	type test struct {
 		name string
-		ns   []byte
-		blob []byte
+		blob *blobtypes.Blob
 		opts []blobtypes.TxBuilderOption
 	}
 
 	tests := []test{
 		{
 			"small random typical",
-			[]byte{1, 2, 3, 4, 5, 6, 7, 8},
-			tmrand.Bytes(3000),
+			mustNewBlob([]byte{1, 2, 3, 4, 5, 6, 7, 8}, tmrand.Bytes(3000)),
 			[]blobtypes.TxBuilderOption{
 				blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1)))),
 			},
 		},
 		{
 			"large random typical",
-			[]byte{2, 3, 4, 5, 6, 7, 8, 9},
-			tmrand.Bytes(700000),
+			mustNewBlob([]byte{2, 3, 4, 5, 6, 7, 8, 9}, tmrand.Bytes(700000)),
 			[]blobtypes.TxBuilderOption{
 				blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(10)))),
 			},
 		},
 		{
 			"medium random with memo",
-			[]byte{2, 3, 4, 5, 6, 7, 8, 9},
-			tmrand.Bytes(100000),
+			mustNewBlob([]byte{2, 3, 4, 5, 6, 7, 8, 9}, tmrand.Bytes(100000)),
 			[]blobtypes.TxBuilderOption{
 				blobtypes.SetMemo("lol I could stick the rollup block here if I wanted to"),
 			},
 		},
 		{
 			"medium random with timeout height",
-			[]byte{2, 3, 4, 5, 6, 7, 8, 9},
-			tmrand.Bytes(100000),
+			mustNewBlob([]byte{2, 3, 4, 5, 6, 7, 8, 9}, tmrand.Bytes(100000)),
 			[]blobtypes.TxBuilderOption{
 				blobtypes.SetTimeoutHeight(1000),
 			},
@@ -240,7 +241,7 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 				require.NoError(s.network.WaitForNextBlock())
 			}
 			signer := blobtypes.NewKeyringSigner(s.kr, s.accounts[0], val.ClientCtx.ChainID)
-			res, err := blob.SubmitPayForBlob(context.TODO(), signer, val.ClientCtx.GRPCClient, tc.ns, tc.blob, appconsts.ShareVersionZero, 1000000000, tc.opts...)
+			res, err := blob.SubmitPayForBlob(context.TODO(), signer, val.ClientCtx.GRPCClient, tc.blob, 1000000000, tc.opts...)
 			require.NoError(err)
 			require.NotNil(res)
 			assert.Equal(abci.CodeTypeOK, res.Code)

--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -27,6 +27,10 @@ const (
 	// ShareVersionZero is the first share version format.
 	ShareVersionZero = uint8(0)
 
+	// DefaultShareVersion is the defacto share version. Use this if you are
+	// unsure of which version to use.
+	DefaultShareVersion = ShareVersionZero
+
 	// CompactShareReservedBytes is the number of bytes reserved for the location of
 	// the first unit (transaction, ISR) in a compact share.
 	CompactShareReservedBytes = 4

--- a/testutil/blobfactory/payforblob_factory.go
+++ b/testutil/blobfactory/payforblob_factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/testutil/namespace"
 	"github.com/celestiaorg/celestia-app/testutil/testfactory"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/rand"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 	"google.golang.org/grpc"
 )
@@ -22,8 +24,11 @@ func RandMsgPayForBlobWithSigner(singer string, size int) (*blobtypes.MsgPayForB
 	blob := tmrand.Bytes(size)
 	msg, err := blobtypes.NewMsgPayForBlob(
 		singer,
-		namespace.RandomBlobNamespace(),
-		blob,
+		&tmproto.Blob{
+			NamespaceId:  namespace.RandomBlobNamespace(),
+			Data:         blob,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -35,8 +40,11 @@ func RandMsgPayForBlobWithNamespaceAndSigner(signer string, nid []byte, size int
 	blob := tmrand.Bytes(size)
 	msg, err := blobtypes.NewMsgPayForBlob(
 		signer,
-		nid,
-		blob,
+		&tmproto.Blob{
+			NamespaceId:  nid,
+			Data:         blob,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -48,8 +56,11 @@ func RandMsgPayForBlob(size int) (*blobtypes.MsgPayForBlob, []byte) {
 	blob := tmrand.Bytes(size)
 	msg, err := blobtypes.NewMsgPayForBlob(
 		defaultSigner,
-		namespace.RandomBlobNamespace(),
-		blob,
+		&tmproto.Blob{
+			NamespaceId:  namespace.RandomBlobNamespace(),
+			Data:         blob,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/testutil/testnode/node_interaction_api.go
+++ b/testutil/testnode/node_interaction_api.go
@@ -14,6 +14,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
@@ -113,8 +114,11 @@ func (c *Context) PostData(account, broadcastMode string, ns, blobData []byte) (
 
 	msg, err := types.NewMsgPayForBlob(
 		addr.String(),
-		ns,
-		blobData,
+		&tmproto.Blob{
+			NamespaceId:  ns,
+			Data:         blobData,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/x/blob/client/cli/wirepayfordata.go
+++ b/x/blob/client/cli/wirepayfordata.go
@@ -48,7 +48,7 @@ func CmdWirePayForBlob() *cobra.Command {
 
 			// TODO: allow the user to override the share version via a new flag
 			// See https://github.com/celestiaorg/celestia-app/issues/1041
-			pfbMsg, err := types.NewMsgPayForBlob(clientCtx.FromAddress.String(), namespace, blob.Data)
+			pfbMsg, err := types.NewMsgPayForBlob(clientCtx.FromAddress.String(), blob)
 			if err != nil {
 				return err
 			}

--- a/x/blob/payforblob.go
+++ b/x/blob/payforblob.go
@@ -8,8 +8,10 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdk_tx "github.com/cosmos/cosmos-sdk/types/tx"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/celestiaorg/nmt/namespace"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
@@ -32,8 +34,11 @@ func SubmitPayForBlob(
 	}
 	msg, err := types.NewMsgPayForBlob(
 		addr.String(),
-		nID,
-		blob,
+		&tmproto.Blob{
+			NamespaceId:  nID,
+			Data:         blob,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/x/blob/payforblob.go
+++ b/x/blob/payforblob.go
@@ -8,10 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdk_tx "github.com/cosmos/cosmos-sdk/types/tx"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/x/blob/types"
-	"github.com/celestiaorg/nmt/namespace"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
@@ -21,9 +18,7 @@ func SubmitPayForBlob(
 	ctx context.Context,
 	signer *types.KeyringSigner,
 	conn *grpc.ClientConn,
-	nID namespace.ID,
-	blob []byte,
-	shareVersion uint8,
+	blob *types.Blob,
 	gasLim uint64,
 	opts ...types.TxBuilderOption,
 ) (*sdk.TxResponse, error) {
@@ -34,11 +29,7 @@ func SubmitPayForBlob(
 	}
 	msg, err := types.NewMsgPayForBlob(
 		addr.String(),
-		&tmproto.Blob{
-			NamespaceId:  nID,
-			Data:         blob,
-			ShareVersion: uint32(appconsts.ShareVersionZero),
-		},
+		blob,
 	)
 	if err != nil {
 		return nil, err
@@ -52,15 +43,11 @@ func SubmitPayForBlob(
 	if err != nil {
 		return nil, err
 	}
-	wblob, err := types.NewBlob(msg.NamespaceId, blob)
-	if err != nil {
-		return nil, err
-	}
 	rawTx, err := signer.EncodeTx(stx)
 	if err != nil {
 		return nil, err
 	}
-	blobTx, err := coretypes.MarshalBlobTx(rawTx, wblob)
+	blobTx, err := coretypes.MarshalBlobTx(rawTx, blob)
 	if err != nil {
 		return nil, err
 	}

--- a/x/blob/types/blob_tx.go
+++ b/x/blob/types/blob_tx.go
@@ -12,13 +12,16 @@ import (
 
 // ProcessedBlobTx caches the unmarshalled result of the BlobTx
 type ProcessedBlobTx struct {
-	Blobs []tmproto.Blob
+	Blobs []Blob
 	Tx    []byte
 }
 
+// Blob wraps the tendermint type so that users can simply import this one.
+type Blob = tmproto.Blob
+
 // NewBlob creates a new coretypes.Blob from the provided data after performing
 // basic stateless checks over it.
-func NewBlob(ns namespace.ID, blob []byte) (*tmproto.Blob, error) {
+func NewBlob(ns namespace.ID, blob []byte) (*Blob, error) {
 	err := ValidateBlobNamespaceID(ns)
 	if err != nil {
 		return nil, err
@@ -31,7 +34,7 @@ func NewBlob(ns namespace.ID, blob []byte) (*tmproto.Blob, error) {
 	return &tmproto.Blob{
 		NamespaceId:  ns,
 		Data:         blob,
-		ShareVersion: uint32(appconsts.ShareVersionZero),
+		ShareVersion: uint32(appconsts.DefaultShareVersion),
 	}, nil
 }
 

--- a/x/blob/types/blob_tx.go
+++ b/x/blob/types/blob_tx.go
@@ -84,11 +84,7 @@ func ProcessBlobTx(txcfg client.TxEncodingConfig, bTx tmproto.BlobTx) (Processed
 	}
 
 	// verify that the commitment of the blob matches that of the PFB
-	calculatedCommit, err := CreateMultiShareCommitment(
-		[][]byte{pfb.NamespaceId},
-		[][]byte{blob.Data},
-		[]uint32{uint32(appconsts.ShareVersionZero)},
-	)
+	calculatedCommit, err := CreateMultiShareCommitment(blob)
 	if err != nil {
 		return ProcessedBlobTx{}, ErrCalculateCommit
 	}

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/testutil/namespace"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
@@ -109,8 +110,11 @@ func randMsgPayForBlobWithNamespaceAndSigner(signer string, nid []byte, size int
 	blob := tmrand.Bytes(size)
 	msg, err := NewMsgPayForBlob(
 		signer,
-		nid,
-		blob,
+		&tmproto.Blob{
+			NamespaceId:  nid,
+			Data:         blob,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
 	)
 	if err != nil {
 		panic(err)

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -11,7 +11,6 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
-	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 	"golang.org/x/exp/constraints"
 )
@@ -26,7 +25,7 @@ const (
 
 var _ sdk.Msg = &MsgPayForBlob{}
 
-func NewMsgPayForBlob(signer string, blob *tmproto.Blob) (*MsgPayForBlob, error) {
+func NewMsgPayForBlob(signer string, blob *Blob) (*MsgPayForBlob, error) {
 	commitment, err := CreateCommitment(blob.NamespaceId, blob.Data, appconsts.ShareVersionZero)
 	if err != nil {
 		return nil, err

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -26,7 +26,7 @@ const (
 var _ sdk.Msg = &MsgPayForBlob{}
 
 func NewMsgPayForBlob(signer string, blob *Blob) (*MsgPayForBlob, error) {
-	commitment, err := CreateMultiShareCommitment([][]byte{blob.NamespaceId}, [][]byte{blob.Data}, []uint32{blob.ShareVersion})
+	commitment, err := CreateMultiShareCommitment(blob)
 	if err != nil {
 		return nil, err
 	}
@@ -90,16 +90,16 @@ func (msg *MsgPayForBlob) GetSigners() []sdk.AccAddress {
 //
 // [Message layout rationale]: https://github.com/celestiaorg/celestia-specs/blob/e59efd63a2165866584833e91e1cb8a6ed8c8203/src/rationale/message_block_layout.md?plain=1#L12
 // [Non-interactive default rules]: https://github.com/celestiaorg/celestia-specs/blob/e59efd63a2165866584833e91e1cb8a6ed8c8203/src/rationale/message_block_layout.md?plain=1#L36
-func CreateCommitment(namespace []byte, blobData []byte, shareVersion uint8) ([]byte, error) {
-	blob := coretypes.Blob{
-		NamespaceID:  namespace,
-		Data:         blobData,
-		ShareVersion: shareVersion,
+func CreateCommitment(blob *Blob) ([]byte, error) {
+	coreblob := coretypes.Blob{
+		NamespaceID:  blob.NamespaceId,
+		Data:         blob.Data,
+		ShareVersion: uint8(blob.ShareVersion),
 	}
 
 	// split into shares that are length delimited and include the namespace in
 	// each share
-	shares, err := appshares.SplitBlobs(0, nil, []coretypes.Blob{blob}, false)
+	shares, err := appshares.SplitBlobs(0, nil, []coretypes.Blob{coreblob}, false)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +107,7 @@ func CreateCommitment(namespace []byte, blobData []byte, shareVersion uint8) ([]
 	// the commitment is the root of a merkle mountain range with max tree size
 	// equal to the minimum square size the blob can be included in. See
 	// https://github.com/celestiaorg/celestia-app/blob/fbfbf111bcaa056e53b0bc54d327587dee11a945/docs/architecture/adr-008-blocksize-independent-commitment.md
-	minSquareSize := BlobMinSquareSize(len(blobData))
+	minSquareSize := BlobMinSquareSize(len(blob.Data))
 	treeSizes := merkleMountainRangeSizes(uint64(len(shares)), uint64(minSquareSize))
 	leafSets := make([][][]byte, len(treeSizes))
 	cursor := uint64(0)
@@ -128,7 +128,7 @@ func CreateCommitment(namespace []byte, blobData []byte, shareVersion uint8) ([]
 			// the namespace in the share, and therefore the parity data, while
 			// also allowing for the manual addition of the parity namespace to
 			// the parity data.
-			nsLeaf := append(make([]byte, 0), append(namespace, leaf...)...)
+			nsLeaf := append(make([]byte, 0), append(blob.NamespaceId, leaf...)...)
 			err := tree.Push(nsLeaf)
 			if err != nil {
 				return nil, err
@@ -143,10 +143,10 @@ func CreateCommitment(namespace []byte, blobData []byte, shareVersion uint8) ([]
 // CreateMultiShareCommitment generates a commitment over multiple blobs at
 // arbitrary points in the square. It uses the normal commitment creation
 // function per blob, and then creates a merkle root of those commitments.
-func CreateMultiShareCommitment(nsids [][]byte, blobs [][]byte, shareVersions []uint32) ([]byte, error) {
-	commitments := make([][]byte, len(nsids))
-	for i := range nsids {
-		c, err := CreateCommitment(nsids[i], blobs[i], uint8(shareVersions[i]))
+func CreateMultiShareCommitment(blobs ...*Blob) ([]byte, error) {
+	commitments := make([][]byte, len(blobs))
+	for i, blob := range blobs {
+		c, err := CreateCommitment(blob)
 		if err != nil {
 			return nil, err
 		}

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -11,6 +11,7 @@ import (
 	"github.com/celestiaorg/nmt/namespace"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/tendermint/tendermint/crypto/merkle"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
 	"golang.org/x/exp/constraints"
 )
@@ -25,19 +26,19 @@ const (
 
 var _ sdk.Msg = &MsgPayForBlob{}
 
-func NewMsgPayForBlob(signer string, nid namespace.ID, blob []byte) (*MsgPayForBlob, error) {
-	commitment, err := CreateCommitment(nid, blob, appconsts.ShareVersionZero)
+func NewMsgPayForBlob(signer string, blob *tmproto.Blob) (*MsgPayForBlob, error) {
+	commitment, err := CreateCommitment(blob.NamespaceId, blob.Data, appconsts.ShareVersionZero)
 	if err != nil {
 		return nil, err
 	}
-	if len(blob) == 0 {
+	if len(blob.Data) == 0 {
 		return nil, ErrZeroBlobSize
 	}
 	msg := &MsgPayForBlob{
 		Signer:          signer,
-		NamespaceId:     nid,
+		NamespaceId:     blob.NamespaceId,
 		ShareCommitment: commitment,
-		BlobSize:        uint32(len(blob)),
+		BlobSize:        uint32(len(blob.Data)),
 	}
 	return msg, msg.ValidateBasic()
 }

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
 func Test_merkleMountainRangeHeights(t *testing.T) {
@@ -216,7 +217,14 @@ func validMsgPayForBlob(t *testing.T) *MsgPayForBlob {
 	addr, err := signer.GetSignerInfo().GetAddress()
 	require.NoError(t, err)
 
-	pfb, err := NewMsgPayForBlob(addr.String(), ns, blob)
+	pfb, err := NewMsgPayForBlob(
+		addr.String(),
+		&tmproto.Blob{
+			NamespaceId:  ns,
+			Data:         blob,
+			ShareVersion: uint32(appconsts.ShareVersionZero),
+		},
+	)
 	assert.NoError(t, err)
 
 	return pfb
@@ -269,7 +277,14 @@ func TestNewMsgPayForBlob(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		res, err := NewMsgPayForBlob(tt.signer, tt.nid, tt.blob)
+		res, err := NewMsgPayForBlob(
+			tt.signer,
+			&tmproto.Blob{
+				NamespaceId:  tt.nid,
+				Data:         tt.blob,
+				ShareVersion: uint32(appconsts.ShareVersionZero),
+			},
+		)
 		if tt.expectedErr {
 			assert.Error(t, err)
 			continue

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -283,9 +283,7 @@ func TestNewMsgPayForBlob(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		b, err := NewBlob(tt.nids[0], tt.blobs[0])
-		require.NoError(t, err)
-		res, err := NewMsgPayForBlob(tt.signer, b)
+		res, err := NewMsgPayForBlob(tt.signer, &Blob{NamespaceId: tt.nids[0], Data: tt.blobs[0], ShareVersion: uint32(appconsts.DefaultShareVersion)})
 		if tt.expectedErr {
 			assert.Error(t, err)
 			continue

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -98,7 +98,8 @@ func TestCreateCommitment(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, err := CreateCommitment(tt.namespace, tt.blob, tt.shareVersion)
+			blob := &Blob{NamespaceId: tt.namespace, Data: tt.blob, ShareVersion: uint32(tt.shareVersion)}
+			res, err := CreateCommitment(blob)
 			if tt.expectErr {
 				assert.Error(t, err)
 				return
@@ -283,13 +284,14 @@ func TestNewMsgPayForBlob(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		res, err := NewMsgPayForBlob(tt.signer, &Blob{NamespaceId: tt.nids[0], Data: tt.blobs[0], ShareVersion: uint32(appconsts.DefaultShareVersion)})
+		blob := &Blob{NamespaceId: tt.nids[0], Data: tt.blobs[0], ShareVersion: uint32(appconsts.DefaultShareVersion)}
+		res, err := NewMsgPayForBlob(tt.signer, blob)
 		if tt.expectedErr {
 			assert.Error(t, err)
 			continue
 		}
 
-		expectedCommitment, err := CreateMultiShareCommitment(tt.nids, tt.blobs, make([]uint32, len(tt.blobs)))
+		expectedCommitment, err := CreateMultiShareCommitment(blob)
 		require.NoError(t, err)
 		assert.Equal(t, expectedCommitment, res.ShareCommitment)
 

--- a/x/blob/types/test/blob_tx_test.go
+++ b/x/blob/types/test/blob_tx_test.go
@@ -94,8 +94,7 @@ func TestProcessBlobTx(t *testing.T) {
 				rawblob := rand.Bytes(100)
 				msg, err := types.NewMsgPayForBlob(
 					signerAddr.String(),
-					namespace.RandomBlobNamespace(),
-					rawblob,
+					&tmproto.Blob{NamespaceId: namespace.RandomBlobNamespace(), Data: rawblob, ShareVersion: 0},
 				)
 				require.NoError(t, err)
 

--- a/x/blob/types/test/blob_tx_test.go
+++ b/x/blob/types/test/blob_tx_test.go
@@ -99,10 +99,11 @@ func TestProcessBlobTx(t *testing.T) {
 				require.NoError(t, err)
 
 				badCommit, err := types.CreateCommitment(
-					namespace.RandomBlobNamespace(),
-					rand.Bytes(99),
-					appconsts.ShareVersionZero,
-				)
+					&types.Blob{
+						NamespaceId:  namespace.RandomBlobNamespace(),
+						Data:         rand.Bytes(99),
+						ShareVersion: uint32(appconsts.ShareVersionZero),
+					})
 				require.NoError(t, err)
 
 				msg.ShareCommitment = badCommit


### PR DESCRIPTION
## Overview

part of #388 and split off from #1154. This is just a minor refactor for `NewMsgPayForBlob` to accept a `tmproto.Blob`, instead of the individual components.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
