### PR TITLE
feat!: upper bound for data commitment window

### DIFF
--- a/x/qgb/types/genesis.go
+++ b/x/qgb/types/genesis.go
@@ -3,6 +3,8 @@ package types
 import (
 	"fmt"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+
 	"cosmossdk.io/errors"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
@@ -60,6 +62,12 @@ func validateDataCommitmentWindow(i interface{}) error {
 			"data commitment window %v must be >= minimum data commitment window %v",
 			val,
 			MinimumDataCommitmentWindow,
+		))
+	} else if val > uint64(appconsts.DataCommitmentBlocksLimit) {
+		return errors.Wrap(ErrInvalidDataCommitmentWindow, fmt.Sprintf(
+			"data commitment window %v must be < data commitment blocks limit %v",
+			val,
+			appconsts.DataCommitmentBlocksLimit,
 		))
 	}
 	return nil

--- a/x/qgb/types/genesis_test.go
+++ b/x/qgb/types/genesis_test.go
@@ -3,6 +3,8 @@ package types_test
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+
 	"github.com/celestiaorg/celestia-app/x/qgb/types"
 
 	"github.com/stretchr/testify/require"
@@ -13,15 +15,48 @@ func TestGenesisStateValidate(t *testing.T) {
 		src    *types.GenesisState
 		expErr bool
 	}{
-		"default params": {src: types.DefaultGenesis(), expErr: false},
-		"empty params": {src: &types.GenesisState{
-			Params: &types.Params{},
-		}, expErr: true},
-		"invalid params: short block time": {src: &types.GenesisState{
-			Params: &types.Params{
-				DataCommitmentWindow: 10,
+		"default params": {
+			src:    types.DefaultGenesis(),
+			expErr: false,
+		},
+		"empty params": {
+			src: &types.GenesisState{
+				Params: &types.Params{},
 			},
-		}, expErr: true},
+			expErr: true,
+		},
+		"invalid params: short block time": {
+			src: &types.GenesisState{
+				Params: &types.Params{
+					DataCommitmentWindow: types.MinimumDataCommitmentWindow - 1,
+				},
+			},
+			expErr: true,
+		},
+		"invalid params: long block time": {
+			src: &types.GenesisState{
+				Params: &types.Params{
+					DataCommitmentWindow: uint64(appconsts.DataCommitmentBlocksLimit + 1),
+				},
+			},
+			expErr: true,
+		},
+		"valid params: data commitments blocks limit": {
+			src: &types.GenesisState{
+				Params: &types.Params{
+					DataCommitmentWindow: uint64(appconsts.DataCommitmentBlocksLimit),
+				},
+			},
+			expErr: false,
+		},
+		"valid params: minimum data commitment window": {
+			src: &types.GenesisState{
+				Params: &types.Params{
+					DataCommitmentWindow: types.MinimumDataCommitmentWindow,
+				},
+			},
+			expErr: false,
+		},
 	}
 	for msg, spec := range specs {
 		t.Run(msg, func(t *testing.T) {


### PR DESCRIPTION
## Overview

Use the constant in core as an upper bound for the data commitment window
