### PR TITLE
chore: remove packr2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,9 @@ help: Makefile
 
 ## build: Build the celestia-appd binary into the ./build directory.
 build: mod
-	@go install github.com/gobuffalo/packr/v2/packr2@latest
-	@cd ./cmd/celestia-appd && packr2
+	@cd ./cmd/celestia-appd
 	@mkdir -p build/
 	@go build $(BUILD_FLAGS) -o build/ ./cmd/celestia-appd
-	@packr2 clean
 	@go mod tidy -compat=1.18
 .PHONY: build
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1478

## Testing

The before / after binaries are the exact same size

```
-rwxr-xr-x    1 rootulp  staff  81822242 Mar 13 11:58 celestia-appd-after
-rwxr-xr-x    1 rootulp  staff  81822242 Mar 13 11:57 celestia-appd-before
```

Based on a `./celestia-appd --help` invocation, they appear to behave identically