### PR TITLE
chore: explicitly reject share commitments that are not == hash len

### DIFF
--- a/pkg/appconsts/global_consts.go
+++ b/pkg/appconsts/global_consts.go
@@ -76,9 +76,17 @@ var (
 	// if another hash.Hash should be used as a base hasher in the NMT.
 	NewBaseHashFunc = consts.NewBaseHashFunc
 
+	// hashLength is the length of a hash in bytes.
+	hashLength = NewBaseHashFunc().Size()
+
 	// DefaultCodec is the default codec creator used for data erasure.
 	DefaultCodec = rsmt2d.NewLeoRSCodec
 
 	// SupportedShareVersions is a list of supported share versions.
 	SupportedShareVersions = []uint8{ShareVersionZero}
 )
+
+// HashLen returns the length of a hash in bytes.
+func HashLength() int {
+	return hashLength
+}

--- a/pkg/appconsts/global_consts.go
+++ b/pkg/appconsts/global_consts.go
@@ -86,7 +86,7 @@ var (
 	SupportedShareVersions = []uint8{ShareVersionZero}
 )
 
-// HashLen returns the length of a hash in bytes.
+// HashLength returns the length of a hash in bytes.
 func HashLength() int {
 	return hashLength
 }

--- a/x/blob/types/errors.go
+++ b/x/blob/types/errors.go
@@ -17,7 +17,6 @@ var (
 	ErrParitySharesNamespace          = errors.Register(ModuleName, 11117, "cannot use parity shares namespace ID")
 	ErrTailPaddingNamespace           = errors.Register(ModuleName, 11118, "cannot use tail padding namespace ID")
 	ErrTxNamespace                    = errors.Register(ModuleName, 11119, "cannot use transaction namespace ID")
-	ErrEmptyShareCommitment           = errors.Register(ModuleName, 11121, "empty share commitment")
 	ErrInvalidShareCommitments        = errors.Register(ModuleName, 11122, "invalid share commitments: all relevant square sizes must be committed to")
 	ErrUnsupportedShareVersion        = errors.Register(ModuleName, 11123, "unsupported share version")
 	ErrZeroBlobSize                   = errors.Register(ModuleName, 11124, "cannot use zero blob size")

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -125,8 +125,8 @@ func (msg *MsgPayForBlobs) ValidateBasic() error {
 	}
 
 	for _, commitment := range msg.ShareCommitments {
-		if len(commitment) == 0 {
-			return ErrEmptyShareCommitment
+		if len(commitment) != appconsts.HashLength() {
+			return ErrInvalidShareCommitment
 		}
 	}
 

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -147,7 +147,7 @@ func TestValidateBasic(t *testing.T) {
 	emptyShareCommitment := validMsgPayForBlobs(t)
 	emptyShareCommitment.ShareCommitments[0] = []byte{}
 
-	// MsgPayForBlobs that has an empty share commitment
+	// MsgPayForBlobs that has an invalid share commitment size
 	invalidShareCommitmentSize := validMsgPayForBlobs(t)
 	invalidShareCommitmentSize.ShareCommitments[0] = bytes.Repeat([]byte{0x1}, 31)
 

--- a/x/blob/types/payforblob_test.go
+++ b/x/blob/types/payforblob_test.go
@@ -147,6 +147,10 @@ func TestValidateBasic(t *testing.T) {
 	emptyShareCommitment := validMsgPayForBlobs(t)
 	emptyShareCommitment.ShareCommitments[0] = []byte{}
 
+	// MsgPayForBlobs that has an empty share commitment
+	invalidShareCommitmentSize := validMsgPayForBlobs(t)
+	invalidShareCommitmentSize.ShareCommitments[0] = bytes.Repeat([]byte{0x1}, 31)
+
 	// MsgPayForBlobs that has no namespace ids
 	noNamespaceIds := validMsgPayForBlobs(t)
 	noNamespaceIds.Namespaces = [][]byte{}
@@ -197,7 +201,12 @@ func TestValidateBasic(t *testing.T) {
 		{
 			name:    "empty share commitment",
 			msg:     emptyShareCommitment,
-			wantErr: ErrEmptyShareCommitment,
+			wantErr: ErrInvalidShareCommitment,
+		},
+		{
+			name:    "incorrect hash size share commitment",
+			msg:     invalidShareCommitmentSize,
+			wantErr: ErrInvalidShareCommitment,
 		},
 		{
 			name:    "no namespace ids",
@@ -225,6 +234,7 @@ func TestValidateBasic(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.msg.ValidateBasic()
 			if tt.wantErr != nil {
+				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.wantErr.Error())
 				space, code, log := sdkerrors.ABCIInfo(err, false)
 				assert.Equal(t, tt.wantErr.Codespace(), space)


### PR DESCRIPTION
## Overview

Noticed this while I was writing the block validity rules. This was still failing as expected since the commitment is check, but now we're being more explicit.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
