### PR TITLE
feat: add multiple excluded directories to the test coverage script

### DIFF
--- a/scripts/test_cover.sh
+++ b/scripts/test_cover.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 set -e
 
-PKGS=$(go list ./... | grep -v '/simapp')
+# Define the directories to exclude
+EXCLUDE_DIRS=("/malicious")
 
-set -e
+# Initialize PKGS variable with the list of all packages
+PKGS=$(go list ./...)
+
+# Loop over the directories to exclude and remove them from PKGS
+for DIR in "${EXCLUDE_DIRS[@]}"; do
+    PKGS=$(echo "$PKGS" | grep -v "$DIR")
+done
+
 echo "mode: atomic" > coverage.txt
 for pkg in ${PKGS[@]}; do
     go test -v -timeout 30m -race -test.short -coverprofile=profile.out -covermode=atomic "$pkg"


### PR DESCRIPTION
## Overview

this pr enables us to add multiple directories to the exclusion list for measuring test coverage, and then adds the malicious package to that list

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
