### PR TITLE
fix: fix data commitment ranges overlap

### DIFF
--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -179,3 +179,49 @@ func TestDataCommitmentCreation(t *testing.T) {
 	require.Less(t, newHeight, ctx.BlockHeight())
 	assert.Equal(t, uint64(2), qk.GetLatestAttestationNonce(ctx))
 }
+
+func TestDataCommitmentRange(t *testing.T) {
+	input, ctx := testutil.SetupFiveValChain(t)
+	qk := input.QgbKeeper
+
+	// run abci methods after chain init
+	staking.EndBlocker(input.Context, input.StakingKeeper)
+	qgb.EndBlocker(ctx, *qk)
+
+	// current attestation nonce should be 1 because a valset has been emitted upon chain init.
+	currentAttestationNonce := qk.GetLatestAttestationNonce(ctx)
+	require.Equal(t, uint64(1), currentAttestationNonce)
+
+	// increment height to be the same as the data commitment window
+	newHeight := int64(qk.GetDataCommitmentWindowParam(ctx))
+	input.Context = ctx.WithBlockHeight(newHeight)
+	qgb.EndBlocker(input.Context, *qk)
+
+	require.Less(t, newHeight, ctx.BlockHeight())
+	assert.Equal(t, uint64(2), qk.GetLatestAttestationNonce(ctx))
+
+	att1, found, err := qk.GetAttestationByNonce(input.Context, 2)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	assert.Equal(t, types.DataCommitmentRequestType, att1.Type())
+	dc1, ok := att1.(*types.DataCommitment)
+	require.True(t, ok)
+	assert.Equal(t, newHeight-1, int64(dc1.EndBlock))
+	assert.Equal(t, int64(0), int64(dc1.BeginBlock))
+
+	// increment height to 2*data commitment window
+	newHeight = int64(qk.GetDataCommitmentWindowParam(ctx)) * 2
+	input.Context = ctx.WithBlockHeight(newHeight)
+	qgb.EndBlocker(input.Context, *qk)
+
+	att2, found, err := qk.GetAttestationByNonce(input.Context, 3)
+	require.NoError(t, err)
+	require.True(t, found)
+
+	assert.Equal(t, types.DataCommitmentRequestType, att2.Type())
+	dc2, ok := att2.(*types.DataCommitment)
+	require.True(t, ok)
+	assert.Equal(t, newHeight-1, int64(dc2.EndBlock))
+	assert.Equal(t, dc1.EndBlock+1, dc2.BeginBlock)
+}

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -11,6 +11,8 @@ import (
 // the data commitment window specified
 func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment, error) {
 	beginBlock := uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx)
+	// to avoid having overlapped ranges of data commitments such as: 0-400;400-800;800-1200
+	// we will commit to the previous block height so that the ranges are as follows: 0-399;400-799;800-1199
 	endBlock := uint64(ctx.BlockHeight()) - 1
 	nonce := k.GetLatestAttestationNonce(ctx) + 1
 

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -7,11 +7,11 @@ import (
 
 // TODO add unit tests for all the keepers
 
-// GetCurrentDataCommitment creates latest data commitment at current height according to
+// GetCurrentDataCommitment creates the latest data commitment at current height according to
 // the data commitment window specified
 func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment, error) {
 	beginBlock := uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx)
-	endBlock := uint64(ctx.BlockHeight())
+	endBlock := uint64(ctx.BlockHeight()) - 1
 	nonce := k.GetLatestAttestationNonce(ctx) + 1
 
 	dataCommitment := types.NewDataCommitment(nonce, beginBlock, endBlock)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
Fixes https://github.com/celestiaorg/celestia-app/issues/1204

Now, the ranges will be as follows, with a data commitment window of 400:
- 0-399
- 400-799
- 800-1199
- ...
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
