### PR TITLE
chore: bump celestiaorg/cosmos-sdk to v1.13.0-sdk-v0.46.11

### DIFF
--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -37,7 +37,7 @@ func TestIntegrationTestSuite(t *testing.T) {
 	cfg.EnableTMLogging = false
 	cfg.MinGasPrices = "0utia"
 	cfg.NumValidators = 1
-	cfg.TimeoutCommit = time.Millisecond * 400
+	cfg.TargetHeightDuration = time.Millisecond * 400
 	suite.Run(t, NewIntegrationTestSuite(cfg))
 }
 

--- a/go.mod
+++ b/go.mod
@@ -200,7 +200,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.13.0-sdk-v0.46.11
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.19.0-tm-v0.34.27
 )

--- a/go.sum
+++ b/go.sum
@@ -171,8 +171,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.19.0-tm-v0.34.27 h1:GLdDJRu1fRSMft4IqQz4/x/H1U3eN2TFlYbAycbSiN4=
 github.com/celestiaorg/celestia-core v1.19.0-tm-v0.34.27/go.mod h1:8PbX2OIPehldawXWAzNWPxBPnfFtcYtjHecE45b2Beg=
-github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11 h1:Y+/dAyu7t0F8+EZz+jU3tyZqG10W8LTCQpnHe8Ejuec=
-github.com/celestiaorg/cosmos-sdk v1.12.0-sdk-v0.46.11/go.mod h1:uKEyhG8H8hbjebOEEgtyqghJWpuMyF+u61MK5cis+pk=
+github.com/celestiaorg/cosmos-sdk v1.13.0-sdk-v0.46.11 h1:Rd5EvJx1nG3KurBspVN51RVmvif0Lp2UVURbG2ad3Cs=
+github.com/celestiaorg/cosmos-sdk v1.13.0-sdk-v0.46.11/go.mod h1:xCG6OUkJy5KUMEg20Zk010lra9XjkmKS3+bk0wp7bd8=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
 github.com/celestiaorg/nmt v0.15.0 h1:ID9QlMIeP6WK/iiGcfnYLu2qqVIq0UYe/dc3TVPt6EA=


### PR DESCRIPTION
## Overview

bumps to the most recent version of our fork of the sdk

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
