### PR TITLE
test: adds missing unittest for leftPad

### DIFF
--- a/pkg/namespace/namespace.go
+++ b/pkg/namespace/namespace.go
@@ -173,6 +173,8 @@ func (n Namespace) IsGreaterOrEqualThan(n2 Namespace) bool {
 	return bytes.Compare(n.Bytes(), n2.Bytes()) > -1
 }
 
+// leftPad returns a new byte slice with the provided byte slice left-padded to the provided size.
+// If the provided byte slice is already larger than the provided size, the original byte slice is returned.
 func leftPad(b []byte, size int) []byte {
 	if len(b) >= size {
 		return b

--- a/pkg/namespace/namespace_test.go
+++ b/pkg/namespace/namespace_test.go
@@ -2,6 +2,7 @@ package namespace
 
 import (
 	"bytes"
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -194,4 +195,34 @@ func TestBytes(t *testing.T) {
 	got := namespace.Bytes()
 
 	assert.Equal(t, want, got)
+}
+
+func TestLeftPad(t *testing.T) {
+	tests := []struct {
+		input    []byte
+		size     int
+		expected []byte
+	}{
+		// input smaller than pad size
+		{[]byte{1, 2, 3}, 10, []byte{0, 0, 0, 0, 0, 0, 0, 1, 2, 3}},
+		{[]byte{1}, 5, []byte{0, 0, 0, 0, 1}},
+		{[]byte{1, 2}, 4, []byte{0, 0, 1, 2}},
+
+		// input equal to pad size
+		{[]byte{1, 2, 3}, 3, []byte{1, 2, 3}},
+		{[]byte{1, 2, 3, 4}, 4, []byte{1, 2, 3, 4}},
+
+		// input larger than pad size
+		{[]byte{1, 2, 3, 4, 5}, 4, []byte{1, 2, 3, 4, 5}},
+		{[]byte{1, 2, 3, 4, 5, 6, 7}, 3, []byte{1, 2, 3, 4, 5, 6, 7}},
+
+		// input size 0
+		{[]byte{}, 8, []byte{0, 0, 0, 0, 0, 0, 0, 0}},
+		{[]byte{}, 0, []byte{}},
+	}
+
+	for _, test := range tests {
+		result := leftPad(test.input, test.size)
+		assert.True(t, reflect.DeepEqual(result, test.expected))
+	}
 }


### PR DESCRIPTION
## Overview

A unit test for `leftPad` was missing, which is added in this PR.

## Checklist
- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
