### PR TITLE
fix: txsim uses the same gas estimation method

### DIFF
--- a/test/txsim/blob.go
+++ b/test/txsim/blob.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/rand"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	ns "github.com/celestiaorg/celestia-app/pkg/namespace"
 	"github.com/celestiaorg/celestia-app/test/util/blobfactory"
 	blob "github.com/celestiaorg/celestia-app/x/blob/types"
@@ -107,12 +106,6 @@ func (r Range) Rand(rand *rand.Rand) int {
 	return rand.Intn(r.Max-r.Min) + r.Min
 }
 
-// This is a rough estimation of the gas that arises from several other places:
-// - signature verification
-// - tx size
-// - read access to accounts
-const pfbGasFixedCost     = 80000
-
 // estimateGas estimates the gas required to pay for a set of blobs in a PFB.
 func estimateGas(blobSizes []int) uint64 {
 	size := make([]uint32, len(blobSizes))
@@ -120,5 +113,5 @@ func estimateGas(blobSizes []int) uint64 {
 		size[i] = uint32(s)
 	}
 
-	return blob.GasToConsume(size, appconsts.DefaultGasPerBlobByte) + pfbGasFixedCost
+	return blob.DefaultEstimateGas(size)
 }

--- a/test/txsim/sequence.go
+++ b/test/txsim/sequence.go
@@ -42,9 +42,9 @@ type Operation struct {
 }
 
 const (
-	// set default gas limit to cover the costs of most transactions
-	// At 0.1 utia per gas, this equates to 20000utia per transaction
-	DefaultGasLimit = 200000
+	// Set the default gas limit to cover the costs of most transactions.
+	// At 0.1 utia per gas, this equates to 20_000utia per transaction.
+	DefaultGasLimit = 200_000
 )
 
 // ErrEndOfSequence is a special error which indicates that the sequence has been terminated

--- a/test/txsim/sequence.go
+++ b/test/txsim/sequence.go
@@ -43,8 +43,8 @@ type Operation struct {
 
 const (
 	// set default gas limit to cover the costs of most transactions
-	// At 0.001 utia per gas, this equates to 1000utia per transaction
-	DefaultGasLimit = 1000000
+	// At 0.1 utia per gas, this equates to 20000utia per transaction
+	DefaultGasLimit = 200000
 )
 
 // ErrEndOfSequence is a special error which indicates that the sequence has been terminated

--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -1,8 +1,6 @@
 package ante
 
 import (
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/x/blob/types"
 
 	"cosmossdk.io/errors"
@@ -38,7 +36,7 @@ func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 				// lazily fetch the gas per byte param
 				gasPerByte = d.k.GasPerBlobByte(ctx)
 			}
-			gasToConsume := gasToConsume(pfb, gasPerByte)
+			gasToConsume := pfb.Gas(gasPerByte)
 			if gasToConsume > txGas {
 				return ctx, errors.Wrapf(sdkerrors.ErrInsufficientFee, "not enough gas to pay for blobs (minimum: %d, got: %d)", gasToConsume, txGas)
 			}
@@ -46,15 +44,6 @@ func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 	}
 
 	return next(ctx, tx, simulate)
