### PR TITLE
fix: explicit int64 for NanosecondsPerYear

### DIFF
--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -73,7 +73,7 @@ func (s *IntegrationTestSuite) TestInflationRate() {
 	require := s.Require()
 
 	type testCase struct {
-		year int
+		year int64
 		want sdktypes.Dec
 	}
 	testCases := []testCase{

--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -12,7 +12,7 @@ const (
 	// https://en.wikipedia.org/wiki/Year
 	DaysPerYear        = 365.2425
 	SecondsPerYear     = int(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
-	NanosecondsPerYear = int(NanosecondsPerSecond * SecondsPerYear)                         // 31,556,952,000,000,000
+	NanosecondsPerYear = int64(NanosecondsPerSecond * SecondsPerYear)                       // 31,556,952,000,000,000
 
 	InitialInflationRate = 0.08
 	DisinflationRate     = 0.1

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -17,7 +17,7 @@ func TestCalculateInflationRate(t *testing.T) {
 	genesisTime := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	type testCase struct {
-		year int
+		year int64
 		want float64
 	}
 
@@ -66,7 +66,7 @@ func TestCalculateInflationRate(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		years := time.Duration(tc.year * NanosecondsPerYear * int(time.Nanosecond))
+		years := time.Duration(tc.year * NanosecondsPerYear * int64(time.Nanosecond))
 		blockTime := genesisTime.Add(years)
 		ctx := sdk.NewContext(nil, tmproto.Header{}, false, nil).WithBlockTime(blockTime)
 		inflationRate := minter.CalculateInflationRate(ctx, genesisTime)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2120

On a 32-bit system, an int can store values up to 2,147,483,647, which is much smaller than 31,556,952,000,000,000 (number of nanoseconds in a year).

After this merges I will cherry-pick it to the `v1.x` release branch
