### PR TITLE
chore!: upgrade to rsmt2d v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.0-beta.3
-	github.com/celestiaorg/rsmt2d v0.8.0
+	github.com/celestiaorg/rsmt2d v0.9.0
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8
 	github.com/cosmos/cosmos-sdk v0.46.11
 	github.com/cosmos/gogoproto v1.4.2
@@ -180,7 +180,6 @@ require (
 	github.com/tklauser/go-sysconf v0.3.10 // indirect
 	github.com/tklauser/numcpus v0.4.0 // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
-	github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3 // indirect
 	github.com/zondax/hid v0.9.1 // indirect
 	github.com/zondax/ledger-go v0.14.1 // indirect
 	go.etcd.io/bbolt v1.3.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,8 +179,8 @@ github.com/celestiaorg/nmt v0.15.0 h1:ID9QlMIeP6WK/iiGcfnYLu2qqVIq0UYe/dc3TVPt6E
 github.com/celestiaorg/nmt v0.15.0/go.mod h1:GfwIvQPhUakn1modWxJ+rv8dUjJzuXg5H+MLFM1o7nY=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0 h1:9zPIp7w1FWfkPnn16y3S4FpFLnQtS7rm81CUVcHEts0=
 github.com/celestiaorg/quantum-gravity-bridge v1.3.0/go.mod h1:6WOajINTDEUXpSj5UZzod16UZ96ZVB/rFNKyM+Mt1gI=
-github.com/celestiaorg/rsmt2d v0.8.0 h1:ZUxTCELZCM9zMGKNF3cT+rUqMddXMeiuyleSJPZ3Wn4=
-github.com/celestiaorg/rsmt2d v0.8.0/go.mod h1:hhlsTi6G3+X5jOP/8Lb/d7i5y2XNFmnyMddYbFSmrgo=
+github.com/celestiaorg/rsmt2d v0.9.0 h1:kon78I748ZqjNzI8OAqPN+2EImuZuanj/6gTh8brX3o=
+github.com/celestiaorg/rsmt2d v0.9.0/go.mod h1:E06nDxfoeBDltWRvTR9dLviiUZI5/6mLXAuhSJzz3Iw=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -1017,8 +1017,6 @@ github.com/urfave/cli/v2 v2.17.2-0.20221006022127-8f469abc00aa h1:5SqCsI/2Qya2bC
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
-github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3 h1:zMsHhfK9+Wdl1F7sIKLyx3wrOFofpb3rWFbA4HgcK5k=
-github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3/go.mod h1:R0Gbuw7ElaGSLOZUSwBm/GgVwMd30jWxBDdAyMOeTuc=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/willf/bitset v1.1.3/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=

--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -98,13 +98,20 @@ func NewShareInclusionProof(
 		// we have to re-create the tree as the eds one is not accessible.
 		tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(squareSize), uint(i))
 		for _, share := range row {
-			tree.Push(
+			err := tree.Push(
 				share.ToBytes(),
 			)
+			if err != nil {
+				return types.ShareProof{}, err
+			}
 		}
 
 		// make sure that the generated root is the same as the eds row root.
-		if !bytes.Equal(rowRoots[i].Bytes(), tree.Root()) {
+		root, err := tree.Root()
+		if err != nil {
+			return types.ShareProof{}, err
+		}
+		if !bytes.Equal(rowRoots[i].Bytes(), root) {
 			return types.ShareProof{}, errors.New("eds row root is different than tree root")
 		}
 

--- a/pkg/wrapper/nmt_wrapper_test.go
+++ b/pkg/wrapper/nmt_wrapper_test.go
@@ -34,9 +34,8 @@ func TestPushErasuredNamespacedMerkleTree(t *testing.T) {
 			tree := NewErasuredNamespacedMerkleTree(uint64(tc.squareSize), 0)
 
 			for _, d := range generateErasuredData(t, tc.squareSize, appconsts.DefaultCodec()) {
-				// push test data to the tree. push will panic if there's an
-				// error.
-				tree.Push(d)
+				err := tree.Push(d)
+				assert.NoError(t, err)
 			}
 		})
 	}
@@ -49,64 +48,61 @@ func TestPushErasuredNamespacedMerkleTree(t *testing.T) {
 func TestRootErasuredNamespacedMerkleTree(t *testing.T) {
 	size := 8
 	data := generateRandNamespacedRawData(size)
-	tree := NewErasuredNamespacedMerkleTree(uint64(size), 0)
-	nmtTree := nmt.New(sha256.New(), nmt.NamespaceIDSize(namespace.NamespaceSize), nmt.IgnoreMaxNamespace(true))
+	nmtErasured := NewErasuredNamespacedMerkleTree(uint64(size), 0)
+	nmtStandard := nmt.New(sha256.New(), nmt.NamespaceIDSize(namespace.NamespaceSize), nmt.IgnoreMaxNamespace(true))
 
 	for _, d := range data {
-		tree.Push(d)
-		err := nmtTree.Push(d)
+		err := nmtErasured.Push(d)
+		if err != nil {
+			t.Error(err)
+		}
+		err = nmtStandard.Push(d)
 		if err != nil {
 			t.Error(err)
 		}
 	}
 
-	root, err := nmtTree.Root()
+	rootErasured, err := nmtErasured.Root()
 	assert.NoError(t, err)
-	assert.NotEqual(t, root, tree.Root())
+
+	rootStandard, err := nmtStandard.Root()
+	assert.NoError(t, err)
+
+	assert.NotEqual(t, rootStandard, rootErasured)
 }
 
-func TestErasureNamespacedMerkleTreePanics(t *testing.T) {
+func TestErasureNamespacedMerkleTreeErrors(t *testing.T) {
+	squareSize := 16
+	dataOverSquareSize := generateErasuredData(t, squareSize+1, appconsts.DefaultCodec())
+	dataUnsorted := generateErasuredData(t, squareSize, appconsts.DefaultCodec())
+	dataUnsorted[0], dataUnsorted[1] = dataUnsorted[1], dataUnsorted[0]
+	dataWithoutNamespace := [][]byte{{0x1}}
+
 	testCases := []struct {
-		name  string
-		pFunc assert.PanicTestFunc
+		name string
+		data [][]byte
 	}{
 		{
-			"push over square size",
-			assert.PanicTestFunc(
-				func() {
-					data := generateErasuredData(t, 16, appconsts.DefaultCodec())
-					tree := NewErasuredNamespacedMerkleTree(uint64(15), 0)
-					for _, d := range data {
-						tree.Push(d)
-					}
-				}),
+			name: "push over square size",
+			data: dataOverSquareSize,
 		},
 		{
-			"push in incorrect lexigraphic order",
-			assert.PanicTestFunc(
-				func() {
-					data := generateErasuredData(t, 16, appconsts.DefaultCodec())
-					tree := NewErasuredNamespacedMerkleTree(uint64(16), 0)
-					for i := len(data) - 1; i > 0; i-- {
-						tree.Push(data[i])
-					}
-				},
-			),
+			name: "push in incorrect lexicographic order",
+			data: dataUnsorted,
 		},
 		{
-			"push data that is too short to contain a namespace ID",
-			assert.PanicTestFunc(
-				func() {
-					data := []byte{0x1}
-					tree := NewErasuredNamespacedMerkleTree(uint64(16), 0)
-					tree.Push(data)
-				},
-			),
+			name: "push data that is too short to contain a namespace",
+			data: dataWithoutNamespace,
 		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Panics(t, tc.pFunc, tc.name)
+			tree := NewErasuredNamespacedMerkleTree(uint64(squareSize), 0)
+			var err error
+			for _, d := range tc.data {
+				err = tree.Push(d)
+			}
+			assert.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Upgrade to latest rsmt2d. Marked breaking because the public API of NMT wrapper changed slightly.