### PR TITLE
chore: enable tx indexing on dev scripts

### DIFF
--- a/scripts/build-run-single-node.sh
+++ b/scripts/build-run-single-node.sh
@@ -30,6 +30,7 @@ ${BIN_PATH} collect-gentxs --home ${HOME_DIR}
 # If you encounter: `sed: -I or -i may not be used with stdin` on MacOS you can mitigate by installing gnu-sed
 # https://gist.github.com/andre3k1/e3a1a7133fded5de5a9ee99c87c6fa0d?permalink_comment_id=3082272#gistcomment-3082272
 sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ${HOME_DIR}/config/config.toml
+sed -i'.bak' 's#"null"#"kv"#g' ${HOME_DIR}/config/config.toml
 
 # Start the celestia-app
 ${BIN_PATH} start --home ${HOME_DIR}

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -25,6 +25,7 @@ celestia-appd collect-gentxs --home ${HOME_DIR}
 # If you encounter: `sed: -I or -i may not be used with stdin` on MacOS you can mitigate by installing gnu-sed
 # https://gist.github.com/andre3k1/e3a1a7133fded5de5a9ee99c87c6fa0d?permalink_comment_id=3082272#gistcomment-3082272
 sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ${HOME_DIR}/config/config.toml
+sed -i'.bak' 's#"null"#"kv"#g' ${HOME_DIR}/config/config.toml
 
 # Start the celestia-app
 celestia-appd start --home ${HOME_DIR}


### PR DESCRIPTION
While debugging PFB txs, I found it helpful to enable tx indexing for the local node that gets run via the scripts in `./scripts`. Totally optional PR.