### PR TITLE
feat!: correctly creating the data commitments when the window is changed

### DIFF
--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -133,7 +133,7 @@ func TestGetDataCommitment(t *testing.T) {
 	require.Equal(t, uint64(1), dc1.BeginBlock)
 	require.Equal(t, uint64(dcWindow), dc1.EndBlock)
 	require.Equal(t, uint64(1), dc1.Nonce)
-	// setting the first data commitment
+	// set the first data commitment
 	err = qk.SetAttestationRequest(ctx, &dc1)
 	require.Nil(t, err)
 

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -148,7 +148,7 @@ func TestGetDataCommitment(t *testing.T) {
 	err = qk.SetAttestationRequest(ctx, &dc2)
 	require.Nil(t, err)
 
-	// shrinking the data commitment window
+	// shrink the data commitment window
 	genesis := types.DefaultGenesis()
 	newShrinkedDCWindow := dcWindow - 299 // 101, since the default one is 400
 	genesis.Params.DataCommitmentWindow = newShrinkedDCWindow

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -174,7 +174,7 @@ func TestGetDataCommitment(t *testing.T) {
 	qk.SetParams(ctx, *genesis.Params)
 	require.Equal(t, newExpandedDCWindow, qk.GetDataCommitmentWindowParam(ctx))
 
-	// getting the fourth data commitment window
+	// get the fourth data commitment window
 	wantedHeight = nextMultiple(int64(newShrinkedDCWindow), wantedHeight)
 	// to simulate the condition in endBlocker: ctx.BlockHeight()%int64(k.GetDataCommitmentWindowParam(ctx))
 	ctx = ctx.WithBlockHeight(wantedHeight)

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -113,7 +113,7 @@ func TestSetDataCommitment(t *testing.T) {
 
 	ctx = ctx.WithBlockHeight(int64(qk.GetDataCommitmentWindowParam(ctx)))
 	dc, err := qk.GetCurrentDataCommitment(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	err = qk.SetAttestationRequest(ctx, &dc)
 	require.NoError(t, err)
 

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -137,7 +137,7 @@ func TestGetDataCommitment(t *testing.T) {
 	err = qk.SetAttestationRequest(ctx, &dc1)
 	require.Nil(t, err)
 
-	// getting the second data commitment
+	// get the second data commitment
 	ctx = ctx.WithBlockHeight(int64(dcWindow) * 2)
 	dc2, err := qk.GetCurrentDataCommitment(ctx)
 	require.Nil(t, err)

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -179,7 +179,7 @@ func TestGetDataCommitment(t *testing.T) {
 	require.Nil(t, err)
 
 	// expand the data commitment window
-	newExpandedDCWindow := dcWindow + 100 // 500, since the default one is 400
+	newExpandedDCWindow := 500
 	genesis.Params.DataCommitmentWindow = newExpandedDCWindow
 	qk.SetParams(ctx, *genesis.Params)
 	require.Equal(t, newExpandedDCWindow, qk.GetDataCommitmentWindowParam(ctx))

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -126,7 +126,7 @@ func TestGetDataCommitment(t *testing.T) {
 
 	dcWindow := qk.GetDataCommitmentWindowParam(ctx)
 
-	// getting the first data commitment
+	// get the first data commitment
 	ctx = ctx.WithBlockHeight(int64(dcWindow))
 	dc1, err := qk.GetCurrentDataCommitment(ctx)
 	require.NoError(t, err)

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -168,7 +168,7 @@ func TestGetDataCommitment(t *testing.T) {
 	err = qk.SetAttestationRequest(ctx, &dc3)
 	require.Nil(t, err)
 
-	// expanding the data commitment window
+	// expand the data commitment window
 	newExpandedDCWindow := dcWindow + 100 // 500, since the default one is 400
 	genesis.Params.DataCommitmentWindow = newExpandedDCWindow
 	qk.SetParams(ctx, *genesis.Params)

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -164,7 +164,7 @@ func TestGetDataCommitment(t *testing.T) {
 	require.Equal(t, dc2.EndBlock+1, dc3.BeginBlock)
 	require.Equal(t, dc2.EndBlock+newShrinkedDCWindow, dc3.EndBlock)
 	require.Equal(t, uint64(3), dc3.Nonce)
-	// setting the third data commitment
+	// set the third data commitment
 	err = qk.SetAttestationRequest(ctx, &dc3)
 	require.Nil(t, err)
 

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -129,7 +129,7 @@ func TestGetDataCommitment(t *testing.T) {
 	// getting the first data commitment
 	ctx = ctx.WithBlockHeight(int64(dcWindow))
 	dc1, err := qk.GetCurrentDataCommitment(ctx)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Equal(t, uint64(1), dc1.BeginBlock)
 	require.Equal(t, uint64(dcWindow), dc1.EndBlock)
 	require.Equal(t, uint64(1), dc1.Nonce)

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -115,7 +115,7 @@ func TestSetDataCommitment(t *testing.T) {
 	dc, err := qk.GetCurrentDataCommitment(ctx)
 	require.Nil(t, err)
 	err = qk.SetAttestationRequest(ctx, &dc)
-	require.Nil(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, uint64(1), qk.GetLatestAttestationNonce(input.Context))
 }

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -271,13 +271,3 @@ func TestDataCommitmentRange(t *testing.T) {
 	assert.Equal(t, newHeight, int64(dc2.EndBlock))
 	assert.Equal(t, dc1.EndBlock+1, dc2.BeginBlock)
 }
-
-// nextMultiple calculates the next multiple of the base starting from num.
-// for example, nextMultiple(10, 101) will return 110.
-func nextMultiple(base, num int64) int64 {
-	remainder := num % base
-	if remainder == 0 {
-		return num
-	}
-	return num + base - remainder
-}

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -144,7 +144,7 @@ func TestGetDataCommitment(t *testing.T) {
 	require.Equal(t, dc1.EndBlock+1, dc2.BeginBlock)
 	require.Equal(t, dc1.EndBlock+dcWindow, dc2.EndBlock)
 	require.Equal(t, uint64(2), dc2.Nonce)
-	// setting the second data commitment
+	// set the second data commitment
 	err = qk.SetAttestationRequest(ctx, &dc2)
 	require.Nil(t, err)
 

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -120,6 +120,16 @@ func TestSetDataCommitment(t *testing.T) {
 	require.Equal(t, uint64(1), qk.GetLatestAttestationNonce(input.Context))
 }
 
+// TestGetDataCommitment This test will test the create of data commitment ranges
+// in the event of the data commitment window changing via an upgrade or a gov proposal.
+// The test goes as follows:
+//   - Start with a data commitment window of 400
+//   - Get the first data commitment, its range should be: [1, 400]
+//   - Get the second data commitment, its range should be: [401, 800]
+//   - Shrink the data commitment window to 101
+//   - Get the third data commitment, its range should be: [801, 901]
+//   - Expand the data commitment window to 500
+//   - Get the fourth data commitment, its range should be: [902, 1401]
 func TestGetDataCommitment(t *testing.T) {
 	input, ctx := testutil.SetupFiveValChain(t)
 	qk := input.QgbKeeper

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -155,7 +155,7 @@ func TestGetDataCommitment(t *testing.T) {
 	qk.SetParams(ctx, *genesis.Params)
 	require.Equal(t, newShrinkedDCWindow, qk.GetDataCommitmentWindowParam(ctx))
 
-	// getting the third data commitment window
+	// get the third data commitment window
 	wantedHeight := nextMultiple(int64(newShrinkedDCWindow), int64(dcWindow)*2)
 	// to simulate the condition in endBlocker: ctx.BlockHeight()%int64(k.GetDataCommitmentWindowParam(ctx))
 	ctx = ctx.WithBlockHeight(wantedHeight)

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -24,6 +24,7 @@ func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment,
 	// for a data commitment window of 400, the ranges will be: 1-400;401-800;801-1200
 	var beginBlock, endBlock uint64
 	if ctx.BlockHeight() == int64(dcWindow) {
+		// only for the first data commitment range, which is: [1, data commitment window]
 		beginBlock = 1
 		endBlock = dcWindow
 	} else {

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -11,16 +11,29 @@ import (
 // TODO add unit tests for all the keepers
 
 // GetCurrentDataCommitment creates the latest data commitment at current height according to
-// the data commitment window specified
+// the data commitment window specified.
+// Assumes that this method is called when:
+//
+//	ctx.BlockHeight() != 0 && ctx.BlockHeight()%int64(k.GetDataCommitmentWindowParam(ctx)) == 0
 func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment, error) {
-	beginBlock := uint64(ctx.BlockHeight()) - k.GetDataCommitmentWindowParam(ctx) + 1
-	// for a data commitment window of 400, the ranges will be: 1-400;401-800;801-1200
-	endBlock := uint64(ctx.BlockHeight())
-
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return types.DataCommitment{}, types.ErrLatestAttestationNonceStillNotInitialized
 	}
 	nonce := k.GetLatestAttestationNonce(ctx) + 1
+	dcWindow := k.GetDataCommitmentWindowParam(ctx)
+	// for a data commitment window of 400, the ranges will be: 1-400;401-800;801-1200
+	var beginBlock, endBlock uint64
+	if ctx.BlockHeight() == int64(dcWindow) {
+		beginBlock = 1
+		endBlock = dcWindow
+	} else {
+		lastDCC, err := k.GetLastDataCommitment(ctx)
+		if err != nil {
+			return types.DataCommitment{}, err
+		}
+		beginBlock = lastDCC.EndBlock + 1
+		endBlock = beginBlock + dcWindow - 1
+	}
 
 	dataCommitment := types.NewDataCommitment(nonce, beginBlock, endBlock)
 	return *dataCommitment, nil

--- a/x/qgb/keeper/keeper_data_commitment.go
+++ b/x/qgb/keeper/keeper_data_commitment.go
@@ -32,7 +32,7 @@ func (k Keeper) GetCurrentDataCommitment(ctx sdk.Context) (types.DataCommitment,
 			return types.DataCommitment{}, err
 		}
 		beginBlock = lastDCC.EndBlock + 1
-		endBlock = beginBlock + dcWindow - 1
+		endBlock = lastDCC.EndBlock + dcWindow
 	}
 
 	dataCommitment := types.NewDataCommitment(nonce, beginBlock, endBlock)


### PR DESCRIPTION
## Overview

This PR allows creating the data commitments correctly when the data commitments window changes. This change can be via an upgrade or a gov proposal. 

Closes https://github.com/celestiaorg/celestia-app/issues/1685