### PR TITLE
fix: stop overwriting chain-id in testnode

### DIFF
--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/libs/log"
-	tmrand "github.com/tendermint/tendermint/libs/rand"
 	"github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"

--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -168,7 +168,10 @@ func NewNetwork(t testing.TB, cfg *Config) (cctx Context, rpcAddr, grpcAddr stri
 		genState = opt(genState)
 	}
 
-	chainID := tmrand.Str(6)
+    chainID := cfg.ChainID
+    if chainID == "" {
+        chainID = tmrand.Str(6)
+    }
 
 	baseDir, kr, err := InitFiles(t, cfg.ConsensusParams, tmCfg, genState, kr, chainID)
 	require.NoError(t, err)

--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -169,9 +169,6 @@ func NewNetwork(t testing.TB, cfg *Config) (cctx Context, rpcAddr, grpcAddr stri
 	}
 
 	chainID := cfg.ChainID
-	if chainID == "" {
-		chainID = tmrand.Str(6)
-	}
 
 	baseDir, kr, err := InitFiles(t, cfg.ConsensusParams, tmCfg, genState, kr, chainID)
 	require.NoError(t, err)

--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -168,10 +168,10 @@ func NewNetwork(t testing.TB, cfg *Config) (cctx Context, rpcAddr, grpcAddr stri
 		genState = opt(genState)
 	}
 
-    chainID := cfg.ChainID
-    if chainID == "" {
-        chainID = tmrand.Str(6)
-    }
+	chainID := cfg.ChainID
+	if chainID == "" {
+		chainID = tmrand.Str(6)
+	}
 
 	baseDir, kr, err := InitFiles(t, cfg.ConsensusParams, tmCfg, genState, kr, chainID)
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview

Closes https://github.com/celestiaorg/celestia-app/issues/2026

Now the testnode uses the configured chain-id and relies on the default to set the initial random value instead of overwriting it with a random value.

## Checklist

- [X] New and updated code has appropriate documentation
- [X] New and updated code has new and/or updated testing
- [X] Required CI checks are passing
- [X] Visual proof for any user facing features like CLI or documentation updates
- [X] Linked issues closed with keywords
