### PR TITLE
fix: Docker publish permissions

### DIFF
--- a/.github/workflows/docker-build-publish-common.yml
+++ b/.github/workflows/docker-build-publish-common.yml
@@ -14,6 +14,9 @@ on:
 
 jobs:
   docker-security-build:
+    permissions:
+      contents: write
+      packages: write
     uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.1.1 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile


### PR DESCRIPTION
Fixes https://github.com/celestiaorg/celestia-app/actions/runs/4883675301/workflow

I will cut v0.13.2 after this merges