### PR TITLE
chore: bump core to v1.13.0-tm-v0.34.23

### DIFF
--- a/app/estimate_square_size.go
+++ b/app/estimate_square_size.go
@@ -81,8 +81,9 @@ func estimateCompactShares(squareSize uint64, ptxs []parsedTx) int {
 func maxWrappedTxOverhead(squareSize uint64) int {
 	maxTxLen := squareSize * squareSize * appconsts.ContinuationCompactShareContentSize
 	wtx, err := coretypes.MarshalIndexWrapper(
+		make([]byte, maxTxLen),
 		uint32(squareSize*squareSize),
-		make([]byte, maxTxLen))
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/app/estimate_square_size_test.go
+++ b/app/estimate_square_size_test.go
@@ -76,8 +76,8 @@ func Test_estimateCompactShares(t *testing.T) {
 					continue
 				}
 				wPFBTx, err := coretypes.MarshalIndexWrapper(
-					uint32(tt.squareSize*tt.squareSize),
 					ptx.blobTx.Tx,
+					uint32(tt.squareSize*tt.squareSize),
 				)
 				require.NoError(t, err)
 				txs[i] = wPFBTx

--- a/app/parse_txs.go
+++ b/app/parse_txs.go
@@ -51,7 +51,7 @@ func processTxs(logger log.Logger, txs []parsedTx) [][]byte {
 
 		// if this is a blob transaction, then we need to encode and wrap the
 		// underlying MsgPFB containing transaction
-		wTx, err := coretypes.MarshalIndexWrapper(pTx.shareIndex, pTx.blobTx.Tx)
+		wTx, err := coretypes.MarshalIndexWrapper(pTx.blobTx.Tx, pTx.shareIndex)
 		if err != nil {
 			// note: Its not safe to bubble this error up and stop the block
 			// creation process.

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -118,7 +118,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 			}
 		}
 
-		commitment, err := inclusion.GetMultiCommit(cacher, dah, []uint32{wrappedTx.ShareIndex}, []uint32{pfb.BlobSize})
+		commitment, err := inclusion.GetMultiCommit(cacher, dah, wrappedTx.ShareIndexes, []uint32{pfb.BlobSize})
 		if err != nil {
 			logInvalidPropBlockError(app.Logger(), req.Header, "commitment not found", err)
 			return abci.ResponseProcessProposal{

--- a/go.mod
+++ b/go.mod
@@ -186,5 +186,5 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.5.1-sdk-v0.46.6
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.12.1-tm-v0.34.23
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.13.0-tm-v0.34.23
 )

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.12.1-tm-v0.34.23 h1:Y450PTkAP0ezz2qxC1Tdo1JBiXu+uwGP0HxDpVFq7SI=
-github.com/celestiaorg/celestia-core v1.12.1-tm-v0.34.23/go.mod h1:S0QMQWprpLDnBooMFbQYEVUGzZJaLMwOvtG7tbWoAiY=
+github.com/celestiaorg/celestia-core v1.13.0-tm-v0.34.23 h1:nMg928RIanyA2ICN3PHpIE6jgg+008BtD5XmxeObEhM=
+github.com/celestiaorg/celestia-core v1.13.0-tm-v0.34.23/go.mod h1:Iu2XuSzF+QG3rzd60/sGhhk3n4wOAm8YyadU80KlcMs=
 github.com/celestiaorg/cosmos-sdk v1.5.1-sdk-v0.46.6 h1:G7c1qcM2WTVdiLsyHASyP4pOK7D4QsOrbXl0qP3GKpk=
 github.com/celestiaorg/cosmos-sdk v1.5.1-sdk-v0.46.6/go.mod h1:2Oq+pYLgUOdcv++AXR77Nv/Yiw4dckswSQN1iyScUqk=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/pkg/shares/share_splitting.go
+++ b/pkg/shares/share_splitting.go
@@ -86,10 +86,10 @@ func ExtractShareIndexes(txs coretypes.Txs) []uint32 {
 			// it. It checks for 0 because if there is a message in the block,
 			// then there must also be a tx, which will take up at least one
 			// share.
-			if malleatedTx.ShareIndex == 0 {
+			if len(malleatedTx.ShareIndexes) == 0 {
 				return nil
 			}
-			shareIndexes = append(shareIndexes, malleatedTx.ShareIndex)
+			shareIndexes = append(shareIndexes, malleatedTx.ShareIndexes...)
 		}
 	}
 

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -70,7 +70,7 @@ func TestPadFirstIndexedBlob(t *testing.T) {
 	tx := tmrand.Bytes(300)
 	blob := tmrand.Bytes(300)
 	index := 100
-	indexedTx, err := coretypes.MarshalIndexWrapper(100, tx)
+	indexedTx, err := coretypes.MarshalIndexWrapper(tx, 100)
 	require.NoError(t, err)
 
 	bd := coretypes.Data{

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -66,7 +66,7 @@ func TestVerifySignature(t *testing.T) {
 	uTx, isBlob := coretypes.UnmarshalBlobTx(cTx)
 	require.True(t, isBlob)
 
-	wTx, err := coretypes.MarshalIndexWrapper(100, uTx.Tx)
+	wTx, err := coretypes.MarshalIndexWrapper(uTx.Tx, 100)
 	require.NoError(t, err)
 
 	uwTx, isMal := coretypes.UnmarshalIndexWrapper(wTx)


### PR DESCRIPTION
## Overview

bumps core to v1.13.0-tm-v0.34.23

blocking #1154 and #1042

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
