### PR TITLE
feat: add testRandBlob CLI for testground tests

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+
 	"path/filepath"
 	"time"
 

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-
 	"path/filepath"
 	"time"
 

--- a/x/blob/client/cli/testrandblob.go
+++ b/x/blob/client/cli/testrandblob.go
@@ -23,10 +23,10 @@ func CmdTestRandBlob() *cobra.Command {
 		Short: "Generates a random blob for a random namespace to be published to the Celestia blockchain",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// decode the message size
+			// decode the blob size
 			size, err := strconv.Atoi(args[0])
 			if err != nil {
-				return fmt.Errorf("failure to decode message size: %w", err)
+				return fmt.Errorf("failure to decode blob size: %w", err)
 			}
 
 			nid := namespace.RandomBlobNamespace()

--- a/x/blob/client/cli/testrandblob.go
+++ b/x/blob/client/cli/testrandblob.go
@@ -2,10 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/celestiaorg/celestia-app/testutil/namespace"
 	"github.com/celestiaorg/celestia-app/testutil/testfactory"
 	"github.com/celestiaorg/celestia-app/x/blob/types"
-	"strconv"
 
 	"github.com/spf13/cobra"
 

--- a/x/blob/client/cli/testrandblob.go
+++ b/x/blob/client/cli/testrandblob.go
@@ -3,10 +3,11 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"strconv"
+
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/nmt/namespace"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
-	"strconv"
 
 	"github.com/spf13/cobra"
 

--- a/x/blob/client/cli/testrandblob.go
+++ b/x/blob/client/cli/testrandblob.go
@@ -25,16 +25,14 @@ func CmdTestRandBlob() *cobra.Command {
 		Short: "Generates a random blob for a random namespace to be published to the Celestia blockchain",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			// decode the namespace
 			namespace := getRandomNamespace()
 
-			// decode the message
+			// decode the message size
 			size, err := strconv.Atoi(args[0])
 			if err != nil {
 				return fmt.Errorf("failure to decode message size: %w", err)
 			}
 
-			// decode the blob
 			rawblob := getRandomBlobBySize(size)
 
 			// TODO: allow for more than one blob to be sumbmitted via the cli

--- a/x/blob/client/cli/testrandblob.go
+++ b/x/blob/client/cli/testrandblob.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/nmt/namespace"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/celestiaorg/celestia-app/x/blob/types"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+)
+
+// CmdTestRandBlob is triggered by testground's tests as part of apps' node scenario
+// to increase the block size by user-defined amount.
+//
+// CAUTION: This func should not be used in production env!
+func CmdTestRandBlob() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "TestRandBlob [blobSize]",
+		Short: "Generates a random blob for a random namespace to be published to the Celestia blockchain",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// decode the namespace
+			namespace := getRandomNamespace()
+
+			// decode the message
+			size, err := strconv.Atoi(args[0])
+			if err != nil {
+				return fmt.Errorf("failure to decode message size: %w", err)
+			}
+
+			// decode the blob
+			rawblob := getRandomBlobBySize(size)
+
+			// TODO: allow for more than one blob to be sumbmitted via the cli
+			blob, err := types.NewBlob(namespace, rawblob)
+			if err != nil {
+				return err
+			}
+
+			return broadcastPFB(cmd, blob)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+
+	return cmd
+}
+
+func getRandomNamespace() namespace.ID {
+	for {
+		s := tmrand.Bytes(8)
+		if bytes.Compare(s, appconsts.MaxReservedNamespace) > 0 {
+			return s
+		}
+	}
+}
+
+func getRandomBlobBySize(size int) []byte {
+	return tmrand.Bytes(size)
+}

--- a/x/blob/client/cli/tx.go
+++ b/x/blob/client/cli/tx.go
@@ -21,7 +21,7 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	cmd.AddCommand(CmdWirePayForBlob())
-
+	cmd.AddCommand(CmdPayForBlob())
+	cmd.AddCommand(CmdTestRandBlob())
 	return cmd
 }

--- a/x/blob/client/cli/tx.go
+++ b/x/blob/client/cli/tx.go
@@ -23,5 +23,6 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(CmdPayForBlob())
 	cmd.AddCommand(CmdTestRandBlob())
+	
 	return cmd
 }

--- a/x/blob/client/cli/tx.go
+++ b/x/blob/client/cli/tx.go
@@ -23,6 +23,6 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(CmdPayForBlob())
 	cmd.AddCommand(CmdTestRandBlob())
-	
+
 	return cmd
 }

--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -91,7 +91,7 @@ func (s *IntegrationTestSuite) TestSubmitWirePayForBlob() {
 		tc := tc
 		s.Require().NoError(s.network.WaitForNextBlock())
 		s.Run(tc.name, func() {
-			cmd := paycli.CmdWirePayForBlob()
+			cmd := paycli.CmdPayForBlob()
 			clientCtx := val.ClientCtx
 
 			out, err := clitestutil.ExecTestCLICmd(clientCtx, cmd, tc.args)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

ATM, `test-infra` repo is using my fork of celestia-app, which is not ok. 
We need a CLI command for tests to trigger PFBs from apps' side, hence we have added another command named `TestRandBlob`

This PR contains another renaming, touching removal of `Wire` prefixes

Ref: https://github.com/celestiaorg/test-infra/issues/159
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
