### PR TITLE
feat: implement the update logic for data commitment creation

### DIFF
--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -168,8 +168,8 @@ func TestDataCommitmentRange(t *testing.T) {
 	assert.Equal(t, types.DataCommitmentRequestType, att1.Type())
 	dc1, ok := att1.(*types.DataCommitment)
 	require.True(t, ok)
-	assert.Equal(t, newHeight, int64(dc1.EndBlock))
-	assert.Equal(t, int64(1), int64(dc1.BeginBlock))
+	assert.Equal(t, newHeight-1, int64(dc1.EndBlock))
+	assert.Equal(t, int64(0), int64(dc1.BeginBlock))
 
 	// increment height to 2*data commitment window
 	newHeight = int64(qk.GetDataCommitmentWindowParam(ctx)) * 2
@@ -183,6 +183,6 @@ func TestDataCommitmentRange(t *testing.T) {
 	assert.Equal(t, types.DataCommitmentRequestType, att2.Type())
 	dc2, ok := att2.(*types.DataCommitment)
 	require.True(t, ok)
-	assert.Equal(t, newHeight, int64(dc2.EndBlock))
+	assert.Equal(t, newHeight-1, int64(dc2.EndBlock))
 	assert.Equal(t, dc1.EndBlock+1, dc2.BeginBlock)
 }

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -13,10 +13,16 @@ import (
 // GetCurrentDataCommitment creates the latest data commitment at current height according to
 // the data commitment window specified
 func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment, error) {
-	beginBlock := uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx) + 1
-	// for a data commitment window of 400, the ranges will be: 1-400;401-800;801-1200
-	endBlock := uint64(ctx.BlockHeight())
-
+	var beginBlock, endBlock uint64
+	if ctx.BlockHeader().Version.App == 0 {
+		beginBlock = uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx)
+		// for a data commitment window of 400, the ranges will be: 0-399;400-799;800-1199
+		endBlock = uint64(ctx.BlockHeight()) - 1
+	} else {
+		beginBlock = uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx) + 1
+		// for a data commitment window of 400, the ranges will be: 1-400;401-800;801-1200
+		endBlock = uint64(ctx.BlockHeight())
+	}
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return types.DataCommitment{}, types.ErrLatestAttestationNonceStillNotInitialized
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Implements the update logic for data commitment creation. Because, this is changing the state between the two versions and if a validator starts syncing from genesis (even using the new version), it will end up failing.

Thus, we need to implement the same mechanism we did for the `threshold` so that new binaries are able to sync from genesis.

More information in: https://github.com/celestiaorg/celestia-app/issues/1676#issuecomment-1532231143

Note: this will result in missing a block between the updates. But it's okey for BSR. However, we have an issue to update the data commitment creation to support changes in the window:  https://github.com/celestiaorg/celestia-app/issues/1685

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
