### PR TITLE
testing: add extra tests to ensure we remove txs correctly

### DIFF
--- a/app/write_square_test.go
+++ b/app/write_square_test.go
@@ -147,6 +147,50 @@ func Test_finalizeLayout(t *testing.T) {
 			expectedIndexes: [][]uint32{{4}, {6, 8}, {5}},
 		},
 		{
+			// no blob txs should make it in the square
+			squareSize:      2,
+			nonreserveStart: 4,
+			blobTxs: generateBlobTxsWithNIDs(
+				t,
+				[][]byte{ns1, ns2, ns3},
+				[][]int{{1000}, {1000}, {1000}},
+			),
+			expectedIndexes: [][]uint32{},
+		},
+		{
+			// only two blob txs should make it in the square
+			squareSize:      4,
+			nonreserveStart: 4,
+			blobTxs: generateBlobTxsWithNIDs(
+				t,
+				[][]byte{ns1, ns2, ns3},
+				[][]int{{2000}, {2000}, {6000}},
+			),
+			expectedIndexes: [][]uint32{{4}, {8}},
+		},
+		{
+			// only one blob tx should make it in the square (after reordering)
+			squareSize:      4,
+			nonreserveStart: 4,
+			blobTxs: generateBlobTxsWithNIDs(
+				t,
+				[][]byte{ns3, ns2, ns1},
+				[][]int{{2000}, {2000}, {6000}},
+			),
+			expectedIndexes: [][]uint32{{4}},
+		},
+		{
+			squareSize:      4,
+			nonreserveStart: 4,
+			blobTxs: generateBlobTxsWithNIDs(
+				t,
+				[][]byte{ns3, ns3, ns2, ns1},
+				[][]int{{2000, 1000}, {6000}, {2000}},
+			),
+			// should be ns1 and {ns3, ns3} as ns2 is too large
+			expectedIndexes: [][]uint32{{8, 12}, {4}},
+		},
+		{
 			squareSize:      4,
 			nonreserveStart: 4,
 			blobTxs: generateBlobTxsWithNIDs(
@@ -170,6 +214,7 @@ func Test_finalizeLayout(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(fmt.Sprintf("case%d", i), func(t *testing.T) {
 			wrappedPFBs, blobs := finalizeBlobLayout(tt.squareSize, tt.nonreserveStart, tt.blobTxs)
+			require.Equal(t, len(wrappedPFBs), len(tt.expectedIndexes))
 			for j, pfbBytes := range wrappedPFBs {
 				wrappedPFB, isWrappedPFB := coretypes.UnmarshalIndexWrapper(pfbBytes)
 				require.True(t, isWrappedPFB)


### PR DESCRIPTION
Addresses: https://github.com/celestiaorg/celestia-app/issues/1102

> this test could be as simple adding an additional check to an existing test that creates square not the max square size, and ensure that each transaction is getting included in the block.

`Test_finalizeLayout` already includes tests where a non max square size square is created and none of the transactions are dropped so I'm a little confused about this. I've added tests to include that we are dropping transactions if the blobs exceed the square size.
