### PR TITLE
chore: delete testnode home dir during cleanup

### DIFF
--- a/testutil/testnode/full_node.go
+++ b/testutil/testnode/full_node.go
@@ -214,6 +214,7 @@ func DefaultNetwork(t *testing.T, blockTime time.Duration) (accounts []string, c
 		t.Log("tearing down testnode")
 		require.NoError(t, stopNode())
 		require.NoError(t, cleanupGRPC())
+		require.NoError(t, os.RemoveAll(tmCfg.RootDir))
 	})
 
 	return accounts, cctx


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Deletes testnode home directory during cleanup.

In fact, we have the following structure when creating the testnode: `/tmp/TestOrchestrator3541559682/001/.celestia-app/config`:

- we will delete `/tmp/TestOrchestrator3541559682/001/.celestia-app`  ourselves in the cleanup (this PR)
- the `testing` package will delete `/tmp/TestOrchestrator3541559682` automatically

This would leave the created `t.tempDir()` empty and hopefully reduce the frequency we see this flakiness https://github.com/celestiaorg/celestia-app/actions/runs/4242679413/jobs/7374501607

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
