### PR TITLE
feat!: restrict `MaxBytes` to values at or below that of `MaxSquareSize`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -85,6 +85,7 @@ import (
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/proof"
 	blobmodule "github.com/celestiaorg/celestia-app/x/blob"
 	blobmodulekeeper "github.com/celestiaorg/celestia-app/x/blob/keeper"
@@ -285,7 +286,7 @@ func New(
 	app.ParamsKeeper = initParamsKeeper(appCodec, cdc, keys[paramstypes.StoreKey], tkeys[paramstypes.TStoreKey])
 
 	// set the BaseApp's parameter store
-	bApp.SetParamStore(app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramstypes.ConsensusParamsKeyTable()))
+	bApp.SetParamStore(app.ParamsKeeper.Subspace(baseapp.Paramspace).WithKeyTable(paramfilter.ConsensusParamsKeyTable(appconsts.MaxSquareSize)))
 
 	// add capability keeper and ScopeToModule for ibc module
 	app.CapabilityKeeper = capabilitykeeper.NewKeeper(appCodec, keys[capabilitytypes.StoreKey], memKeys[capabilitytypes.MemStoreKey])
@@ -713,6 +714,8 @@ func (*App) BlockedParams() [][2]string {
 		{stakingtypes.ModuleName, string(stakingtypes.KeyBondDenom)},
 		// consensus.validator.PubKeyTypes
 		{baseapp.Paramspace, string(baseapp.ParamStoreKeyValidatorParams)},
+		// consensus.Evidence
+		{baseapp.Paramspace, string(baseapp.ParamStoreKeyEvidenceParams)},
 	}
 }
 

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -25,7 +25,7 @@ func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePr
 
 	// build the square from the set of valid and prioritised transactions.
 	// The txs returned are the ones used in the square and block
-	dataSquare, txs, err := square.Build(txs, appconsts.DefaultMaxSquareSize)
+	dataSquare, txs, err := square.Build(txs, appconsts.MaxSquareSize)
 	if err != nil {
 		panic(err)
 	}

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -99,7 +99,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 	}
 
 	// Construct the data square from the block's transactions
-	dataSquare, err := square.Construct(req.BlockData.Txs, appconsts.DefaultMaxSquareSize)
+	dataSquare, err := square.Construct(req.BlockData.Txs, appconsts.MaxSquareSize)
 	if err != nil {
 		logInvalidPropBlockError(app.Logger(), req.Header, "failure to compute data square from transactions:", err)
 		return reject()

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -208,12 +208,12 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 				size := blockRes.Block.Data.SquareSize
 
 				// perform basic checks on the size of the square
-				require.LessOrEqual(size, uint64(appconsts.DefaultMaxSquareSize))
-				require.GreaterOrEqual(size, uint64(appconsts.DefaultMinSquareSize))
+				require.LessOrEqual(size, uint64(appconsts.MaxSquareSize))
+				require.GreaterOrEqual(size, uint64(appconsts.MinSquareSize))
 				sizes = append(sizes, size)
 			}
 			// ensure that at least one of the blocks used the max square size
-			assert.Contains(sizes, uint64(appconsts.DefaultMaxSquareSize))
+			assert.Contains(sizes, uint64(appconsts.MaxSquareSize))
 		})
 		require.NoError(s.network.WaitForNextBlock())
 	}

--- a/app/test/limited_block_size_test.go
+++ b/app/test/limited_block_size_test.go
@@ -1,0 +1,59 @@
+package app_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/pkg/square"
+	"github.com/celestiaorg/celestia-app/test/txsim"
+	"github.com/celestiaorg/celestia-app/test/util/testnode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLimitedBlockSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping Limited Block Size integration test in short mode.")
+	}
+
+	desiredSquareSize := uint64(64)
+
+	cparams := testnode.DefaultParams()
+	// limit the max block size to 64 x 64 via the consensus parameter
+	cparams.Block.MaxBytes = square.EstimateMaxBlockBytes(desiredSquareSize)
+
+	kr, rpcAddr, grpcAddr := txsim.Setup(t, cparams)
+
+	// using lots of individual small blobs will result in a large amount of
+	// overhead added to the square
+	seqs := txsim.NewBlobSequence(
+		txsim.NewRange(1, 10000),
+		txsim.NewRange(1, 50),
+	).Clone(25)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+
+	_ = txsim.Run(
+		ctx,
+		[]string{rpcAddr},
+		[]string{grpcAddr},
+		kr,
+		rand.Int63(),
+		time.Second,
+		seqs...,
+	)
+
+	// check the block sizes
+	blocks, err := testnode.ReadBlockchain(context.Background(), rpcAddr)
+	require.NoError(t, err)
+
+	for _, block := range blocks {
+		fmt.Println(block.Data.SquareSize)
+		assert.LessOrEqual(t, block.Data.SquareSize, desiredSquareSize)
+	}
+
+}

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -216,7 +216,7 @@ func TestProcessProposal(t *testing.T) {
 				d.Txs = [][]byte{blobTx}
 
 				// Erasure code the data to update the data root so this doesn't doesn't fail on an incorrect data root.
-				dataSquare, err := square.Construct(d.Txs, appconsts.DefaultMaxSquareSize)
+				dataSquare, err := square.Construct(d.Txs, appconsts.MaxSquareSize)
 				require.NoError(t, err)
 				eds, err := da.ExtendShares(shares.ToBytes(dataSquare))
 				require.NoError(t, err)
@@ -280,7 +280,7 @@ func TestProcessProposal(t *testing.T) {
 				Txs: coretypes.Txs(sendTxs).ToSliceOfBytes(),
 			},
 			mutator: func(d *core.Data) {
-				dataSquare, err := square.Construct(d.Txs, appconsts.DefaultMaxSquareSize)
+				dataSquare, err := square.Construct(d.Txs, appconsts.MaxSquareSize)
 				require.NoError(t, err)
 
 				b := shares.NewEmptyBuilder().ImportRawShare(dataSquare[1].ToBytes())

--- a/app/test/qgb_rpc_test.go
+++ b/app/test/qgb_rpc_test.go
@@ -15,7 +15,7 @@ func TestQGBRPCQueries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping QGB integration test in short mode.")
 	}
-	_, cctx := testnode.DefaultNetwork(t, time.Millisecond)
+	_, cctx := testnode.DefaultNetwork(t, time.Millisecond, nil)
 	h, err := cctx.WaitForHeightWithTimeout(405, time.Minute)
 	require.NoError(t, err, h)
 	require.Greater(t, h, int64(401))

--- a/cmd/celestia-appd/cmd/overrides.go
+++ b/cmd/celestia-appd/cmd/overrides.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/x/paramfilter"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
 )
