### PR TITLE
chore!: rename `RowsRoots` => `RowRoots`

### DIFF
--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -29,7 +29,7 @@ const (
 // https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#availabledataheader
 type DataAvailabilityHeader struct {
 	// RowRoot_j = root((M_{j,1} || M_{j,2} || ... || M_{j,2k} ))
-	RowsRoots [][]byte `json:"row_roots"`
+	RowRoots [][]byte `json:"row_roots"`
 	// ColumnRoot_j = root((M_{1,j} || M_{2,j} || ... || M_{2k,j} ))
 	ColumnRoots [][]byte `json:"column_roots"`
 	// hash is the Merkle root of the row and column roots. This field is the
@@ -41,7 +41,7 @@ type DataAvailabilityHeader struct {
 func NewDataAvailabilityHeader(eds *rsmt2d.ExtendedDataSquare) DataAvailabilityHeader {
 	// generate the row and col roots using the EDS
 	dah := DataAvailabilityHeader{
-		RowsRoots:   eds.RowRoots(),
+		RowRoots:    eds.RowRoots(),
 		ColumnRoots: eds.ColRoots(),
 	}
 
@@ -97,9 +97,9 @@ func (dah *DataAvailabilityHeader) Hash() []byte {
 		return dah.hash
 	}
 
-	rowsCount := len(dah.RowsRoots)
+	rowsCount := len(dah.RowRoots)
 	slices := make([][]byte, rowsCount+rowsCount)
-	copy(slices[0:rowsCount], dah.RowsRoots)
+	copy(slices[0:rowsCount], dah.RowRoots)
 	copy(slices[rowsCount:], dah.ColumnRoots)
 	// The single data root is computed using a simple binary merkle tree.
 	// Effectively being root(rowRoots || columnRoots):
@@ -113,7 +113,7 @@ func (dah *DataAvailabilityHeader) ToProto() (*daproto.DataAvailabilityHeader, e
 	}
 
 	dahp := new(daproto.DataAvailabilityHeader)
-	dahp.RowRoots = dah.RowsRoots
+	dahp.RowRoots = dah.RowRoots
 	dahp.ColumnRoots = dah.ColumnRoots
 	return dahp, nil
 }
@@ -124,7 +124,7 @@ func DataAvailabilityHeaderFromProto(dahp *daproto.DataAvailabilityHeader) (dah 
 	}
 
 	dah = new(DataAvailabilityHeader)
-	dah.RowsRoots = dahp.RowRoots
+	dah.RowRoots = dahp.RowRoots
 	dah.ColumnRoots = dahp.ColumnRoots
 
 	return dah, dah.ValidateBasic()
@@ -135,22 +135,22 @@ func (dah *DataAvailabilityHeader) ValidateBasic() error {
 	if dah == nil {
 		return errors.New("nil data availability header is not valid")
 	}
-	if len(dah.ColumnRoots) < minExtendedSquareWidth || len(dah.RowsRoots) < minExtendedSquareWidth {
+	if len(dah.ColumnRoots) < minExtendedSquareWidth || len(dah.RowRoots) < minExtendedSquareWidth {
 		return fmt.Errorf(
 			"minimum valid DataAvailabilityHeader has at least %d row and column roots",
 			minExtendedSquareWidth,
 		)
 	}
-	if len(dah.ColumnRoots) > maxExtendedSquareWidth || len(dah.RowsRoots) > maxExtendedSquareWidth {
+	if len(dah.ColumnRoots) > maxExtendedSquareWidth || len(dah.RowRoots) > maxExtendedSquareWidth {
 		return fmt.Errorf(
 			"maximum valid DataAvailabilityHeader has at most %d row and column roots",
 			maxExtendedSquareWidth,
 		)
 	}
-	if len(dah.ColumnRoots) != len(dah.RowsRoots) {
+	if len(dah.ColumnRoots) != len(dah.RowRoots) {
 		return fmt.Errorf(
 			"unequal number of row and column roots: row %d col %d",
-			len(dah.RowsRoots),
+			len(dah.RowRoots),
 			len(dah.ColumnRoots),
 		)
 	}
@@ -165,7 +165,7 @@ func (dah *DataAvailabilityHeader) IsZero() bool {
 	if dah == nil {
 		return true
 	}
-	return len(dah.ColumnRoots) == 0 || len(dah.RowsRoots) == 0
+	return len(dah.ColumnRoots) == 0 || len(dah.RowRoots) == 0
 }
 
 // MinDataAvailabilityHeader returns the minimum valid data availability header.

--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -60,7 +60,7 @@ func TestNewDataAvailabilityHeader(t *testing.T) {
 			require.NoError(t, err)
 			resdah := NewDataAvailabilityHeader(eds)
 			require.Equal(t, tt.squareSize*2, uint64(len(resdah.ColumnRoots)), tt.name)
-			require.Equal(t, tt.squareSize*2, uint64(len(resdah.RowsRoots)), tt.name)
+			require.Equal(t, tt.squareSize*2, uint64(len(resdah.RowRoots)), tt.name)
 			require.Equal(t, tt.expectedHash, resdah.hash, tt.name)
 		})
 	}
@@ -150,15 +150,15 @@ func Test_DAHValidateBasic(t *testing.T) {
 	// make a mutant dah that has too many roots
 	var tooBigDah DataAvailabilityHeader
 	tooBigDah.ColumnRoots = make([][]byte, appconsts.DefaultMaxSquareSize*appconsts.DefaultMaxSquareSize)
-	tooBigDah.RowsRoots = make([][]byte, appconsts.DefaultMaxSquareSize*appconsts.DefaultMaxSquareSize)
+	tooBigDah.RowRoots = make([][]byte, appconsts.DefaultMaxSquareSize*appconsts.DefaultMaxSquareSize)
 	copy(tooBigDah.ColumnRoots, bigdah.ColumnRoots)
-	copy(tooBigDah.RowsRoots, bigdah.RowsRoots)
+	copy(tooBigDah.RowRoots, bigdah.RowRoots)
 	tooBigDah.ColumnRoots = append(tooBigDah.ColumnRoots, bytes.Repeat([]byte{1}, 32))
-	tooBigDah.RowsRoots = append(tooBigDah.RowsRoots, bytes.Repeat([]byte{1}, 32))
+	tooBigDah.RowRoots = append(tooBigDah.RowRoots, bytes.Repeat([]byte{1}, 32))
 	// make a mutant dah that has too few roots
 	var tooSmallDah DataAvailabilityHeader
 	tooSmallDah.ColumnRoots = [][]byte{bytes.Repeat([]byte{2}, 32)}
-	tooSmallDah.RowsRoots = [][]byte{bytes.Repeat([]byte{2}, 32)}
+	tooSmallDah.RowRoots = [][]byte{bytes.Repeat([]byte{2}, 32)}
 	// use a bad hash
 	badHashDah := MinDataAvailabilityHeader()
 	badHashDah.hash = []byte{1, 2, 3, 4}

--- a/pkg/inclusion/get_commit.go
+++ b/pkg/inclusion/get_commit.go
@@ -10,7 +10,7 @@ import (
 // GetCommitment gets the share commitment for a blob in the original data
 // square.
 func GetCommitment(cacher *EDSSubTreeRootCacher, dah da.DataAvailabilityHeader, start, blobShareLen int) ([]byte, error) {
-	squareSize := len(dah.RowsRoots) / 2
+	squareSize := len(dah.RowRoots) / 2
 	if start+blobShareLen > squareSize*squareSize {
 		return nil, errors.New("cannot get commitment for blob that doesn't fit in square")
 	}

--- a/pkg/inclusion/nmt_caching.go
+++ b/pkg/inclusion/nmt_caching.go
@@ -115,14 +115,14 @@ func (stc *EDSSubTreeRootCacher) Constructor(axis rsmt2d.Axis, axisIndex uint) r
 // getSubTreeRoot traverses the nmt of the selected row and returns the
 // subtree root. An error is thrown if the subtree cannot be found.
 func (stc *EDSSubTreeRootCacher) getSubTreeRoot(dah da.DataAvailabilityHeader, row int, path []WalkInstruction) ([]byte, error) {
-	if len(stc.caches) != len(dah.RowsRoots) {
-		return nil, fmt.Errorf("data availability header has unexpected number of row roots: expected %d got %d", len(stc.caches), len(dah.RowsRoots))
+	if len(stc.caches) != len(dah.RowRoots) {
+		return nil, fmt.Errorf("data availability header has unexpected number of row roots: expected %d got %d", len(stc.caches), len(dah.RowRoots))
 	}
 	if row >= len(stc.caches) {
 		return nil, fmt.Errorf("row exceeds range of cache: max %d got %d", len(stc.caches), row)
 	}
 	stc.mut.RLock()
-	sbt, err := stc.caches[uint(row)].walk(dah.RowsRoots[row], path)
+	sbt, err := stc.caches[uint(row)].walk(dah.RowRoots[row], path)
 	stc.mut.RUnlock()
 	return sbt, err
 }

--- a/pkg/inclusion/nmt_caching_test.go
+++ b/pkg/inclusion/nmt_caching_test.go
@@ -118,7 +118,7 @@ func TestEDSSubRootCacher(t *testing.T) {
 
 	dah := da.NewDataAvailabilityHeader(eds)
 
-	for i := range dah.RowsRoots[:squareSize] {
+	for i := range dah.RowRoots[:squareSize] {
 		expectedSubTreeRoots := calculateSubTreeRoots(eds.Row(uint(i))[:squareSize], 2)
 		require.NotNil(t, expectedSubTreeRoots)
 		// note: the depth is one greater than expected because we're dividing


### PR DESCRIPTION
## Overview

Rename RowsRoots to RowRoots to conform with ColumnRoots.
- Closes #1609 