### PR TITLE
feat!: Remove support for legacy plain text proposals

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -350,8 +350,7 @@ func New(
 
 	// register the proposal types
 	govRouter := oldgovtypes.NewRouter()
-	govRouter.AddRoute(govtypes.RouterKey, oldgovtypes.ProposalHandler).
-		AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
+	govRouter.AddRoute(paramproposal.RouterKey, params.NewParamChangeProposalHandler(app.ParamsKeeper)).
 		AddRoute(distrtypes.RouterKey, distr.NewCommunityPoolSpendProposalHandler(app.DistrKeeper)).
 		AddRoute(ibcclienttypes.RouterKey, ibcclient.NewClientProposalHandler(app.IBCKeeper.ClientKeeper))
 

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -199,7 +199,7 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 			},
 			// plain text proposals have been removed, so we expect an error. "No
 			// handler exists for proposal type"
-			expectedCode: errors.ErrInvalidAddress.ABCICode(),
+			expectedCode: errors.ErrUnknownAddress.ABCICode(),
 		},
 		{
 			name: "multiple send sdk.Msgs in one sdk.Tx",

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -198,7 +199,7 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 			},
 			// plain text proposals have been removed, so we expect an error. "No
 			// handler exists for proposal type"
-			expectedCode: uint32(9),
+			expectedCode: errors.ErrInvalidAddress.ABCICode(),
 		},
 		{
 			name: "multiple send sdk.Msgs in one sdk.Tx",

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/testutil/mock"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/cosmos/cosmos-sdk/types/errors"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
+	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 	oldgov "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -199,7 +199,7 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 			},
 			// plain text proposals have been removed, so we expect an error. "No
 			// handler exists for proposal type"
-			expectedCode: errors.ErrUnknownAddress.ABCICode(),
+			expectedCode: govtypes.ErrNoProposalHandlerExists.ABCICode(),
 		},
 		{
 			name: "multiple send sdk.Msgs in one sdk.Tx",

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -196,7 +196,9 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 				require.NoError(t, err)
 				return []sdk.Msg{msg}, account
 			},
-			expectedCode: uint32(9), // plain text proposals have been removed
+			// plain text proposals have been removed, so we expect an error. "No
+			// handler exists for proposal type"
+			expectedCode: uint32(9),
 		},
 		{
 			name: "multiple send sdk.Msgs in one sdk.Tx",

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -15,6 +15,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	disttypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	oldgov "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -157,7 +158,30 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 			expectedCode: abci.CodeTypeOK,
 		},
 		{
-			name: "create legacy governance proposal",
+			name: "create legacy community spend governance proposal",
+			msgFunc: func() (msgs []sdk.Msg, signer string) {
+				account := s.unusedAccount()
+				coins := sdk.NewCoins(sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000)))
+				content := disttypes.NewCommunityPoolSpendProposal(
+					"title",
+					"description",
+					getAddress(s.unusedAccount(), s.cctx.Keyring),
+					coins,
+				)
+				addr := getAddress(account, s.cctx.Keyring)
+				msg, err := oldgov.NewMsgSubmitProposal(
+					content,
+					sdk.NewCoins(
+						sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000000))),
+					addr,
+				)
+				require.NoError(t, err)
+				return []sdk.Msg{msg}, account
+			},
+			expectedCode: abci.CodeTypeOK,
+		},
+		{
+			name: "create legacy text governance proposal",
 			msgFunc: func() (msgs []sdk.Msg, signer string) {
 				account := s.unusedAccount()
 				content, ok := oldgov.ContentFromProposalType("title", "description", "text")
@@ -172,9 +196,7 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 				require.NoError(t, err)
 				return []sdk.Msg{msg}, account
 			},
-			// despite token voting being removed, we still expect a code of 0.
-			// However, the tx still fails. See tests in local upgrade module
-			expectedCode: abci.CodeTypeOK,
+			expectedCode: uint32(9), // plain text proposals have been removed
 		},
 		{
 			name: "multiple send sdk.Msgs in one sdk.Tx",


### PR DESCRIPTION
## Overview

This PR removes legacy text proposals. While it is still possible to submit other proposals that are functionally very similar, here we are being explicit by removing the ability to handle text proposals.

part of #1593

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
