### PR TITLE
chore: simplify next share index

### DIFF
--- a/pkg/inclusion/paths.go
+++ b/pkg/inclusion/paths.go
@@ -14,7 +14,7 @@ type path struct {
 // calculateCommitmentPaths calculates all of the paths to subtree roots needed to
 // create the commitment for a given blob.
 func calculateCommitmentPaths(squareSize, start, blobShareLen, subtreeRootThreshold int) []path {
-	start = shares.NextShareIndex(start, blobShareLen, squareSize, subtreeRootThreshold)
+	start = shares.NextShareIndex(start, blobShareLen, subtreeRootThreshold)
 	startRow, endRow := start/squareSize, (start+blobShareLen-1)/squareSize
 	normalizedStartIndex := start % squareSize
 	normalizedEndIndex := (start + blobShareLen) - endRow*squareSize

--- a/pkg/shares/blob_share_commitment_rules.go
+++ b/pkg/shares/blob_share_commitment_rules.go
@@ -52,11 +52,6 @@ func BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThresho
 // See https://github.com/celestiaorg/celestia-app/blob/main/specs/src/specs/data_square_layout.md
 // for more information.
 func NextShareIndex(cursor, blobShareLen, squareSize, subtreeRootThreshold int) int {
-	// if we're starting at the beginning of the row, then return as there are
-	// no cases where we don't start at 0.
-	if isStartOfRow(cursor, squareSize) {
-		return cursor
-	}
 
 	// Calculate the subtreewidth. This is the width of the first mountain in the
 	// merkle mountain range that makes up the blob share commitment (given the

--- a/pkg/shares/blob_share_commitment_rules.go
+++ b/pkg/shares/blob_share_commitment_rules.go
@@ -24,19 +24,19 @@ func FitsInSquare(cursor, squareSize, subtreeRootThreshold int, blobShareLens ..
 		firstBlobLen = blobShareLens[0]
 	}
 	// here we account for padding between the compact and sparse shares
-	cursor = NextShareIndex(cursor, firstBlobLen, squareSize, subtreeRootThreshold)
-	sharesUsed, _ := BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThreshold, blobShareLens...)
+	cursor = NextShareIndex(cursor, firstBlobLen, subtreeRootThreshold)
+	sharesUsed, _ := BlobSharesUsedNonInteractiveDefaults(cursor, subtreeRootThreshold, blobShareLens...)
 	return cursor+sharesUsed <= squareSize*squareSize, sharesUsed
 }
 
 // BlobSharesUsedNonInteractiveDefaults returns the number of shares used by a given set
 // of blobs share lengths. It follows the blob share commitment rules and
 // returns the share indexes for each blob.
-func BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThreshold int, blobShareLens ...int) (sharesUsed int, indexes []uint32) {
+func BlobSharesUsedNonInteractiveDefaults(cursor, subtreeRootThreshold int, blobShareLens ...int) (sharesUsed int, indexes []uint32) {
 	start := cursor
 	indexes = make([]uint32, len(blobShareLens))
 	for i, blobLen := range blobShareLens {
-		cursor = NextShareIndex(cursor, blobLen, squareSize, subtreeRootThreshold)
+		cursor = NextShareIndex(cursor, blobLen, subtreeRootThreshold)
 		indexes[i] = uint32(cursor)
 		cursor += blobLen
 	}
@@ -51,8 +51,7 @@ func BlobSharesUsedNonInteractiveDefaults(cursor, squareSize, subtreeRootThresho
 //
 // See https://github.com/celestiaorg/celestia-app/blob/main/specs/src/specs/data_square_layout.md
 // for more information.
-func NextShareIndex(cursor, blobShareLen, squareSize, subtreeRootThreshold int) int {
-
+func NextShareIndex(cursor, blobShareLen, subtreeRootThreshold int) int {
 	// Calculate the subtreewidth. This is the width of the first mountain in the
 	// merkle mountain range that makes up the blob share commitment (given the
 	// subtreeRootThreshold and the BlobMinSquareSize).
@@ -110,9 +109,4 @@ func min[T constraints.Integer](i, j T) T {
 		return i
 	}
 	return j
-}
-
-// isStartOfRow returns true if cursor is at the start of a row
-func isStartOfRow(cursor, squareSize int) bool {
-	return cursor == 0 || cursor%squareSize == 0
 }

--- a/pkg/shares/blob_share_commitment_rules.go
+++ b/pkg/shares/blob_share_commitment_rules.go
@@ -58,8 +58,8 @@ func NextShareIndex(cursor, blobShareLen, squareSize, subtreeRootThreshold int) 
 		return cursor
 	}
 
-	// Calculate the subtreewidth. This is the width of the first mountain in the 
-	// merkle mountain range that makes up the blob share commitment (given the 
+	// Calculate the subtreewidth. This is the width of the first mountain in the
+	// merkle mountain range that makes up the blob share commitment (given the
 	// subtreeRootThreshold and the BlobMinSquareSize).
 	treeWidth := SubTreeWidth(blobShareLen, subtreeRootThreshold)
 	// We round up the cursor to the next multiple of this value i.e. if the cursor
@@ -120,9 +120,4 @@ func min[T constraints.Integer](i, j T) T {
 // isStartOfRow returns true if cursor is at the start of a row
 func isStartOfRow(cursor, squareSize int) bool {
 	return cursor == 0 || cursor%squareSize == 0
-}
-
-// getStartOfRow returns the index of the first share in the next row
-func getStartOfNextRow(cursor, squareSize int) int {
-	return ((cursor / squareSize) + 1) * squareSize
 }

--- a/pkg/shares/blob_share_commitment_rules_test.go
+++ b/pkg/shares/blob_share_commitment_rules_test.go
@@ -350,7 +350,7 @@ func Test_roundUpBy(t *testing.T) {
 				tt.expectedIndex,
 			),
 			func(t *testing.T) {
-				res := roundUpBy(tt.cursor, tt.v)
+				res := roundUpByMultipleOf(tt.cursor, tt.v)
 				assert.Equal(t, tt.expectedIndex, res)
 			})
 	}

--- a/pkg/shares/blob_share_commitment_rules_test.go
+++ b/pkg/shares/blob_share_commitment_rules_test.go
@@ -10,29 +10,29 @@ import (
 
 func TestBlobSharesUsedNonInteractiveDefaults(t *testing.T) {
 	type test struct {
-		cursor, squareSize, expected int
-		blobLens                     []int
-		indexes                      []uint32
+		cursor, expected int
+		blobLens         []int
+		indexes          []uint32
 	}
 	tests := []test{
-		{2, 4, 1, []int{1}, []uint32{2}},
-		{2, 2, 1, []int{1}, []uint32{2}},
-		{3, 4, 6, []int{3, 3}, []uint32{3, 6}},
-		{0, 8, 8, []int{8}, []uint32{0}},
-		{1, 8, 6, []int{3, 3}, []uint32{1, 4}},
-		{1, 8, 32, []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}},
-		{3, 8, 12, []int{5, 7}, []uint32{3, 8}},
-		{0, 8, 20, []int{5, 5, 5, 5}, []uint32{0, 5, 10, 15}},
-		{0, 8, 10, []int{10}, []uint32{0}},
-		{1, 8, 20, []int{10, 10}, []uint32{1, 11}},
-		{0, appconsts.DefaultSquareSizeUpperBound, 1000, []int{1000}, []uint32{0}},
-		{0, appconsts.DefaultSquareSizeUpperBound, appconsts.DefaultSquareSizeUpperBound + 1, []int{appconsts.DefaultSquareSizeUpperBound + 1}, []uint32{0}},
-		{1, 128, 385, []int{128, 128, 128}, []uint32{2, 130, 258}},
-		{1024, appconsts.DefaultSquareSizeUpperBound, 32, []int{32}, []uint32{1024}},
+		{2, 1, []int{1}, []uint32{2}},
+		{2, 1, []int{1}, []uint32{2}},
+		{3, 6, []int{3, 3}, []uint32{3, 6}},
+		{0, 8, []int{8}, []uint32{0}},
+		{1, 6, []int{3, 3}, []uint32{1, 4}},
+		{1, 32, []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}, []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32}},
+		{3, 12, []int{5, 7}, []uint32{3, 8}},
+		{0, 20, []int{5, 5, 5, 5}, []uint32{0, 5, 10, 15}},
+		{0, 10, []int{10}, []uint32{0}},
+		{1, 20, []int{10, 10}, []uint32{1, 11}},
+		{0, 1000, []int{1000}, []uint32{0}},
+		{0, appconsts.DefaultSquareSizeUpperBound + 1, []int{appconsts.DefaultSquareSizeUpperBound + 1}, []uint32{0}},
+		{1, 385, []int{128, 128, 128}, []uint32{2, 130, 258}},
+		{1024, 32, []int{32}, []uint32{1024}},
 	}
 	for i, tt := range tests {
-		res, indexes := BlobSharesUsedNonInteractiveDefaults(tt.cursor, tt.squareSize, appconsts.DefaultSubtreeRootThreshold, tt.blobLens...)
-		test := fmt.Sprintf("test %d: cursor %d, squareSize %d", i, tt.cursor, tt.squareSize)
+		res, indexes := BlobSharesUsedNonInteractiveDefaults(tt.cursor, appconsts.DefaultSubtreeRootThreshold, tt.blobLens...)
+		test := fmt.Sprintf("test %d: cursor %d", i, tt.cursor)
 		assert.Equal(t, tt.expected, res, test)
 		assert.Equal(t, tt.indexes, indexes, test)
 	}
@@ -287,7 +287,7 @@ func TestNextShareIndex(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			res := NextShareIndex(tt.cursor, tt.blobLen, tt.squareSize, appconsts.DefaultSubtreeRootThreshold)
+			res := NextShareIndex(tt.cursor, tt.blobLen, appconsts.DefaultSubtreeRootThreshold)
 			assert.Equal(t, tt.expectedIndex, res)
 		})
 	}

--- a/pkg/square/builder.go
+++ b/pkg/square/builder.go
@@ -155,7 +155,7 @@ func (b *Builder) Export() (Square, error) {
 	for i, element := range b.blobs {
 		// NextShareIndex returned where the next blob should start so as to comply with the share commitment rules
 		// We fill out the remaining
-		cursor = shares.NextShareIndex(cursor, element.numShares, ss, b.subtreeRootThreshold)
+		cursor = shares.NextShareIndex(cursor, element.numShares, b.subtreeRootThreshold)
 		if i == 0 {
 			nonReservedStart = cursor
 		}


### PR DESCRIPTION
This PR pulls out a lot of redundant logic, simplifying the `NextShareIndex` function to make it more readable and understandable. I've also added more comments and updated the links.

Rationale: There is no subtreeWidth value that is not a multiple of the square size given that both must be powers of 2 and that the subtreewidth can't be greater than the minimum blob square size (and the blob has to fit in the square). This reinforces the notion that this algorithm is square size independent