### PR TITLE
chore!: rename `TxSharePosition` to `TxShareRange`

### DIFF
--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -29,7 +29,7 @@ func NewTxInclusionProof(data types.Data, txIndex uint64) (types.ShareProof, err
 		return types.ShareProof{}, err
 	}
 
-	startShare, endShare, err := TxSharePosition(data, txIndex)
+	startShare, endShare, err := TxShareRange(data, txIndex)
 	if err != nil {
 		return types.ShareProof{}, err
 	}
@@ -46,10 +46,9 @@ func getTxNamespace(tx types.Tx) (ns namespace.ID) {
 	return appconsts.TxNamespaceID
 }
 
-// TxSharePosition returns the start and end positions for the shares that
-// include a given txIndex. Returns an error if index is greater than the length
-// of txs.
-func TxSharePosition(data types.Data, txIndex uint64) (startShare uint64, endShare uint64, err error) {
+// TxShareRange returns the range of shares that include a given txIndex.
+// Returns an error if index is greater than the length of txs.
+func TxShareRange(data types.Data, txIndex uint64) (startShare uint64, endShare uint64, err error) {
 	if int(txIndex) >= len(data.Txs) {
 		return 0, 0, errors.New("transaction index is greater than the number of txs")
 	}

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -218,7 +218,7 @@ func TestNewShareInclusionProof(t *testing.T) {
 	}
 }
 
-func TestTxSharePosition(t *testing.T) {
+func TestTxShareRange(t *testing.T) {
 	type test struct {
 		name      string
 		data      types.Data
@@ -281,7 +281,7 @@ func TestTxSharePosition(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			start, end, err := TxSharePosition(tc.data, tc.txIndex)
+			start, end, err := TxShareRange(tc.data, tc.txIndex)
 			if tc.wantErr {
 				assert.Error(t, err)
 			}

--- a/x/qgb/client/verify.go
+++ b/x/qgb/client/verify.go
@@ -79,7 +79,7 @@ func txCmd() *cobra.Command {
 				return err
 			}
 
-			beginTxShare, endTxShare, err := proof.TxSharePosition(blockRes.Block.Data, uint64(tx.Index))
+			beginTxShare, endTxShare, err := proof.TxShareRange(blockRes.Block.Data, uint64(tx.Index))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1241

The new name `TxShareRange` is consistent with https://github.com/celestiaorg/celestia-app/blob/fd6382278f6fff4ab3d272e5f3034203c9378126/pkg/proof/proof.go#L66

Technically API breaking because this is an exported function but I doubt there are external users of this function.