### PR TITLE
chore: register blob msg server in module

### DIFF
--- a/x/blob/module.go
+++ b/x/blob/module.go
@@ -127,6 +127,7 @@ func (am AppModule) LegacyQuerierHandler(legacyQuerierCdc *codec.LegacyAmino) sd
 // RegisterServices registers a GRPC query service to respond to the
 // module-specific GRPC queries.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
+	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 


### PR DESCRIPTION
## Overview

This is pretty standard to do in the sdk, not sure how we haven't done this yet given over two years of running the state machine and audits lol 

Everything was still occurring via the legacy sdk.Router, but still... 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
