### PR TITLE
chore!: rename `testutil` to `util`

### DIFF
--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -30,7 +30,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 		accounts[i] = tmrand.Str(20)
 	}
 
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(accounts...)
+	testApp, kr := util.SetupTestAppWithGenesisValSet(accounts...)
 
 	type test struct {
 		name                   string
@@ -50,7 +50,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 				case <-timer:
 					return
 				default:
-					txs := testutil.RandBlobTxsWithAccounts(
+					txs := util.RandBlobTxsWithAccounts(
 						t,
 						testApp,
 						encConf.TxConfig.TxEncoder(),
@@ -62,7 +62,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 						accounts[:tt.count],
 					)
 					// create 100 send transactions
-					sendTxs := testutil.SendTxsWithAccounts(
+					sendTxs := util.SendTxsWithAccounts(
 						t,
 						testApp,
 						encConf.TxConfig.TxEncoder(),

--- a/test/util/common.go
+++ b/test/util/common.go
@@ -1,4 +1,4 @@
-package testutil
+package util
 
 import (
 	"bytes"

--- a/test/util/direct_tx_gen.go
+++ b/test/util/direct_tx_gen.go
@@ -1,4 +1,4 @@
-package testutil
+package util
 
 import (
 	"math/rand"

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -1,4 +1,4 @@
-package testutil
+package util
 
 import (
 	"encoding/json"


### PR DESCRIPTION
Follow up to https://github.com/celestiaorg/celestia-app/commit/058442df522867a23e333977783a1d8147a924f1

## Motivation
My editor auto adds a type alias in https://github.com/celestiaorg/celestia-app/pull/1578/files#r1182927751 which seemed fishy. Opted to do this instead b/c:

> By convention, the last element of the package path is the package name

[Source](https://go.dev/blog/package-names)

