### PR TITLE
ci: stop Deploy PR Preview for fork branches

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,7 +39,7 @@ jobs:
           keep_files: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Deploy PR preview
-        # Only run this job if the PR was created from a branch on celestiaorg/celestia-app 
+        # Only run this job if the PR was created from a branch on celestiaorg/celestia-app
         # because this job will fail for branches from forks.
         # https://github.com/celestiaorg/celestia-app/issues/1506
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -39,7 +39,10 @@ jobs:
           keep_files: ${{ github.event_name != 'workflow_dispatch' }}
 
       - name: Deploy PR preview
-        if: github.event_name == 'pull_request'
+        # Only run this job if the PR was created from a branch on celestiaorg/celestia-app 
+        # because this job will fail for branches from forks.
+        # https://github.com/celestiaorg/celestia-app/issues/1506
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: ./specs/book


### PR DESCRIPTION
An attempt to stop this Github action from running for fork branches

<img width="842" alt="Screenshot 2023-04-14 at 10 56 35 AM" src="https://user-images.githubusercontent.com/3699047/232079662-f72a99ee-7ae7-4188-9ff3-f079eef043f4.png">
