### PR TITLE
doc: clarifies the exact range of reserved namespaces

### DIFF
--- a/specs/src/specs/namespace.md
+++ b/specs/src/specs/namespace.md
@@ -59,9 +59,10 @@ The ID is encoded as a byte slice of length 28.
 
 Celestia reserves certain namespaces with specific meanings.
 Celestia makes use of the reserved namespaces to properly organize and order transactions and blobs inside the [data square](./data_square_layout.md).
-Applications MUST NOT use these reserved namespaces for their blob data. 
+Applications MUST NOT use these reserved namespaces for their blob data.  
 
 Below is a list of reserved namespaces, along with a brief description of each.
+In addition to the items listed in this table, it should be noted that namespaces with values less than `0x00000000000000000000000000000000000000000000000000000000FF` are exclusively reserved for use within the Celestia protocols.
 In the table, you will notice that the `PARITY_SHARE_NAMESPACE` and `TAIL_PADDING_NAMESPACE` utilize the namespace version `255`, which differs from the supported user-specified versions.
 The reason for employing version `255` for the `PARITY_SHARE_NAMESPACE` is to enable more efficient proof generation within the context of [nmt](https://github.com/celestiaorg/nmt), where it is used in conjunction with the `IgnoreMaxNamespace` feature.
 Similarly, the `TAIL_PADDING_NAMESPACE` utilizes the namespace version `255` to ensure that padding shares are always properly ordered and placed at the end of the Celestia data square even if a new namespace version is introduced.

--- a/specs/src/specs/namespace.md
+++ b/specs/src/specs/namespace.md
@@ -59,7 +59,7 @@ The ID is encoded as a byte slice of length 28.
 
 Celestia reserves certain namespaces with specific meanings.
 Celestia makes use of the reserved namespaces to properly organize and order transactions and blobs inside the [data square](./data_square_layout.md).
-Applications MUST NOT use these reserved namespaces for their blob data.  
+Applications MUST NOT use these reserved namespaces for their blob data. 
 
 Below is a list of reserved namespaces, along with a brief description of each.
 In addition to the items listed in this table, it should be noted that namespaces with values less than `0x00000000000000000000000000000000000000000000000000000000FF` are exclusively reserved for use within the Celestia protocols.


### PR DESCRIPTION
## Overview

Upon reviewing the namespace module, it came to my attention that namespaces below the [maximum reserved namespace ](https://github.com/celestiaorg/celestia-app/blob/5615205760ac3921506e2c457fc2deb924f8aed5/pkg/namespace/consts.go#L56)are being treated as reserved (see [IsReserved](https://github.com/celestiaorg/celestia-app/blob/2b74a9d970618de76f82d385f46f176452c12bb3/pkg/namespace/namespace.go#L133)), regardless of their current usage. Therefore, this pull request aims to revise the specifications to accurately reflect this fact. It is important to note that the list of reserved namespaces extends beyond what is included in the table and encompasses namespaces below the maximum reserved namespace.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
