### PR TITLE
feat: add the ability to log directly to a file 

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -115,7 +115,7 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	rootCmd.Flags().String(FlagLogToFile, "", "Log to file")
+	rootCmd.Flags().String(FlagLogToFile, "", "Write logs directly to a file. If empty, logs are written to stderr")
 	initRootCmd(rootCmd, encodingConfig)
 
 	return rootCmd
@@ -301,7 +301,7 @@ func createAppAndExport(
 }
 
 // replaceLogger optionally replaces the logger with a file logger if the flag
-// is set.
+// is set to something other than the default.
 func replaceLogger(cmd *cobra.Command) error {
 	logFilePath, err := cmd.Flags().GetString(flags.FlagLogFormat)
 	if err != nil {
@@ -316,7 +316,9 @@ func replaceLogger(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+
 	sctx := server.GetServerContextFromCmd(cmd)
 	sctx.Logger = log.NewTMLogger(log.NewSyncWriter(file))
+
 	return server.SetCmdServerContext(cmd, sctx)
 }

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -67,7 +67,7 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd := &cobra.Command{
 		Use:   "celestia-appd",
-		Short: "interface with the celestia blockchain",
+		Short: "Start celestia app",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
 			if err != nil {

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -312,7 +312,7 @@ func replaceLogger(cmd *cobra.Command) error {
 		return nil
 	}
 
-	file, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	file, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o644)
 	if err != nil {
 		return err
 	}

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -312,8 +312,6 @@ func replaceLogger(cmd *cobra.Command) error {
 		return nil
 	}
 
-	fmt.Println("logging to file ", logFilePath)
-
 	file, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return err

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -115,7 +115,7 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage: true,
 	}
 
-	rootCmd.Flags().String(FlagLogToFile, "", "Write logs directly to a file. If empty, logs are written to stderr")
+	rootCmd.PersistentFlags().String(FlagLogToFile, "", "Write logs directly to a file. If empty, logs are written to stderr")
 	initRootCmd(rootCmd, encodingConfig)
 
 	return rootCmd
@@ -303,7 +303,7 @@ func createAppAndExport(
 // replaceLogger optionally replaces the logger with a file logger if the flag
 // is set to something other than the default.
 func replaceLogger(cmd *cobra.Command) error {
-	logFilePath, err := cmd.Flags().GetString(flags.FlagLogFormat)
+	logFilePath, err := cmd.Flags().GetString(FlagLogToFile)
 	if err != nil {
 		return err
 	}
@@ -312,6 +312,8 @@ func replaceLogger(cmd *cobra.Command) error {
 		return nil
 	}
 
+	fmt.Println("logging to file ", logFilePath)
+
 	file, err := os.OpenFile(logFilePath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		return err
@@ -319,6 +321,5 @@ func replaceLogger(cmd *cobra.Command) error {
 
 	sctx := server.GetServerContextFromCmd(cmd)
 	sctx.Logger = log.NewTMLogger(log.NewSyncWriter(file))
-
 	return server.SetCmdServerContext(cmd, sctx)
 }


### PR DESCRIPTION
## Overview

This PR simply adds the option via a new flag to log directly to a file. This feature was requested by @Bidon15 to not have to use the `&>` in the cli. If this turns out to be a desirable feature, we can easily expand on this in the future.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
