### PR TITLE
doc: fix incorrect usage of `MaxBytes`

### DIFF
--- a/docs/architecture/adr-021-restricted-block-size.md
+++ b/docs/architecture/adr-021-restricted-block-size.md
@@ -17,7 +17,7 @@ will determine what the protocol considers to be a valid block size.
 | Parameter        | Size   | Unit   | Description  | Value Control |
 |------------------|--------|--------|--------------|---------------|
 | `MaxBlockSizeBytes` | 100 | MiB | Maximum total size of the protobuf encoded block, a hard coded constant acting as a cap for `MaxBytes`. | Hard coded |
-| `MaxBytes`     |  21 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
+| `MaxBytes`     |  21 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBlockSizeBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
 | `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Hard coded |
 
 Using the currently set/default values, `MaxSquareSize` is limiting the block
@@ -78,7 +78,7 @@ Option 2: Introduce a new parameter, `GovMaxSquareSize`. After implemented, the 
 | Parameter        | Size   | Unit   | Description  | Value Control |
 |------------------|--------|--------|--------------|---------------|
 | `MaxBlockSizeBytes` | 100 | MiB | Maximum total size of the protobuf encoded block, a hard coded constant acting as a cap for `MaxBytes`. | Hard coded |
-| `MaxBytes`     |  ~1.8 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
+| `MaxBytes`     |  ~1.8 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBlockSizeBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
 | `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Hard coded |
 | `GovMaxSquareSize`     |  ~1.8 | MiB | Governance modifiable parameter that determines valid square sizes. Must be smaller than the `MaxSquareSize`. Default set to 64. | Modifiable |
 


### PR DESCRIPTION
Fix a small issue in ADR-021. I don't think these lines meant to use `MaxBytes` b/c there is a separate field `MaxBlockSizeBytes` that acts as an upper bound for `MaxBytes`.