-}
-
-func gasToConsume(pfb *types.MsgPayForBlobs, gasPerByte uint32) uint64 {
-	var totalSharesUsed uint64
-	for _, size := range pfb.BlobSizes {
-		totalSharesUsed += uint64(shares.SparseSharesNeeded(size))
-	}
-
-	return totalSharesUsed * appconsts.ShareSize * uint64(gasPerByte)
 }
 
 type BlobKeeper interface {

--- a/x/blob/keeper/keeper.go
+++ b/x/blob/keeper/keeper.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
@@ -52,12 +50,7 @@ func (k Keeper) Logger(ctx sdk.Context) log.Logger {
 func (k Keeper) PayForBlobs(goCtx context.Context, msg *types.MsgPayForBlobs) (*types.MsgPayForBlobsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	var totalSharesUsed uint64
-	for _, size := range msg.BlobSizes {
-		totalSharesUsed += uint64(shares.SparseSharesNeeded(size))
-	}
-
-	gasToConsume := totalSharesUsed * appconsts.ShareSize * uint64(k.GasPerBlobByte(ctx))
+	gasToConsume := types.GasToConsume(msg.BlobSizes, k.GasPerBlobByte(ctx))
 	ctx.GasMeter().ConsumeGas(gasToConsume, payForBlobGasDescriptor)
 
 	err := ctx.EventManager().EmitTypedEvent(

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -149,7 +149,7 @@ func (msg *MsgPayForBlobs) Gas(gasPerByte uint32) uint64 {
 	return GasToConsume(msg.BlobSizes, gasPerByte)
 }
 
-// GasToConsume works out the gas required to pay for a set of blobs in a PFB.
+// GasToConsume works out the extra gas charged to pay for a set of blobs in a PFB.
 // Note that tranasctions will incur other gas costs, such as the signature verification
 // and reads to the user's account.
 func GasToConsume(blobSizes []uint32, gasPerByte uint32) uint64 {
@@ -161,7 +161,7 @@ func GasToConsume(blobSizes []uint32, gasPerByte uint32) uint64 {
 	return totalSharesUsed * appconsts.ShareSize * uint64(gasPerByte)
 }
 
-// EstimateGas estimates the gas required to pay for a set of blobs in a PFB.
+// EstimateGas estimates the total gas required to pay for a set of blobs in a PFB.
 // It is based on a linear model that is dependent on the governance parameters:
 // gasPerByte and txSizeCost. It assumes other variables are constant. This includes
 // assuming the PFB is the only message in the transaction.

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -23,14 +23,20 @@ const (
 	URLMsgPayForBlobs = "/celestia.blob.v1.MsgPayForBlobs"
 	ShareSize         = appconsts.ShareSize
 
-	// PFBGasFixedCost is a rough estimation of the gas that arises from several other places:
-	// - signature verification
-	// - tx size
-	// - read access to accounts
-	// From modelling PFB gas consumption we arrive at the following formula:
-	// 8 * 512 * shares + 65000. This has a correlation coefficient of 0.996
-	// To be conservative, we round up to 75000 because the first tx always
-	// takes up 10,000 more gas.
+	// PFBGasFixedCost is a rough estimate for the "fixed cost" in the gas cost
+	// formula: gas cost = gas per byte * bytes per share * shares occupied by
+	// blob + "fixed cost". In this context, "fixed cost" accounts for the gas
+	// consumed by operations outside the blob's GasToConsume function (i.e.
+	// signature verification, tx size, read access to accounts).
+	//
+	// Since the gas cost of these operations is not easy to calculate, linear
+	// regression was performed on a set of observed data points to derive an
+	// approximate formula for gas cost. Assuming gas per byte = 8 and bytes per
+	// share = 512, we can solve for "fixed cost" and arrive at 65,000. gas cost
+	// = 8 * 512 * number of shares occupied by the blob + 65,000 has a
+	// correlation coefficient of 0.996. To be conservative, we round up "fixed
+	// cost" to 75,000 because the first tx always takes up 10,000 more gas than
+	// subsequent txs.
 	PFBGasFixedCost = 75000
 
 	// BytesPerBlobInfo is a rough estimation for the amount of extra bytes in

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -33,8 +33,8 @@ const (
 	// takes up 10,000 more gas.
 	PFBGasFixedCost = 75000
 
-	// BytesPerBlobInfo is the amount of extra bytes in information a blob
-	// adds to the size of the underlying transaction
+	// BytesPerBlobInfo is a rough estimation for the amount of extra bytes in
+	// information a blob adds to the size of the underlying transaction.
 	BytesPerBlobInfo = 70
 )
 

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -130,6 +130,19 @@ func (msg *MsgPayForBlobs) ValidateBasic() error {
 	return nil
 }
 
+func (msg *MsgPayForBlobs) Gas(gasPerByte uint32) uint64 {
+	return GasToConsume(msg.BlobSizes, gasPerByte)
+}
+
+func GasToConsume(blobSizes []uint32, gasPerByte uint32) uint64 {
+	var totalSharesUsed uint64
+	for _, size := range blobSizes {
+		totalSharesUsed += uint64(appshares.SparseSharesNeeded(size))
+	}
+
+	return totalSharesUsed * appconsts.ShareSize * uint64(gasPerByte)
+}
+
 // ValidateBlobNamespace returns an error if the provided namespace is reserved,
 // parity shares, or tail padding.
 func ValidateBlobNamespace(ns appns.Namespace) error {


### PR DESCRIPTION
This also simplifies some of the gas consumption logic between the ante handler and blob keeper