### PR TITLE
chore: deduplicate `MinSquareSize`

### DIFF
--- a/pkg/inclusion/paths.go
+++ b/pkg/inclusion/paths.go
@@ -4,7 +4,6 @@ import (
 	"math"
 
 	"github.com/celestiaorg/celestia-app/pkg/shares"
-	"github.com/celestiaorg/celestia-app/x/blob/types"
 )
 
 type path struct {
@@ -37,7 +36,7 @@ func calculateCommitPaths(squareSize, start, blobShareLen int) []path {
 		// subTreeRootMaxHeight is the maximum height of a subtree root that was
 		// used to generate the commitment. The height is based on the minimum
 		// square size the blob can fit into. See ADR-008 for more details.
-		subTreeRootMaxHeight := int(math.Log2(float64(types.MinSquareSize(blobShareLen))))
+		subTreeRootMaxHeight := int(math.Log2(float64(shares.MinSquareSize(blobShareLen))))
 		minDepth := maxDepth - subTreeRootMaxHeight
 		coords := calculateSubTreeRootCoordinates(maxDepth, minDepth, start, end)
 		for _, c := range coords {

--- a/pkg/shares/non_interactive_defaults.go
+++ b/pkg/shares/non_interactive_defaults.go
@@ -85,8 +85,6 @@ func roundUpBy(cursor, v int) int {
 
 // MinSquareSize returns the minimum square size that can contain shareCount
 // number of shares.
-//
-// NOTE: this function was duplicated to avoid import cycles.
 func MinSquareSize(shareCount int) int {
 	return RoundUpPowerOfTwo(int(math.Ceil(math.Sqrt(float64(shareCount)))))
 }

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	"crypto/sha256"
-	"math"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
@@ -266,13 +265,7 @@ func extractBlobComponents(pblobs []*tmproto.Blob) (nsIDs [][]byte, sizes []uint
 // shares or non-interactive defaults, so it is a minimum.
 func BlobMinSquareSize[T constraints.Integer](blobSize T) T {
 	shareCount := appshares.SparseSharesNeeded(uint32(blobSize))
-	return T(MinSquareSize(shareCount))
-}
-
-// MinSquareSize returns the minimum square size that can contain shareCount
-// number of shares.
-func MinSquareSize[T constraints.Integer](shareCount T) T {
-	return T(appshares.RoundUpPowerOfTwo(uint64(math.Ceil(math.Sqrt(float64(shareCount))))))
+	return T(appshares.MinSquareSize(shareCount))
 }
 
 // merkleMountainRangeSizes returns the sizes (number of leaf nodes) of the


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1101 b/c deletes a duplicate function definition. `MinSquareSize` in the shares package already has unit tests [here](https://github.com/celestiaorg/celestia-app/blob/150e65de9a6559a64693be88c591d541b2812a8b/pkg/shares/non_interactive_defaults_test.go#L323).