### PR TITLE
Refactor variable name from len to length

### DIFF
--- a/pkg/shares/share_builder_test.go
+++ b/pkg/shares/share_builder_test.go
@@ -142,10 +142,10 @@ func TestShareBuilderWriteSequenceLen(t *testing.T) {
 			share, err := tc.builder.Build()
 			require.NoError(t, err)
 
-			len, err := share.SequenceLen()
+			length, err := share.SequenceLen()
 			require.NoError(t, err)
 
-			assert.Equal(t, tc.wantLen, len)
+			assert.Equal(t, tc.wantLen, length)
 		})
 	}
 }

--- a/pkg/shares/shares_test.go
+++ b/pkg/shares/shares_test.go
@@ -117,14 +117,14 @@ func TestSequenceLen(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			len, err := tc.share.SequenceLen()
+			length, err := tc.share.SequenceLen()
 
 			if tc.wantErr {
 				assert.Error(t, err)
 				return
 			}
-			if tc.wantLen != len {
-				t.Errorf("want %d, got %d", tc.wantLen, len)
+			if tc.wantLen != length {
+				t.Errorf("want %d, got %d", tc.wantLen, length)
 			}
 		})
 	}


### PR DESCRIPTION
I have made some changes to the code in this pull request. The main change is that I have renamed the variable `len` to `length`. This is because `len` is a built-in function in Go, and using it as a variable name can cause confusion and potential issues down the line. It is best practice to use a different name, and `length` is a clear and descriptive alternative.

