### PR TITLE
chore: backport fixes into v1.x for rc5

### DIFF
--- a/app/ante.go
+++ b/app/ante.go
@@ -1,0 +1,38 @@
+package app
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	"github.com/cosmos/cosmos-sdk/x/auth/signing"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	ibcante "github.com/cosmos/ibc-go/v6/modules/core/ante"
+	ibckeeper "github.com/cosmos/ibc-go/v6/modules/core/keeper"
+)
+
+func NewAnteHandler(
+	accountKeeper ante.AccountKeeper,
+	bankKeeper authtypes.BankKeeper,
+	feegrantKeeper ante.FeegrantKeeper,
+	signModeHandler signing.SignModeHandler,
+	sigGasConsumer ante.SignatureVerificationGasConsumer,
+	channelKeeper *ibckeeper.Keeper,
+) sdk.AnteHandler {
+	return sdk.ChainAnteDecorators(
+		ante.NewSetUpContextDecorator(), // outermost AnteDecorator. SetUpContext must be called first
+		// reject all tx extensions
+		ante.NewExtensionOptionsDecorator(nil),
+		ante.NewValidateBasicDecorator(),
+		ante.NewTxTimeoutHeightDecorator(),
+		ante.NewValidateMemoDecorator(accountKeeper),
+		ante.NewConsumeGasForTxSizeDecorator(accountKeeper),
+		// check that the fee matches the gas and the local minimum gas price
+		// of the validator
+		ante.NewDeductFeeDecorator(accountKeeper, bankKeeper, feegrantKeeper, nil),
+		ante.NewSetPubKeyDecorator(accountKeeper), // SetPubKeyDecorator must be called before all signature verification decorators
+		ante.NewValidateSigCountDecorator(accountKeeper),
+		ante.NewSigGasConsumeDecorator(accountKeeper, sigGasConsumer),
+		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
+		ante.NewIncrementSequenceDecorator(accountKeeper),
+		ibcante.NewRedundantRelayDecorator(channelKeeper),
+	)
+}

--- a/app/ante.go
+++ b/app/ante.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	blobante "github.com/celestiaorg/celestia-app/x/blob/ante"
+	blob "github.com/celestiaorg/celestia-app/x/blob/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"
 	"github.com/cosmos/cosmos-sdk/x/auth/signing"
