### PR TITLE
Remove shebang from Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-#!/usr/bin/make -f
-
 VERSION := $(shell echo $(shell git describe --tags) | sed 's/^v//')
 COMMIT := $(shell git log -1 --format='%H')
 DOCKER := $(shell which docker)


### PR DESCRIPTION
## Overview

#360 introduced a [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) incorrectly. The shebang is only used for executable files (from the Wikipedia link above, emphasis mine):

> When a text file with a shebang is used **as if it is an executable** in a Unix-like operating system, the program loader mechanism parses the rest of the file's initial line as an interpreter directive.

Makefiles aren't self-executable, rather they're inputs to the `make` command.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
