### PR TITLE
chore!: bump `nmt` from v0.13 to v0.14 and remove the codec from `NewTxInclusionProof`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/celestiaorg/celestia-app
 go 1.18
 
 require (
-	github.com/celestiaorg/nmt v0.13.0
+	github.com/celestiaorg/nmt v0.14.0
 	github.com/celestiaorg/quantum-gravity-bridge v1.3.0
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/celestiaorg/cosmos-sdk v1.7.0-sdk-v0.46.7 h1:jy24W2wTCnDY843A/5hy79QP
 github.com/celestiaorg/cosmos-sdk v1.7.0-sdk-v0.46.7/go.mod h1:qH1Q0s96i4Op0WSh6qC72yWkoWdZNs0CY4HPUrWaK44=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
-github.com/celestiaorg/nmt v0.12.0 h1:6CmaMPri9FdSiytZP7yCrEq3ewebFiIEjlJhasrS6oQ=
-github.com/celestiaorg/nmt v0.12.0/go.mod h1:NN3W8EEoospv8EHCw50DDNWwPLpJkFHoEFiqCEcNCH4=
+github.com/celestiaorg/nmt v0.14.0 h1:ET1PXBm8f3KHCAB7+sRVMTmvejkpQp6HAQsGLjIRtcY=
+github.com/celestiaorg/nmt v0.14.0/go.mod h1:b+pwd9cGTSSYLZnUIQSJl07pusJdFeEvCVsVfSRH9gA=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0 h1:9zPIp7w1FWfkPnn16y3S4FpFLnQtS7rm81CUVcHEts0=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0/go.mod h1:6WOajINTDEUXpSj5UZzod16UZ96ZVB/rFNKyM+Mt1gI=
 github.com/celestiaorg/rsmt2d v0.8.0 h1:ZUxTCELZCM9zMGKNF3cT+rUqMddXMeiuyleSJPZ3Wn4=

--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -15,7 +15,6 @@ import (
 	blobmodule "github.com/celestiaorg/celestia-app/x/blob"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/celestiaorg/nmt/namespace"
-	"github.com/celestiaorg/rsmt2d"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -24,7 +23,7 @@ import (
 
 // NewTxInclusionProof returns a new share inclusion proof for the given
 // transaction index.
-func NewTxInclusionProof(codec rsmt2d.Codec, data types.Data, txIndex uint64) (types.ShareProof, error) {
+func NewTxInclusionProof(data types.Data, txIndex uint64) (types.ShareProof, error) {
 	rawShares, err := shares.Split(data, true)
 	if err != nil {
 		return types.ShareProof{}, err

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -60,7 +60,6 @@ func TestNewTxInclusionProof(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			proof, err := NewTxInclusionProof(
-				appconsts.DefaultCodec(),
 				tt.data,
 				tt.txIndex,
 			)

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -8,7 +8,6 @@ import (
 	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/nmt/namespace"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -46,7 +45,7 @@ func QueryTxInclusionProof(_ sdk.Context, path []string, req abci.RequestQuery) 
 	}
 
 	// create and marshal the tx inclusion proof, which we return in the form of []byte
-	shareProof, err := NewTxInclusionProof(appconsts.DefaultCodec(), data, uint64(index))
+	shareProof, err := NewTxInclusionProof(data, uint64(index))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Latest v0.12.0-rc5 is not compliant with what node will have to upcoming v0.7.0-rc`x`, as celestia-node is using nmt `v0.14.0` and dropped v0.13.0

This PR fixes this, hence I propose to make a `v0.12.0-rc6` afterwards 🙏 
In addition, this PR cleans up codec from the signature that is not used in `NewTxInclusionProof ` anymore
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
