### PR TITLE
chore: document that `MsgPayForBlobs` implements LegacyMsg interface

### DIFF
--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -11,6 +11,7 @@ import (
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/nmt"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	"github.com/tendermint/tendermint/crypto/merkle"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	coretypes "github.com/tendermint/tendermint/types"
@@ -24,7 +25,9 @@ const (
 	NamespaceIDSize   = appconsts.NamespaceSize
 )
 
-var _ sdk.Msg = &MsgPayForBlobs{}
+// MsgPayForBlobs implements the `LegacyMsg` interface.
+// See: https://docs.cosmos.network/v0.46/building-modules/messages-and-queries.html#legacy-amino-legacymsgs
+var _ legacytx.LegacyMsg = &MsgPayForBlobs{}
 
 func NewMsgPayForBlobs(signer string, blobs ...*Blob) (*MsgPayForBlobs, error) {
 	err := ValidateBlobs(blobs...)
@@ -67,10 +70,10 @@ func namespacesToBytes(namespaces []appns.Namespace) (result [][]byte) {
 	return result
 }
 
-// Route fulfills the sdk.Msg interface
+// Route fulfills the legacytx.LegacyMsg interface
 func (msg *MsgPayForBlobs) Route() string { return RouterKey }
 
-// Type fulfills the sdk.Msg interface
+// Type fulfills the legacytx.LegacyMsg interface
 func (msg *MsgPayForBlobs) Type() string {
 	return URLMsgPayForBlobs
 }
@@ -149,7 +152,7 @@ func ValidateBlobNamespaceID(ns appns.Namespace) error {
 	return nil
 }
 
-// GetSignBytes fulfills the sdk.Msg interface by returning a deterministic set
+// GetSignBytes fulfills the legacytx.LegacyMsg interface by returning a deterministic set
 // of bytes to sign over
 func (msg *MsgPayForBlobs) GetSignBytes() []byte {
 	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))


### PR DESCRIPTION
The Cosmos SDK docs are pretty confusing. They describe two different ways to define a message:
1. https://docs.cosmos.network/v0.46/building-modules/messages-and-queries.html#msg-services
2. https://docs.cosmos.network/v0.46/building-modules/messages-and-queries.html#legacy-amino-legacymsgs

`MsgPayForBlobs` uses option 2. This PR attempts to clarify that.