### PR TITLE
test: skip tx sim tests in short mode to avoid data races

### DIFF
--- a/test/cmd/txsim/cli_test.go
+++ b/test/cmd/txsim/cli_test.go
@@ -51,6 +51,9 @@ func TestTxsimCommandEnvVar(t *testing.T) {
 }
 
 func setup(t testing.TB) (keyring.Keyring, string, string) {
+	if testing.Short() {
+		t.Skip("skipping tx sim in short mode.")
+	}
 	t.Helper()
 
 	// set the consensus params to allow for the max square size


### PR DESCRIPTION

## Overview

The tx sim tests use the baseapp which is full of data races. Thus, we need to skip running these tests in short mode, so that they're not run when we execute `make test-race`.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
