### PR TITLE
feat: `make help`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 IMAGE := ghcr.io/tendermint/docker-build-proto:latest
 DOCKER_PROTO_BUILDER := docker run -v $(shell pwd):/workspace --workdir /workspace $(IMAGE)
+PROJECTNAME=$(shell basename "$(PWD)")
 
 # process linker flags
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app \
@@ -17,24 +18,14 @@ ldflags += $(LDFLAGS)
 
 BUILD_FLAGS := -ldflags '$(ldflags)'
 
-all: install
 
-install: go.sum
-	@echo "--> Installing celestia-appd"
-	@go install -mod=readonly $(BUILD_FLAGS) ./cmd/celestia-appd
+## help: Get more info on make commands.
+help: Makefile
+	@echo " Choose a command run in "$(PROJECTNAME)":"
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+.PHONY: help
 
-go.sum: mod
-	@echo "--> Verifying dependencies have expected content"
-	GO111MODULE=on go mod verify
-
-mod:
-	@echo "--> Updating go.mod"
-	@go mod tidy -compat=1.18
-
-pre-build:
-	@echo "--> Fetching latest git tags"
-	@git fetch --tags
-
+## build: Build the celestia-appd binary into the ./build directory.
 build: mod
 	@go install github.com/gobuffalo/packr/v2/packr2@latest
 	@cd ./cmd/celestia-appd && packr2
@@ -42,27 +33,53 @@ build: mod
 	@go build $(BUILD_FLAGS) -o build/ ./cmd/celestia-appd
 	@packr2 clean
 	@go mod tidy -compat=1.18
+.PHONY: build
 
+## install: Build and install the celestia-appd binary into the $GOPATH/bin directory.
+install: go.sum
+	@echo "--> Installing celestia-appd"
+	@go install -mod=readonly $(BUILD_FLAGS) ./cmd/celestia-appd
+.PHONY: install
+
+## mod: Update go.mod.
+mod:
+	@echo "--> Updating go.mod"
+	@go mod tidy -compat=1.18
+.PHONY: mod
+
+## mod-verify: Verify dependencies have expected content.
+mod-verify: mod
+	@echo "--> Verifying dependencies have expected content"
+	GO111MODULE=on go mod verify
+.PHONY: mod-verify
+
+
+
+## proto-gen: Generate protobuf files. Requires docker.
 proto-gen:
 	@echo "--> Generating Protobuf files"
 	$(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace tendermintdev/sdk-proto-gen:v0.7 sh ./scripts/protocgen.sh
 .PHONY: proto-gen
 
+## proto-lint: Lint protobuf files. Requires docker.
 proto-lint:
 	@echo "--> Linting Protobuf files"
 	@$(DOCKER_BUF) lint --error-format=json
 .PHONY: proto-lint
 
+## proto-format: Format protobuf files. Requires docker.
 proto-format:
 	@echo "--> Formatting Protobuf files"
 	@$(DOCKER_PROTO_BUILDER) find . -name '*.proto' -path "./proto/*" -exec clang-format -i {} \;
 .PHONY: proto-format
 
+## build-docker: Build the celestia-appd docker image. Requires docker.
 build-docker:
 	@echo "--> Building Docker image"
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/Dockerfile .
 .PHONY: build-docker
 
+## lint: Run linters golangci-lint and markdownlint.
 lint:
 	@echo "--> Running golangci-lint"
 	@golangci-lint run
@@ -70,6 +87,7 @@ lint:
 	@markdownlint --config .markdownlint.yaml '**/*.md'
 .PHONY: lint
 
+## fmt: Format files per linters golangci-lint and markdownlint.
 fmt:
 	@echo "--> Running golangci-lint --fix"
 	@golangci-lint run --fix
@@ -77,29 +95,32 @@ fmt:
 	@markdownlint --fix --quiet --config .markdownlint.yaml .
 .PHONY: fmt
 
+## test: Run unit tests.
 test:
 	@echo "--> Running unit tests"
 	@go test -mod=readonly ./...
 .PHONY: test
 
+## test-short: Run unit tests in short mode.
 test-short:
-	@echo "--> Running unit tests in short mode"
+	@echo "--> Running tests in short mode"
 	@go test -mod=readonly ./... -short
 .PHONY: test-short
 
-test-all: test-race test-cover
-
+## test-race: Run unit tests in race mode.
 test-race:
-	@echo "--> Running tests with -race"
-	@VERSION=$(VERSION) go test -mod=readonly -race -test.short ./...
+	@echo "--> Running tests in race mode"
+	@VERSION=$(VERSION) go test -mod=readonly -race -short ./...
 .PHONY: test-race
 
+## test-bench: Run unit tests in bench mode.
+test-bench:
+	@echo "--> Running tests in bench mode"
+	@go test -mod=readonly -bench=. ./...
+.PHONY: test-bench
+
+## test-cover: Generate test coverage.txt
 test-cover:
 	@echo "--> Generating coverage.txt"
 	@export VERSION=$(VERSION); bash -x scripts/test_cover.sh
 .PHONY: test-cover
-
-benchmark:
-	@echo "--> Running tests with -bench"
-	@go test -mod=readonly -bench=. ./...
-.PHONY: benchmark


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1339

```shell
$ make
 Choose a command run in celestia-app:
  help           Get more info on make commands.
  build          Build the celestia-appd binary into the ./build directory.
  install        Build and install the celestia-appd binary into the $GOPATH/bin directory.
  mod            Update go.mod.
  mod-verify     Verify dependencies have expected content.
  proto-gen      Generate protobuf files. Requires docker.
  proto-lint     Lint protobuf files. Requires docker.
  proto-format   Format protobuf files. Requires docker.
  build-docker   Build the celestia-appd docker image. Requires docker.
  lint           Run linters golangci-lint and markdownlint.
  fmt            Format files per linters golangci-lint and markdownlint.
  test           Run unit tests.
  test-short     Run unit tests in short mode.
  test-race      Run unit tests in race mode.
  test-bench     Run unit tests in bench mode.
  test-cover     Generate test coverage.txt
```