### PR TITLE
feat: expose the EVM private key used to create the testnode validator

### DIFF
--- a/testutil/testnode/node_init.go
+++ b/testutil/testnode/node_init.go
@@ -29,6 +29,10 @@ import (
 	tmtime "github.com/tendermint/tendermint/types/time"
 )
 
+// NodeEVMPrivateKey the key used to initialize the test node validator.
+// Its corresponding address is: "0x9c2B12b5a07FC6D719Ed7646e5041A7E85758329".
+var NodeEVMPrivateKey, _ = crypto.HexToECDSA("64a1d6f0e760a8d62b4afdde4096f16f51b401eaaecc915740f71770ea76a8ad")
+
 func collectGenFiles(tmCfg *config.Config, encCfg encoding.Config, pubKey cryptotypes.PubKey, nodeID, chainID, rootDir string) error {
 	genTime := tmtime.Now()
 
@@ -120,11 +124,7 @@ func createValidator(
 	if err != nil {
 		return err
 	}
-	ethPrivateKey, err := crypto.GenerateKey()
-	if err != nil {
-		return err
-	}
-	orchEVMPublicKey := ethPrivateKey.Public().(*ecdsa.PublicKey)
+	orchEVMPublicKey := NodeEVMPrivateKey.Public().(*ecdsa.PublicKey)
 	evmAddr := crypto.PubkeyToAddress(*orchEVMPublicKey)
 
 	createValMsg, err := stakingtypes.NewMsgCreateValidator(


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

I will need this on the orchestrat-relayer repo tests to be able to sign attestations with the private key that was  used to initialized the testnode validator.
 
## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
