### PR TITLE
fix: use the right key for `EarliestAvailableAttestationNonce` check method

### DIFF
--- a/x/qgb/keeper/keeper_attestation.go
+++ b/x/qgb/keeper/keeper_attestation.go
@@ -82,7 +82,7 @@ func (k Keeper) GetLatestAttestationNonce(ctx sdk.Context) uint64 {
 // attestation nonce has been initialized in store, and false if not.
 func (k Keeper) CheckEarliestAvailableAttestationNonce(ctx sdk.Context) bool {
 	store := ctx.KVStore(k.storeKey)
-	has := store.Has([]byte(types.LatestAttestationtNonce))
+	has := store.Has([]byte(types.EarliestAvailableAttestationNonce))
 	return has
 }
 


### PR DESCRIPTION
## Overview

We were using the wrong key when checking if the `EarliestAvailableAttestationNonce` exists in store

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
