### PR TITLE
chore: bump NMT to v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/celestiaorg/celestia-app
 go 1.18
 
 require (
-	github.com/celestiaorg/nmt v0.14.0
+	github.com/celestiaorg/nmt v0.15.0
 	github.com/celestiaorg/quantum-gravity-bridge v1.3.0
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/gogo/protobuf v1.3.3

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7 h1:EADZy33ufskVIy6Rj6jbi3SO
 github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7/go.mod h1:vg3Eza9adJJ5Mdx6boz5MpZsZcTZyrfTVYZHyi2zLm4=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
-github.com/celestiaorg/nmt v0.14.0 h1:ET1PXBm8f3KHCAB7+sRVMTmvejkpQp6HAQsGLjIRtcY=
-github.com/celestiaorg/nmt v0.14.0/go.mod h1:b+pwd9cGTSSYLZnUIQSJl07pusJdFeEvCVsVfSRH9gA=
+github.com/celestiaorg/nmt v0.15.0 h1:ID9QlMIeP6WK/iiGcfnYLu2qqVIq0UYe/dc3TVPt6EA=
+github.com/celestiaorg/nmt v0.15.0/go.mod h1:GfwIvQPhUakn1modWxJ+rv8dUjJzuXg5H+MLFM1o7nY=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0 h1:9zPIp7w1FWfkPnn16y3S4FpFLnQtS7rm81CUVcHEts0=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0/go.mod h1:6WOajINTDEUXpSj5UZzod16UZ96ZVB/rFNKyM+Mt1gI=
 github.com/celestiaorg/rsmt2d v0.8.0 h1:ZUxTCELZCM9zMGKNF3cT+rUqMddXMeiuyleSJPZ3Wn4=

--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -89,7 +89,11 @@ func (w *ErasuredNamespacedMerkleTree) Push(data []byte) {
 // Root fulfills the rsmt.Tree interface by generating and returning the
 // underlying NamespaceMerkleTree Root.
 func (w *ErasuredNamespacedMerkleTree) Root() []byte {
-	return w.tree.Root()
+	root, err := w.tree.Root()
+	if err != nil {
+		panic(err)
+	}
+	return root
 }
 
 func (w *ErasuredNamespacedMerkleTree) Prove(ind int) (nmt.Proof, error) {

--- a/pkg/wrapper/nmt_wrapper_test.go
+++ b/pkg/wrapper/nmt_wrapper_test.go
@@ -114,8 +114,12 @@ func TestErasuredNamespacedMerkleTree(t *testing.T) {
 		tree.Push(d)
 	}
 
+	publicRoot, err := tree.Tree().Root()
+	assert.NoError(t, err)
+	privateRoot, err := tree.tree.Root()
+	assert.NoError(t, err)
 	assert.Equal(t, tree.Tree(), tree.tree)
-	assert.Equal(t, tree.Tree().Root(), tree.tree.Root())
+	assert.Equal(t, publicRoot, privateRoot)
 }
 
 // generateErasuredData produces a slice that is twice as long as it erasures

--- a/pkg/wrapper/nmt_wrapper_test.go
+++ b/pkg/wrapper/nmt_wrapper_test.go
@@ -50,7 +50,9 @@ func TestRootErasuredNamespacedMerkleTree(t *testing.T) {
 		}
 	}
 
-	assert.NotEqual(t, nmtTree.Root(), tree.Root())
+	root, err := nmtTree.Root()
+	assert.NoError(t, err)
+	assert.NotEqual(t, root, tree.Root())
 }
 
 func TestErasureNamespacedMerkleTreePanics(t *testing.T) {

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -175,7 +175,11 @@ func CreateCommitment(blob *Blob) ([]byte, error) {
 			}
 		}
 		// add the root
-		subTreeRoots[i] = tree.Root()
+		root, err := tree.Root()
+		if err != nil {
+			return nil, err
+		}
+		subTreeRoots[i] = root
 	}
 	return merkle.HashFromByteSlices(subTreeRoots), nil
 }


### PR DESCRIPTION
Cherry-pick https://github.com/celestiaorg/celestia-app/commit/ee84e3de2ea4d45537f95477c2bc6006b28a418c to the v0.13.x release branch. Will cut a new v0.13.x RC after this merges.

