### PR TITLE
chore!: remove unused fitsInRow return value

### DIFF
--- a/pkg/inclusion/paths.go
+++ b/pkg/inclusion/paths.go
@@ -14,7 +14,7 @@ type path struct {
 // calculateCommitmentPaths calculates all of the paths to subtree roots needed to
 // create the commitment for a given blob.
 func calculateCommitmentPaths(squareSize, start, blobShareLen, subtreeRootThreshold int) []path {
-	start, _ = shares.NextShareIndex(start, blobShareLen, squareSize, subtreeRootThreshold)
+	start = shares.NextShareIndex(start, blobShareLen, squareSize, subtreeRootThreshold)
 	startRow, endRow := start/squareSize, (start+blobShareLen-1)/squareSize
 	normalizedStartIndex := start % squareSize
 	normalizedEndIndex := (start + blobShareLen) - endRow*squareSize

--- a/pkg/shares/non_interactive_defaults.go
+++ b/pkg/shares/non_interactive_defaults.go
@@ -44,8 +44,7 @@ func BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThresho
 }
 
 // NextShareIndex determines the next index in a square that can be used. It
-// follows the non-interactive default rules defined in ADR013. This function
-// returns false if the entire the blob cannot fit on the given row. Assumes
+// follows the non-interactive default rules defined in ADR013. Assumes
 // that all args are non negative, and that squareSize is a power of two.
 // https://github.com/celestiaorg/celestia-specs/blob/master/src/rationale/message_block_layout.md#non-interactive-default-rules
 // https://github.com/celestiaorg/celestia-app/blob/0334749a9e9b989fa0a42b7f011f4a79af8f61aa/docs/architecture/adr-013-non-interactive-default-rules-for-zero-padding.md

--- a/pkg/shares/non_interactive_defaults.go
+++ b/pkg/shares/non_interactive_defaults.go
@@ -24,7 +24,7 @@ func FitsInSquare(cursor, squareSize, subtreeRootThreshold int, blobShareLens ..
 		firstBlobLen = blobShareLens[0]
 	}
 	// here we account for padding between the compact and sparse shares
-	cursor, _ = NextShareIndex(cursor, firstBlobLen, squareSize, subtreeRootThreshold)
+	cursor = NextShareIndex(cursor, firstBlobLen, squareSize, subtreeRootThreshold)
 	sharesUsed, _ := BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThreshold, blobShareLens...)
 	return cursor+sharesUsed <= squareSize*squareSize, sharesUsed
 }
@@ -36,7 +36,7 @@ func BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThresho
 	start := cursor
 	indexes = make([]uint32, len(blobShareLens))
 	for i, blobLen := range blobShareLens {
-		cursor, _ = NextShareIndex(cursor, blobLen, squareSize, subtreeRootThreshold)
+		cursor = NextShareIndex(cursor, blobLen, squareSize, subtreeRootThreshold)
 		indexes[i] = uint32(cursor)
 		cursor += blobLen
 	}
@@ -49,26 +49,26 @@ func BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThresho
 // that all args are non negative, and that squareSize is a power of two.
 // https://github.com/celestiaorg/celestia-specs/blob/master/src/rationale/message_block_layout.md#non-interactive-default-rules
 // https://github.com/celestiaorg/celestia-app/blob/0334749a9e9b989fa0a42b7f011f4a79af8f61aa/docs/architecture/adr-013-non-interactive-default-rules-for-zero-padding.md
