### PR TITLE
chore: always enable API in local dev scripts

### DIFF
--- a/scripts/build-run-single-node.sh
+++ b/scripts/build-run-single-node.sh
@@ -33,4 +33,4 @@ sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ${HOME_DIR}/con
 sed -i'.bak' 's#"null"#"kv"#g' ${HOME_DIR}/config/config.toml
 
 # Start the celestia-app
-${BIN_PATH} start --home ${HOME_DIR}
+${BIN_PATH} start --home ${HOME_DIR} --api.enable

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -28,4 +28,4 @@ sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ${HOME_DIR}/con
 sed -i'.bak' 's#"null"#"kv"#g' ${HOME_DIR}/config/config.toml
 
 # Start the celestia-app
-celestia-appd start --home ${HOME_DIR}
+celestia-appd start --home ${HOME_DIR} --api.enable


### PR DESCRIPTION
While debugging https://github.com/celestiaorg/celestia-app/issues/2098 I frequently applied this patch to previous releases. Since these scripts exist for development purposes, I think it would save devs time by always enabling the API. 