### PR TITLE
fix!: use correct chain-id when filtering and checking txs

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -18,7 +18,7 @@ import (
 func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
 	// create a context using a branch of the state and loaded using the
 	// proposal height and chain-id
-	sdkCtx := app.NewProposalContext(core.Header{ChainID: app.GetChainID(), Height: app.LastBlockHeight() + 1})
+	sdkCtx := app.NewProposalContext(core.Header{ChainID: req.ChainId, Height: app.LastBlockHeight() + 1})
 	// filter out invalid transactions.
 	// TODO: we can remove all state independent checks from the ante handler here such as signature verification
 	// and only check the state dependent checks like fees and nonces as all these transactions have already

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -41,7 +41,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 		ante.DefaultSigVerificationGasConsumer,
 		app.IBCKeeper,
 	)
-	sdkCtx := app.NewProposalContext(req.Header).WithChainID(app.GetChainID())
+	sdkCtx := app.NewProposalContext(req.Header)
 
 	// iterate over all txs and ensure that all blobTxs are valid, PFBs are correctly signed and non
 	// blobTxs have no PFBs present

--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/app/encoding"
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/test/util"
+	testutil "github.com/celestiaorg/celestia-app/test/util"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -82,14 +82,14 @@ func TestPrepareProposalConsistency(t *testing.T) {
 		cparams := app.DefaultConsensusParams()
 		cparams.Block.MaxBytes = size.maxBytes
 
-		testApp, kr := util.SetupTestAppWithGenesisValSet(cparams, accounts...)
+		testApp, kr := testutil.SetupTestAppWithGenesisValSet(cparams, accounts...)
 
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				// repeat the test multiple times with random data each
 				// iteration.
 				for i := 0; i < tt.iterations; i++ {
-					txs := util.RandBlobTxsWithAccounts(
+					txs := testutil.RandBlobTxsWithAccounts(
 						t,
 						testApp,
 						encConf.TxConfig.TxEncoder(),
@@ -101,7 +101,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 						accounts[:tt.count],
 					)
 					// create 100 send transactions
-					sendTxs := util.SendTxsWithAccounts(
+					sendTxs := testutil.SendTxsWithAccounts(
 						t,
 						testApp,
 						encConf.TxConfig.TxEncoder(),
@@ -116,6 +116,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 						BlockData: &core.Data{
 							Txs: coretypes.Txs(txs).ToSliceOfBytes(),
 						},
+						ChainId: testutil.ChainID,
 					})
 
 					// check that the square size is smaller than or equal to

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -183,6 +183,7 @@ func TestPrepareProposalFiltering(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := testApp.PrepareProposal(abci.RequestPrepareProposal{
 				BlockData: &tmproto.Data{Txs: tt.txs()},
+				ChainId:   testutil.ChainID,
 			})
 			// check that we have the expected number of transactions
 			require.Equal(t, len(tt.txs())-len(tt.prunedTxs), len(resp.BlockData.Txs))

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -60,6 +60,7 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 		BlockData: &tmproto.Data{
 			Txs: txs,
 		},
+		ChainId: testutil.ChainID,
 	})
 	require.Len(t, resp.BlockData.Txs, numBlobTxs+numNormalTxs)
 	for idx, txBytes := range resp.BlockData.Txs {

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -310,6 +310,7 @@ func TestProcessProposal(t *testing.T) {
 				Header: tmproto.Header{
 					Height:   1,
 					DataHash: resp.BlockData.Hash,
+					ChainID:  testutil.ChainID,
 				},
 			})
 			assert.Equal(t, tt.expectedResult, res.Result, fmt.Sprintf("expected %v, got %v", tt.expectedResult, res.Result))

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -301,6 +301,7 @@ func TestProcessProposal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := testApp.PrepareProposal(abci.RequestPrepareProposal{
 				BlockData: tt.input,
+				ChainId:   testutil.ChainID,
 			})
 			require.Equal(t, len(tt.input.Txs), len(resp.BlockData.Txs))
 			tt.mutator(resp.BlockData)

--- a/go.mod
+++ b/go.mod
@@ -201,5 +201,5 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.15.0-sdk-v0.46.13
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28.0.20230704120103-c770402dfd69 // v1.22.0-tm-v0.34.28
 )

--- a/go.mod
+++ b/go.mod
@@ -201,5 +201,5 @@ replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.15.0-sdk-v0.46.13
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28.0.20230704120103-c770402dfd69 // v1.22.0-tm-v0.34.28
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.23.0-tm-v0.34.28
 )

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/bufbuild/protocompile v0.1.0 h1:HjgJBI85hY/qmW5tw/66sNDZ7z0UDdVSi/5r4
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28 h1:idHJK9i4WCkYOf5PXVWZbOs8pWkCiHHQGI4MZr0iMtQ=
-github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28/go.mod h1:LOxHW9nA++/9U8TgvTyKo9TO3F09sWv8asKQs00m73U=
+github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28.0.20230704120103-c770402dfd69 h1:UejCneLOrXLyE83W9ulx4zWzrr/30wux/0eYbdO8wZQ=
+github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28.0.20230704120103-c770402dfd69/go.mod h1:J/GsBjoTZaFz71VeyrLZbG8rV+Rzi6oFEUZUipQ97hQ=
 github.com/celestiaorg/cosmos-sdk v1.15.0-sdk-v0.46.13 h1:vaQKgaOm0w58JAvOgn2iDohqjH7kvvRqVKiMcBDWifA=
 github.com/celestiaorg/cosmos-sdk v1.15.0-sdk-v0.46.13/go.mod h1:G9XkhOJZde36FH0kt/1ayg4ZaioZEQmmRfMa/zQig0I=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/go.sum
