### PR TITLE
chore: adds _flaky suffix to flaky tests

### DIFF
--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -66,8 +66,8 @@ func (s *SquareSizeIntegrationTest) SetupSuite() {
 
 // TestSquareSizeUpperBound sets the app's params to specific sizes, then fills the
 // block with spam txs to measure that the desired max is getting hit
-// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
-func (s *SquareSizeIntegrationTest) TestSquareSizeUpperBound() {
+// The "_Flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+func (s *SquareSizeIntegrationTest) TestSquareSizeUpperBound_Flaky() {
 	t := s.T()
 
 	type test struct {

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -67,7 +67,8 @@ func (s *SquareSizeIntegrationTest) SetupSuite() {
 
 // TestMaxSquareSize sets the app's params to specific sizes, then fills the
 // block with spam txs to measure that the desired max is getting hit
-func (s *SquareSizeIntegrationTest) TestMaxSquareSize() {
+// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+func (s *SquareSizeIntegrationTest) TestMaxSquareSize_Flaky() {
 	t := s.T()
 
 	type test struct {
@@ -89,7 +90,7 @@ func (s *SquareSizeIntegrationTest) TestMaxSquareSize() {
 			maxPFBsPerBlock: 10,
 		},
 		{
-			name:             "gov square size == hardcoded max",
+			name:             "gov square size == hardcoded max", // this test may behave flaky in the CIs
 			govMaxSquareSize: appconsts.MaxSquareSize,
 			maxBytes:         int64(appconsts.MaxShareCount * appconsts.ContinuationSparseShareContentSize),
 			blobSize:         10_000,

--- a/pkg/square/square_test.go
+++ b/pkg/square/square_test.go
@@ -130,7 +130,7 @@ func generateBlobTxsWithNamespaces(t *testing.T, namespaces []ns.Namespace, blob
 	)
 }
 
-// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+// The "_Flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
 func TestSquareBlobShareRange_Flaky(t *testing.T) {
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	txs := blobfactory.RandBlobTxsRandomlySized(encCfg.TxConfig.TxEncoder(), 10, 1000, 10).ToSliceOfBytes()

--- a/pkg/square/square_test.go
+++ b/pkg/square/square_test.go
@@ -302,7 +302,8 @@ func generateBlobTxsWithNamespaces(t *testing.T, namespaces []ns.Namespace, blob
 	)
 }
 
-func TestSquareBlobShareRange(t *testing.T) {
+// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+func TestSquareBlobShareRange_Flaky(t *testing.T) {
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	txs := blobfactory.RandBlobTxsRandomlySized(encCfg.TxConfig.TxEncoder(), 10, 1000, 10).ToSliceOfBytes()
 

--- a/test/util/testnode/full_node_test.go
+++ b/test/util/testnode/full_node_test.go
@@ -59,7 +59,8 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.accounts = accounts
 }
 
-func (s *IntegrationTestSuite) Test_Liveness() {
+// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+func (s *IntegrationTestSuite) Test_Liveness_Flaky() {
 	require := s.Require()
 	err := s.cctx.WaitForNextBlock()
 	require.NoError(err)

--- a/test/util/testnode/full_node_test.go
+++ b/test/util/testnode/full_node_test.go
@@ -58,7 +58,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.accounts = accounts
 }
 
-// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+// The "_Flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
 func (s *IntegrationTestSuite) Test_Liveness_Flaky() {
 	require := s.Require()
 	err := s.cctx.WaitForNextBlock()

--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -41,6 +41,7 @@ func NewIntegrationTestSuite(cfg cosmosnet.Config) *IntegrationTestSuite {
 	return &IntegrationTestSuite{cfg: cfg}
 }
 
+// Note: the SetupSuite may act flaky in the CIs.
 func (s *IntegrationTestSuite) SetupSuite() {
 	if testing.Short() {
 		s.T().Skip("skipping integration test in short mode.")
@@ -182,6 +183,7 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 	}
 }
 
-func TestIntegrationTestSuite(t *testing.T) {
+// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+func TestIntegrationTestSuite_Flaky(t *testing.T) {
 	suite.Run(t, NewIntegrationTestSuite(network.DefaultConfig()))
 }

--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -41,7 +41,7 @@ func NewIntegrationTestSuite(cfg cosmosnet.Config) *IntegrationTestSuite {
 	return &IntegrationTestSuite{cfg: cfg}
 }
 
-// Note: the SetupSuite may act flaky in the CIs.
+// Note: the SetupSuite may act flaky especially in CI.
 func (s *IntegrationTestSuite) SetupSuite() {
 	if testing.Short() {
 		s.T().Skip("skipping integration test in short mode.")
@@ -183,7 +183,7 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 	}
 }
 
-// The "_flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
+// The "_Flaky" suffix indicates that the test may fail non-deterministically especially when executed in CI.
 func TestIntegrationTestSuite_Flaky(t *testing.T) {
 	suite.Run(t, NewIntegrationTestSuite(network.DefaultConfig()))
 }


### PR DESCRIPTION
## Overview
As per our call, this PR adds a _flaky suffix to flaky tests identified so far.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
