### PR TITLE
docs: update the nonces docs in QGB store

### DIFF
--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -65,7 +65,7 @@ func (k Keeper) CheckLatestAttestationNonce(ctx sdk.Context) bool {
 }
 
 // GetLatestAttestationNonce returns the latest attestation request nonce.
-// Panics if the latest attestation nonce doesn't exit in store. This value is
+// Panics if the latest attestation nonce doesn't exist in store. This value is
 // set on chain startup. However, it won't be written to store until height = 1.
 // To check if this value exists in store, use the `CheckLatestAttestationNonce`
 // method.

--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -89,7 +89,7 @@ func (k Keeper) CheckEarliestAvailableAttestationNonce(ctx sdk.Context) bool {
 // GetEarliestAvailableAttestationNonce returns the earliest available
 // attestation nonce. The nonce is of the earliest available attestation in
 // store that can be retrieved. Panics if the earliest available attestation
-// nonce doesn't exit in store. This value is set on chain startup. However, it
+// nonce doesn't exist in store. This value is set on chain startup. However, it
 // won't be written to store until height = 1. To check if this value exists in
 // store, use the `CheckEarliestAvailableAttestationNonce` method.
 func (k Keeper) GetEarliestAvailableAttestationNonce(ctx sdk.Context) uint64 {

--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -65,11 +65,10 @@ func (k Keeper) CheckLatestAttestationNonce(ctx sdk.Context) bool {
 }
 
 // GetLatestAttestationNonce returns the latest attestation request nonce.
-// Panics if the latest attestation nonce doesn't exit. Make sure to call
-// `CheckLatestAttestationNonce` before getting the nonce. This value is set on
-// chain startup. However, it won't be written to store until height = 1. Thus,
-// it's mandatory to run `CheckLatestAttestationNonce` before calling this
-// method. Check x/qgb/genesis.go for more information.
+// Panics if the latest attestation nonce doesn't exit in store. This value is
+// set on chain startup. However, it won't be written to store until height = 1.
+// To check if this value exists in store, use the `CheckLatestAttestationNonce`
+// method.
 func (k Keeper) GetLatestAttestationNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
 	bytes := store.Get([]byte(types.LatestAttestationtNonce))
@@ -90,9 +89,9 @@ func (k Keeper) CheckEarliestAvailableAttestationNonce(ctx sdk.Context) bool {
 // GetEarliestAvailableAttestationNonce returns the earliest available
 // attestation nonce. The nonce is of the earliest available attestation in
 // store that can be retrieved. Panics if the earliest available attestation
-// nonce doesn't exit. This value is set on chain startup. However, it won't be
-// written to store until height = 1. Thus, it's mandatory to run
-// `CheckEarliestAvailableAttestationNonce` before calling this method.
+// nonce doesn't exit in store. This value is set on chain startup. However, it
+// won't be written to store until height = 1. To check if this value exists in
+// store, use the `CheckEarliestAvailableAttestationNonce` method.
 func (k Keeper) GetEarliestAvailableAttestationNonce(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
 	bytes := store.Get([]byte(types.EarliestAvailableAttestationNonce))


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Closes https://github.com/celestiaorg/celestia-app/issues/1805

The latest attestation nonce and earliest attestation nonce are values written to store. In order to get them, we use the `getLatestAttestationNonce` and the `getEarliestAvailableAttestationNonce` methods. 

These methods panic if these values don't exist in store. However, the only time these values don't exist in store, if no manual changes were done to the store, is during the period between chain startup and block 1. 

So, we have the `CheckLatestAttestationNonce` method that checks if the value exists in store and returns true if so. And we use it in `abci.EndBlocker` and in queries not to return a stack trace, but a relevant error when querying during the period between chain startup and block 1.

Thus, the only change we can do is think about in this case, is having these methods return an error instead of panicking, but it returns the same thing via using the `CheckLatestAttestationNonce`, instead of using `if errors.Is(...)`.

This is why this PR removes the misleading docs but makes no changes on the methods.
