### PR TITLE
chore: bump NMT to v0.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/celestiaorg/celestia-app
 go 1.19
 
 require (
-	github.com/celestiaorg/nmt v0.14.0
+	github.com/celestiaorg/nmt v0.15.0
 	github.com/celestiaorg/quantum-gravity-bridge v1.3.0
 	github.com/ethereum/go-ethereum v1.11.5
 	github.com/gogo/protobuf v1.3.3
@@ -28,10 +28,10 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.0-beta.3
 	github.com/celestiaorg/rsmt2d v0.8.0
+	github.com/cosmos/cosmos-proto v1.0.0-alpha8
 	github.com/cosmos/cosmos-sdk v0.46.7
 	github.com/cosmos/gogoproto v1.4.2
 	github.com/cosmos/ibc-go/v6 v6.1.0
-	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/tendermint/tendermint v0.34.24
 	golang.org/x/exp v0.0.0-20230206171751-46f607a40771
 	gopkg.in/yaml.v2 v2.4.0
@@ -65,7 +65,6 @@ require (
 	github.com/cometbft/cometbft-db v0.7.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
-	github.com/cosmos/cosmos-proto v1.0.0-alpha8 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
 	github.com/cosmos/gorocksdb v1.2.0 // indirect
 	github.com/cosmos/iavl v0.19.5 // indirect
@@ -150,6 +149,7 @@ require (
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rakyll/statik v0.1.7 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
+	github.com/regen-network/cosmos-proto v0.3.1 // indirect
 	github.com/rs/cors v1.8.2 // indirect
 	github.com/rs/zerolog v1.27.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/celestiaorg/cosmos-sdk v1.9.0-sdk-v0.46.11 h1:4pHUj2JP27fEJ1daxlJNGi/
 github.com/celestiaorg/cosmos-sdk v1.9.0-sdk-v0.46.11/go.mod h1:O3Pnh/fALx6KV5678ckfemIzvidYbVF5H8ol1rb/3+E=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
-github.com/celestiaorg/nmt v0.14.0 h1:ET1PXBm8f3KHCAB7+sRVMTmvejkpQp6HAQsGLjIRtcY=
-github.com/celestiaorg/nmt v0.14.0/go.mod h1:b+pwd9cGTSSYLZnUIQSJl07pusJdFeEvCVsVfSRH9gA=
+github.com/celestiaorg/nmt v0.15.0 h1:ID9QlMIeP6WK/iiGcfnYLu2qqVIq0UYe/dc3TVPt6EA=
+github.com/celestiaorg/nmt v0.15.0/go.mod h1:GfwIvQPhUakn1modWxJ+rv8dUjJzuXg5H+MLFM1o7nY=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0 h1:9zPIp7w1FWfkPnn16y3S4FpFLnQtS7rm81CUVcHEts0=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0/go.mod h1:6WOajINTDEUXpSj5UZzod16UZ96ZVB/rFNKyM+Mt1gI=
 github.com/celestiaorg/rsmt2d v0.8.0 h1:ZUxTCELZCM9zMGKNF3cT+rUqMddXMeiuyleSJPZ3Wn4=

--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -107,7 +107,11 @@ func (w *ErasuredNamespacedMerkleTree) Push(data []byte) {
 // Root fulfills the rsmt.Tree interface by generating and returning the
 // underlying NamespaceMerkleTree Root.
 func (w *ErasuredNamespacedMerkleTree) Root() []byte {
-	return w.tree.Root()
+	root, err := w.tree.Root()
+	if err != nil {
+		panic(err)
+	}
+	return root
 }
 
 // Prove returns a Merkle inclusion proof for the leaf at index `ind`.

--- a/pkg/wrapper/nmt_wrapper_test.go
+++ b/pkg/wrapper/nmt_wrapper_test.go
@@ -59,7 +59,9 @@ func TestRootErasuredNamespacedMerkleTree(t *testing.T) {
 		}
 	}
 
-	assert.NotEqual(t, nmtTree.Root(), tree.Root())
+	root, err := nmtTree.Root()
+	assert.NoError(t, err)
+	assert.NotEqual(t, root, tree.Root())
 }
 
 func TestErasureNamespacedMerkleTreePanics(t *testing.T) {

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -223,7 +223,11 @@ func CreateCommitment(blob *Blob) ([]byte, error) {
 			}
 		}
 		// add the root
-		subTreeRoots[i] = tree.Root()
+		root, err := tree.Root()
+		if err != nil {
+			return nil, err
+		}
+		subTreeRoots[i] = root
 	}
 	return merkle.HashFromByteSlices(subTreeRoots), nil
 }


### PR DESCRIPTION
Cherry-pick https://github.com/celestiaorg/celestia-app/commit/ee84e3de2ea4d45537f95477c2bc6006b28a418c to the v0.14.x release branch. Will cut a new v0.14.x RC after this merges.