### PR TITLE
fix: stop running the malicious integration test during short mode

### DIFF
--- a/test/util/malicious/app_test.go
+++ b/test/util/malicious/app_test.go
@@ -68,6 +68,9 @@ func TestOutOfOrderNMT(t *testing.T) {
 // TestMaliciousTestNode runs a single validator network using the malicious
 // node. This will begin to produce out of order blocks after block height of 5.
 func TestMaliciousTestNode(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping MaliciousTestNode in short mode.")
+	}
 	accounts := testfactory.RandomAccountNames(5)
 	cfg := OutOfOrderNamespaceConfig(5).
 		WithAccounts(accounts)


### PR DESCRIPTION
## Overview

the testnode is still hitting the race detector #1369, so we aren't running those integration tests with the race detector

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