@@ -13,5 +14,11 @@ func overrideServerConfig(command *cobra.Command) error {
 	ctx.Config.Consensus.TimeoutPropose = appconsts.TimeoutPropose
 	ctx.Config.Consensus.TargetHeightDuration = appconsts.TargetHeightDuration
 	ctx.Config.Consensus.SkipTimeoutCommit = false
+	return server.SetCmdServerContext(command, ctx)
+}
+
+func setDefaultConsensusParams(command *cobra.Command) error {
+	ctx := server.GetServerContextFromCmd(command)
+	ctx.DefaultConsensusParams = paramfilter.DefaultConsensusParams(appconsts.MaxSquareSize)
 	return server.SetCmdServerContext(command, ctx)
 }

--- a/cmd/celestia-appd/cmd/overrides.go
+++ b/cmd/celestia-appd/cmd/overrides.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/square"
 	"github.com/celestiaorg/celestia-app/x/paramfilter"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
@@ -19,6 +20,7 @@ func overrideServerConfig(command *cobra.Command) error {
 
 func setDefaultConsensusParams(command *cobra.Command) error {
 	ctx := server.GetServerContextFromCmd(command)
-	ctx.DefaultConsensusParams = paramfilter.DefaultConsensusParams(appconsts.MaxSquareSize)
+	ctx.DefaultConsensusParams = paramfilter.DefaultConsensusParams()
+	ctx.DefaultConsensusParams.Block.MaxBytes = square.EstimateMaxBlockBytes(64)
 	return server.SetCmdServerContext(command, ctx)
 }

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -110,6 +110,11 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
+			err = setDefaultConsensusParams(cmd)
+			if err != nil {
+				return err
+			}
+
 			return overrideServerConfig(cmd)
 		},
 		SilenceUsage: true,

--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11.0.20230511190231-e7fc8b26c224 // v1.12.0-sdk-v0.46.11
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.19.0-tm-v0.34.27
 )

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.19.0-tm-v0.34.27 h1:GLdDJRu1fRSMft4IqQz4/x/H1U3eN2TFlYbAycbSiN4=
 github.com/celestiaorg/celestia-core v1.19.0-tm-v0.34.27/go.mod h1:8PbX2OIPehldawXWAzNWPxBPnfFtcYtjHecE45b2Beg=
-github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11 h1:Y+/dAyu7t0F8+EZz+jU3tyZqG10W8LTCQpnHe8Ejuec=
-github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11/go.mod h1:uKEyhG8H8hbjebOEEgtyqghJWpuMyF+u61MK5cis+pk=
+github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11.0.20230511190231-e7fc8b26c224 h1:0b7jjToGzeH1ZYIL9v/shigidfavO+UtBoAzc4reZB0=
+github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11.0.20230511190231-e7fc8b26c224/go.mod h1:xCG6OUkJy5KUMEg20Zk010lra9XjkmKS3+bk0wp7bd8=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
 github.com/celestiaorg/nmt v0.15.0 h1:ID9QlMIeP6WK/iiGcfnYLu2qqVIq0UYe/dc3TVPt6EA=

