### PR TITLE
chore!: use updated hardfork height

### DIFF
--- a/x/version/chains.go
+++ b/x/version/chains.go
@@ -18,7 +18,7 @@ func StandardChainVersions() map[string]ChainVersionConfig {
 	})
 	bsr := NewChainVersionConfig(map[uint64]int64{
 		0: 0,
-		1: 674000,
+		1: 446500,
 	})
 	return map[string]ChainVersionConfig{
 		MochaChainID:          version0Only,


### PR DESCRIPTION
## Overview

this updates the hardfork height for blockspacerace-0

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
