### PR TITLE
fix: better way to delete tendermint config folder

### DIFF
--- a/testutil/testnode/full_node.go
+++ b/testutil/testnode/full_node.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"path"
 	"testing"
 	"time"
 
@@ -215,32 +214,9 @@ func DefaultNetwork(t *testing.T, blockTime time.Duration) (accounts []string, c
 		t.Log("tearing down testnode")
 		require.NoError(t, stopNode())
 		require.NoError(t, cleanupGRPC())
-		require.NoError(t, removeDir(path.Join([]string{tmCfg.RootDir, "config"}...)))
 	})
 
 	return accounts, cctx
-}
-
-// removeDir removes the directory `rootDir`.
-// The main reason for using it is to know if some file is used by some leaking process during
-// cleanup and be able to identify where the leak is occurring.
-// TODO: remove after fixing the CI flakiness
-func removeDir(rootDir string) error {
-	dir, err := os.ReadDir(rootDir)
-	if err != nil {
-		return err
-	}
-	for _, d := range dir {
-		err := os.RemoveAll(path.Join([]string{rootDir, d.Name()}...))
-		if err != nil {
-			return err
-		}
-	}
-	err = os.RemoveAll(rootDir)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func getFreePort() int {

--- a/testutil/testnode/rpc_client.go
+++ b/testutil/testnode/rpc_client.go
@@ -2,6 +2,8 @@ package testnode
 
 import (
 	"context"
+	"os"
+	"path"
 	"strings"
 
 	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
@@ -34,7 +36,7 @@ func StartNode(tmNode *node.Node, cctx Context) (Context, func() error, error) {
 			return err
 		}
 		tmNode.Wait()
-		return nil
+		return removeDir(path.Join([]string{cctx.HomeDir, "config"}...))
 	}
 
 	return cctx, cleanup, nil
@@ -73,4 +75,23 @@ func StartGRPCServer(app srvtypes.Application, appCfg *srvconfig.Config, cctx Co
 // DefaultAppConfig wraps the default config described in the server
 func DefaultAppConfig() *srvconfig.Config {
 	return srvconfig.DefaultConfig()
+}
+
+// removeDir removes the directory `rootDir`.
+// The main use of this is to reduce the flakiness of the CI when it's unable to delete
+// the config folder of the tendermint node.
+// This will manually go over the files contained inside the provided `rootDir`
+// and delete them one by one.
+func removeDir(rootDir string) error {
+	dir, err := os.ReadDir(rootDir)
+	if err != nil {
+		return err
+	}
+	for _, d := range dir {
+		err := os.RemoveAll(path.Join([]string{rootDir, d.Name()}...))
+		if err != nil {
+			return err
+		}
+	}
+	return os.RemoveAll(rootDir)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Now that this function, apparently, reduces flakiness a lot (I haven't seen any on orchestrator-relayer repo). I guess we can put it in the start node cleanup so that users won't have to worry about it.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
