### PR TITLE
feat: override consensus configs

### DIFF
--- a/cmd/celestia-appd/cmd/overrides.go
+++ b/cmd/celestia-appd/cmd/overrides.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+)
+
+func overrideServerConfig(command *cobra.Command) error {
+	ctx := server.GetServerContextFromCmd(command)
+	ctx.Config.Consensus.TimeoutPropose = appconsts.TimeoutPropose
+	ctx.Config.Consensus.TimeoutCommit = appconsts.TimeoutCommit
+	ctx.Config.Consensus.SkipTimeoutCommit = false
+	return server.SetCmdServerContext(command, ctx)
+}

--- a/cmd/celestia-appd/cmd/overrides.go
+++ b/cmd/celestia-appd/cmd/overrides.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// overrideServerConfig applies overrides to the embedded server context's
+// configurations.
 func overrideServerConfig(command *cobra.Command) error {
 	ctx := server.GetServerContextFromCmd(command)
 	ctx.Config.Consensus.TimeoutPropose = appconsts.TimeoutPropose

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	qgbcmd "github.com/celestiaorg/celestia-app/x/qgb/client"
 
 	"github.com/celestiaorg/celestia-app/app"
@@ -92,13 +93,16 @@ func NewRootCmd() *cobra.Command {
 			tmCfg.Mempool.TTLNumBlocks = 10
 			tmCfg.Mempool.MaxTxBytes = 2 * 1024 * 1024 // 2 MiB
 			tmCfg.Mempool.Version = "v1"               // prioritized mempool
-			tmCfg.Consensus.TimeoutPropose = time.Second * 10
-			tmCfg.Consensus.TimeoutCommit = time.Second * 8
+			tmCfg.Consensus.TimeoutPropose = appconsts.TimeoutPropose
+			tmCfg.Consensus.TimeoutCommit = appconsts.TimeoutCommit
 			tmCfg.Consensus.SkipTimeoutCommit = false
 			tmCfg.TxIndex.Indexer = "null"
 
 			customAppTemplate, customAppConfig := initAppConfig()
-			return server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmCfg)
+
+			server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmCfg)
+
+			return overrideServerConfig(cmd)
 		},
 		SilenceUsage: true,
 	}

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -100,7 +100,10 @@ func NewRootCmd() *cobra.Command {
 
 			customAppTemplate, customAppConfig := initAppConfig()
 
-			server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmCfg)
+			err = server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmCfg)
+			if err != nil {
+				return err
+			}
 
 			return overrideServerConfig(cmd)
 		},

--- a/pkg/appconsts/consensus_consts.go
+++ b/pkg/appconsts/consensus_consts.go
@@ -1,0 +1,8 @@
+package appconsts
+
+import "time"
+
+const (
+	TimeoutPropose = time.Second * 10
+	TimeoutCommit  = time.Second * 10
+)


### PR DESCRIPTION
## Overview

This PR introduces a function that overrides configs when starting the in process tendermint node from the cli. This approach has the benefit of keeping the override logic in the application but still allows for all CI and tests to run as fast as we want.

close #1326 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
