### PR TITLE
chore: cherry-pick qgb changes for BSR update

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -186,5 +186,5 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23.0.20230427163051-acab135b0610
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23-BSR-hardfork
 )

--- a/go.mod
+++ b/go.mod
@@ -186,5 +186,5 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23.0.20230427163051-acab135b0610
 )

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23.0.20230427163051-acab135b0610 h1:h0+5xus7Xhfaf3RoETZi89N3v5qOj0KXAuSIqwcqCRI=
-github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23.0.20230427163051-acab135b0610/go.mod h1:nL+vkAMKy/A8wWemWqMwBy4pOGWYYbboAVTEe3N5gIU=
+github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23-BSR-hardfork h1:2U7Zh07sEXYlPdJJffNsD9em1QAR3zIoG5quoQc12VA=
+github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23-BSR-hardfork/go.mod h1:nL+vkAMKy/A8wWemWqMwBy4pOGWYYbboAVTEe3N5gIU=
 github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7 h1:EADZy33ufskVIy6Rj6jbi3SOVCeYYo26zUi7iYx+QR0=
 github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7/go.mod h1:vg3Eza9adJJ5Mdx6boz5MpZsZcTZyrfTVYZHyi2zLm4=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/go.sum
+++ b/go.sum
@@ -186,8 +186,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23 h1:1moC5rXA7to8Neci5KWQcYVjSrGpkKH7dIHIhT8UsYw=
-github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23/go.mod h1:nL+vkAMKy/A8wWemWqMwBy4pOGWYYbboAVTEe3N5gIU=
+github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23.0.20230427163051-acab135b0610 h1:h0+5xus7Xhfaf3RoETZi89N3v5qOj0KXAuSIqwcqCRI=
+github.com/celestiaorg/celestia-core v1.15.1-tm-v0.34.23.0.20230427163051-acab135b0610/go.mod h1:nL+vkAMKy/A8wWemWqMwBy4pOGWYYbboAVTEe3N5gIU=
 github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7 h1:EADZy33ufskVIy6Rj6jbi3SOVCeYYo26zUi7iYx+QR0=
 github.com/celestiaorg/cosmos-sdk v1.8.0-sdk-v0.46.7/go.mod h1:vg3Eza9adJJ5Mdx6boz5MpZsZcTZyrfTVYZHyi2zLm4=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -168,8 +168,8 @@ func TestDataCommitmentRange(t *testing.T) {
 	assert.Equal(t, types.DataCommitmentRequestType, att1.Type())
 	dc1, ok := att1.(*types.DataCommitment)
 	require.True(t, ok)
-	assert.Equal(t, newHeight-1, int64(dc1.EndBlock))
-	assert.Equal(t, int64(0), int64(dc1.BeginBlock))
+	assert.Equal(t, newHeight, int64(dc1.EndBlock))
+	assert.Equal(t, int64(1), int64(dc1.BeginBlock))
 
 	// increment height to 2*data commitment window
 	newHeight = int64(qk.GetDataCommitmentWindowParam(ctx)) * 2
@@ -183,6 +183,6 @@ func TestDataCommitmentRange(t *testing.T) {
 	assert.Equal(t, types.DataCommitmentRequestType, att2.Type())
 	dc2, ok := att2.(*types.DataCommitment)
 	require.True(t, ok)
-	assert.Equal(t, newHeight-1, int64(dc2.EndBlock))
+	assert.Equal(t, newHeight, int64(dc2.EndBlock))
 	assert.Equal(t, dc1.EndBlock+1, dc2.BeginBlock)
 }

--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -66,7 +66,8 @@ func (k Keeper) CheckLatestAttestationNonce(ctx sdk.Context) bool {
 // GetLatestAttestationNonce returns the latest attestation request nonce.
 // Panics if the latest attestation nonce doesn't exit. Make sure to call `CheckLatestAttestationNonce`
 // before getting the nonce.
-// This value is set on chain startup, it shouldn't panic in normal conditions.
+// This value is set on chain startup. However, it won't be written to store until height = 1.
+// Thus, it's mandatory to run `CheckLatestAttestationNonce` before calling this method.
 // Check x/qgb/genesis.go for more information.
 func (k Keeper) GetLatestAttestationNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -12,10 +12,9 @@ import (
 // GetCurrentDataCommitment creates the latest data commitment at current height according to
 // the data commitment window specified
 func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment, error) {
-	beginBlock := uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx)
-	// to avoid having overlapped ranges of data commitments such as: 0-400;400-800;800-1200
-	// we will commit to the previous block height so that the ranges are as follows: 0-399;400-799;800-1199
-	endBlock := uint64(ctx.BlockHeight()) - 1
+	beginBlock := uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx) + 1
+	// for a data commitment window of 400, the ranges will be: 1-400;401-800;801-1200
+	endBlock := uint64(ctx.BlockHeight())
 	nonce := k.GetLatestAttestationNonce(ctx) + 1
 
 	dataCommitment := types.NewDataCommitment(nonce, beginBlock, endBlock)

--- a/x/qgb/keeper/keeper_data_commitment_test.go
+++ b/x/qgb/keeper/keeper_data_commitment_test.go
@@ -90,7 +90,7 @@ func TestGetDataCommitmentForHeight(t *testing.T) {
 			height:        window * 100,
 			expectedDCC:   types.DataCommitment{},
 			expectError:   true,
-			expectedError: "data commitment for height not found",
+			expectedError: "Last height 3999 < 40000: no data commitment has been generated for the provided height",
 		},
 	}
 	for _, tt := range tests {

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -18,6 +18,9 @@ import (
 // Panics if no valset is found. Because, a valset is always created when starting
 // the chain. Check x/qgb/abci.go:68 for more information.
 func (k Keeper) GetLatestValset(ctx sdk.Context) (*types.Valset, error) {
+	if !k.CheckLatestAttestationNonce(ctx) {
+		return nil, types.ErrLatestAttestationNonceStillNotInitialized
+	}
 	nonce := k.GetLatestAttestationNonce(ctx)
 	for i := uint64(0); i <= nonce; i++ {
 		at, found, err := k.GetAttestationByNonce(ctx, nonce-i)
@@ -98,6 +101,9 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 	}
 
 	// increment the nonce, since this potential future valset should be after the current valset
+	if !k.CheckLatestAttestationNonce(ctx) {
+		return types.Valset{}, types.ErrLatestAttestationNonceStillNotInitialized
+	}
 	valsetNonce := k.GetLatestAttestationNonce(ctx) + 1
 
 	valset, err := types.NewValset(valsetNonce, uint64(ctx.BlockHeight()), bridgeValidators)
@@ -132,6 +138,9 @@ func normalizeValidatorPower(rawPower uint64, totalValidatorPower cosmosmath.Int
 // the `nonce` can be a valset, but this method will return the valset before it.
 // If the provided nonce is 1, it will return an error, because, there is no valset before nonce 1.
 func (k Keeper) GetLastValsetBeforeNonce(ctx sdk.Context, nonce uint64) (*types.Valset, error) {
+	if !k.CheckLatestAttestationNonce(ctx) {
+		return nil, types.ErrLatestAttestationNonceStillNotInitialized
+	}
 	if nonce == 1 {
 		return nil, types.ErrNoValsetBeforeNonceOne
 	}

--- a/x/qgb/keeper/keeper_valset_test.go
+++ b/x/qgb/keeper/keeper_valset_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/testutil"
 	"github.com/celestiaorg/celestia-app/x/qgb/types"
+	"github.com/cosmos/cosmos-sdk/x/staking"
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -60,6 +61,61 @@ func TestCurrentValsetNormalization(t *testing.T) {
 			rMembers, err := types.BridgeValidators(r.Members).ToInternal()
 			require.NoError(t, err)
 			assert.Equal(t, spec.expPowers, rMembers.GetPowers())
+		})
+	}
+}
+
+func TestCheckingLatestAttestationNonceInValsets(t *testing.T) {
+	input := testutil.CreateTestEnvWithoutAttestationNonceInit(t)
+	k := input.QgbKeeper
+	// create a validator to have a  realistic scenario
+	testutil.CreateValidator(
+		t,
+		input,
+		testutil.AccAddrs[0],
+		testutil.AccPubKeys[0],
+		0,
+		testutil.ValAddrs[0],
+		testutil.ConsPubKeys[0],
+		testutil.StakingAmount,
+		testutil.EVMAddrs[0],
+	)
+	// Run the staking endblocker to ensure valset is correct in state
+	staking.EndBlocker(input.Context, input.StakingKeeper)
+	tests := []struct {
+		name          string
+		requestFunc   func() error
+		expectedError error
+	}{
+		{
+			name: "check latest nonce before getting the latest valset",
+			requestFunc: func() error {
+				_, err := k.GetLatestValset(input.Context)
+				return err
+			},
+			expectedError: types.ErrLatestAttestationNonceStillNotInitialized,
+		},
+		{
+			name: "check latest nonce before getting the current valset",
+			requestFunc: func() error {
+				_, err := k.GetCurrentValset(input.Context)
+				return err
+			},
+			expectedError: types.ErrLatestAttestationNonceStillNotInitialized,
+		},
+		{
+			name: "check latest nonce before getting last valset before nonce",
+			requestFunc: func() error {
+				_, err := k.GetLastValsetBeforeNonce(input.Context, 1)
+				return err
+			},
+			expectedError: types.ErrLatestAttestationNonceStillNotInitialized,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.requestFunc()
+			assert.ErrorIs(t, err, tt.expectedError)
 		})
 	}
 }

--- a/x/qgb/keeper/query_attestation.go
+++ b/x/qgb/keeper/query_attestation.go
@@ -36,6 +36,9 @@ func (k Keeper) LatestAttestationNonce(
 	ctx context.Context,
 	request *types.QueryLatestAttestationNonceRequest,
 ) (*types.QueryLatestAttestationNonceResponse, error) {
+	if !k.CheckLatestAttestationNonce(sdk.UnwrapSDKContext(ctx)) {
+		return nil, types.ErrLatestAttestationNonceStillNotInitialized
+	}
 	return &types.QueryLatestAttestationNonceResponse{
 		Nonce: k.GetLatestAttestationNonce(sdk.UnwrapSDKContext(ctx)),
 	}, nil

--- a/x/qgb/types/errors.go
+++ b/x/qgb/types/errors.go
@@ -1,18 +1,21 @@
 package types
 
-import sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+import "cosmossdk.io/errors"
 
 var (
-	ErrDuplicate                             = sdkerrors.Register(ModuleName, 2, "duplicate")
-	ErrEmpty                                 = sdkerrors.Register(ModuleName, 6, "empty")
-	ErrNoValidators                          = sdkerrors.Register(ModuleName, 12, "no bonded validators in active set")
-	ErrInvalidValAddress                     = sdkerrors.Register(ModuleName, 13, "invalid validator address in current valset %v")
-	ErrInvalidEVMAddress                     = sdkerrors.Register(ModuleName, 14, "discovered invalid EVM address stored for validator %v")
-	ErrInvalidValset                         = sdkerrors.Register(ModuleName, 15, "generated invalid valset")
-	ErrAttestationNotValsetRequest           = sdkerrors.Register(ModuleName, 16, "attestation is not a valset request")
-	ErrAttestationNotFound                   = sdkerrors.Register(ModuleName, 18, "attestation not found")
-	ErrNilAttestation                        = sdkerrors.Register(ModuleName, 22, "nil attestation")
-	ErrUnmarshalllAttestation                = sdkerrors.Register(ModuleName, 26, "couldn't unmarshall attestation from store")
-	ErrNonceHigherThanLatestAttestationNonce = sdkerrors.Register(ModuleName, 27, "the provided nonce is higher than the latest attestation nonce")
-	ErrNoValsetBeforeNonceOne                = sdkerrors.Register(ModuleName, 28, "there is no valset before attestation nonce 1")
+	ErrDuplicate                                 = errors.Register(ModuleName, 2, "duplicate")
+	ErrEmpty                                     = errors.Register(ModuleName, 6, "empty")
+	ErrNoValidators                              = errors.Register(ModuleName, 12, "no bonded validators in active set")
+	ErrInvalidValAddress                         = errors.Register(ModuleName, 13, "invalid validator address in current valset %v")
+	ErrInvalidEVMAddress                         = errors.Register(ModuleName, 14, "discovered invalid EVM address stored for validator %v")
+	ErrInvalidValset                             = errors.Register(ModuleName, 15, "generated invalid valset")
+	ErrAttestationNotValsetRequest               = errors.Register(ModuleName, 16, "attestation is not a valset request")
+	ErrAttestationNotFound                       = errors.Register(ModuleName, 18, "attestation not found")
+	ErrNilAttestation                            = errors.Register(ModuleName, 22, "nil attestation")
+	ErrUnmarshalllAttestation                    = errors.Register(ModuleName, 26, "couldn't unmarshall attestation from store")
+	ErrNonceHigherThanLatestAttestationNonce     = errors.Register(ModuleName, 27, "the provided nonce is higher than the latest attestation nonce")
+	ErrNoValsetBeforeNonceOne                    = errors.Register(ModuleName, 28, "there is no valset before attestation nonce 1")
+	ErrDataCommitmentNotGenerated                = errors.Register(ModuleName, 29, "no data commitment has been generated for the provided height")
+	ErrDataCommitmentNotFound                    = errors.Register(ModuleName, 30, "data commitment not found")
+	ErrLatestAttestationNonceStillNotInitialized = errors.Register(ModuleName, 31, "the latest attestation nonce has still not been defined in store")
 )


### PR DESCRIPTION
## Overview

cherry picks 3 relevant qgb changes from main, along with 3 from core (using the `v1.15.1-tm-v0.34.23-BSR-hardfork` tag)


## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords