### PR TITLE
chore!: refactor testnode to expose appcreator

### DIFF
--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -53,13 +53,9 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		s.accounts[i] = tmrand.Str(20)
 	}
 
-	cctx, _, _ := testnode.NewNetwork(
-		t,
-		testnode.DefaultParams(),
-		testnode.DefaultTendermintConfig(),
-		testnode.DefaultAppConfig(),
-		s.accounts,
-	)
+	cfg := testnode.DefaultConfig().WithAccounts(s.accounts)
+
+	cctx, _, _ := testnode.NewNetwork(t, cfg)
 
 	s.cctx = cctx
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)

--- a/app/test/qgb_rpc_test.go
+++ b/app/test/qgb_rpc_test.go
@@ -15,7 +15,7 @@ func TestQGBRPCQueries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping QGB integration test in short mode.")
 	}
-	cfg := testnode.DefaultConfig().WithAccounts([]string{})
+	cfg := testnode.DefaultConfig()
 
 	cctx, _, _ := testnode.NewNetwork(t, cfg)
 

--- a/app/test/qgb_rpc_test.go
+++ b/app/test/qgb_rpc_test.go
@@ -15,16 +15,10 @@ func TestQGBRPCQueries(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping QGB integration test in short mode.")
 	}
-	tmCfg := testnode.DefaultTendermintConfig()
-	tmCfg.Consensus.TargetHeightDuration = time.Millisecond
+	cfg := testnode.DefaultConfig().WithAccounts([]string{})
 
-	cctx, _, _ := testnode.NewNetwork(
-		t,
-		testnode.DefaultParams(),
-		tmCfg,
-		testnode.DefaultAppConfig(),
-		[]string{},
-	)
+	cctx, _, _ := testnode.NewNetwork(t, cfg)
+
 	h, err := cctx.WaitForHeightWithTimeout(105, 2*time.Minute)
 	require.NoError(t, err, h)
 	require.Greater(t, h, int64(101))

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -44,7 +44,6 @@ func (s *SquareSizeIntegrationTest) SetupSuite() {
 	t.Log("setting up square size integration test")
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	cfg := testnode.DefaultConfig().
-		WithAccounts([]string{}).
 		WithGenesisOptions(testnode.ImmediateProposals(s.ecfg.Codec))
 
 	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(t, cfg)

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -34,7 +34,6 @@ func TestSquareSizeIntegrationTest(t *testing.T) {
 type SquareSizeIntegrationTest struct {
 	suite.Suite
 
-	accounts          []string
 	cctx              testnode.Context
 	rpcAddr, grpcAddr string
 	ecfg              encoding.Config
@@ -44,19 +43,12 @@ func (s *SquareSizeIntegrationTest) SetupSuite() {
 	t := s.T()
 	t.Log("setting up square size integration test")
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)
-	accounts := []string{}
+	cfg := testnode.DefaultConfig().
+		WithAccounts([]string{}).
+		WithGenesisOptions(testnode.ImmediateProposals(s.ecfg.Codec))
 
-	cparams := testnode.DefaultParams()
-	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(
-		t,
-		cparams,
-		testnode.DefaultTendermintConfig(),
-		testnode.DefaultAppConfig(),
-		accounts,
-		testnode.ImmediateProposals(s.ecfg.Codec), // pass param changes in 5 seconds
-	)
+	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(t, cfg)
 
-	s.accounts = accounts
 	s.cctx = cctx
 	s.rpcAddr = rpcAddr
 	s.grpcAddr = grpcAddr

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -47,8 +47,9 @@ type StandardSDKIntegrationTestSuite struct {
 func (s *StandardSDKIntegrationTestSuite) SetupSuite() {
 	t := s.T()
 	t.Log("setting up integration test suite")
-	accounts, cctx := testnode.DefaultNetwork(t)
-	s.accounts = accounts
+	cfg := testnode.DefaultConfig()
+	cctx, _, _ := testnode.NewNetwork(t, cfg)
+	s.accounts = cfg.Accounts
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	s.cctx = cctx
 }

--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
 )
 
 func TestStandardSDKIntegrationTestSuite(t *testing.T) {
@@ -47,7 +48,13 @@ type StandardSDKIntegrationTestSuite struct {
 func (s *StandardSDKIntegrationTestSuite) SetupSuite() {
 	t := s.T()
 	t.Log("setting up integration test suite")
-	cfg := testnode.DefaultConfig()
+
+	accounts := make([]string, 300)
+	for i := 0; i < len(accounts); i++ {
+		accounts[i] = tmrand.Str(9)
+	}
+
+	cfg := testnode.DefaultConfig().WithAccounts(accounts)
 	cctx, _, _ := testnode.NewNetwork(t, cfg)
 	s.accounts = cfg.Accounts
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)

--- a/test/cmd/txsim/cli_test.go
+++ b/test/cmd/txsim/cli_test.go
@@ -60,13 +60,11 @@ func setup(t testing.TB) (keyring.Keyring, string, string) {
 	cparams := testnode.DefaultParams()
 	cparams.Block.MaxBytes = int64(appconsts.DefaultSquareSizeUpperBound*appconsts.DefaultSquareSizeUpperBound) * appconsts.ContinuationSparseShareContentSize
 
-	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(
-		t,
-		cparams,
-		testnode.DefaultTendermintConfig(),
-		testnode.DefaultAppConfig(),
-		[]string{testfactory.TestAccName},
-	)
+	cfg := testnode.DefaultConfig().
+		WithConsensusParams(cparams).
+		WithAccounts([]string{testfactory.TestAccName})
+
+	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(t, cfg)
 
 	return cctx.Keyring, rpcAddr, grpcAddr
 }

--- a/test/txsim/run_test.go
+++ b/test/txsim/run_test.go
@@ -117,7 +117,7 @@ func TestTxSimulator(t *testing.T) {
 func Setup(t testing.TB) (keyring.Keyring, string, string) {
 	t.Helper()
 
-	cfg := testnode.DefaultConfig().WithAccounts([]string{})
+	cfg := testnode.DefaultConfig()
 
 	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(t, cfg)
 

--- a/test/txsim/run_test.go
+++ b/test/txsim/run_test.go
@@ -117,13 +117,9 @@ func TestTxSimulator(t *testing.T) {
 func Setup(t testing.TB) (keyring.Keyring, string, string) {
 	t.Helper()
 
-	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(
-		t,
-		testnode.DefaultParams(),
-		testnode.DefaultTendermintConfig(),
-		testnode.DefaultAppConfig(),
-		[]string{},
-	)
+	cfg := testnode.DefaultConfig().WithAccounts([]string{})
+
+	cctx, rpcAddr, grpcAddr := testnode.NewNetwork(t, cfg)
 
 	return cctx.Keyring, rpcAddr, grpcAddr
 }

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -1,0 +1,163 @@
+package testnode
+
+import (
+	"time"
+
+	"github.com/celestiaorg/celestia-app/cmd/celestia-appd/cmd"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
+	"github.com/cosmos/cosmos-sdk/server"
+	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
+	srvtypes "github.com/cosmos/cosmos-sdk/server/types"
+	"github.com/tendermint/tendermint/config"
+	tmconfig "github.com/tendermint/tendermint/config"
+	tmrand "github.com/tendermint/tendermint/libs/rand"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	"github.com/tendermint/tendermint/types"
+)
+
+// Config is the configuration of a test node.
+type Config struct {
+	// ChainID is the chain ID of the network.
+	ChainID string
+	// TmConfig is the Tendermint configuration used for the network.
+	TmConfig *tmconfig.Config
+	// AppConfig is the application configuration of the test node.
+	AppConfig *srvconfig.Config
+	// ConsensusParams are the consensus parameters of the test node.
+	ConsensusParams *tmproto.ConsensusParams
+	// AppOptions are the application options of the test node.
+	AppOptions *KVAppOptions
+	// GenesisOptions are the genesis options of the test node.
+	GenesisOptions []GenesisOption
+	// Accounts are the accounts of the test node.
+	Accounts []string
+	// AppCreator is used to create the application for the testnode.
+	AppCreator srvtypes.AppCreator
+	// SupressLogs
+	SupressLogs bool
+}
+
+// WithChainID sets the ChainID and returns the Config.
+func (c *Config) WithChainID(s string) *Config {
+	c.ChainID = s
+	return c
+}
+
+// WithTendermintConfig sets the TmConfig and returns the *Config.
+func (c *Config) WithTendermintConfig(conf *tmconfig.Config) *Config {
+	c.TmConfig = conf
+	return c
+}
+
+// WithAppConfig sets the AppConfig and returns the Config.
+func (c *Config) WithAppConfig(conf *srvconfig.Config) *Config {
+	c.AppConfig = conf
+	return c
+}
+
+// WithConsensusParams sets the ConsensusParams and returns the Config.
+func (c *Config) WithConsensusParams(params *tmproto.ConsensusParams) *Config {
+	c.ConsensusParams = params
+	return c
+}
+
+// WithAppOptions sets the AppOptions and returns the Config.
+func (c *Config) WithAppOptions(opts *KVAppOptions) *Config {
+	c.AppOptions = opts
+	return c
+}
+
+// WithGenesisOptions sets the GenesisOptions and returns the Config.
+func (c *Config) WithGenesisOptions(opts ...GenesisOption) *Config {
+	c.GenesisOptions = opts
+	return c
+}
+
+// WithAccounts sets the Accounts and returns the Config.
+func (c *Config) WithAccounts(accs []string) *Config {
+	c.Accounts = accs
+	return c
+}
+
+// WithAppCreator sets the AppCreator and returns the Config.
+func (c *Config) WithAppCreator(creator srvtypes.AppCreator) *Config {
+	c.AppCreator = creator
+	return c
+}
+
+// WithSupressLogs sets the SupressLogs and returns the Config.
+func (c *Config) WithSupressLogs(sl bool) *Config {
+	c.SupressLogs = sl
+	return c
+}
+
+func DefaultConfig() *Config {
+	// we create an arbitrary number of funded accounts
+	accounts := make([]string, 300)
+	for i := 0; i < 300; i++ {
+		accounts[i] = tmrand.Str(9)
+	}
+	tmcfg := DefaultTendermintConfig()
+	tmcfg.Consensus.TargetHeightDuration = 1 * time.Millisecond
+	cfg := &Config{}
+	return cfg.
+		WithAccounts(accounts).
+		WithChainID(tmrand.Str(6)).
+		WithTendermintConfig(DefaultTendermintConfig()).
+		WithAppConfig(DefaultAppConfig()).
+		WithConsensusParams(DefaultParams()).
+		WithAppOptions(DefaultAppOptions()).
+		WithGenesisOptions().
+		WithAppCreator(cmd.NewAppServer).
+		WithSupressLogs(true)
+
+}
+
+type KVAppOptions struct {
+	options map[string]interface{}
+}
+
+// Get implements AppOptions
+func (ao *KVAppOptions) Get(o string) interface{} {
+	return ao.options[o]
+}
+
+// Set adds an option to the KVAppOptions
+func (ao *KVAppOptions) Set(o string, v interface{}) {
+	ao.options[o] = v
+}
+
+// DefaultAppOptions returns the default application options.
+func DefaultAppOptions() *KVAppOptions {
+	opts := &KVAppOptions{options: make(map[string]interface{})}
+	opts.Set(server.FlagPruning, pruningtypes.PruningOptionNothing)
+	return opts
+}
+
+func DefaultParams() *tmproto.ConsensusParams {
+	cparams := types.DefaultConsensusParams()
+	cparams.Block.TimeIotaMs = 1
+	cparams.Block.MaxBytes = appconsts.DefaultMaxBytes
+	return cparams
+}
+
+func DefaultTendermintConfig() *config.Config {
+	tmCfg := config.DefaultConfig()
+	// Reduce the target height duration so that blocks are produced faster
+	// during tests.
+	tmCfg.Consensus.TargetHeightDuration = 300 * time.Millisecond
+	tmCfg.Consensus.TimeoutPropose = 200 * time.Millisecond
+
+	// set the mempool's MaxTxBytes to allow the testnode to accept a
+	// transaction that fills the entire square. Any blob transaction larger
+	// than the square size will still fail no matter what.
+	tmCfg.Mempool.MaxTxBytes = appconsts.DefaultMaxBytes
+
+	// remove all barriers from the testnode being able to accept very large
+	// transactions and respond to very queries with large responses (~200MB was
+	// chosen only as an arbitrary large number).
+	tmCfg.RPC.MaxBodyBytes = 200_000_000
+
+	return tmCfg
+}

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -93,16 +93,11 @@ func (c *Config) WithSupressLogs(sl bool) *Config {
 }
 
 func DefaultConfig() *Config {
-	// we create an arbitrary number of funded accounts
-	accounts := make([]string, 300)
-	for i := 0; i < 300; i++ {
-		accounts[i] = tmrand.Str(9)
-	}
 	tmcfg := DefaultTendermintConfig()
 	tmcfg.Consensus.TargetHeightDuration = 1 * time.Millisecond
 	cfg := &Config{}
 	return cfg.
-		WithAccounts(accounts).
+		WithAccounts([]string{}).
 		WithChainID(tmrand.Str(6)).
 		WithTendermintConfig(DefaultTendermintConfig()).
 		WithAppConfig(DefaultAppConfig()).

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -106,7 +106,6 @@ func DefaultConfig() *Config {
 		WithGenesisOptions().
 		WithAppCreator(cmd.NewAppServer).
 		WithSupressLogs(true)
-
 }
 
 type KVAppOptions struct {

--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -1,19 +1,16 @@
 package testnode
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
-	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
-	"github.com/cosmos/cosmos-sdk/server"
-	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
 	srvtypes "github.com/cosmos/cosmos-sdk/server/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -27,143 +24,88 @@ import (
 	"github.com/tendermint/tendermint/privval"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/proxy"
-	"github.com/tendermint/tendermint/types"
 	dbm "github.com/tendermint/tm-db"
 
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/app/encoding"
-	"github.com/celestiaorg/celestia-app/cmd/celestia-appd/cmd"
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/util/testfactory"
 	qgbtypes "github.com/celestiaorg/celestia-app/x/qgb/types"
 )
 
-// New creates a ready to use tendermint node that operates a single validator
-// celestia-app network using the provided genesis state. The provided keyring
-// is stored in the client.Context that is returned.
-//
-// NOTE: the forced delay between blocks, TimeIotaMs in the consensus
-// parameters, is set to the lowest possible value (1ms).
-func New(
-	t testing.TB,
-	cparams *tmproto.ConsensusParams,
-	tmCfg *config.Config,
-	supressLog bool,
-	genState map[string]json.RawMessage,
-	kr keyring.Keyring,
-	chainID string,
-) (*node.Node, srvtypes.Application, Context, error) {
+// NewCometNode creates a ready to use comet node that operates a single
+// validator celestia-app network. It expects that all configuration files are
+// already initialized and saved to the baseDir.
+func NewCometNode(t testing.TB, baseDir string, cfg *Config) (*node.Node, srvtypes.Application, error) {
 	var logger log.Logger
-	if supressLog {
+	if cfg.SupressLogs {
 		logger = log.NewNopLogger()
 	} else {
 		logger = log.NewTMLogger(log.NewSyncWriter(os.Stdout))
 		logger = log.NewFilter(logger, log.AllowError())
 	}
 
+	dbPath := filepath.Join(cfg.TmConfig.RootDir, "data")
+	db, err := dbm.NewGoLevelDB("application", dbPath)
+	require.NoError(t, err)
+
+	cfg.AppOptions.Set(flags.FlagHome, baseDir)
+
+	app := cfg.AppCreator(logger, db, nil, cfg.AppOptions)
+
+	nodeKey, err := p2p.LoadOrGenNodeKey(cfg.TmConfig.NodeKeyFile())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tmNode, err := node.NewNode(
+		cfg.TmConfig,
+		privval.LoadOrGenFilePV(cfg.TmConfig.PrivValidatorKeyFile(), cfg.TmConfig.PrivValidatorStateFile()),
+		nodeKey,
+		proxy.NewLocalClientCreator(app),
+		node.DefaultGenesisDocProviderFunc(cfg.TmConfig),
+		node.DefaultDBProvider,
+		node.DefaultMetricsProvider(cfg.TmConfig.Instrumentation),
+		logger,
+	)
+
+	return tmNode, app, err
+}
+
+// InitFiles initializes the files for a new tendermint node with the provided
+// genesis state and consensus parameters. The provided keyring is used to
+// create a validator key and the chainID is used to initialize the genesis
+// state. The keyring is returned with the validator account added.
+func InitFiles(
+	t testing.TB,
+	cparams *tmproto.ConsensusParams,
+	tmCfg *config.Config,
+	genState map[string]json.RawMessage,
+	kr keyring.Keyring,
+	chainID string,
+) (string, keyring.Keyring, error) {
 	baseDir, err := initFileStructure(t, tmCfg)
 	if err != nil {
-		return nil, nil, Context{}, err
+		return baseDir, kr, err
 	}
 
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
-	nodeKey, err := p2p.LoadOrGenNodeKey(tmCfg.NodeKeyFile())
-	if err != nil {
-		return nil, nil, Context{}, err
-	}
-
 	nodeID, pubKey, err := genutil.InitializeNodeValidatorFiles(tmCfg)
 	if err != nil {
-		return nil, nil, Context{}, err
+		return baseDir, kr, err
 	}
 
 	err = createValidator(kr, encCfg, pubKey, "validator", nodeID, chainID, baseDir)
 	if err != nil {
-		return nil, nil, Context{}, err
+		return baseDir, kr, err
 	}
 
 	err = initGenFiles(cparams, genState, encCfg.Codec, tmCfg.GenesisFile(), chainID)
 	if err != nil {
-		return nil, nil, Context{}, err
+		return baseDir, kr, err
 	}
 
-	err = collectGenFiles(tmCfg, encCfg, pubKey, nodeID, chainID, baseDir)
-	if err != nil {
-		return nil, nil, Context{}, err
-	}
-
-	dbPath := filepath.Join(tmCfg.RootDir, "data")
-	db, err := dbm.NewGoLevelDB("application", dbPath)
-	require.NoError(t, err)
-
-	appOpts := appOptions{
-		options: map[string]interface{}{
-			server.FlagPruning: pruningtypes.PruningOptionNothing,
-			flags.FlagHome:     baseDir,
-		},
-	}
-
-	app := cmd.NewAppServer(logger, db, nil, appOpts)
-
-	tmNode, err := node.NewNode(
-		tmCfg,
-		privval.LoadOrGenFilePV(tmCfg.PrivValidatorKeyFile(), tmCfg.PrivValidatorStateFile()),
-		nodeKey,
-		proxy.NewLocalClientCreator(app),
-		node.DefaultGenesisDocProviderFunc(tmCfg),
-		node.DefaultDBProvider,
-		node.DefaultMetricsProvider(tmCfg.Instrumentation),
-		logger,
-	)
-
-	cCtx := Context{}.
-		WithKeyring(kr).
-		WithHomeDir(tmCfg.RootDir).
-		WithChainID(chainID).
-		WithInterfaceRegistry(encCfg.InterfaceRegistry).
-		WithCodec(encCfg.Codec).
-		WithLegacyAmino(encCfg.Amino).
-		WithTxConfig(encCfg.TxConfig).
-		WithAccountRetriever(authtypes.AccountRetriever{})
-
-	return tmNode, app, Context{Context: cCtx}, err
-}
-
-type appOptions struct {
-	options map[string]interface{}
-}
-
-// Get implements AppOptions
-func (ao appOptions) Get(o string) interface{} {
-	return ao.options[o]
-}
-
-func DefaultParams() *tmproto.ConsensusParams {
-	cparams := types.DefaultConsensusParams()
-	cparams.Block.TimeIotaMs = 1
-	cparams.Block.MaxBytes = appconsts.DefaultMaxBytes
-	return cparams
-}
-
-func DefaultTendermintConfig() *config.Config {
-	tmCfg := config.DefaultConfig()
-	// Reduce the target height duration so that blocks are produced faster
-	// during tests.
-	tmCfg.Consensus.TargetHeightDuration = 300 * time.Millisecond
-	tmCfg.Consensus.TimeoutPropose = 200 * time.Millisecond
-
-	// set the mempool's MaxTxBytes to allow the testnode to accept a
-	// transaction that fills the entire square. Any blob transaction larger
-	// than the square size will still fail no matter what.
-	tmCfg.Mempool.MaxTxBytes = appconsts.DefaultMaxBytes
-
-	// remove all barriers from the testnode being able to accept very large
-	// transactions and respond to very queries with large responses (~200MB was
-	// chosen only as an arbitrary large number).
-	tmCfg.RPC.MaxBodyBytes = 200_000_000
-
-	return tmCfg
+	return baseDir, kr, collectGenFiles(tmCfg, encCfg, pubKey, nodeID, chainID, baseDir)
 }
 
 // DefaultGenesisState returns a default genesis state and a keyring with
@@ -205,39 +147,41 @@ func DefaultGenesisState(fundedAccounts ...string) (map[string]json.RawMessage, 
 }
 
 // NewNetwork starts a single valiator celestia-app network using the provided
-// configurations. Provided accounts will be funded and their keys can be
+// configurations. Configured accounts will be funded and their keys can be
 // accessed in keyring returned client.Context. All rpc, p2p, and grpc addresses
 // in the provided configs are overwritten to use open ports. The node can be
 // accessed via the returned client.Context or via the returned rpc and grpc
-// addresses. Provided genesis options will be applied after all accounts have
+// addresses. Configured genesis options will be applied after all accounts have
 // been initialized.
-func NewNetwork(
-	t testing.TB,
-	cparams *tmproto.ConsensusParams,
-	tmCfg *config.Config,
-	appCfg *srvconfig.Config,
-	accounts []string,
-	genesisOpts ...GenesisOption,
-) (cctx Context, rpcAddr, grpcAddr string) {
+func NewNetwork(t testing.TB, cfg *Config) (cctx Context, rpcAddr, grpcAddr string) {
 	t.Helper()
 
+	tmCfg := cfg.TmConfig
 	tmCfg.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetFreePort())
 	tmCfg.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetFreePort())
 	tmCfg.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetFreePort())
 
-	genState, kr, err := DefaultGenesisState(accounts...)
+	genState, kr, err := DefaultGenesisState(cfg.Accounts...)
 	require.NoError(t, err)
 
-	for _, opt := range genesisOpts {
+	for _, opt := range cfg.GenesisOptions {
 		genState = opt(genState)
 	}
 
-	tmNode, app, cctx, err := New(t, cparams, tmCfg, false, genState, kr, tmrand.Str(6))
+	chainID := tmrand.Str(6)
+
+	baseDir, kr, err := InitFiles(t, cfg.ConsensusParams, tmCfg, genState, kr, chainID)
 	require.NoError(t, err)
+
+	tmNode, app, err := NewCometNode(t, baseDir, cfg)
+	require.NoError(t, err)
+
+	cctx = NewContext(context.TODO(), kr, tmCfg, chainID)
 
 	cctx, stopNode, err := StartNode(tmNode, cctx)
 	require.NoError(t, err)
 
+	appCfg := cfg.AppConfig
 	appCfg.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", GetFreePort())
 	appCfg.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", GetFreePort())
 
@@ -251,27 +195,6 @@ func NewNetwork(
 	})
 
 	return cctx, tmCfg.RPC.ListenAddress, appCfg.GRPC.Address
-}
-
-// DefaultNetwork starts a single valiator celestia-app network using test
-// friendly defaults. These defaults include all default values and genesis
-// params, modified for fast block times and 300 funded accounts. The returned
-// client.Context has a keyring with all of the funded keys stored in it, which
-// can be accessed using the returned accounts.
-func DefaultNetwork(t *testing.T) (accounts []string, cctx Context) {
-	// we create an arbitrary number of funded accounts
-	accounts = make([]string, 300)
-	for i := 0; i < 300; i++ {
-		accounts[i] = tmrand.Str(9)
-	}
-
-	tmCfg := DefaultTendermintConfig()
-	tmCfg.Consensus.TargetHeightDuration = time.Millisecond * 1
-	appConf := DefaultAppConfig()
-
-	cctx, _, _ = NewNetwork(t, DefaultParams(), tmCfg, appConf, accounts)
-
-	return accounts, cctx
 }
 
 func GetFreePort() int {

--- a/test/util/testnode/full_node_test.go
+++ b/test/util/testnode/full_node_test.go
@@ -36,8 +36,6 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	}
 	t := s.T()
 
-	cparams := DefaultParams()
-
 	accounts := make([]string, 40)
 	for i := 0; i < 40; i++ {
 		accounts[i] = tmrand.Str(10)
@@ -46,14 +44,12 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	ecfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	blobGenState := blobtypes.DefaultGenesis()
 	blobGenState.Params.GovMaxSquareSize = uint64(appconsts.DefaultSquareSizeUpperBound)
-	cctx, _, _ := NewNetwork(
-		t,
-		cparams,
-		DefaultTendermintConfig(),
-		DefaultAppConfig(),
-		accounts,
-		SetBlobParams(ecfg.Codec, blobGenState.Params),
-	)
+
+	cfg := DefaultConfig().
+		WithAccounts(accounts).
+		WithGenesisOptions(SetBlobParams(ecfg.Codec, blobGenState.Params))
+
+	cctx, _, _ := NewNetwork(t, cfg)
 	s.cctx = cctx
 	s.accounts = accounts
 }

--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -40,8 +40,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	cparams.Block.TimeIotaMs = int64(sixMonths.Milliseconds())
 
 	cfg := testnode.DefaultConfig().
-		WithConsensusParams(cparams).
-		WithAccounts([]string{})
+		WithConsensusParams(cparams)
 
 	cctx, _, _ := testnode.NewNetwork(t, cfg)
 	s.cctx = cctx

--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -39,7 +39,11 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	// longer work.
 	cparams.Block.TimeIotaMs = int64(sixMonths.Milliseconds())
 
-	cctx, _, _ := testnode.NewNetwork(t, cparams, testnode.DefaultTendermintConfig(), testnode.DefaultAppConfig(), []string{})
+	cfg := testnode.DefaultConfig().
+		WithConsensusParams(cparams).
+		WithAccounts([]string{})
+
+	cctx, _, _ := testnode.NewNetwork(t, cfg)
 	s.cctx = cctx
 }
 

--- a/x/qgb/client/verify.go
+++ b/x/qgb/client/verify.go
@@ -189,11 +189,11 @@ func sharesCmd() *cobra.Command {
 func VerifyShares(ctx context.Context, logger tmlog.Logger, config VerifyConfig, height uint64, startShare uint64, endShare uint64) (isCommittedTo bool, err error) {
 	trpc, err := http.New(config.TendermintRPC, "/websocket")
 	if err != nil {
-		return
+		return false, err
 	}
 	err = trpc.Start()
 	if err != nil {
-		return
+		return false, err
 	}
 	defer func(trpc *http.HTTP) {
 		err := trpc.Stop()


### PR DESCRIPTION
## Overview

This refactor is mainly targeting #1990, but doing so in a way that uses common patters to avoid continuing to blow up the api

closes #1990

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
