### PR TITLE
chore: refactor `stripCompactShares`

### DIFF
--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -122,7 +122,8 @@ func TestTxSharePosition(t *testing.T) {
 
 		for i, pos := range positions {
 			rawTx := []byte(tt.txs[i])
-			rawTxDataForRange := stripCompactShares(shares, pos.start, pos.end)
+			rawTxDataForRange, err := stripCompactShares(shares, pos.start, pos.end)
+			assert.NoError(t, err)
 			assert.Contains(
 				t,
 				string(rawTxDataForRange),
@@ -172,14 +173,13 @@ func TestTxShareIndex(t *testing.T) {
 // stripCompactShares strips the universal prefix (namespace, info byte, sequence length) and
 // reserved bytes from a list of compact shares and joins them into a single byte
 // slice.
-func stripCompactShares(compactShares []shares.Share, start uint64, end uint64) (result []byte) {
-	for i := start; i <= end; i++ {
-		if i == 0 {
-			// the first compact share includes the sequence length
-			result = append(result, compactShares[i][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.SequenceLenBytes+appconsts.CompactShareReservedBytes:]...)
-		} else {
-			result = append(result, compactShares[i][appconsts.NamespaceSize+appconsts.ShareInfoBytes+appconsts.CompactShareReservedBytes:]...)
+func stripCompactShares(compactShares []shares.Share, start uint64, end uint64) (result []byte, err error) {
+	for _, compactShare := range compactShares {
+		rawData, err := compactShare.RawData()
+		if err != nil {
+			return []byte{}, err
 		}
+		result = append(result, rawData...)
 	}
-	return result
+	return result, nil
 }

--- a/pkg/prove/proof_test.go
+++ b/pkg/prove/proof_test.go
@@ -122,7 +122,7 @@ func TestTxSharePosition(t *testing.T) {
 
 		for i, pos := range positions {
 			rawTx := []byte(tt.txs[i])
-			rawTxDataForRange, err := stripCompactShares(shares, pos.start, pos.end)
+			rawTxDataForRange, err := stripCompactShares(shares[pos.start : pos.end+1])
 			assert.NoError(t, err)
 			assert.Contains(
 				t,
@@ -173,7 +173,7 @@ func TestTxShareIndex(t *testing.T) {
 // stripCompactShares strips the universal prefix (namespace, info byte, sequence length) and
 // reserved bytes from a list of compact shares and joins them into a single byte
 // slice.
-func stripCompactShares(compactShares []shares.Share, start uint64, end uint64) (result []byte, err error) {
+func stripCompactShares(compactShares []shares.Share) (result []byte, err error) {
 	for _, compactShare := range compactShares {
 		rawData, err := compactShare.RawData()
 		if err != nil {


### PR DESCRIPTION
This is a minor refactor that I extracted from a larger in-progress PR. Prior to this PR, implementation details for compact shares leaked out to the `prove` package. Instead of leaking these implementation details, we can use the [`RawData()`](https://github.com/rootulp/celestia-app/blob/c72e9c1935e296ff599728f7fa4b9952d62da1b7/pkg/shares/shares.go#L99-L107) method.