+++ b/go.sum
@@ -170,8 +170,8 @@ github.com/bufbuild/protocompile v0.1.0 h1:HjgJBI85hY/qmW5tw/66sNDZ7z0UDdVSi/5r4
 github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOCSiVIqS34=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28.0.20230704120103-c770402dfd69 h1:UejCneLOrXLyE83W9ulx4zWzrr/30wux/0eYbdO8wZQ=
-github.com/celestiaorg/celestia-core v1.22.0-tm-v0.34.28.0.20230704120103-c770402dfd69/go.mod h1:J/GsBjoTZaFz71VeyrLZbG8rV+Rzi6oFEUZUipQ97hQ=
+github.com/celestiaorg/celestia-core v1.23.0-tm-v0.34.28 h1:G7/rq6xTnuFf3XsVZEcl/Sa6vtagm9NQNhaUaSgjvy0=
+github.com/celestiaorg/celestia-core v1.23.0-tm-v0.34.28/go.mod h1:J/GsBjoTZaFz71VeyrLZbG8rV+Rzi6oFEUZUipQ97hQ=
 github.com/celestiaorg/cosmos-sdk v1.15.0-sdk-v0.46.13 h1:vaQKgaOm0w58JAvOgn2iDohqjH7kvvRqVKiMcBDWifA=
 github.com/celestiaorg/cosmos-sdk v1.15.0-sdk-v0.46.13/go.mod h1:G9XkhOJZde36FH0kt/1ayg4ZaioZEQmmRfMa/zQig0I=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/pkg/shares/parse_sparse_shares_test.go
+++ b/pkg/shares/parse_sparse_shares_test.go
@@ -3,7 +3,6 @@ package shares
 import (
 	"bytes"
 	"fmt"
-	"sort"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
@@ -59,7 +58,7 @@ func Test_parseSparseShares(t *testing.T) {
 				blobs[i] = testfactory.GenerateRandomBlob(tc.blobSize)
 			}
 
-			sort.Sort(coretypes.BlobsByNamespace(blobs))
+			blobs = testfactory.SortBlobs(blobs)
 
 			shares, err := SplitBlobs(blobs...)
 			require.NoError(t, err)
@@ -135,7 +134,7 @@ func Test_parseSparseSharesWithNamespacedPadding(t *testing.T) {
 		randomSmallBlob,
 		randomLargeBlob,
 	}
-	sort.Sort(coretypes.BlobsByNamespace(blobs))
+	blobs = testfactory.SortBlobs(blobs)
 
 	err := sss.Write(blobs[0])
 	require.NoError(t, err)

--- a/test/util/testfactory/blob.go
+++ b/test/util/testfactory/blob.go
@@ -25,12 +25,12 @@ func GenerateRandomlySizedBlobs(count, maxBlobSize int) []types.Blob {
 		blobs = nil
 	}
 
-	sort.Sort(types.BlobsByNamespace(blobs))
+	blobs = SortBlobs(blobs)
 	return blobs
 }
 
 // GenerateBlobsWithNamespace generates blobs with namespace ns.
-func GenerateBlobsWithNamespace(count int, blobSize int, ns appns.Namespace) types.BlobsByNamespace {
+func GenerateBlobsWithNamespace(count int, blobSize int, ns appns.Namespace) []types.Blob {
 	blobs := make([]types.Blob, count)
 	for i := 0; i < count; i++ {
 		blobs[i] = types.Blob{
@@ -77,4 +77,9 @@ func rawBlobSize(totalSize int) int {
 func DelimLen(size uint64) int {
 	lenBuf := make([]byte, binary.MaxVarintLen64)
 	return binary.PutUvarint(lenBuf, size)
+}
+
+func SortBlobs(blobs []types.Blob) []types.Blob {
+	sort.Slice(blobs, func(i, j int) bool { return bytes.Compare(blobs[i].NamespaceID, blobs[j].NamespaceID) < 0 })
+	return blobs
 }


### PR DESCRIPTION
## Overview

consistently pass the correct chain-id to the application using `RequestPrepareProposal` and `RequestProcessProposal`

this PR still needs to update the go.mod to use the official tag of tendermint after its released

closes #2020 and #2021

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
