### PR TITLE
Adjusted TimeoutCommit config comment to explain block interval relationship

### DIFF
--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -137,8 +137,9 @@ func DefaultParams() *tmproto.ConsensusParams {
 
 func DefaultTendermintConfig() *tmconfig.Config {
 	tmCfg := tmconfig.DefaultConfig()
-	// Reduce the target height duration so that blocks are produced faster
-	// during tests.
+	// TimeoutCommit sets the maximum duration the application waits for transactions to be committed. 
+	// This duration influences the time interval between blocks - 
+	// a smaller TimeoutCommit value could lead to faster block intervals.
 	tmCfg.Consensus.TimeoutCommit = 300 * time.Millisecond
 	tmCfg.Consensus.TimeoutPropose = 200 * time.Millisecond
 


### PR DESCRIPTION
closes "2096"