### PR TITLE
fix: add size check in RandBlobTxsWithAccounts

### DIFF
--- a/testutil/blobfactory/payforblob_factory.go
+++ b/testutil/blobfactory/payforblob_factory.go
@@ -122,7 +122,7 @@ func RandBlobTxsWithAccounts(
 	enc sdk.TxEncoder,
 	kr keyring.Keyring,
 	conn *grpc.ClientConn,
-	size int,
+	size uint,
 	randSize bool,
 	chainid string,
 	accounts []string,
@@ -150,9 +150,9 @@ func RandBlobTxsWithAccounts(
 			panic(err)
 		}
 
-		randomizedSize := size
+		randomizedSize := int(size)
 		if randSize {
-			randomizedSize = rand.Intn(size)
+			randomizedSize = rand.Intn(int(size))
 			if randomizedSize == 0 {
 				randomizedSize = 1
 			}

--- a/testutil/blobfactory/payforblob_factory.go
+++ b/testutil/blobfactory/payforblob_factory.go
@@ -122,7 +122,7 @@ func RandBlobTxsWithAccounts(
 	enc sdk.TxEncoder,
 	kr keyring.Keyring,
 	conn *grpc.ClientConn,
-	size uint,
+	size int,
 	randSize bool,
 	chainid string,
 	accounts []string,
@@ -150,9 +150,12 @@ func RandBlobTxsWithAccounts(
 			panic(err)
 		}
 
-		randomizedSize := int(size)
+		if size <= 0 {
+			panic("size should be positive")
+		}
+		randomizedSize := size
 		if randSize {
-			randomizedSize = rand.Intn(int(size))
+			randomizedSize = rand.Intn(size)
 			if randomizedSize == 0 {
 				randomizedSize = 1
 			}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The parameter `size` in `RandBlobTxsWithAccounts` accepts positive values as well as negative.
However, passing a negative value will make the random generator panic, thus making the integration tests fail without any clear error message. An example of this: https://github.com/celestiaorg/celestia-app/actions/runs/3911542927/jobs/6685657620

Thus, adding a check on `size` would fix this and never allow anyone to pass a negative value.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