--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -55,22 +55,22 @@ const (
 	// in a continuation sparse share of a sequence.
 	ContinuationSparseShareContentSize = ShareSize - NamespaceSize - ShareInfoBytes
 
-	// DefaultMaxSquareSize is the maximum original square width.
+	// MaxSquareSize is the maximum original square width.
 	//
 	// Note: 128 shares in a row * 128 shares in a column * 512 bytes in a share
 	// = 8 MiB
-	DefaultMaxSquareSize = 128
+	MaxSquareSize = 128
 
 	// MaxShareCount is the maximum number of shares allowed in the original
 	// data square.
-	MaxShareCount = DefaultMaxSquareSize * DefaultMaxSquareSize
+	MaxShareCount = MaxSquareSize * MaxSquareSize
 
-	// DefaultMinSquareSize is the smallest original square width.
-	DefaultMinSquareSize = 1
+	// MinSquareSize is the smallest original square width. This value should always be 1.
+	MinSquareSize = 1
 
 	// MinshareCount is the minimum number of shares allowed in the original
 	// data square.
-	MinShareCount = DefaultMinSquareSize * DefaultMinSquareSize
+	MinShareCount = MinSquareSize * MinSquareSize
 
 	// SubtreeRootThreshold works as a target value for the number of subtree roots in the
 	// share commitment. If a blob contains more shares than this number, than the height
@@ -78,7 +78,7 @@ const (
 	// The rationale for this value is described in more detail in ADR013
 	// (./docs/architecture/adr-013).
 	// ADR013 https://github.com/celestiaorg/celestia-app/blob/e905143e8fe138ce6085ae9a5c1af950a2d87638/docs/architecture/adr-013-non-interactive-default-rules-for-zero-padding.md //nolint: lll
-	SubtreeRootThreshold = DefaultMaxSquareSize
+	SubtreeRootThreshold = MaxSquareSize
 
 	// MaxShareVersion is the maximum value a share version can be.
 	MaxShareVersion = 127

--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -17,8 +17,8 @@ import (
 )
 
 const (
-	maxExtendedSquareWidth = appconsts.DefaultMaxSquareSize * 2
-	minExtendedSquareWidth = appconsts.DefaultMinSquareSize * 2
+	maxExtendedSquareWidth = appconsts.MaxSquareSize * 2
+	minExtendedSquareWidth = appconsts.MinSquareSize * 2
 )
 
 // DataAvailabilityHeader (DAHeader) contains the row and column roots of the
@@ -60,11 +60,11 @@ func ExtendShares(s [][]byte) (*rsmt2d.ExtendedDataSquare, error) {
 
 	squareSize := square.Size(len(s))
 
-	if squareSize < appconsts.DefaultMinSquareSize || squareSize > appconsts.DefaultMaxSquareSize {
+	if squareSize < appconsts.MinSquareSize || squareSize > appconsts.MaxSquareSize {
 		return nil, fmt.Errorf(
 			"invalid square size: min %d max %d provided %d",
-			appconsts.DefaultMinSquareSize,
-			appconsts.DefaultMaxSquareSize,
+			appconsts.MinSquareSize,
+			appconsts.MaxSquareSize,
 			squareSize,
 		)
 	}

--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -49,8 +49,8 @@ func TestNewDataAvailabilityHeader(t *testing.T) {
 		{
 			name:         "max square size",
 			expectedHash: []byte{0xce, 0x5c, 0xf3, 0xc9, 0x15, 0xeb, 0xbf, 0xb0, 0x67, 0xe1, 0xa5, 0x97, 0x35, 0xf3, 0x25, 0x7b, 0x1c, 0x47, 0x74, 0x1f, 0xec, 0x6a, 0x33, 0x19, 0x7f, 0x8f, 0xc2, 0x4a, 0xe, 0xe2, 0xbe, 0x73},
-			squareSize:   appconsts.DefaultMaxSquareSize,
-			shares:       generateShares(appconsts.DefaultMaxSquareSize * appconsts.DefaultMaxSquareSize),
+			squareSize:   appconsts.MaxSquareSize,
+			shares:       generateShares(appconsts.MaxSquareSize * appconsts.MaxSquareSize),
 		},
 	}
 
@@ -77,7 +77,7 @@ func TestExtendShares(t *testing.T) {
 		{
 			name:        "too large square size",
 			expectedErr: true,
-			shares:      generateShares((appconsts.DefaultMaxSquareSize + 1) * (appconsts.DefaultMaxSquareSize + 1)),
+			shares:      generateShares((appconsts.MaxSquareSize + 1) * (appconsts.MaxSquareSize + 1)),
 		},
 		{
 			name:        "invalid number of shares",
@@ -103,7 +103,7 @@ func TestDataAvailabilityHeaderProtoConversion(t *testing.T) {
 		dah  DataAvailabilityHeader
 	}
 
-	shares := generateShares(appconsts.DefaultMaxSquareSize * appconsts.DefaultMaxSquareSize)
+	shares := generateShares(appconsts.MaxSquareSize * appconsts.MaxSquareSize)
 	eds, err := ExtendShares(shares)
 	require.NoError(t, err)
 	bigdah := NewDataAvailabilityHeader(eds)
@@ -138,15 +138,15 @@ func Test_DAHValidateBasic(t *testing.T) {
 		errStr    string
 	}
 
-	shares := generateShares(appconsts.DefaultMaxSquareSize * appconsts.DefaultMaxSquareSize)
+	shares := generateShares(appconsts.MaxSquareSize * appconsts.MaxSquareSize)
 	eds, err := ExtendShares(shares)
 	require.NoError(t, err)
 	bigdah := NewDataAvailabilityHeader(eds)
 
 	// make a mutant dah that has too many roots
 	var tooBigDah DataAvailabilityHeader
-	tooBigDah.ColumnRoots = make([][]byte, appconsts.DefaultMaxSquareSize*appconsts.DefaultMaxSquareSize)
-	tooBigDah.RowRoots = make([][]byte, appconsts.DefaultMaxSquareSize*appconsts.DefaultMaxSquareSize)
+	tooBigDah.ColumnRoots = make([][]byte, appconsts.MaxSquareSize*appconsts.MaxSquareSize)
+	tooBigDah.RowRoots = make([][]byte, appconsts.MaxSquareSize*appconsts.MaxSquareSize)
 	copy(tooBigDah.ColumnRoots, bigdah.ColumnRoots)
 	copy(tooBigDah.RowRoots, bigdah.RowRoots)
 	tooBigDah.ColumnRoots = append(tooBigDah.ColumnRoots, bytes.Repeat([]byte{1}, 32))

--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -24,7 +24,7 @@ func NewTxInclusionProof(txs [][]byte, txIndex uint64) (types.ShareProof, error)
 		return types.ShareProof{}, fmt.Errorf("txIndex %d out of bounds", txIndex)
 	}
 
-	builder, err := square.NewBuilder(appconsts.DefaultMaxSquareSize, txs...)
+	builder, err := square.NewBuilder(appconsts.MaxSquareSize, txs...)
 	if err != nil {
 		return types.ShareProof{}, err
 	}

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -99,7 +99,7 @@ func TestNewShareInclusionProof(t *testing.T) {
 
 	// not setting useShareIndexes because the transactions indexes do not refer
 	// to the messages because the square and transactions were created manually.
-	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.DefaultMaxSquareSize)
+	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.MaxSquareSize)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -87,7 +87,7 @@ func QueryShareInclusionProof(_ sdk.Context, path []string, req abci.RequestQuer
 		return nil, fmt.Errorf("error reading block: %w", err)
 	}
 
-	dataSquare, err := square.Construct(pbb.Data.Txs, appconsts.DefaultMaxSquareSize)
+	dataSquare, err := square.Construct(pbb.Data.Txs, appconsts.MaxSquareSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/shares/non_interactive_defaults_test.go
+++ b/pkg/shares/non_interactive_defaults_test.go
@@ -25,10 +25,10 @@ func TestBlobSharesUsedNonInteractiveDefaults(t *testing.T) {
 		{0, 8, 20, []int{5, 5, 5, 5}, []uint32{0, 5, 10, 15}},
 		{0, 8, 10, []int{10}, []uint32{0}},
 		{1, 8, 20, []int{10, 10}, []uint32{1, 11}},
-		{0, appconsts.DefaultMaxSquareSize, 1000, []int{1000}, []uint32{0}},
-		{0, appconsts.DefaultMaxSquareSize, appconsts.DefaultMaxSquareSize + 1, []int{appconsts.DefaultMaxSquareSize + 1}, []uint32{0}},
+		{0, appconsts.MaxSquareSize, 1000, []int{1000}, []uint32{0}},
+		{0, appconsts.MaxSquareSize, appconsts.MaxSquareSize + 1, []int{appconsts.MaxSquareSize + 1}, []uint32{0}},
 		{1, 128, 384, []int{128, 128, 128}, []uint32{1, 129, 257}},
-		{1024, appconsts.DefaultMaxSquareSize, 32, []int{32}, []uint32{1024}},
+		{1024, appconsts.MaxSquareSize, 32, []int{32}, []uint32{1024}},
 	}
 	for i, tt := range tests {
 		res, indexes := BlobSharesUsedNonInteractiveDefaults(tt.cursor, tt.squareSize, tt.blobLens...)
@@ -467,7 +467,7 @@ func TestSubTreeWidth(t *testing.T) {
 			want:       8,
 		},
 		{
-			shareCount: (appconsts.SubtreeRootThreshold * appconsts.DefaultMaxSquareSize) - 1,
+			shareCount: (appconsts.SubtreeRootThreshold * appconsts.MaxSquareSize) - 1,
 			want:       128,
 		},
 	}

--- a/pkg/square/builder_test.go
+++ b/pkg/square/builder_test.go
@@ -27,24 +27,24 @@ func TestBuilderSquareSizeEstimation(t *testing.T) {
 		expectedSquareSize uint64
 	}
 	tests := []test{
-		{"empty block", 0, 0, 0, appconsts.DefaultMinSquareSize},
+		{"empty block", 0, 0, 0, appconsts.MinSquareSize},
 		{"one normal tx", 1, 0, 0, 1},
 		{"one small pfb small block", 0, 1, 100, 2},
 		{"mixed small block", 10, 12, 500, 8},
 		{"small block 2", 0, 12, 1000, 8},
 		{"mixed medium block 2", 10, 20, 10000, 32},
 		{"one large pfb large block", 0, 1, 1000000, 64},
-		{"one hundred large pfb large block", 0, 100, 100000, appconsts.DefaultMaxSquareSize},
-		{"one hundred large pfb medium block", 100, 100, 100000, appconsts.DefaultMaxSquareSize},
-		{"mixed transactions large block", 100, 100, 100000, appconsts.DefaultMaxSquareSize},
-		{"mixed transactions large block 2", 1000, 1000, 10000, appconsts.DefaultMaxSquareSize},
-		{"mostly transactions large block", 10000, 1000, 100, appconsts.DefaultMaxSquareSize},
-		{"only small pfb large block", 0, 10000, 1, appconsts.DefaultMaxSquareSize},
+		{"one hundred large pfb large block", 0, 100, 100000, appconsts.MaxSquareSize},
+		{"one hundred large pfb medium block", 100, 100, 100000, appconsts.MaxSquareSize},
+		{"mixed transactions large block", 100, 100, 100000, appconsts.MaxSquareSize},
+		{"mixed transactions large block 2", 1000, 1000, 10000, appconsts.MaxSquareSize},
+		{"mostly transactions large block", 10000, 1000, 100, appconsts.MaxSquareSize},
+		{"only small pfb large block", 0, 10000, 1, appconsts.MaxSquareSize},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			txs := generateMixedTxs(tt.normalTxs, tt.pfbCount, tt.pfbSize)
-			square, _, err := square.Build(txs, appconsts.DefaultMaxSquareSize)
+			square, _, err := square.Build(txs, appconsts.MaxSquareSize)
 			require.NoError(t, err)
 			require.EqualValues(t, tt.expectedSquareSize, square.Size())
 		})
@@ -144,7 +144,7 @@ func TestBuilderFindTxShareRange(t *testing.T) {
 	blockTxs = append(blockTxs, blobfactory.RandBlobTxsRandomlySized(encCfg.TxConfig.TxEncoder(), 5, 1000, 10).ToSliceOfBytes()...)
 	require.Len(t, blockTxs, 10)
 
-	builder, err := square.NewBuilder(appconsts.DefaultMaxSquareSize, blockTxs...)
+	builder, err := square.NewBuilder(appconsts.MaxSquareSize, blockTxs...)
 	require.NoError(t, err)
 
 	dataSquare, err := builder.Export()

--- a/pkg/square/square.go
+++ b/pkg/square/square.go
@@ -55,7 +55,7 @@ func Construct(txs [][]byte, maxSquareSize int) (Square, error) {
 // TxShareRange returns the range of share indexes that the tx, specified by txIndex, occupies.
 // Both ends of the range are inclusive.
 func TxShareRange(txs [][]byte, txIndex int) (shares.ShareRange, error) {
-	builder, err := NewBuilder(appconsts.DefaultMaxSquareSize, txs...)
+	builder, err := NewBuilder(appconsts.MaxSquareSize, txs...)
 	if err != nil {
 		return shares.ShareRange{}, err
 	}
@@ -66,7 +66,7 @@ func TxShareRange(txs [][]byte, txIndex int) (shares.ShareRange, error) {
 // BlobShareRange returns the range of share indexes that the blob, identified by txIndex and blobIndex, occupies.
 // Both ends of the range are inclusive.
 func BlobShareRange(txs [][]byte, txIndex, blobIndex int) (shares.ShareRange, error) {
-	builder, err := NewBuilder(appconsts.DefaultMaxSquareSize, txs...)
+	builder, err := NewBuilder(appconsts.MaxSquareSize, txs...)
 	if err != nil {
 		return shares.ShareRange{}, err
 	}
@@ -93,7 +93,7 @@ func (s Square) Size() uint64 {
 }
 
 func Size(len int) uint64 {
-	return uint64(math.Sqrt(float64(len)))
+	return shares.RoundUpPowerOfTwo(uint64(math.Sqrt(float64(len))))
 }
 
 // Equals returns true if two squares are equal

--- a/pkg/square/utils.go
+++ b/pkg/square/utils.go
@@ -1,0 +1,11 @@
+package square
+
+import "github.com/celestiaorg/celestia-app/pkg/appconsts"
+
+// EstimateMaxBlockBytes estimates the maximum number of bytes a block can have.
+// This value overestimates by < .1% and should be treated as such. Each block
+// has different amounts of overhead based on how many blobs and transactions it
+// contains.
+func EstimateMaxBlockBytes(squareSize uint64) int64 {
+	return int64(squareSize * squareSize * appconsts.ContinuationSparseShareContentSize)
+}

--- a/pkg/square/utils.go
+++ b/pkg/square/utils.go
@@ -3,9 +3,11 @@ package square
 import "github.com/celestiaorg/celestia-app/pkg/appconsts"
 
 // EstimateMaxBlockBytes estimates the maximum number of bytes a block can have.
-// This value overestimates by < .1% and should be treated as such. Each block
-// has different amounts of overhead based on how many blobs and transactions it
-// contains.
+// This function overestimates by < .1% and the value produced does not
+// guarantee that a square of the desired size will always be created using the
+// resulting parameter. Each block has different amounts of overhead based on
+// how many blobs and transactions it contains.
 func EstimateMaxBlockBytes(squareSize uint64) int64 {
-	return int64(squareSize * squareSize * appconsts.ContinuationSparseShareContentSize)
+	bsize := squareSize * squareSize * appconsts.ContinuationSparseShareContentSize
+	return int64(bsize)
 }

--- a/pkg/square/utils.go
+++ b/pkg/square/utils.go
@@ -3,11 +3,13 @@ package square
 import "github.com/celestiaorg/celestia-app/pkg/appconsts"
 
 // EstimateMaxBlockBytes estimates the maximum number of bytes a block can have.
-// This function overestimates by < .1% and the value produced does not
-// guarantee that a square of the desired size will always be created using the
-// resulting parameter. Each block has different amounts of overhead based on
-// how many blobs and transactions it contains.
+// This function assumes 2% of the block is padding. The value produced does
+// not guarantee that a square of the desired size will always be created using
+// the resulting parameter. Each block has different amounts of overhead based
+// on how many blobs and transactions it contains.
 func EstimateMaxBlockBytes(squareSize uint64) int64 {
 	bsize := squareSize * squareSize * appconsts.ContinuationSparseShareContentSize
+	// assume 2% of the block is padding
+	bsize = bsize - bsize/50
 	return int64(bsize)
 }

--- a/pkg/square/utils.go
+++ b/pkg/square/utils.go
@@ -3,13 +3,22 @@ package square
 import "github.com/celestiaorg/celestia-app/pkg/appconsts"
 
 // EstimateMaxBlockBytes estimates the maximum number of bytes a block can have.
-// This function assumes 2% of the block is padding. The value produced does
-// not guarantee that a square of the desired size will always be created using
-// the resulting parameter. Each block has different amounts of overhead based
-// on how many blobs and transactions it contains.
+// The value produced does not guarantee that a square of the desired size will
+// always be created using the resulting parameter, however it has been fuzzed
+// extensively to work for a 64 x 64 square.
+//
+// NOTE: We make an assumption that 6.25% of the block, not counting namespaces,
+// will be overhead. Values lower than that will occasionally fail the fuzz test
+// for squares of size 64.
+//
+// Note that we can't actually come up with a worst case value here that is also
+// efficiently fills the square, because the worst case scenario involves many
+// individual blobs of size 1 byte. Since each blob fills the square is a sparse
+// way, each will be padded to single share. Since tendermint doesn't gossip or
+// know about that padding, it will reap many txs from the mempool that will
+// cause the square to be increased beyond the desired size.
 func EstimateMaxBlockBytes(squareSize uint64) int64 {
 	bsize := squareSize * squareSize * appconsts.ContinuationSparseShareContentSize
-	// assume 2% of the block is padding
-	bsize = bsize - bsize/50
+	bsize = bsize - bsize/16
 	return int64(bsize)
 }

--- a/pkg/square/utils_test.go
+++ b/pkg/square/utils_test.go
@@ -15,10 +15,10 @@ func TestEstimateMaxBlockSize(t *testing.T) {
 	}
 
 	tests := []test{
-		{squareSize: 64, expect: 1957888},
-		{squareSize: appconsts.MaxSquareSize, expect: 7831552},
-		{squareSize: 256, expect: 31326208},
-		{squareSize: 512, expect: 125304832},
+		{squareSize: 64, expect: 1918731},
+		{squareSize: appconsts.MaxSquareSize, expect: 7674921},
+		{squareSize: 256, expect: 30699684},
+		{squareSize: 512, expect: 122798736},
 	}
 	for _, tc := range tests {
 		res := EstimateMaxBlockBytes(tc.squareSize)

--- a/pkg/square/utils_test.go
+++ b/pkg/square/utils_test.go
@@ -1,10 +1,11 @@
-package square
+package square_test
 
 import (
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/shares"
+	"github.com/celestiaorg/celestia-app/pkg/square"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,18 +16,18 @@ func TestEstimateMaxBlockSize(t *testing.T) {
 	}
 
 	tests := []test{
-		{squareSize: 64, expect: 1918731},
-		{squareSize: appconsts.MaxSquareSize, expect: 7674921},
-		{squareSize: 256, expect: 30699684},
-		{squareSize: 512, expect: 122798736},
+		{squareSize: 64, expect: 1835520},
+		{squareSize: appconsts.MaxSquareSize, expect: 7342080},
+		{squareSize: 256, expect: 29368320},
+		{squareSize: 512, expect: 117473280},
 	}
 	for _, tc := range tests {
-		res := EstimateMaxBlockBytes(tc.squareSize)
+		res := square.EstimateMaxBlockBytes(tc.squareSize)
 		assert.Equal(t, tc.expect, res)
 
 		// check that the result is within the bounds of the square size
 		sharesUsed := shares.SparseSharesNeeded(uint32(res))
-		roundTripSquareSize := Size(int(sharesUsed))
+		roundTripSquareSize := square.Size(int(sharesUsed))
 		assert.Equal(t, tc.squareSize, roundTripSquareSize)
 	}
 }

--- a/pkg/square/utils_test.go
+++ b/pkg/square/utils_test.go
@@ -1,0 +1,32 @@
+package square
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/shares"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEstimateMaxBlockSize(t *testing.T) {
+	type test struct {
+		squareSize uint64
+		expect     int64
+	}
+
+	tests := []test{
+		{squareSize: 64, expect: 1957888},
+		{squareSize: appconsts.MaxSquareSize, expect: 7831552},
+		{squareSize: 256, expect: 31326208},
+		{squareSize: 512, expect: 125304832},
+	}
+	for _, tc := range tests {
+		res := EstimateMaxBlockBytes(tc.squareSize)
+		assert.Equal(t, tc.expect, res)
+
+		// check that the result is within the bounds of the square size
+		sharesUsed := shares.SparseSharesNeeded(uint32(res))
+		roundTripSquareSize := Size(int(sharesUsed))
+		assert.Equal(t, tc.squareSize, roundTripSquareSize)
+	}
+}

--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -182,8 +182,10 @@ func DefaultGenesisState(fundedAccounts ...string) (map[string]json.RawMessage, 
 // DefaultNetwork creates an in-process single validator celestia-app network
 // using test friendly defaults. These defaults include fast block times and
 // funded accounts. The returned client.Context has a keyring with all of the
-// funded keys stored in it.
-func DefaultNetwork(t *testing.T, blockTime time.Duration) (accounts []string, cctx Context) {
+// funded keys stored in it. If no custom consensus parameters are provided, the
+// default are used. If providing custom consensus parameters and fast block
+// time is desired, the caller must set the TimeIotaMs parameter to 1.
+func DefaultNetwork(t *testing.T, blockTime time.Duration, customParams *tmproto.ConsensusParams) (accounts []string, cctx Context) {
 	// we create an arbitrary number of funded accounts
 	accounts = make([]string, 300)
 	for i := 0; i < 300; i++ {
@@ -199,7 +201,11 @@ func DefaultNetwork(t *testing.T, blockTime time.Duration) (accounts []string, c
 	genState, kr, err := DefaultGenesisState(accounts...)
 	require.NoError(t, err)
 
-	tmNode, app, cctx, err := New(t, DefaultParams(), tmCfg, false, genState, kr, tmrand.Str(6))
+	if customParams == nil {
+		customParams = DefaultParams()
+	}
+
+	tmNode, app, cctx, err := New(t, customParams, tmCfg, false, genState, kr, tmrand.Str(6))
 	require.NoError(t, err)
 
 	cctx, stopNode, err := StartNode(tmNode, cctx)

--- a/test/util/testnode/full_node_test.go
+++ b/test/util/testnode/full_node_test.go
@@ -69,7 +69,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 func (s *IntegrationTestSuite) Test_FillBlock() {
 	require := s.Require()
 
-	for squareSize := 2; squareSize <= appconsts.DefaultMaxSquareSize; squareSize *= 2 {
+	for squareSize := 2; squareSize <= appconsts.MaxSquareSize; squareSize *= 2 {
 		resp, err := s.cctx.FillBlock(squareSize, s.accounts, flags.BroadcastAsync)
 		require.NoError(err)
 

--- a/test/util/testnode/node_interaction_api.go
+++ b/test/util/testnode/node_interaction_api.go
@@ -168,7 +168,7 @@ func (c *Context) PostData(account, broadcastMode string, ns appns.Namespace, bl
 // should be submitted async, sync, or block. (see flags.BroadcastModeSync). If
 // broadcast mode is the string zero value, then it will be set to block.
 func (c *Context) FillBlock(squareSize int, accounts []string, broadcastMode string) (*sdk.TxResponse, error) {
-	if squareSize < appconsts.DefaultMinSquareSize+1 || (squareSize&(squareSize-1) != 0) {
+	if squareSize < appconsts.MinSquareSize+1 || (squareSize&(squareSize-1) != 0) {
 		return nil, fmt.Errorf("unsupported squareSize: %d", squareSize)
 	}
 

--- a/x/paramfilter/block_params.go
+++ b/x/paramfilter/block_params.go
@@ -1,0 +1,75 @@
+package paramfilter
+
+import (
+	"fmt"
+
+	"github.com/celestiaorg/celestia-app/pkg/square"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	abci "github.com/tendermint/tendermint/abci/types"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	coretypes "github.com/tendermint/tendermint/types"
+)
+
+// DefaultConsensusParams returns a default ConsensusParams.
+func DefaultConsensusParams(maxSquareSize uint64) *tmproto.ConsensusParams {
+	return &tmproto.ConsensusParams{
+		Block:     DefaultBlockParams(maxSquareSize),
+		Evidence:  coretypes.DefaultEvidenceParams(),
+		Validator: coretypes.DefaultValidatorParams(),
+		Version:   coretypes.DefaultVersionParams(),
+	}
+}
+
+// DefaultBlockParams returns a default BlockParams.
+func DefaultBlockParams(maxSquareSize uint64) tmproto.BlockParams {
+	return tmproto.BlockParams{
+		MaxBytes:   square.EstimateMaxBlockBytes(maxSquareSize),
+		MaxGas:     -1,
+		TimeIotaMs: 1000, // 1s
+	}
+}
+
+// ConsensusParamsKeyTable returns an x/params module keyTable to be used in the
+// BaseApp's ParamStore. The KeyTable registers the types along with the their
+// validation functions. Note that this replaces the standard block params
+// validation with a custom function.
+func ConsensusParamsKeyTable(maxSquareSize uint64) paramtypes.KeyTable {
+	return paramtypes.NewKeyTable(
+		paramtypes.NewParamSetPair(
+			baseapp.ParamStoreKeyBlockParams, abci.BlockParams{}, newBlockParamsValidator(maxSquareSize),
+		),
+		paramtypes.NewParamSetPair(
+			baseapp.ParamStoreKeyEvidenceParams, tmproto.EvidenceParams{}, baseapp.ValidateEvidenceParams,
+		),
+		paramtypes.NewParamSetPair(
+			baseapp.ParamStoreKeyValidatorParams, tmproto.ValidatorParams{}, baseapp.ValidateValidatorParams,
+		),
+	)
+}
+
+// validateBlockParams defines a stateless validation on BlockParams. This function
+// is called whenever the parameters are updated or stored.
+func newBlockParamsValidator(squareSize uint64) func(i interface{}) error {
+	return func(i interface{}) error {
+		v, ok := i.(abci.BlockParams)
+		if !ok {
+			return fmt.Errorf("invalid parameter type: %T", i)
+		}
+
+		if v.MaxBytes <= 0 {
+			return fmt.Errorf("block maximum bytes must be positive: %d", v.MaxBytes)
+		}
+
+		maxBlockBytes := square.EstimateMaxBlockBytes(squareSize)
+		if v.MaxBytes > maxBlockBytes {
+			return fmt.Errorf("block maximum bytes must be less than or equal to %d: %d", maxBlockBytes, v.MaxBytes)
+		}
+
+		if v.MaxGas < -1 {
+			return fmt.Errorf("block maximum gas must be greater than or equal to -1: %d", v.MaxGas)
+		}
+
+		return nil
+	}
+}

--- a/x/paramfilter/block_params.go
+++ b/x/paramfilter/block_params.go
@@ -19,7 +19,7 @@ func DefaultConsensusParams() *tmproto.ConsensusParams {
 		Block:     DefaultBlockParams(),
 		Evidence:  coretypes.DefaultEvidenceParams(),
 		Validator: coretypes.DefaultValidatorParams(),
-		Version:   coretypes.DefaultVersionParams(),
+		Version:   coretypes.DefaultVersionParams(), // TODO: set the default version to 1
 	}
 }
 
@@ -27,6 +27,10 @@ func DefaultConsensusParams() *tmproto.ConsensusParams {
 // using a goal square size.
 func DefaultBlockParams() tmproto.BlockParams {
 	return tmproto.BlockParams{
+		// since the max square size is already enforced as a hard cap, the only
+		// benefit we are getting here is stopping governance proposals from
+		// proposing a useless proposal. Its possible that this value is not
+		// as efficient as a larger value.
 		MaxBytes:   square.EstimateMaxBlockBytes(appconsts.MaxSquareSize),
 		MaxGas:     -1,
 		TimeIotaMs: 1000, // 1s

--- a/x/paramfilter/block_params.go
+++ b/x/paramfilter/block_params.go
@@ -3,6 +3,7 @@ package paramfilter
 import (
 	"fmt"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/square"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
@@ -11,20 +12,22 @@ import (
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
-// DefaultConsensusParams returns a default ConsensusParams.
-func DefaultConsensusParams(maxSquareSize uint64) *tmproto.ConsensusParams {
+// DefaultConsensusParams returns a ConsensusParams with a MaxBytes
+// determined using a goal square size.
+func DefaultConsensusParams() *tmproto.ConsensusParams {
 	return &tmproto.ConsensusParams{
-		Block:     DefaultBlockParams(maxSquareSize),
+		Block:     DefaultBlockParams(),
 		Evidence:  coretypes.DefaultEvidenceParams(),
 		Validator: coretypes.DefaultValidatorParams(),
 		Version:   coretypes.DefaultVersionParams(),
 	}
 }
 
-// DefaultBlockParams returns a default BlockParams.
-func DefaultBlockParams(maxSquareSize uint64) tmproto.BlockParams {
+// DefaultBlockParams returns a default BlockParams with a MaxBytes determined
+// using a goal square size.
+func DefaultBlockParams() tmproto.BlockParams {
 	return tmproto.BlockParams{
-		MaxBytes:   square.EstimateMaxBlockBytes(maxSquareSize),
+		MaxBytes:   square.EstimateMaxBlockBytes(appconsts.MaxSquareSize),
 		MaxGas:     -1,
 		TimeIotaMs: 1000, // 1s
 	}

--- a/x/paramfilter/block_params_test.go
+++ b/x/paramfilter/block_params_test.go
@@ -1,0 +1,33 @@
+package paramfilter
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/square"
+
+	"github.com/stretchr/testify/require"
+	abci "github.com/tendermint/tendermint/abci/types"
+)
+
+func Test_validateBlockParams(t *testing.T) {
+	maxBlockBytes := square.EstimateMaxBlockBytes(appconsts.MaxSquareSize)
+	testCases := []struct {
+		arg       interface{}
+		expectErr bool
+	}{
+		{nil, true},
+		{&abci.BlockParams{}, true},
+		{abci.BlockParams{}, true},
+		{abci.BlockParams{MaxBytes: -1, MaxGas: -1}, true},
+		{abci.BlockParams{MaxBytes: 2000000, MaxGas: -5}, true},
+		{abci.BlockParams{MaxBytes: maxBlockBytes, MaxGas: -1}, false},
+		{abci.BlockParams{MaxBytes: maxBlockBytes + 1, MaxGas: -1}, true},
+	}
+
+	validator := newBlockParamsValidator(appconsts.MaxSquareSize)
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.expectErr, validator(tc.arg) != nil)
+	}
+}


### PR DESCRIPTION
## Overview

Leaving as a draft for now until we merge https://github.com/celestiaorg/cosmos-sdk/pull/317 and decide on if this is actually the approach that we want to use to try to limit the square size.

closes https://github.com/celestiaorg/celestia-app/issues/1592 closes https://github.com/celestiaorg/celestia-app/issues/1737

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
