### PR TITLE
fix: enable node grpc service in tests

### DIFF
--- a/test/util/testnode/rpc_client.go
+++ b/test/util/testnode/rpc_client.go
@@ -53,6 +53,11 @@ func StartGRPCServer(app srvtypes.Application, appCfg *srvconfig.Config, cctx Co
 	// Add the tendermint queries service in the gRPC router.
 	app.RegisterTendermintService(cctx.Context)
 
+	// Add the node service queries to the grpc router.
+	if a, ok := app.(srvtypes.ApplicationQueryService); ok {
+		a.RegisterNodeService(cctx.Context)
+	}
+
 	grpcSrv, err := srvgrpc.StartGRPCServer(cctx.Context, app, appCfg.GRPC)
 	if err != nil {
 		return Context{}, emptycleanup, err


### PR DESCRIPTION
This was missed in https://github.com/celestiaorg/celestia-app/pull/2122 since app construction is different in tests than via the binary