### PR TITLE
fix: add check to `blobCount` in RandBlobTxsWithAccounts

### DIFF
--- a/testutil/blobfactory/payforblob_factory.go
+++ b/testutil/blobfactory/payforblob_factory.go
@@ -181,6 +181,9 @@ func RandBlobTxsWithAccounts(
 				randomizedSize = 1
 			}
 		}
+		if blobCount <= 0 {
+			panic("blobCount should be strictly positive")
+		}
 		randomizedBlobCount := blobCount
 		if randSize {
 			randomizedBlobCount = rand.Intn(blobCount)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Similar to https://github.com/celestiaorg/celestia-app/pull/1235, the `blobCount` is used in the `rand` function, thus needs always to be strictly positive.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
