### PR TITLE
chore: upgrade to cosmos-sdk v1.16.1-sdk-v0.46.13

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -17,6 +17,6 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.0 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.2 # yamllint disable-line rule:line-length
     with:
       dockerfile: Dockerfile

--- a/go.mod
+++ b/go.mod
@@ -198,7 +198,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.16.0-sdk-v0.46.13
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.16.1-sdk-v0.46.13
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.24.0-tm-v0.34.28

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.24.0-tm-v0.34.28 h1:eXS3v26nob8Xs2+flKHVxcTzhzQW44KgTcooR3OxnK4=
 github.com/celestiaorg/celestia-core v1.24.0-tm-v0.34.28/go.mod h1:J/GsBjoTZaFz71VeyrLZbG8rV+Rzi6oFEUZUipQ97hQ=
-github.com/celestiaorg/cosmos-sdk v1.16.0-sdk-v0.46.13 h1:N1PrCWcYkaODeIQyyVBmDKDTwiQWZ31bgtTEYIGeby8=
-github.com/celestiaorg/cosmos-sdk v1.16.0-sdk-v0.46.13/go.mod h1:xpBZc/OYZ736hp0IZlBGNUhEgCD9C+bKs8yNLZibyv0=
+github.com/celestiaorg/cosmos-sdk v1.16.1-sdk-v0.46.13 h1:CxEQDQEQR1ypB+VUmCISIqFVmHfb+mx8x+zh7rHbyU8=
+github.com/celestiaorg/cosmos-sdk v1.16.1-sdk-v0.46.13/go.mod h1:xpBZc/OYZ736hp0IZlBGNUhEgCD9C+bKs8yNLZibyv0=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4/go.mod h1:fzuHnhzj1pUygGz+1ZkB3uQbEUL4htqCGJ4Qs2LwMZA=
 github.com/celestiaorg/nmt v0.17.0 h1:/k8YLwJvuHgT/jQ435zXKaDX811+sYEMXL4B/vYdSLU=

--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -70,7 +70,7 @@ func (s *IntegrationTestSuite) TestInflationRate() {
 	require := s.Require()
 
 	type testCase struct {
-		year int
+		year int64
 		want sdktypes.Dec
 	}
 	testCases := []testCase{

--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -11,8 +11,8 @@ const (
 	// value isn't 365 because 97 out of 400 years are leap years. See
 	// https://en.wikipedia.org/wiki/Year
 	DaysPerYear        = 365.2425
-	SecondsPerYear     = int(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
-	NanosecondsPerYear = int64(NanosecondsPerSecond * SecondsPerYear)                       // 31,556,952,000,000,000
+	SecondsPerYear     = int64(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
+	NanosecondsPerYear = int64(NanosecondsPerSecond * SecondsPerYear)                         // 31,556,952,000,000,000
 
 	InitialInflationRate = 0.08
 	DisinflationRate     = 0.1

--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -11,8 +11,8 @@ const (
 	// value isn't 365 because 97 out of 400 years are leap years. See
 	// https://en.wikipedia.org/wiki/Year
 	DaysPerYear        = 365.2425
-	SecondsPerYear     = int(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear)                        // 31,556,952
-	NanosecondsPerYear = int(NanosecondsPerSecond * SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952,000,000,000
+	SecondsPerYear     = int(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
+	NanosecondsPerYear = int(NanosecondsPerSecond * SecondsPerYear)                         // 31,556,952,000,000,000
 
 	InitialInflationRate = 0.08
 	DisinflationRate     = 0.1

--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -12,7 +12,7 @@ const (
 	// https://en.wikipedia.org/wiki/Year
 	DaysPerYear        = 365.2425
 	SecondsPerYear     = int(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
-	NanosecondsPerYear = int(NanosecondsPerSecond * SecondsPerYear)                         // 31,556,952,000,000,000
+	NanosecondsPerYear = int64(NanosecondsPerSecond * SecondsPerYear)                       // 31,556,952,000,000,000
 
 	InitialInflationRate = 0.08
 	DisinflationRate     = 0.1

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -17,7 +17,7 @@ func TestCalculateInflationRate(t *testing.T) {
 	genesisTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	type testCase struct {
-		year int
+		year int64
 		want float64
 	}
 
@@ -66,7 +66,7 @@ func TestCalculateInflationRate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		years := time.Duration(tc.year * NanosecondsPerYear * int(time.Nanosecond))
+		years := time.Duration(tc.year * NanosecondsPerYear * int64(time.Nanosecond))
 		blockTime := genesisTime.Add(years)
 		ctx := sdk.NewContext(nil, tmproto.Header{}, false, nil).WithBlockTime(blockTime)
 		inflationRate := minter.CalculateInflationRate(ctx, genesisTime)


### PR DESCRIPTION
Cherry-picks a few commits to the `v1.x` release branch so that we can cut celestia-app v1.0.0-rc10. When we merge this, we should probably NOT squash so that the individual commit messages appear in the release notes.

## Testing

I started a full consensus node on `mocha-3` using a `celestia-appd` binary based on this PR. It is synced to the head (112,304 at the time of writing) with no issues.

Note: mocha-3 is on [v1.0.0-rc9](https://github.com/celestiaorg/celestia-app/releases/tag/v1.0.0-rc9) according to [docs](https://docs.celestia.org/nodes/participate/).

