### PR TITLE
chore: run hadolint and yamllint during `make lint`

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+---
+# Built from docs https://yamllint.readthedocs.io/en/stable/configuration.html
+extends: default
+
+rules:
+  # 120 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 120
+    level: warning

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ lint:
 	@golangci-lint run
 	@echo "--> Running markdownlint"
 	@markdownlint --config .markdownlint.yaml '**/*.md'
+	@echo "--> Running hadolint"
+	@hadolint Dockerfile
+	@echo "--> Running yamllint"
+	@yamllint --no-warnings . -c .yamllint.yml
+
 .PHONY: lint
 
 ## fmt: Format files per linters golangci-lint and markdownlint.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ See <https://docs.celestia.org/category/celestia-app> for more information
 
 1. Install [golangci-lint](https://golangci-lint.run/usage/install/)
 1. Install [markdownlint](https://github.com/DavidAnson/markdownlint)
+1. Install [hadolint](https://github.com/hadolint/hadolint)
+1. Install [yamllint](https://yamllint.readthedocs.io/en/stable/quickstart.html)
 
 ### Helpful Commands
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1403

yamllint config copied from https://github.com/celestiaorg/.github/blob/main/.yamllint.yml