### PR TITLE
chore: update to golangci-lint 1.50.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
             go.sum
       - uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.47.2
+          version: v1.50.1
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF


### PR DESCRIPTION
Update to the latest release of golangci-lint: https://github.com/golangci/golangci-lint/releases while I try debugging an issue with golangci-lint failures on a different PR