### PR TITLE
feat: introduce ibc redundant relay decorator

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -22,7 +22,7 @@ func NewAnteHandler(
 		// reject all tx extensions
 		ante.NewExtensionOptionsDecorator(nil),
 		ante.NewValidateBasicDecorator(),
-		ante.TxTimeoutHeightDecorator{},
+		ante.NewTxTimeoutHeightDecorator(),
 		ante.NewValidateMemoDecorator(accountKeeper),
 		ante.NewConsumeGasForTxSizeDecorator(accountKeeper),
 		// check that the fee matches the gas and the local minimum gas price

--- a/app/ante.go
+++ b/app/ante.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	ibcante "github.com/cosmos/ibc-go/v6/modules/core/ante"
+	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
+)
+
+func NewAnteHandler(
+	accountKeeper ante.AccountKeeper,
+	bankKeeper authtypes.BankKeeper,
+	feegrantKeeper ante.FeegrantKeeper,
+	signModeHandler signing.SignModeHandler,
+	sigGasConsumer ante.SignatureVerificationGasConsumer,
+	channelKeeper *ibckeeper.Keeper,
+) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		// reject all tx extensions
+		ante.NewExtensionOptionsDecorator(nil),
+		ante.NewValidateBasicDecorator(),
+		ante.TxTimeoutHeightDecorator{},
+		ante.NewValidateMemoDecorator(accountKeeper),
+		ante.NewConsumeGasForTxSizeDecorator(accountKeeper),
+		// check that the fee matches the gas and the local minimum gas price
+		// of the validator
+		ante.NewDeductFeeDecorator(accountKeeper, bankKeeper, feegrantKeeper, nil),
+		ante.NewSetPubKeyDecorator(accountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		ante.NewValidateSigCountDecorator(accountKeeper),
+		ante.NewSigGasConsumeDecorator(accountKeeper, sigGasConsumer),
+		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
+		ante.NewIncrementSequenceDecorator(accountKeeper),
+		ibcante.NewRedundantRelayDecorator(channelKeeper),
+	)
+}

--- a/app/app.go
+++ b/app/app.go
@@ -531,19 +531,14 @@ func New(
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
-	anteHandler, err := ante.NewAnteHandler(
-		ante.HandlerOptions{
-			AccountKeeper:   app.AccountKeeper,
-			BankKeeper:      app.BankKeeper,
-			SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
-			FeegrantKeeper:  app.FeeGrantKeeper,
-			SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
-	app.SetAnteHandler(anteHandler)
+	app.SetAnteHandler(NewAnteHandler(
+		app.AccountKeeper,
+		app.BankKeeper,
+		app.FeeGrantKeeper,
+		encodingConfig.TxConfig.SignModeHandler(),
+		ante.DefaultSigVerificationGasConsumer,
+		app.IBCKeeper,
+	))
 	app.setPostHanders()
 
 	if loadLatest {


### PR DESCRIPTION
Non state-breaking change that improves the efficiency of relayers by gating redundant transactions at the mempool layer.

This also extracts out the ante handler into its own file for readability