### PR TITLE
chore: specifies minimum square size in non-interactive default rules

### DIFF
--- a/specs/src/rationale/message_block_layout.md
+++ b/specs/src/rationale/message_block_layout.md
@@ -39,6 +39,7 @@ As a non-consensus-critical default, we can impose one additional rule on messag
 
 > Messages start at an index that is a multiple of the message minimum square size. The message minimum square size is the smallest square that can contain the message in isolation (i.e. a square with only this message and no other transactions or messages).
 
+In the constraint mentioned above, the number of rows/columns in the minimum square size should be a power of 2.
 With the above constraint, we can compute subtree roots deterministically. In order to compute the subtree roots, split the message into chunks that are of maximum size: message minimum square size. As an example, a message of length `11` has a minimum square size of `4` because `11` is not greater than `4 * 4 = 16` total shares. Split the message into chunks of length `4, 4, 2, 1`. The resulting slices are the leaves of subtrees whose roots can be computed. These subtree roots will be present as internal nodes in the NMT of _some_ row(s).
 
 This is similar to [Merkle Mountain Ranges](https://www.usenix.org/legacy/event/sec09/tech/full_papers/crosby.pdf), though with the largest subtree bounded by the message minimum square size rather than being unbounded.


### PR DESCRIPTION
This aims to clarify that the minimum square size in non-interactive default rules should be a power of 2. For example, for a message of length 23,  the minimum square size is  `8*8` (but not `5*5`). (based on a discussion in Slack)

- [x] NA ~~New and updated code has appropriate documentation~~
- [x] NA ~~New and updated code has new and/or updated testing~~
- [x] Required CI checks are passing
- [x] NA ~~Visual proof for any user facing features like CLI or documentation updates~~
- [x] NA ~~Linked issues closed with keywords~~
