### PR TITLE
fix: stop saving snapshot files to wrong directory during tests

### DIFF
--- a/testutil/testnode/full_node.go
+++ b/testutil/testnode/full_node.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-app/app/encoding"
 	"github.com/celestiaorg/celestia-app/cmd/celestia-appd/cmd"
 	"github.com/celestiaorg/celestia-app/testutil/testfactory"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
 	"github.com/cosmos/cosmos-sdk/server"
@@ -91,6 +92,7 @@ func New(
 	appOpts := appOptions{
 		options: map[string]interface{}{
 			server.FlagPruning: pruningtypes.PruningOptionNothing,
+			flags.FlagHome:     baseDir,
 		},
 	}
 


### PR DESCRIPTION
## Overview

by not setting the testing directory during integration tests, we end up saving the LOCK and LOG files from the snapshot directory to permanent directories instead of the temp ones created during the test.

this can be testing by running the integration tests locally without this change, and then with this change.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
