### PR TITLE
feat!: use `consensus.MaxBytes` to determine `GovMaxSquareSize` (option 3 from ADR021)

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/pkg/square"
@@ -25,7 +24,7 @@ func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePr
 
 	// build the square from the set of valid and prioritised transactions.
 	// The txs returned are the ones used in the square and block
-	dataSquare, txs, err := square.Build(txs, appconsts.MaxSquareSize)
+	dataSquare, txs, err := square.Build(txs, app.GovMaxSquareSize(sdkCtx))
 	if err != nil {
 		panic(err)
 	}

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/pkg/square"
@@ -92,7 +91,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 	}
 
 	// Construct the data square from the block's transactions
-	dataSquare, err := square.Construct(req.BlockData.Txs, appconsts.MaxSquareSize)
+	dataSquare, err := square.Construct(req.BlockData.Txs, app.GovMaxSquareSize(sdkCtx))
 	if err != nil {
 		logInvalidPropBlockError(app.Logger(), req.Header, "failure to compute data square from transactions:", err)
 		return reject()

--- a/app/square_size.go
+++ b/app/square_size.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/square"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// GovMaxSquareSize returns the maximum square size that can be used for a block
+// using the max bytes value from the consensus params. Governance can change
+// the result of this value by changing the MaxBytes consensus parameter.
+func (app *App) GovMaxSquareSize(ctx sdk.Context) int {
+	params := app.GetConsensusParams(ctx)
+	return int(SquareSizeFromMaxBytes(params.Block.MaxBytes))
+}
+
+// SquareSizeFromMaxBytes returns the square size that will be used for a given
+// max bytes value. It does not account for any encoding overhead. It will
+// return the hardcoded appconsts.MaxSquareSize if the size is greater than
+// that.
+func SquareSizeFromMaxBytes(mbytes int64) uint64 {
+	sharesUsed := mbytes / appconsts.ContinuationSparseShareContentSize
+	size := square.Size(int(sharesUsed))
+	if size > appconsts.MaxSquareSize {
+		size = appconsts.MaxSquareSize
+	}
+	return size
+}

--- a/app/square_size.go
+++ b/app/square_size.go
@@ -14,8 +14,8 @@ func (app *App) GovMaxSquareSize(ctx sdk.Context) int {
 	// 64. This is due to tendermint not technically supposed to be calling
 	// PrepareProposal when heights are not >= 1. This is remedied in versions
 	// of the sdk and coment that have full support of PreparePropsoal, although
-	// celestia-app does not currently using those.
-	// https://github.com/cosmos/cosmos-sdk/pull/14505
+	// celestia-app does not currently use those. see this PR for more
+	// details https://github.com/cosmos/cosmos-sdk/pull/14505
 	if ctx.BlockHeader().Height == 0 {
 		return int(SquareSizeFromMaxBytes(int64(appconsts.DefaultMaxBytes)))
 	}

--- a/app/square_size.go
+++ b/app/square_size.go
@@ -10,6 +10,14 @@ import (
 // using the max bytes value from the consensus params. Governance can change
 // the result of this value by changing the MaxBytes consensus parameter.
 func (app *App) GovMaxSquareSize(ctx sdk.Context) int {
+	// TODO: fix hack that forces the max square size for the first height to
+	// 64. This is due to the sdk not loading state until calling commit for
+	// height 1. This means that even if the actual GovMaxSquareSize is supposed
+	// to be something other than 64, it will be 64 for the first block
+	// prodcuced.
+	if ctx.BlockHeader().Height == 0 {
+		return int(SquareSizeFromMaxBytes(int64(appconsts.DefaultMaxBytes)))
+	}
 	params := app.GetConsensusParams(ctx)
 	return int(SquareSizeFromMaxBytes(params.Block.MaxBytes))
 }

--- a/app/square_size.go
+++ b/app/square_size.go
@@ -11,10 +11,11 @@ import (
 // the result of this value by changing the MaxBytes consensus parameter.
 func (app *App) GovMaxSquareSize(ctx sdk.Context) int {
 	// TODO: fix hack that forces the max square size for the first height to
-	// 64. This is due to the sdk not loading state until calling commit for
-	// height 1. This means that even if the actual GovMaxSquareSize is supposed
-	// to be something other than 64, it will be 64 for the first block
-	// prodcuced.
+	// 64. This is due to tendermint not technically supposed to be calling
+	// PrepareProposal when heights are not >= 1. This is remedied in versions
+	// of the sdk and coment that have full support of PreparePropsoal, although
+	// celestia-app does not currently using those.
+	// https://github.com/cosmos/cosmos-sdk/pull/14505
 	if ctx.BlockHeader().Height == 0 {
 		return int(SquareSizeFromMaxBytes(int64(appconsts.DefaultMaxBytes)))
 	}

--- a/app/square_size_test.go
+++ b/app/square_size_test.go
@@ -17,6 +17,8 @@ func TestSquareSizeFromMaxBytes(t *testing.T) {
 		{input: appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize, want: appconsts.MaxSquareSize},
 		{input: appconsts.MaxShareCount*appconsts.ContinuationSparseShareContentSize + 1, want: appconsts.MaxSquareSize},
 		{input: appconsts.DefaultMaxBytes, want: appconsts.DefaultGovMaxSquareSize},
+		// increase the default by 1 share to rquire a larger square
+		{input: appconsts.DefaultMaxBytes + appconsts.ContinuationSparseShareContentSize, want: appconsts.MaxSquareSize},
 	}
 	for _, tt := range tests {
 		got := SquareSizeFromMaxBytes(tt.input)

--- a/app/square_size_test.go
+++ b/app/square_size_test.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSquareSizeFromMaxBytes(t *testing.T) {
+	type test struct {
+		input int64
+		want  uint64
+	}
+	tests := []test{
+		{input: 0, want: 1},
+		{input: appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize, want: appconsts.MaxSquareSize},
+		{input: appconsts.MaxShareCount*appconsts.ContinuationSparseShareContentSize + 1, want: appconsts.MaxSquareSize},
+		{input: appconsts.DefaultMaxBytes, want: appconsts.DefaultGovMaxSquareSize},
+	}
+	for _, tt := range tests {
+		got := SquareSizeFromMaxBytes(tt.input)
+		assert.Equal(t, tt.want, got)
+	}
+}

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -24,7 +24,7 @@ func TestCheckTx(t *testing.T) {
 
 	accs := []string{"a", "b", "c", "d", "e", "f"}
 
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(accs...)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accs...)
 
 	type test struct {
 		name             string

--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -2,10 +2,10 @@ package app_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/util"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -18,8 +18,8 @@ import (
 // PrepareProposal and then tests those blocks by calling ProcessProposal. All
 // blocks produced by PrepareProposal should be accepted by ProcessProposal. It
 // doesn't use the standard go tools for fuzzing as those tools only support
-// fuzzing limited types, instead we create blocks our selves using random
-// transactions.
+// fuzzing limited types, instead we repeatedly create random blocks using
+// various square sizes.
 func TestPrepareProposalConsistency(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping TestPrepareProposalConsistency in short mode.")
@@ -30,26 +30,64 @@ func TestPrepareProposalConsistency(t *testing.T) {
 		accounts[i] = tmrand.Str(20)
 	}
 
-	testApp, kr := util.SetupTestAppWithGenesisValSet(accounts...)
-
 	type test struct {
 		name                   string
 		count, blobCount, size int
+		iterations             int
 	}
 	tests := []test{
-		{"many small single share single blob transactions", 1000, 1, 400},
-		{"one hundred normal sized single blob transactions", 100, 1, 400000},
-		{"many single share multi-blob transactions", 1000, 100, 400},
-		{"one hundred normal sized multi-blob transactions", 100, 4, 400000},
+		// running these tests more than once in CI will sometimes timout, so we
+		// have to run them each once per square size. However, we can run these
+		// more locally by increasing the iterations.
+		{"many small single share single blob transactions", 1000, 1, 400, 1},
+		{"one hundred normal sized single blob transactions", 100, 1, 400000, 1},
+		{"many single share multi-blob transactions", 1000, 100, 400, 1},
+		{"one hundred normal sized multi-blob transactions", 100, 4, 400000, 1},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			timer := time.After(time.Second * 20)
-			for {
-				select {
-				case <-timer:
-					return
-				default:
+
+	type testSize struct {
+		name             string
+		maxBytes         int64
+		govMaxSquareSize uint64
+	}
+	sizes := []testSize{
+		{
+			"default (should be 64 as of mainnet)",
+			appconsts.DefaultMaxBytes,
+			appconsts.DefaultGovMaxSquareSize,
+		},
+		{
+			"max",
+			appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize,
+			appconsts.MaxSquareSize,
+		},
+		{
+			"over max (square size 256)",
+			256 * 256 * appconsts.ContinuationSparseShareContentSize,
+			appconsts.MaxSquareSize,
+		},
+		{
+			"square size of 32",
+			32 * 32 * appconsts.ContinuationSparseShareContentSize,
+			32,
+		},
+	}
+
+	// run the above test case for each square size the specified number of
+	// iterations
+	for _, size := range sizes {
+		// setup a new application with different MaxBytes consensus parameter
+		// values.
+		cparams := app.DefaultConsensusParams()
+		cparams.Block.MaxBytes = size.maxBytes
+
+		testApp, kr := util.SetupTestAppWithGenesisValSet(cparams, accounts...)
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// repeat the test multiple times with random data each
+				// iteration.
+				for i := 0; i < tt.iterations; i++ {
 					txs := util.RandBlobTxsWithAccounts(
 						t,
 						testApp,
@@ -78,6 +116,11 @@ func TestPrepareProposalConsistency(t *testing.T) {
 							Txs: coretypes.Txs(txs).ToSliceOfBytes(),
 						},
 					})
+
+					// check that the square size is smaller than or equal to
+					// the specified size
+					require.LessOrEqual(t, resp.BlockData.SquareSize, size.govMaxSquareSize)
+
 					res := testApp.ProcessProposal(abci.RequestProcessProposal{
 						BlockData: resp.BlockData,
 						Header: core.Header{
@@ -86,7 +129,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 					})
 					require.Equal(t, abci.ResponseProcessProposal_ACCEPT, res.Result)
 				}
-			}
-		})
+			})
+		}
 	}
 }

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -23,7 +23,7 @@ import (
 func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 	numBlobTxs, numNormalTxs := 3, 3
 	accnts := testfactory.GenerateAccounts(numBlobTxs + numNormalTxs)
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(accnts...)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accnts...)
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	infos := queryAccountInfo(testApp, accnts, kr)
 
@@ -74,7 +74,7 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 func TestPrepareProposalFiltering(t *testing.T) {
 	encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	accounts := testfactory.GenerateAccounts(6)
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(accounts...)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 	infos := queryAccountInfo(testApp, accounts, kr)
 
 	// create 3 single blob blobTxs that are signed with valid account numbers

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -29,7 +29,7 @@ import (
 func TestProcessProposal(t *testing.T) {
 	encConf := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	accounts := testfactory.GenerateAccounts(6)
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(accounts...)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 	infos := queryAccountInfo(testApp, accounts, kr)
 	signer := types.GenerateKeyringSigner(t, accounts[0])
 

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -1,0 +1,94 @@
+package app_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/test/txsim"
+	"github.com/celestiaorg/celestia-app/test/util/testnode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRestrictedBlockSize(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping restricted block size integration test in short mode.")
+	}
+
+	type test struct {
+		name             string
+		maxBytes         int64
+		govMaxSquareSize uint64
+	}
+	tests := []test{
+		{
+			"default (should be 64 as of mainnet)",
+			appconsts.DefaultMaxBytes,
+			appconsts.DefaultGovMaxSquareSize,
+		},
+		// the testnode cannot consistently be started and stopped in the same
+		// test, so we only run this test once. See
+		// TestPrepareProposalConsistency for the below
+		//
+		// {
+		//  "max",
+		//  appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize,
+		//  appconsts.MaxSquareSize,
+		// }, {
+		//  "over max (square size 256)",
+		//  256 * 256 * appconsts.ContinuationSparseShareContentSize,
+		//  appconsts.MaxSquareSize,
+		// }, {
+		//  "square size of 32",
+		//  32 * 32 * appconsts.ContinuationSparseShareContentSize,
+		//  32,
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cparams := testnode.DefaultParams()
+			cparams.Block.MaxBytes = tt.maxBytes
+
+			cctx, rpcAddr, grpcAddr := testnode.NewNetwork(t, cparams, testnode.DefaultTendermintConfig(), testnode.DefaultAppConfig())
+
+			// using lots of individual small blobs will result in a large amount of
+			// overhead added to the square, which helps ensure we are hitting large squares
+			seqs := txsim.NewBlobSequence(
+				txsim.NewRange(1, 10000),
+				txsim.NewRange(20, 100),
+			).Clone(20)
+
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*15)
+			defer cancel()
+
+			_ = txsim.Run(
+				ctx,
+				[]string{rpcAddr},
+				[]string{grpcAddr},
+				cctx.Keyring,
+				rand.Int63(),
+				time.Second,
+				seqs...,
+			)
+
+			// check the block sizes
+			blocks, err := testnode.ReadBlockchain(context.Background(), rpcAddr)
+			require.NoError(t, err)
+
+			atMax := 0
+			for _, block := range blocks {
+				assert.LessOrEqual(t, block.Data.SquareSize, tt.govMaxSquareSize)
+				if block.Data.SquareSize == tt.govMaxSquareSize {
+					atMax++
+				}
+			}
+			// check that at least one block was at or above the goal size
+			assert.GreaterOrEqual(t, atMax, 1)
+
+		})
+	}
+}

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -88,7 +88,6 @@ func TestRestrictedBlockSize(t *testing.T) {
 			}
 			// check that at least one block was at or above the goal size
 			assert.GreaterOrEqual(t, atMax, 1)
-
 		})
 	}
 }

