### PR TITLE
fix: pass all the app config arguments to the app constructor

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -271,7 +271,6 @@ func NewAppServer(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts se
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(server.FlagHaltTime))),
-		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetInterBlockCache(cache),
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),

--- a/x/upgrade/test/integration_test.go
+++ b/x/upgrade/test/integration_test.go
@@ -73,7 +73,7 @@ func (s *UpgradeTestSuite) SetupSuite() {
 	// replace the default genesis state with the modified one
 	genState[gov.AppModuleBasic{}.Name()] = s.ecfg.Codec.MustMarshalJSON(gdgs)
 
-	tmNode, capp, cctx, err := testnode.New(t, testnode.DefaultParams(), tmCfg, false, genState, kr, tmrand.Str(6))
+	tmNode, capp, cctx, err := testnode.New(t, testnode.DefaultParams(), tmCfg, testnode.DefaultAppConfig(), false, genState, kr, tmrand.Str(6))
 	require.NoError(t, err)
 
 	cctx, stopNode, err := testnode.StartNode(tmNode, cctx)


### PR DESCRIPTION
This is merely a bandaid fix over a much larger problem which is the incongruence with how nodes are constructed and run. 

Previously options set in the app config weren't being passed to the constructor. This PR fixes it