### PR TITLE
chore: remove unnecessary comment

### DIFF
--- a/test/util/testnode/genesis_options.go
+++ b/test/util/testnode/genesis_options.go
@@ -19,7 +19,6 @@ type GenesisOption func(state map[string]json.RawMessage) map[string]json.RawMes
 
 // SetBlobParams will set the provided blob params as genesis state.
 func SetBlobParams(codec codec.Codec, params blobtypes.Params) GenesisOption {
-	// use the minimum data commitment window (100)
 	return func(state map[string]json.RawMessage) map[string]json.RawMessage {
 		blobGenState := blobtypes.DefaultGenesis()
 		blobGenState.Params = params


### PR DESCRIPTION
## Overview

That function is not changing anything related to the data commitment window, so I guess the comment was just copied by mistake