--- a/pkg/appconsts/appconsts.go
+++ b/pkg/appconsts/appconsts.go
@@ -61,8 +61,13 @@ const (
 	// = 8 MiB
 	MaxSquareSize = 128
 
-	// DefaultGovMaxSquareSize is the default value for the governance modifiable
-	// max square size.
+	// DefaultGovMaxSquareSize is the default value for the governance
+	// modifiable max square size.
+	//
+	// NOTE: In order for governance to change this value,
+	// they must change the MaxBytes consensus parameter to be something larger
+	// than DefaultMaxBytes. This is due to the factor that this value is
+	// calculated at each block from the MaxBytes consensus parameter.
 	DefaultGovMaxSquareSize = 64
 
 	// DefaultMaxBytes is the default value for the maximum number of bytes

--- a/test/cmd/txsim/cli_test.go
+++ b/test/cmd/txsim/cli_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -52,9 +53,13 @@ func TestTxsimCommandEnvVar(t *testing.T) {
 func setup(t testing.TB) (keyring.Keyring, string, string) {
 	t.Helper()
 
+	// set the consensus params to allow for the max square size
+	cparams := testnode.DefaultParams()
+	cparams.Block.MaxBytes = appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize
+
 	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(
 		t,
-		testnode.DefaultParams(),
+		cparams,
 		testnode.DefaultTendermintConfig(),
 		testnode.DefaultAppConfig(),
 		testfactory.TestAccName,

--- a/test/txsim/run_test.go
+++ b/test/txsim/run_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/txsim"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -117,9 +118,13 @@ func TestTxSimulator(t *testing.T) {
 func Setup(t testing.TB) (keyring.Keyring, string, string) {
 	t.Helper()
 
+	// set the consensus params to allow for the max square size
+	cparams := testnode.DefaultParams()
+	cparams.Block.MaxBytes = appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize
+
 	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(
 		t,
-		testnode.DefaultParams(),
+		cparams,
 		testnode.DefaultTendermintConfig(),
 		testnode.DefaultAppConfig(),
 	)

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -51,7 +51,7 @@ func (ao emptyAppOptions) Get(_ string) interface{} {
 // that also act as delegators. For simplicity, each validator is bonded with a delegation
 // of one consensus engine unit in the default token of the app from first genesis
 // account. A Nop logger is set in app.
-func SetupTestAppWithGenesisValSet(genAccounts ...string) (*app.App, keyring.Keyring) {
+func SetupTestAppWithGenesisValSet(cparams *tmproto.ConsensusParams, genAccounts ...string) (*app.App, keyring.Keyring) {
 	// var cache sdk.MultiStorePersistentCache
 	// EmptyAppOptions is a stub implementing AppOptions
 	emptyOpts := emptyAppOptions{}
@@ -75,8 +75,6 @@ func SetupTestAppWithGenesisValSet(genAccounts ...string) (*app.App, keyring.Key
 	if err != nil {
 		panic(err)
 	}
-
-	cparams := app.DefaultConsensusParams()
 
 	abciParams := &abci.ConsensusParams{
 		Block: &abci.BlockParams{

--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -147,7 +147,8 @@ func DefaultTendermintConfig() *config.Config {
 	// during tests.
 	tmCfg.Consensus.TargetHeightDuration = 300 * time.Millisecond
 	tmCfg.Consensus.TimeoutPropose = 200 * time.Millisecond
-	tmCfg.Mempool.MaxTxBytes = 22020096 // 21MB
+	tmCfg.Mempool.MaxTxBytes = 220020096 // 210MB
+	tmCfg.RPC.MaxBodyBytes = 220020096   // 210MB
 	return tmCfg
 }
 

--- a/x/paramfilter/test/param_filter_test.go
+++ b/x/paramfilter/test/param_filter_test.go
@@ -3,6 +3,7 @@ package test
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/app"
 	testutil "github.com/celestiaorg/celestia-app/test/util"
 	"github.com/celestiaorg/celestia-app/x/paramfilter"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -14,7 +15,7 @@ import (
 )
 
 func TestParamFilter(t *testing.T) {
-	app, _ := testutil.SetupTestAppWithGenesisValSet()
+	app, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams())
 
 	require.Greater(t, len(app.BlockedParams()), 0)
 

--- a/x/qgb/types/query.pb.go
+++ b/x/qgb/types/query.pb.go
@@ -6,8 +6,8 @@ package types
 import (
 	context "context"
 	fmt "fmt"
-	types "github.com/cosmos/cosmos-sdk/codec/types"
 	_ "github.com/cosmos/cosmos-proto"
+	types "github.com/cosmos/cosmos-sdk/codec/types"
 	_ "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"

--- a/x/upgrade/test/removal_test.go
+++ b/x/upgrade/test/removal_test.go
@@ -3,13 +3,14 @@ package test
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/app"
 	testutil "github.com/celestiaorg/celestia-app/test/util"
 	sdkupgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRemoval(t *testing.T) {
-	app, _ := testutil.SetupTestAppWithGenesisValSet()
+	app, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams())
 	sftwrUpgrd := sdkupgradetypes.MsgSoftwareUpgrade{}
 	router := app.MsgServiceRouter()
 	handler := router.Handler(&sftwrUpgrd)


### PR DESCRIPTION
## Overview

the implementation of option 3 ADR021 #1759, blocked by first making a decision of which option to use.

closes #1592

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
