### PR TITLE
feat: Prevent any errors when creating the data folder

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@
 # only create the priv_validator_state.json if it doesn't exist and the command is start
 if [[ $1 == "start" && ! -f ${CELESTIA_HOME}/data/priv_validator_state.json ]]
 then
-    mkdir ${CELESTIA_HOME}/data # it is alright if it fails, the script will continue executing
+    mkdir -p ${CELESTIA_HOME}/data
     cat <<EOF > ${CELESTIA_HOME}/data/priv_validator_state.json
 {
   "height": "0",


### PR DESCRIPTION
## Overview

Hello team,

This is an small feature/fix that prevents any error when the container starts and try to create the folder in `${CELESTIA_HOME}/data` using the option `-p` in the `mkdir` command.

Thank you!

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
