### PR TITLE
Redundant if-check in Validate function.

### DIFF
--- a/x/blob/types/params.go
+++ b/x/blob/types/params.go
@@ -41,10 +41,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 
 // Validate validates the set of params
 func (p Params) Validate() error {
-	if err := validateGasPerBlobByte(p.GasPerBlobByte); err != nil {
-		return err
-	}
-	return nil
+	return validateGasPerBlobByte(p.GasPerBlobByte)
 }
 
 // String implements the Stringer interface.


### PR DESCRIPTION
The issue is causing a lint error because it is using a redundant `if` statement to check for an error and then returning the error immediately after. This can be simplified by just returning the error directly, without checking for it using an `if` statement.

This issue is a part of a #1671 