### PR TITLE
ci: run `test` workflow even if `*.go` file isn't modified

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,6 @@ jobs:
   #           go.sum
   #     - name: Run cosmovisor tests
   #       run: cd cosmovisor; make
-  #       if: env.GIT_DIFF
 
   split-test-files:
     runs-on: ubuntu-latest
@@ -94,23 +93,15 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: technote-space/get-diff-action@v6.1.2
-        with:
-          PATTERNS: |
-            **/**.go
-            go.mod
-            go.sum
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
-        if: env.GIT_DIFF
       - name: test & coverage report creation
         run: >
           cat pkgs.txt.part.${{ matrix.part }} |
           xargs go test -mod=readonly -timeout 30m
           -coverprofile=${{ matrix.part }}profile.out
           -covermode=atomic
-        if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-coverage"
@@ -130,22 +121,17 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-00-coverage"
-        if: env.GIT_DIFF
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-01-coverage"
-        if: env.GIT_DIFF
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-02-coverage"
-        if: env.GIT_DIFF
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-03-coverage"
-        if: env.GIT_DIFF
       - run: |
           cat ./*profile.out | grep -v "mode: atomic" >> coverage.txt
-        if: env.GIT_DIFF
       - name: filter out DONTCOVER
         # yamllint disable
         run: |
@@ -159,11 +145,9 @@ jobs:
             sed -i.bak "/$(echo $trimmedname | sed 's/\//\\\//g')/d" coverage.txt
           done < excludelist.txt
         # yamllint enable
-        if: env.GIT_DIFF
       - uses: codecov/codecov-action@v3
         with:
           file: ./coverage.txt
-        if: env.GIT_DIFF
 
   test-race:
     runs-on: ubuntu-latest
@@ -186,13 +170,11 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}"
-        if: env.GIT_DIFF
       - name: test & coverage report creation
         run: >
           cat pkgs.txt.part.${{ matrix.part }} |
           xargs go test -mod=readonly -json -timeout 30m
           -race -test.short > ${{ matrix.part }}-race-output.txt
-        if: env.GIT_DIFF
       - uses: actions/upload-artifact@v3
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-race-output"
@@ -214,27 +196,21 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-00-race-output"
-        if: env.GIT_DIFF
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-01-race-output"
-        if: env.GIT_DIFF
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-02-race-output"
-        if: env.GIT_DIFF
       - uses: actions/download-artifact@v3
         with:
           name: "${{ github.sha }}-03-race-output"
-        if: env.GIT_DIFF
       - uses: actions/cache@v3.3.1
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-tparse-binary
-        if: env.GIT_DIFF
       - name: Generate test report (go test -race)
         run: cat ./*-race-output.txt | ~/go/bin/tparse
-        if: env.GIT_DIFF
 
   # # todo(evan) add later
   # liveness-test:
@@ -255,8 +231,6 @@ jobs:
   #     - name: start localnet
   #       run: |
   #         make clean build-simd-linux localnet-start
-  #       if: env.GIT_DIFF
   #     - name: test liveness
   #       run: |
   #         ./contrib/localnet_liveness.sh 100 5 50 localhost
-  #       if: env.GIT_DIFF


### PR DESCRIPTION
## Motivation

`test` is now a mandatory CI check for PRs to merge. Since `test` only runs if a `.go` file was modified, PRs like https://github.com/celestiaorg/celestia-app/pull/1712 won't pass all mandatory CI checks. This change always runs the `test` workflow

## Testing

https://github.com/rootulp/celestia-app/pull/7