-func NextShareIndex(cursor, blobShareLen, squareSize, subtreeRootThreshold int) (index int, fitsInRow bool) {
+func NextShareIndex(cursor, blobShareLen, squareSize, subtreeRootThreshold int) int {
 	// if we're starting at the beginning of the row, then return as there are
 	// no cases where we don't start at 0.
 	if isStartOfRow(cursor, squareSize) {
-		return cursor, true
+		return cursor
 	}
 
 	treeWidth := SubTreeWidth(blobShareLen, subtreeRootThreshold)
-	startOfNextRow := ((cursor / squareSize) + 1) * squareSize
+	startOfNextRow := getStartOfNextRow(cursor, squareSize)
 	cursor = roundUpBy(cursor, treeWidth)
 	switch {
 	// the entire blob fits in this row
 	case cursor+blobShareLen <= startOfNextRow:
-		return cursor, true
+		return cursor
 	// only a portion of the blob fits in this row
 	case cursor+treeWidth <= startOfNextRow:
-		return cursor, false
+		return cursor
 	// none of the blob fits on this row, so return the start of the next row
 	default:
-		return startOfNextRow, false
+		return startOfNextRow
 	}
 }
 
@@ -125,4 +125,9 @@ func min[T constraints.Integer](i, j T) T {
 // isStartOfRow returns true if cursor is at the start of a row
 func isStartOfRow(cursor, squareSize int) bool {
 	return cursor == 0 || cursor%squareSize == 0
+}
+
+// getStartOfRow returns the index of the first share in the next row
+func getStartOfNextRow(cursor, squareSize int) int {
+	return ((cursor / squareSize) + 1) * squareSize
 }

--- a/pkg/shares/non_interactive_defaults_test.go
+++ b/pkg/shares/non_interactive_defaults_test.go
@@ -149,7 +149,6 @@ func TestNextShareIndex(t *testing.T) {
 		name                        string
 		cursor, blobLen, squareSize int
 		expectedIndex               int
-		fits                        bool
 	}
 	tests := []test{
 		{
@@ -157,7 +156,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        0,
 			blobLen:       4,
 			squareSize:    4,
-			fits:          true,
 			expectedIndex: 0,
 		},
 		{
@@ -165,7 +163,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       2,
 			squareSize:    4,
-			fits:          true,
 			expectedIndex: 1,
 		},
 		{
@@ -173,7 +170,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        2,
 			blobLen:       2,
 			squareSize:    4,
-			fits:          true,
 			expectedIndex: 2,
 		},
 		{
@@ -181,7 +177,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        3,
 			blobLen:       4,
 			squareSize:    8,
-			fits:          true,
 			expectedIndex: 3,
 		},
 		{
@@ -189,7 +184,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        3,
 			blobLen:       5,
 			squareSize:    8,
-			fits:          true,
 			expectedIndex: 3,
 		},
 		{
@@ -197,7 +191,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        3,
 			blobLen:       2,
 			squareSize:    8,
-			fits:          true,
 			expectedIndex: 3,
 		},
 		{
@@ -205,7 +198,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        3,
 			blobLen:       5,
 			squareSize:    8,
-			fits:          true,
 			expectedIndex: 3,
 		},
 		{
@@ -213,7 +205,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       12,
 			squareSize:    16,
-			fits:          true,
 			expectedIndex: 1,
 		},
 		{
@@ -221,7 +212,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        10291,
 			blobLen:       1,
 			squareSize:    128,
-			fits:          true,
 			expectedIndex: 10291,
 		},
 		{
@@ -229,7 +219,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        11,
 			blobLen:       2,
 			squareSize:    8,
-			fits:          true,
 			expectedIndex: 11,
 		},
 		{
@@ -237,7 +226,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        11,
 			blobLen:       11,
 			squareSize:    8,
-			fits:          false,
 			expectedIndex: 11,
 		},
 		{
@@ -245,7 +233,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        11,
 			blobLen:       appconsts.DefaultSubtreeRootThreshold,
 			squareSize:    RoundUpPowerOfTwo(appconsts.DefaultSubtreeRootThreshold),
-			fits:          false,
 			expectedIndex: 11,
 		},
 		{
@@ -253,7 +240,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        64,
 			blobLen:       appconsts.DefaultSubtreeRootThreshold + 1,
 			squareSize:    128,
-			fits:          false,
 			expectedIndex: 64,
 		},
 		{
@@ -261,7 +247,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        64,
 			blobLen:       appconsts.DefaultSubtreeRootThreshold - 1,
 			squareSize:    128,
-			fits:          true,
 			expectedIndex: 64,
 		},
 		{
@@ -269,7 +254,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       appconsts.DefaultSubtreeRootThreshold - 1,
 			squareSize:    16,
-			fits:          false,
 			expectedIndex: 1,
 		},
 		{
@@ -277,7 +261,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       16256,
 			squareSize:    128,
-			fits:          false,
 			expectedIndex: 128,
 		},
 		{
@@ -285,7 +268,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       8192,
 			squareSize:    128,
-			fits:          false,
 			expectedIndex: 128,
 		},
 		{
@@ -293,7 +275,6 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       4096,
 			squareSize:    128,
-			fits:          false,
 			expectedIndex: 64,
 		},
 		{
@@ -301,14 +282,12 @@ func TestNextShareIndex(t *testing.T) {
 			cursor:        1,
 			blobLen:       8193,
 			squareSize:    128,
-			fits:          false,
 			expectedIndex: 128,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res, fits := NextShareIndex(tt.cursor, tt.blobLen, tt.squareSize, appconsts.DefaultSubtreeRootThreshold)
-			assert.Equal(t, tt.fits, fits)
+			res := NextShareIndex(tt.cursor, tt.blobLen, tt.squareSize, appconsts.DefaultSubtreeRootThreshold)
 			assert.Equal(t, tt.expectedIndex, res)
 		})
 	}

--- a/pkg/square/builder.go
+++ b/pkg/square/builder.go
@@ -155,7 +155,7 @@ func (b *Builder) Export() (Square, error) {
 	for i, element := range b.blobs {
 		// NextShareIndex returned where the next blob should start so as to comply with the share commitment rules
 		// We fill out the remaining
-		cursor, _ = shares.NextShareIndex(cursor, element.numShares, ss, b.subtreeRootThreshold)
+		cursor = shares.NextShareIndex(cursor, element.numShares, ss, b.subtreeRootThreshold)
 		if i == 0 {
 			nonReservedStart = cursor
 		}


### PR DESCRIPTION
`NextShareIndex` also returns a boolean "fitsInRow" value which isn't used anywhere in the logic anymore. This PR cleans up the function by removing it. Note that this breaks the Go API