### PR TITLE
refactor: initialize the latest unbonding height in genesis

### DIFF
--- a/x/qgb/genesis.go
+++ b/x/qgb/genesis.go
@@ -15,6 +15,7 @@ func InitGenesis(ctx sdk.Context, k keeper.Keeper, genState types.GenesisState) 
 	// set it once here rather than conditionally setting it in abci.EndBlocker
 	// which is executed on every block.
 	k.SetEarliestAvailableAttestationNonce(ctx, 1)
+	k.SetLatestUnBondingBlockHeight(ctx, 0)
 	k.SetParams(ctx, *genState.Params)
 }
 

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -55,9 +55,8 @@ func (k Keeper) GetLatestValset(ctx sdk.Context) (*types.Valset, error) {
 	return &currentVs, err
 }
 
-// SetLatestUnBondingBlockHeight sets the latest unbonding block height. Note
-// this value is not saved to state or loaded at genesis. This value is reset to
-// zero on chain upgrade.
+// SetLatestUnBondingBlockHeight sets the latest unbonding block height.
+// This value is initialized to 0 in genesis.
 func (k Keeper) SetLatestUnBondingBlockHeight(ctx sdk.Context, unbondingBlockHeight uint64) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set([]byte(types.LatestUnBondingBlockHeight), types.UInt64Bytes(unbondingBlockHeight))

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -63,15 +63,13 @@ func (k Keeper) SetLatestUnBondingBlockHeight(ctx sdk.Context, unbondingBlockHei
 	store.Set([]byte(types.LatestUnBondingBlockHeight), types.UInt64Bytes(unbondingBlockHeight))
 }
 
-// GetLatestUnBondingBlockHeight returns the latest unbonding block height or
-// zero if not set. This value is not saved or loaded at genesis. This value is
-// reset to zero on chain upgrade.
+// GetLatestUnBondingBlockHeight returns the latest unbonding block height.
+// This value is set to 0 at genesis.
 func (k Keeper) GetLatestUnBondingBlockHeight(ctx sdk.Context) uint64 {
 	store := ctx.KVStore(k.storeKey)
 	bytes := store.Get([]byte(types.LatestUnBondingBlockHeight))
-
-	if len(bytes) == 0 {
-		return 0
+	if bytes == nil {
+		panic("nil LatestUnbBondingBlockHeight")
 	}
 	return UInt64FromBytes(bytes)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Initialize the unbonding height for QGB in genesis, to be consistent with the other values we're also setting there such as the latest attestation nonce.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