@@ -12,6 +14,7 @@ import (
 func NewAnteHandler(
 	accountKeeper ante.AccountKeeper,
 	bankKeeper authtypes.BankKeeper,
+	blobKeeper blob.Keeper,
 	feegrantKeeper ante.FeegrantKeeper,
 	signModeHandler signing.SignModeHandler,
 	sigGasConsumer ante.SignatureVerificationGasConsumer,
@@ -32,6 +35,7 @@ func NewAnteHandler(
 		ante.NewValidateSigCountDecorator(accountKeeper),
 		ante.NewSigGasConsumeDecorator(accountKeeper, sigGasConsumer),
 		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
+		blobante.NewMinGasPFBDecorator(blobKeeper),
 		ante.NewIncrementSequenceDecorator(accountKeeper),
 		ibcante.NewRedundantRelayDecorator(channelKeeper),
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -531,19 +531,14 @@ func New(
 	app.SetInitChainer(app.InitChainer)
 	app.SetBeginBlocker(app.BeginBlocker)
 	app.SetEndBlocker(app.EndBlocker)
-	anteHandler, err := ante.NewAnteHandler(
-		ante.HandlerOptions{
-			AccountKeeper:   app.AccountKeeper,
-			BankKeeper:      app.BankKeeper,
-			SignModeHandler: encodingConfig.TxConfig.SignModeHandler(),
-			FeegrantKeeper:  app.FeeGrantKeeper,
-			SigGasConsumer:  ante.DefaultSigVerificationGasConsumer,
-		},
-	)
-	if err != nil {
-		panic(err)
-	}
-	app.SetAnteHandler(anteHandler)
+	app.SetAnteHandler(NewAnteHandler(
+		app.AccountKeeper,
+		app.BankKeeper,
+		app.FeeGrantKeeper,
+		encodingConfig.TxConfig.SignModeHandler(),
+		ante.DefaultSigVerificationGasConsumer,
+		app.IBCKeeper,
+	))
 	app.setPostHanders()
 
 	if loadLatest {

--- a/app/app.go
+++ b/app/app.go
@@ -534,6 +534,7 @@ func New(
 	app.SetAnteHandler(NewAnteHandler(
 		app.AccountKeeper,
 		app.BankKeeper,
+		app.BlobKeeper,
 		app.FeeGrantKeeper,
 		encodingConfig.TxConfig.SignModeHandler(),
 		ante.DefaultSigVerificationGasConsumer,

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -12,7 +12,8 @@ import (
 // preparing the proposal block data. The square size is determined by first
 // estimating it via the size of the passed block data. Then, this method
 // generates the data root for the proposal block and passes it back to
-// tendermint via the BlockData.
+// tendermint via the BlockData. Panics indicate a developer error and should
+// immediately halt the node for visibility and so they can be quickly resolved.
 func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
 	// create a context using a branch of the state and loaded using the
 	// proposal height and chain-id

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -17,7 +17,16 @@ import (
 
 const rejectedPropBlockLog = "Rejected proposal block:"
 
-func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponseProcessProposal {
+func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.ResponseProcessProposal) {
+	// In the case of a panic from an unexpected condition, it is better for the liveness of the
+	// network that we catch it, log an error and vote nil than to crash the node.
+	defer func() {
+		if err := recover(); err != nil {
+			logInvalidPropBlock(app.Logger(), req.Header, fmt.Sprintf("%v", err))
+			resp = reject()
+		}
+	}()
+
 	// create the anteHanders that are used to check the validity of
 	// transactions. We verify the signatures of PFB containing txs using the
 	// sigVerifyAnterHandler, and simply increase the nonce of all other

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -24,7 +24,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 	// transactions.
 	svHander := sigVerifyAnteHandler(&app.AccountKeeper, app.txConfig)
 	seqHandler := incrementSequenceAnteHandler(&app.AccountKeeper)
-	sdkCtx := app.NewProposalContext(req.Header)
+	sdkCtx := app.NewProposalContext(req.Header).WithChainID(app.GetChainID())
 
 	// iterate over all txs and ensure that all blobTxs are valid, PFBs are correctly signed and non
 	// blobTxs have no PFBs present
@@ -78,7 +78,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) abci.ResponsePr
 		}
 
 		// validated the PFB signature
-		sdkCtx, err = svHander(sdkCtx, sdkTx, true)
+		sdkCtx, err = svHander(sdkCtx, sdkTx, false)
 		if err != nil {
 			logInvalidPropBlockError(app.Logger(), req.Header, "invalid PFB signature", err)
 			return reject()

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -47,7 +47,7 @@ type IntegrationTestSuite struct {
 func (s *IntegrationTestSuite) SetupSuite() {
 	t := s.T()
 
-	numAccounts := 120
+	numAccounts := 142
 	s.accounts = make([]string, numAccounts)
 	for i := 0; i < numAccounts; i++ {
 		s.accounts[i] = tmrand.Str(20)
@@ -256,7 +256,7 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 			// 20) so we wait a few blocks for the txs to clear
 			require.NoError(t, s.cctx.WaitForBlocks(3))
 
-			signer := blobtypes.NewKeyringSigner(s.cctx.Keyring, s.accounts[0], s.cctx.ChainID)
+			signer := blobtypes.NewKeyringSigner(s.cctx.Keyring, s.accounts[141], s.cctx.ChainID)
 			res, err := blob.SubmitPayForBlob(context.TODO(), signer, s.cctx.GRPCClient, []*blobtypes.Blob{tc.blob, tc.blob}, tc.opts...)
 			require.NoError(t, err)
 			require.NotNil(t, res)
@@ -276,7 +276,7 @@ func (s *IntegrationTestSuite) TestUnwrappedPFBRejection() {
 		1,
 		false,
 		s.cctx.ChainID,
-		s.accounts[:1],
+		s.accounts[140:],
 	)
 
 	btx, isBlob := coretypes.UnmarshalBlobTx(blobTx[0])
@@ -299,7 +299,7 @@ func (s *IntegrationTestSuite) TestShareInclusionProof() {
 		1,
 		true,
 		s.cctx.ChainID,
-		s.accounts[:20],
+		s.accounts[120:140],
 	)
 
 	hashes := make([]string, len(txs))
@@ -311,7 +311,7 @@ func (s *IntegrationTestSuite) TestShareInclusionProof() {
 		hashes[i] = res.TxHash
 	}
 
-	require.NoError(t, s.cctx.WaitForBlocks(10))
+	require.NoError(t, s.cctx.WaitForBlocks(5))
 
 	for _, hash := range hashes {
 		txResp, err := testnode.QueryTx(s.cctx.Context, hash, true)

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
@@ -51,7 +50,7 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 		1000,
 		accnts[0],
 		accnts[numBlobTxs:],
-		"",
+		testutil.ChainID,
 	)
 	txs := append(blobTxs, coretypes.Txs(normalTxs).ToSliceOfBytes()...)
 
@@ -103,7 +102,7 @@ func TestPrepareProposalFiltering(t *testing.T) {
 		1000,
 		accounts[0],
 		accounts[len(accounts)-3:],
-		"",
+		testutil.ChainID,
 	)).ToSliceOfBytes()
 
 	validTxs := func() [][]byte {
@@ -123,7 +122,7 @@ func TestPrepareProposalFiltering(t *testing.T) {
 		1000,
 		accounts[0],
 		accounts[:3],
-		"",
+		testutil.ChainID,
 	)).ToSliceOfBytes()
 
 	// create a transaction with an account that doesn't exist. This will cause the increment nonce
@@ -187,7 +186,7 @@ func TestPrepareProposalFiltering(t *testing.T) {
 			require.Equal(t, len(tt.txs())-len(tt.prunedTxs), len(resp.BlockData.Txs))
 			// check the the expected txs were removed
 			for _, ptx := range tt.prunedTxs {
-				assert.NotContains(t, resp.BlockData.Txs, ptx)
+				require.NotContains(t, resp.BlockData.Txs, ptx)
 			}
 		})
 	}

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -33,15 +33,12 @@ func TestProcessProposal(t *testing.T) {
 	infos := queryAccountInfo(testApp, accounts, kr)
 	signer := types.GenerateKeyringSigner(t, accounts[0])
 
-	// create 3 single blob blobTxs that are signed with valid account numbers
+	enc := encConf.TxConfig.TxEncoder()
+
+	// create 4 single blob blobTxs that are signed with valid account numbers
 	// and sequences
 	blobTxs := blobfactory.ManyMultiBlobTx(
-		t,
-		encConf.TxConfig.TxEncoder(),
-		kr,
-		testutil.ChainID,
-		accounts[:4],
-		infos[:4],
+		t, enc, kr, testutil.ChainID, accounts[:4], infos[:4],
 		blobfactory.NestedBlobs(
 			t,
 			appns.RandomBlobNamespaces(4),
@@ -52,14 +49,7 @@ func TestProcessProposal(t *testing.T) {
 	// create 3 MsgSend transactions that are signed with valid account numbers
 	// and sequences
 	sendTxs := testutil.SendTxsWithAccounts(
-		t,
-		testApp,
-		encConf.TxConfig.TxEncoder(),
-		kr,
-		1000,
-		accounts[0],
-		accounts[len(accounts)-3:],
-		"",
+		t, testApp, enc, kr, 1000, accounts[0], accounts[len(accounts)-3:], "",
 	)
 
 	// block with all blobs included
@@ -70,20 +60,16 @@ func TestProcessProposal(t *testing.T) {
 	}
 
 	mixedData := validData()
-	mixedData.Txs = append(mixedData.Txs, coretypes.Txs(sendTxs).ToSliceOfBytes()...)
+	mixedData.Txs = append(coretypes.Txs(sendTxs).ToSliceOfBytes(), mixedData.Txs...)
 
 	// create an invalid block by adding an otherwise valid PFB, but an invalid
 	// signature since there's no account
 	badSigBlobTx := testutil.RandBlobTxsWithManualSequence(
-		t,
-		encConf.TxConfig.TxEncoder(),
-		kr,
-		1000,
-		1,
-		false,
-		"",
-		accounts[:1],
-		420, 42,
+		t, enc, kr, 1000, 1, false, "", accounts[:1], 1, 1, true,
+	)[0]
+
+	blobTxWithInvalidNonce := testutil.RandBlobTxsWithManualSequence(
+		t, enc, kr, 1000, 1, false, "", accounts[:1], 1, 3, false,
 	)[0]
 
 	ns1 := appns.MustNewV0(bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))
@@ -203,6 +189,18 @@ func TestProcessProposal(t *testing.T) {
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
 		{
+			name:  "pfb namespace version does not match blob",
+			input: validData(),
+			mutator: func(d *core.Data) {
+				blobTx, _ := coretypes.UnmarshalBlobTx(blobTxs[0])
+				blobTx.Blobs[0].NamespaceVersion = appns.NamespaceVersionMax
+				blobTxBytes, _ := blobTx.Marshal()
+				d.Txs[0] = blobTxBytes
+				d.Hash = calculateNewDataHash(t, d.Txs)
+			},
+			expectedResult: abci.ResponseProcessProposal_REJECT,
+		},
+		{
 			name:  "invalid namespace in index wrapper tx",
 			input: validData(),
 			mutator: func(d *core.Data) {
@@ -216,12 +214,7 @@ func TestProcessProposal(t *testing.T) {
 				d.Txs = [][]byte{blobTx}
 
 				// Erasure code the data to update the data root so this doesn't doesn't fail on an incorrect data root.
-				dataSquare, err := square.Construct(d.Txs, appconsts.LatestVersion, appconsts.DefaultSquareSizeUpperBound)
-				require.NoError(t, err)
-				eds, err := da.ExtendShares(shares.ToBytes(dataSquare))
-				require.NoError(t, err)
-				dah := da.NewDataAvailabilityHeader(eds)
-				d.Hash = dah.Hash()
+				d.Hash = calculateNewDataHash(t, d.Txs)
 			},
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
@@ -229,6 +222,7 @@ func TestProcessProposal(t *testing.T) {
 			name:  "swap blobTxs",
 			input: validData(),
 			mutator: func(d *core.Data) {
+				// swapping the order will cause the data root to be different
 				d.Txs[0], d.Txs[1], d.Txs[2] = d.Txs[1], d.Txs[2], d.Txs[0]
 			},
 			expectedResult: abci.ResponseProcessProposal_REJECT,
@@ -251,26 +245,29 @@ func TestProcessProposal(t *testing.T) {
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
 		{
-			name:  "incorrectly sorted wrapped pfb's",
+			name:  "incorrectly sorted; send tx after pfb",
 			input: mixedData,
 			mutator: func(d *core.Data) {
-				// swap txs at index 3 and 4 (essentially swapping a PFB with a normal tx)
-				d.Txs[4], d.Txs[3] = d.Txs[3], d.Txs[4]
+				// swap txs at index 2 and 3 (essentially swapping a PFB with a normal tx)
+				d.Txs[3], d.Txs[2] = d.Txs[2], d.Txs[3]
 			},
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
 		{
-			// while this test passes and the block gets rejected, it is getting
-			// rejected because the data root is different. We need to refactor
-			// prepare proposal to abstract functionality into a different
-			// function or be able to skip the filtering checks. TODO: perform
-			// the mentioned refactor and make it easier to create invalid
-			// blocks for testing.
 			name:  "included pfb with bad signature",
 			input: validData(),
 			mutator: func(d *core.Data) {
 				d.Txs = append(d.Txs, badSigBlobTx)
-				// todo: replace the data root with an updated hash
+				d.Hash = calculateNewDataHash(t, d.Txs)
+			},
+			expectedResult: abci.ResponseProcessProposal_REJECT,
+		},
+		{
+			name:  "included pfb with incorrect nonce",
+			input: validData(),
+			mutator: func(d *core.Data) {
+				d.Txs = append(d.Txs, blobTxWithInvalidNonce)
+				d.Hash = calculateNewDataHash(t, d.Txs)
 			},
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
@@ -306,14 +303,25 @@ func TestProcessProposal(t *testing.T) {
 			resp := testApp.PrepareProposal(abci.RequestPrepareProposal{
 				BlockData: tt.input,
 			})
+			require.Equal(t, len(tt.input.Txs), len(resp.BlockData.Txs))
 			tt.mutator(resp.BlockData)
 			res := testApp.ProcessProposal(abci.RequestProcessProposal{
 				BlockData: resp.BlockData,
 				Header: core.Header{
+					Height:   1,
 					DataHash: resp.BlockData.Hash,
 				},
 			})
 			assert.Equal(t, tt.expectedResult, res.Result, fmt.Sprintf("expected %v, got %v", tt.expectedResult, res.Result))
 		})
 	}
+}
+
+func calculateNewDataHash(t *testing.T, txs [][]byte) []byte {
+	dataSquare, err := square.Construct(txs, appconsts.LatestVersion, appconsts.DefaultSquareSizeUpperBound)
+	require.NoError(t, err)
+	eds, err := da.ExtendShares(shares.ToBytes(dataSquare))
+	require.NoError(t, err)
+	dah := da.NewDataAvailabilityHeader(eds)
+	return dah.Hash()
 }

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -49,7 +49,7 @@ func TestProcessProposal(t *testing.T) {
 	// create 3 MsgSend transactions that are signed with valid account numbers
 	// and sequences
 	sendTxs := testutil.SendTxsWithAccounts(
-		t, testApp, enc, kr, 1000, accounts[0], accounts[len(accounts)-3:], "",
+		t, testApp, enc, kr, 1000, accounts[0], accounts[len(accounts)-3:], testutil.ChainID,
 	)
 
 	// block with all blobs included
@@ -65,11 +65,11 @@ func TestProcessProposal(t *testing.T) {
 	// create an invalid block by adding an otherwise valid PFB, but an invalid
 	// signature since there's no account
 	badSigBlobTx := testutil.RandBlobTxsWithManualSequence(
-		t, enc, kr, 1000, 1, false, "", accounts[:1], 1, 1, true,
+		t, enc, kr, 1000, 1, false, testutil.ChainID, accounts[:1], 1, 1, true,
 	)[0]
 
 	blobTxWithInvalidNonce := testutil.RandBlobTxsWithManualSequence(
-		t, enc, kr, 1000, 1, false, "", accounts[:1], 1, 3, false,
+		t, enc, kr, 1000, 1, false, testutil.ChainID, accounts[:1], 1, 3, false,
 	)[0]
 
 	ns1 := appns.MustNewV0(bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))

--- a/test/util/testnode/node_interaction_api.go
+++ b/test/util/testnode/node_interaction_api.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	DefaultTimeout = 10 * time.Second
+	DefaultTimeout = 30 * time.Second
 )
 
 type Context struct {

--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -1,0 +1,65 @@
+package ante
+
+import (
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/shares"
+	"github.com/celestiaorg/celestia-app/x/blob/types"
+
+	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+)
+
+// MinGasPFBDecorator helps to prevent a PFB from being included in a block
+// but running out of gas in DeliverTx (effectively getting DA for free)
+// This decorator should be run after any decorator that consumes gas.
+type MinGasPFBDecorator struct {
+	k BlobKeeper
+}
+
+func NewMinGasPFBDecorator(k BlobKeeper) MinGasPFBDecorator {
+	return MinGasPFBDecorator{k}
+}
+
+// AnteHandle implemnts the AnteHandler interface. It checks to see
+// if the transaction contains a MsgPayForBlobs and if so, checks that
+// the transaction has allocated enough gas.
+//
+// TODO: We need to run this antehandler in process proposal
+// however this will be a breaking change.
+func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if !ctx.IsCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	var gasPerByte uint32
+	txGas := ctx.GasMeter().GasRemaining()
+	for _, m := range tx.GetMsgs() {
+		// NOTE: here we assume only one PFB per transaction
+		if pfb, ok := m.(*types.MsgPayForBlobs); ok {
+			if gasPerByte == 0 {
+				// lazily fetch the gas per byte param
+				gasPerByte = d.k.GasPerBlobByte(ctx)
+			}
+			gasToConsume := gasToConsume(pfb, gasPerByte)
+			if gasToConsume > txGas {
+				return ctx, errors.Wrapf(sdkerrors.ErrInsufficientFee, "not enough gas to pay for blobs (minimum: %d, got: %d)", gasToConsume, txGas)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+func gasToConsume(pfb *types.MsgPayForBlobs, gasPerByte uint32) uint64 {
+	var totalSharesUsed uint64
+	for _, size := range pfb.BlobSizes {
+		totalSharesUsed += uint64(shares.SparseSharesNeeded(size))
+	}
+
+	return totalSharesUsed * appconsts.ShareSize * uint64(gasPerByte)
+}
+
+type BlobKeeper interface {
+	GasPerBlobByte(ctx sdk.Context) uint32
+}

--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -24,11 +24,8 @@ func NewMinGasPFBDecorator(k BlobKeeper) MinGasPFBDecorator {
 // AnteHandle implemnts the AnteHandler interface. It checks to see
 // if the transaction contains a MsgPayForBlobs and if so, checks that
 // the transaction has allocated enough gas.
-//
-// TODO: We need to run this antehandler in process proposal
-// however this will be a breaking change.
 func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	if !ctx.IsCheckTx() {
+	if ctx.IsReCheckTx() {
 		return next(ctx, tx, simulate)
 	}
 

--- a/x/blob/ante/ante_test.go
+++ b/x/blob/ante/ante_test.go
@@ -1,0 +1,108 @@
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/shares"
+	ante "github.com/celestiaorg/celestia-app/x/blob/ante"
+	blob "github.com/celestiaorg/celestia-app/x/blob/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+const testGasPerBlobByte = 10
+
+func TestPFBAnteHandler(t *testing.T) {
+	txConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...).TxConfig
+	testCases := []struct {
+		name        string
+		pfb         *blob.MsgPayForBlobs
+		txGas       uint64
+		gasConsumed uint64
+		wantErr     bool
+	}{
+		{
+			name: "valid pfb single blob",
+			pfb: &blob.MsgPayForBlobs{
+				// 1 share = 512 bytes = 5120 gas
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1))},
+			},
+			txGas:       appconsts.ShareSize * testGasPerBlobByte,
+			gasConsumed: 0,
+			wantErr:     false,
+		},
+		{
+			name: "valid pfb multi blob",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1)), uint32(shares.AvailableBytesFromSparseShares(2))},
+			},
+			txGas:       3 * appconsts.ShareSize * testGasPerBlobByte,
+			gasConsumed: 0,
+			wantErr:     false,
+		},
+		{
+			name: "pfb single blob not enough gas",
+			pfb: &blob.MsgPayForBlobs{
+				// 2 share = 1024 bytes = 10240 gas
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1) + 1)},
+			},
+			txGas:       2*appconsts.ShareSize*testGasPerBlobByte - 1,
+			gasConsumed: 0,
+			wantErr:     true,
+		},
+		{
+			name: "pfb mulit blob not enough gas",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1)), uint32(shares.AvailableBytesFromSparseShares(2))},
+			},
+			txGas:       3*appconsts.ShareSize*testGasPerBlobByte - 1,
+			gasConsumed: 0,
+			wantErr:     true,
+		},
+		{
+			name: "pfb with existing gas consumed",
+			pfb: &blob.MsgPayForBlobs{
+				// 1 share = 512 bytes = 5120 gas
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1))},
+			},
+			txGas:       appconsts.ShareSize*testGasPerBlobByte + 10000 - 1,
+			gasConsumed: 10000,
+			wantErr:     true,
+		},
+		{
+			name: "valid pfb with existing gas consumed",
+			pfb: &blob.MsgPayForBlobs{
+				// 1 share = 512 bytes = 5120 gas
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(10))},
+			},
+			txGas:       1000000,
+			gasConsumed: 10000,
+			wantErr:     false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			anteHandler := ante.NewMinGasPFBDecorator(mockBlobKeeper{})
+			ctx := sdk.Context{}.WithGasMeter(sdk.NewGasMeter(tc.txGas)).WithIsCheckTx(true)
+			ctx.GasMeter().ConsumeGas(tc.gasConsumed, "test")
+			txBuilder := txConfig.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.pfb))
+			tx := txBuilder.GetTx()
+			_, err := anteHandler.AnteHandle(ctx, tx, false, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) { return ctx, nil })
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+type mockBlobKeeper struct{}
+
+func (mockBlobKeeper) GasPerBlobByte(_ sdk.Context) uint32 {
+	return testGasPerBlobByte
+}

--- a/x/blob/keeper/keeper.go
+++ b/x/blob/keeper/keeper.go
@@ -52,13 +52,13 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) PayForBlobs(goCtx context.Context, msg *types.MsgPayForBlobs) (*types.MsgPayForBlobsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	totalSharesUsed := 0
+	var totalSharesUsed uint64
 	for _, size := range msg.BlobSizes {
-		totalSharesUsed += shares.SparseSharesNeeded(size)
+		totalSharesUsed += uint64(shares.SparseSharesNeeded(size))
 	}
 
-	gasToConsume := uint32(totalSharesUsed*appconsts.ShareSize) * k.GasPerBlobByte(ctx)
-	ctx.GasMeter().ConsumeGas(uint64(gasToConsume), payForBlobGasDescriptor)
+	gasToConsume := totalSharesUsed * appconsts.ShareSize * uint64(k.GasPerBlobByte(ctx))
+	ctx.GasMeter().ConsumeGas(gasToConsume, payForBlobGasDescriptor)
 
 	err := ctx.EventManager().EmitTypedEvent(
 		types.NewPayForBlobsEvent(sdk.AccAddress(msg.Signer).String(), msg.BlobSizes, msg.Namespaces),

--- a/x/blob/types/blob_tx.go
+++ b/x/blob/types/blob_tx.go
@@ -82,6 +82,8 @@ func ValidateBlobTx(txcfg client.TxEncodingConfig, bTx tmproto.BlobTx) error {
 			return err
 		}
 
+		// this not only checks that the pfb namespaces match the ones in the blobs
+		// but that the namespace version and namespace id are valid
 		blobNamespace, err := appns.New(uint8(bTx.Blobs[i].NamespaceVersion), bTx.Blobs[i].NamespaceId)
 		if err != nil {
 			return err

--- a/x/blob/types/errors.go
+++ b/x/blob/types/errors.go
@@ -32,4 +32,5 @@ var (
 	ErrNoBlobSizes                    = errors.Register(ModuleName, 11134, "no blob sizes provided")
 	ErrNoShareCommitments             = errors.Register(ModuleName, 11135, "no share commitments provided")
 	ErrInvalidNamespace               = errors.Register(ModuleName, 11136, "invalid namespace")
+	ErrInvalidNamespaceVersion        = errors.Register(ModuleName, 11137, "invalid namespace version")
 )

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -7,6 +7,7 @@ import (
 	"cosmossdk.io/errors"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/namespace"
 	appns "github.com/celestiaorg/celestia-app/pkg/namespace"
 	appshares "github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/nmt"
@@ -40,9 +41,6 @@ func NewMsgPayForBlobs(signer string, blobs ...*Blob) (*MsgPayForBlobs, error) {
 	namespaceVersions, namespaceIds, sizes, shareVersions := extractBlobComponents(blobs)
 	namespaces := []appns.Namespace{}
 	for i := range namespaceVersions {
-		if namespaceVersions[i] > appconsts.NamespaceVersionMaxValue {
-			return nil, fmt.Errorf("namespace version %d is too large (max %d)", namespaceVersions[i], appconsts.NamespaceVersionMaxValue)
-		}
 		namespace, err := appns.New(uint8(namespaceVersions[i]), namespaceIds[i])
 		if err != nil {
 			return nil, err
@@ -146,6 +144,10 @@ func ValidateBlobNamespace(ns appns.Namespace) error {
 
 	if ns.IsTailPadding() {
 		return ErrTailPaddingNamespace
+	}
+
+	if ns.Version != namespace.NamespaceVersionZero {
+		return ErrInvalidNamespaceVersion
 	}
 
 	return nil


### PR DESCRIPTION
This PR backports the following commits in preparation for rc5

- db3e6584 feat!: run min gas pfb decorator in process proposal (#1985)
- 43b933ee fix!: implement full antehandler checks (#1984)
- c7281149 feat: implement MinGasPFBDecorator (#1936)
- d34f88e0 feat: introduce ibc redundant relay decorator (#1934)
- 639d6243 feat: use panics and recovery appropriately (#1948)
- cd212def fix!: signature validity checks in ProcessProposal (#1981)
- a27d2520 fix!: add namespace version check in pfbs (#1983)

Ideally we should MERGE COMMIT and not SQUASH COMMIT so we can preserve the commit history

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
