### PR TITLE
fix: cherry-pick common Docker CI to `v0.13.x`

### DIFF
--- a/.github/workflows/docker-build-publish-common.yml
+++ b/.github/workflows/docker-build-publish-common.yml
@@ -1,0 +1,19 @@
+name: Docker Build & Publish
+
+# Trigger on all push events, new semantic version tags, and all PRs
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+  pull_request:
+
+jobs:
+  docker-security-build:
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@main # yamllint disable-line rule:line-length
+    with:
+      dockerfile: Dockerfile

--- a/.github/workflows/docker-build-publish-common.yml
+++ b/.github/workflows/docker-build-publish-common.yml
@@ -14,6 +14,6 @@ on:
 
 jobs:
   docker-security-build:
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@main # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.1.1 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile


### PR DESCRIPTION
### Motivation
https://github.com/rollkit/local-celestia-devnet/pull/28#discussion_r1184006249 and https://github.com/rollkit/local-celestia-devnet/pull/28#issuecomment-1534182285

### Description
Cherry pick [7380eec](https://github.com/celestiaorg/celestia-app/commit/7380eec5e1e49a9ce697c950b72d1cfc03f39ab9) to the `v0.13.x` release branch. I will cut `v0.13.1` after this merges.