### PR TITLE
feat!: run min gas pfb decorator in process proposal

### DIFF
--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -24,11 +24,8 @@ func NewMinGasPFBDecorator(k BlobKeeper) MinGasPFBDecorator {
 // AnteHandle implemnts the AnteHandler interface. It checks to see
 // if the transaction contains a MsgPayForBlobs and if so, checks that
 // the transaction has allocated enough gas.
-//
-// TODO: We need to run this antehandler in process proposal
-// however this will be a breaking change.
 func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	if !ctx.IsCheckTx() {
+	if ctx.IsReCheckTx() {
 		return next(ctx, tx, simulate)
 	}
 


### PR DESCRIPTION
Closes: https://github.com/celestiaorg/celestia-app/issues/1971

Yes, I'm aware that there's a lot of redundancy in the checks across the different stages in committing and executing a block. My plan is to start at a point of restrictiveness and then slowly remove redundancy rather than add more restrictiveness (which would be breaking)