### PR TITLE
fix: signal handling for container

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -19,4 +19,4 @@ echo "Starting celestia-appd with command:"
 echo "/bin/celestia-appd $@"
 echo ""
 
-/bin/celestia-appd $@
+exec /bin/celestia-appd $@


### PR DESCRIPTION
Kubernetes and other container schedulers and runtimes send Unix signals to PID 1 in the container.
Currently, PID 1 is the call of `entrypoint.sh`, which starts the celestia-app with another PID. Therefore celestia-app never receives Unix signals (eg. SIGTERM) that where sent.
This PR changes the `entrypoint.sh` in such a way that celestia-app replaces the process itself. This way celestia-app will be PID 1 and then receives signals inside the container.

Interesting read:
- https://hynek.me/articles/docker-signals/