### PR TITLE
feat: introduces NamespaceVersionMaxValue const

### DIFF
--- a/pkg/appconsts/global_consts.go
+++ b/pkg/appconsts/global_consts.go
@@ -3,6 +3,7 @@ package appconsts
 import (
 	"github.com/celestiaorg/rsmt2d"
 	"github.com/tendermint/tendermint/pkg/consts"
+	"math"
 )
 
 // These constants were originally sourced from:
@@ -11,7 +12,8 @@ import (
 // They can not change throughout the lifetime of a network.
 const (
 	// NamespaveVersionSize is the size of a namespace version in bytes.
-	NamespaceVersionSize = 1
+	NamespaceVersionSize     = 1
+	NamespaceVersionMaxValue = math.MaxUint8 // this value should be set according to NamespaceVersionSize, i.e., 2^NamespaceVersionSize - 1
 
 	// NamespaceIDSize is the size of a namespace ID in bytes.
 	NamespaceIDSize = 28

--- a/x/blob/types/blob_tx.go
+++ b/x/blob/types/blob_tx.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"fmt"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	math "math"
 
 	appns "github.com/celestiaorg/celestia-app/pkg/namespace"
@@ -121,7 +122,7 @@ func BlobFromProto(p *tmproto.Blob) (core.Blob, error) {
 		return core.Blob{}, fmt.Errorf("invalid share version %d", p.ShareVersion)
 	}
 
-	if p.NamespaceVersion > math.MaxUint8 {
+	if p.NamespaceVersion > appconsts.NamespaceVersionMaxValue {
 		return core.Blob{}, fmt.Errorf("invalid namespace version %d", p.NamespaceVersion)
 	}
 

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -1,11 +1,9 @@
 package types
 
 import (
+	"cosmossdk.io/errors"
 	"crypto/sha256"
 	fmt "fmt"
-	math "math"
-
-	"cosmossdk.io/errors"
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	appns "github.com/celestiaorg/celestia-app/pkg/namespace"
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
@@ -40,8 +38,8 @@ func NewMsgPayForBlobs(signer string, blobs ...*Blob) (*MsgPayForBlobs, error) {
 	namespaceVersions, namespaceIds, sizes, shareVersions := extractBlobComponents(blobs)
 	namespaces := []appns.Namespace{}
 	for i := range namespaceVersions {
-		if namespaceVersions[i] > math.MaxUint8 {
-			return nil, fmt.Errorf("namespace version %d is too large (max %d)", namespaceVersions[i], math.MaxUint8)
+		if namespaceVersions[i] > appconsts.NamespaceVersionMaxValue {
+			return nil, fmt.Errorf("namespace version %d is too large (max %d)", namespaceVersions[i], appconsts.NamespaceVersionMaxValue)
 		}
 		namespace, err := appns.New(uint8(namespaceVersions[i]), namespaceIds[i])
 		if err != nil {
@@ -254,7 +252,7 @@ func ValidateBlobs(blobs ...*Blob) error {
 	}
 
 	for _, blob := range blobs {
-		if blob.NamespaceVersion > math.MaxUint8 {
+		if blob.NamespaceVersion > appconsts.NamespaceVersionMaxValue {
 			return fmt.Errorf("namespace version %d is too large", blob.NamespaceVersion)
 		}
 		ns, err := appns.New(uint8(blob.NamespaceVersion), blob.NamespaceId)


### PR DESCRIPTION
## Overview
Although we already have a constant `NamespaceVersionSize`, the comparison of the max value of the namespace version of the incoming Blobs is currently hardcoded to `math.uint8`. While this aligns with the current value of `NamespaceVersionSize` which is 1 byte, it would be safer to derive the maximum value from the original constant instead of manually hardcoding it. This  PR incorporates this modification.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user-facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
