### PR TITLE
ci: consolidate linters in lint workflow

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -27,32 +27,16 @@ on:
           - major
 
 jobs:
-  # Dockerfile Linting
-  hadolint:
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@main # yamllint disable-line rule:line-length
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: celestiaorg/.github/.github/actions/yamllint@main
-
-  markdown-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: celestiaorg/.github/.github/actions/markdown-lint@main
 
   lint:
     uses: ./.github/workflows/lint.yml
 
   test:
-    needs: lint
     uses: ./.github/workflows/test.yml
 
   # Make a release if this is a manually trigger job, i.e. workflow_dispatch
   release:
-    needs: [hadolint, yamllint, markdown-lint, lint, test]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions: "write-all"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,13 +1,11 @@
-name: Lint
-# Lint runs golangci-lint over the entire cosmos-sdk repository
-# This workflow is run on every pull request and push to main
-# The `golangci` will pass without running if no *.{go, mod, sum} files have
-# been changed.
+# lint runs all linters in this repository. This workflow is run on every pull
+# request and push to main.
+name: lint
 on:
   workflow_call:
 
 jobs:
-  golangci:
+  golangci-lint:
     name: golangci-lint
     runs-on: ubuntu-latest
     timeout-minutes: 8
@@ -18,6 +16,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: technote-space/get-diff-action@v6.1.2
         with:
+          # This job will pass without running if go.mod, go.sum, and *.go
+          # wasn't modified.
           PATTERNS: |
             **/**.go
             go.mod
@@ -28,3 +28,19 @@ jobs:
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
         if: env.GIT_DIFF
+
+  # hadolint lints the Dockerfile
+  hadolint:
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@main # yamllint disable-line rule:line-length
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: celestiaorg/.github/.github/actions/yamllint@main
+
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: celestiaorg/.github/.github/actions/markdown-lint@main


### PR DESCRIPTION
## Motivation

I found the **Before** workflow diagram a bit confusing. I would expect all linters to run as part of the lint workflow and I wouldn't expect lint to block splitting up test files.

Before | After
--- | ---
<img width="504" alt="Screenshot 2023-02-16 at 5 01 40 PM" src="https://user-images.githubusercontent.com/3699047/219496869-bda2ca44-254f-4b2d-9c6a-763521bf3ba8.png">| <img width="318" alt="Screenshot 2023-02-16 at 5 06 11 PM" src="https://user-images.githubusercontent.com/3699047/219497715-2a9f2bd5-900e-458c-add6-56a6f30a6622.png">

TBH I don't know why **test / cleanup-runs** shows up in the lint block but I think we can get rid of that job soon via a different PR

