### PR TITLE
docs: fix path to x/blob docs

### DIFF
--- a/x/blob/doc.go
+++ b/x/blob/doc.go
@@ -1,4 +1,4 @@
 // blob is a Cosmos SDK module that enables users to pay for data to be
-// published to the Celestia blockchain. Please see ./specs/docs.md for the full
+// published to the Celestia blockchain. Please see ./README.md for the full
 // specification of this module.
 package blob


### PR DESCRIPTION
`x/blob/specs/docs.md` was removed in favor of `x/blob/README.md`

