### PR TITLE
refactor!: remove builder return param from init

### DIFF
--- a/pkg/shares/padding.go
+++ b/pkg/shares/padding.go
@@ -14,8 +14,7 @@ import (
 // provided should be the namespace and shareVersion of the blob that precedes
 // this padding in the data square.
 func NamespacePaddingShare(ns appns.Namespace, shareVersion uint8) (Share, error) {
-	b := NewBuilder(ns, shareVersion, true)
-	err := b.Init()
+	b, err := NewBuilder(ns, shareVersion, true)
 	if err != nil {
 		return Share{}, err
 	}

--- a/pkg/shares/padding.go
+++ b/pkg/shares/padding.go
@@ -14,7 +14,8 @@ import (
 // provided should be the namespace and shareVersion of the blob that precedes
 // this padding in the data square.
 func NamespacePaddingShare(ns appns.Namespace, shareVersion uint8) (Share, error) {
-	b, err := NewBuilder(ns, shareVersion, true).Init()
+	b := NewBuilder(ns, shareVersion, true)
+	err := b.Init()
 	if err != nil {
 		return Share{}, err
 	}

--- a/pkg/shares/share_builder.go
+++ b/pkg/shares/share_builder.go
@@ -22,19 +22,23 @@ func NewEmptyBuilder() *Builder {
 	}
 }
 
-// NewBuilder returns a new share builder. Init() needs to be called right after
-// this method.
-func NewBuilder(ns appns.Namespace, shareVersion uint8, isFirstShare bool) *Builder {
-	return &Builder{
+// NewBuilder returns a new share builder.
+func NewBuilder(ns appns.Namespace, shareVersion uint8, isFirstShare bool) (*Builder, error) {
+	b := Builder{
 		namespace:      ns,
 		shareVersion:   shareVersion,
 		isFirstShare:   isFirstShare,
 		isCompactShare: isCompactShare(ns),
 	}
+	err := b.init()
+	if err != nil {
+		return nil, err
+	}
+	return &b, nil
 }
 
-// Init initializes the share builder. It should be called right after NewBuilder.
-func (b *Builder) Init() error {
+// init initializes the share builder by populating rawShareData.
+func (b *Builder) init() error {
 	if b.isCompactShare {
 		return b.prepareCompactShare()
 	}

--- a/pkg/shares/share_builder.go
+++ b/pkg/shares/share_builder.go
@@ -22,7 +22,8 @@ func NewEmptyBuilder() *Builder {
 	}
 }
 
-// Init() needs to be called right after this method
+// NewBuilder returns a new share builder. Init() needs to be called right after
+// this method.
 func NewBuilder(ns appns.Namespace, shareVersion uint8, isFirstShare bool) *Builder {
 	return &Builder{
 		namespace:      ns,
@@ -32,18 +33,12 @@ func NewBuilder(ns appns.Namespace, shareVersion uint8, isFirstShare bool) *Buil
 	}
 }
 
-func (b *Builder) Init() (*Builder, error) {
+// Init initializes the share builder. It should be called right after NewBuilder.
+func (b *Builder) Init() error {
 	if b.isCompactShare {
-		if err := b.prepareCompactShare(); err != nil {
-			return nil, err
-		}
-	} else {
-		if err := b.prepareSparseShare(); err != nil {
-			return nil, err
-		}
+		return b.prepareCompactShare()
 	}
-
-	return b, nil
+	return b.prepareSparseShare()
 }
 
 func (b *Builder) AvailableBytes() int {

--- a/pkg/shares/share_builder.go
+++ b/pkg/shares/share_builder.go
@@ -30,8 +30,7 @@ func NewBuilder(ns appns.Namespace, shareVersion uint8, isFirstShare bool) (*Bui
 		isFirstShare:   isFirstShare,
 		isCompactShare: isCompactShare(ns),
 	}
-	err := b.init()
-	if err != nil {
+	if err := b.init(); err != nil {
 		return nil, err
 	}
 	return &b, nil

--- a/pkg/shares/share_builder_test.go
+++ b/pkg/shares/share_builder_test.go
@@ -23,49 +23,49 @@ func TestShareBuilderIsEmptyShare(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:    "first compact share empty",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, true),
 			data:    nil,
 			want:    true,
 		},
 		{
 			name:    "first compact share not empty",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, true),
 			data:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			want:    false,
 		},
 		{
 			name:    "first sparse share empty",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, true),
 			data:    nil,
 			want:    true,
 		},
 		{
 			name:    "first sparse share not empty",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, true),
 			data:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			want:    false,
 		},
 		{
 			name:    "continues compact share empty",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, false),
 			data:    nil,
 			want:    true,
 		},
 		{
 			name:    "continues compact share not empty",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, false),
 			data:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			want:    false,
 		},
 		{
 			name:    "continues sparse share not empty",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, false),
 			data:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			want:    false,
 		},
 		{
 			name:    "continues sparse share empty",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, false),
 			data:    nil,
 			want:    true,
 		},
@@ -73,8 +73,6 @@ func TestShareBuilderIsEmptyShare(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.builder.Init()
-			require.NoError(t, err)
 			tc.builder.AddData(tc.data)
 			assert.Equal(t, tc.want, tc.builder.IsEmptyShare())
 		})
@@ -93,31 +91,31 @@ func TestShareBuilderWriteSequenceLen(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:    "first share",
-			builder: NewBuilder(ns1, 1, true),
+			builder: mustNewBuilder(t, ns1, 1, true),
 			wantLen: 10,
 			wantErr: false,
 		},
 		{
 			name:    "first share with long sequence",
-			builder: NewBuilder(ns1, 1, true),
+			builder: mustNewBuilder(t, ns1, 1, true),
 			wantLen: 323,
 			wantErr: false,
 		},
 		{
 			name:    "continuation sparse share",
-			builder: NewBuilder(ns1, 1, false),
+			builder: mustNewBuilder(t, ns1, 1, false),
 			wantLen: 10,
 			wantErr: true,
 		},
 		{
 			name:    "compact share",
-			builder: NewBuilder(appns.TxNamespace, 1, true),
+			builder: mustNewBuilder(t, appns.TxNamespace, 1, true),
 			wantLen: 10,
 			wantErr: false,
 		},
 		{
 			name:    "continuation compact share",
-			builder: NewBuilder(ns1, 1, false),
+			builder: mustNewBuilder(t, ns1, 1, false),
 			wantLen: 10,
 			wantErr: true,
 		},
@@ -131,8 +129,6 @@ func TestShareBuilderWriteSequenceLen(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.builder.Init()
-			require.NoError(t, err)
 			if err := tc.builder.WriteSequenceLen(tc.wantLen); tc.wantErr {
 				assert.Error(t, err)
 				return
@@ -162,55 +158,55 @@ func TestShareBuilderAddData(t *testing.T) {
 	testCases := []testCase{
 		{
 			name:    "small share",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, true),
 			data:    []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
 			want:    nil,
 		},
 		{
 			name:    "exact fit first compact share",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, true),
 			data:    bytes.Repeat([]byte{1}, appconsts.ShareSize-appconsts.NamespaceSize-appconsts.ShareInfoBytes-appconsts.CompactShareReservedBytes-appconsts.SequenceLenBytes),
 			want:    nil,
 		},
 		{
 			name:    "exact fit first sparse share",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, true),
 			data:    bytes.Repeat([]byte{1}, appconsts.ShareSize-appconsts.NamespaceSize-appconsts.SequenceLenBytes-1 /*1 = info byte*/),
 			want:    nil,
 		},
 		{
 			name:    "exact fit continues compact share",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, false),
 			data:    bytes.Repeat([]byte{1}, appconsts.ShareSize-appconsts.NamespaceSize-appconsts.CompactShareReservedBytes-1 /*1 = info byte*/),
 			want:    nil,
 		},
 		{
 			name:    "exact fit continues sparse share",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, false),
 			data:    bytes.Repeat([]byte{1}, appconsts.ShareSize-appconsts.NamespaceSize-1 /*1 = info byte*/),
 			want:    nil,
 		},
 		{
 			name:    "oversize first compact share",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, true),
 			data:    bytes.Repeat([]byte{1}, 1 /*1 extra byte*/ +appconsts.ShareSize-appconsts.NamespaceSize-appconsts.CompactShareReservedBytes-appconsts.SequenceLenBytes-1 /*1 = info byte*/),
 			want:    []byte{1},
 		},
 		{
 			name:    "oversize first sparse share",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, true),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, true),
 			data:    bytes.Repeat([]byte{1}, 1 /*1 extra byte*/ +appconsts.ShareSize-appconsts.NamespaceSize-appconsts.SequenceLenBytes-1 /*1 = info byte*/),
 			want:    []byte{1},
 		},
 		{
 			name:    "oversize continues compact share",
-			builder: NewBuilder(appns.TxNamespace, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, appns.TxNamespace, appconsts.ShareVersionZero, false),
 			data:    bytes.Repeat([]byte{1}, 1 /*1 extra byte*/ +appconsts.ShareSize-appconsts.NamespaceSize-appconsts.CompactShareReservedBytes-1 /*1 = info byte*/),
 			want:    []byte{1},
 		},
 		{
 			name:    "oversize continues sparse share",
-			builder: NewBuilder(ns1, appconsts.ShareVersionZero, false),
+			builder: mustNewBuilder(t, ns1, appconsts.ShareVersionZero, false),
 			data:    bytes.Repeat([]byte{1}, 1 /*1 extra byte*/ +appconsts.ShareSize-appconsts.NamespaceSize-1 /*1 = info byte*/),
 			want:    []byte{1},
 		},
@@ -218,9 +214,6 @@ func TestShareBuilderAddData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := tc.builder.Init()
-			require.NoError(t, err)
-
 			got := tc.builder.AddData(tc.data)
 			assert.Equal(t, tc.want, got)
 		})
@@ -317,4 +310,11 @@ func TestShareBuilderImportRawData(t *testing.T) {
 			}
 		})
 	}
+}
+
+// mustmustNewBuilder returns a new builder with the given parameters. It fails the test if an error is encountered.
+func mustNewBuilder(t *testing.T, ns appns.Namespace, shareVersion uint8, isFirstShare bool) *Builder {
+	b, err := NewBuilder(ns, shareVersion, isFirstShare)
+	require.NoError(t, err)
+	return b
 }

--- a/pkg/shares/share_builder_test.go
+++ b/pkg/shares/share_builder_test.go
@@ -73,7 +73,7 @@ func TestShareBuilderIsEmptyShare(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.builder.Init()
+			err := tc.builder.Init()
 			require.NoError(t, err)
 			tc.builder.AddData(tc.data)
 			assert.Equal(t, tc.want, tc.builder.IsEmptyShare())
@@ -131,7 +131,7 @@ func TestShareBuilderWriteSequenceLen(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.builder.Init()
+			err := tc.builder.Init()
 			require.NoError(t, err)
 			if err := tc.builder.WriteSequenceLen(tc.wantLen); tc.wantErr {
 				assert.Error(t, err)
@@ -218,7 +218,7 @@ func TestShareBuilderAddData(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, err := tc.builder.Init()
+			err := tc.builder.Init()
 			require.NoError(t, err)
 
 			got := tc.builder.AddData(tc.data)

--- a/pkg/shares/share_builder_test.go
+++ b/pkg/shares/share_builder_test.go
@@ -312,7 +312,7 @@ func TestShareBuilderImportRawData(t *testing.T) {
 	}
 }
 
-// mustmustNewBuilder returns a new builder with the given parameters. It fails the test if an error is encountered.
+// mustNewBuilder returns a new builder with the given parameters. It fails the test if an error is encountered.
 func mustNewBuilder(t *testing.T, ns appns.Namespace, shareVersion uint8, isFirstShare bool) *Builder {
 	b, err := NewBuilder(ns, shareVersion, isFirstShare)
 	require.NoError(t, err)

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -29,7 +29,8 @@ type CompactShareSplitter struct {
 // NewCompactShareSplitter returns a CompactShareSplitter using the provided
 // namespace and shareVersion.
 func NewCompactShareSplitter(ns appns.Namespace, shareVersion uint8) *CompactShareSplitter {
-	sb, err := NewBuilder(ns, shareVersion, true).Init()
+	sb := NewBuilder(ns, shareVersion, true)
+	err := sb.Init()
 	if err != nil {
 		panic(err)
 	}
@@ -105,7 +106,8 @@ func (css *CompactShareSplitter) stackPending() error {
 	css.shares = append(css.shares, *pendingShare)
 
 	// Now we need to create a new builder
-	css.shareBuilder, err = NewBuilder(css.namespace, css.shareVersion, false).Init()
+	css.shareBuilder = NewBuilder(css.namespace, css.shareVersion, false)
+	css.shareBuilder.Init()
 	return err
 }
 
@@ -163,7 +165,8 @@ func (css *CompactShareSplitter) writeSequenceLen(sequenceLen uint32) error {
 	}
 
 	// We may find a more efficient way to write seqLen
-	b, err := NewBuilder(css.namespace, css.shareVersion, true).Init()
+	b := NewBuilder(css.namespace, css.shareVersion, true)
+	err := b.Init()
 	if err != nil {
 		return err
 	}

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -29,8 +29,7 @@ type CompactShareSplitter struct {
 // NewCompactShareSplitter returns a CompactShareSplitter using the provided
 // namespace and shareVersion.
 func NewCompactShareSplitter(ns appns.Namespace, shareVersion uint8) *CompactShareSplitter {
-	sb := NewBuilder(ns, shareVersion, true)
-	err := sb.Init()
+	sb, err := NewBuilder(ns, shareVersion, true)
 	if err != nil {
 		panic(err)
 	}
@@ -106,8 +105,7 @@ func (css *CompactShareSplitter) stackPending() error {
 	css.shares = append(css.shares, *pendingShare)
 
 	// Now we need to create a new builder
-	css.shareBuilder = NewBuilder(css.namespace, css.shareVersion, false)
-	err = css.shareBuilder.Init()
+	css.shareBuilder, err = NewBuilder(css.namespace, css.shareVersion, false)
 	return err
 }
 
@@ -165,8 +163,7 @@ func (css *CompactShareSplitter) writeSequenceLen(sequenceLen uint32) error {
 	}
 
 	// We may find a more efficient way to write seqLen
-	b := NewBuilder(css.namespace, css.shareVersion, true)
-	err := b.Init()
+	b, err := NewBuilder(css.namespace, css.shareVersion, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/shares/split_compact_shares.go
+++ b/pkg/shares/split_compact_shares.go
@@ -107,7 +107,7 @@ func (css *CompactShareSplitter) stackPending() error {
 
 	// Now we need to create a new builder
 	css.shareBuilder = NewBuilder(css.namespace, css.shareVersion, false)
-	css.shareBuilder.Init()
+	err = css.shareBuilder.Init()
 	return err
 }
 

--- a/pkg/shares/split_sparse_shares.go
+++ b/pkg/shares/split_sparse_shares.go
@@ -35,7 +35,8 @@ func (sss *SparseShareSplitter) Write(blob coretypes.Blob) error {
 	}
 
 	// First share
-	b, err := NewBuilder(blobNamespace, blob.ShareVersion, true).Init()
+	b := NewBuilder(blobNamespace, blob.ShareVersion, true)
+	err = b.Init()
 	if err != nil {
 		return err
 	}
@@ -57,7 +58,8 @@ func (sss *SparseShareSplitter) Write(blob coretypes.Blob) error {
 		}
 		sss.shares = append(sss.shares, *share)
 
-		b, err = NewBuilder(blobNamespace, blob.ShareVersion, false).Init()
+		b = NewBuilder(blobNamespace, blob.ShareVersion, false)
+		err = b.Init()
 		if err != nil {
 			return err
 		}

--- a/pkg/shares/split_sparse_shares.go
+++ b/pkg/shares/split_sparse_shares.go
@@ -35,8 +35,7 @@ func (sss *SparseShareSplitter) Write(blob coretypes.Blob) error {
 	}
 
 	// First share
-	b := NewBuilder(blobNamespace, blob.ShareVersion, true)
-	err = b.Init()
+	b, err := NewBuilder(blobNamespace, blob.ShareVersion, true)
 	if err != nil {
 		return err
 	}
@@ -58,8 +57,7 @@ func (sss *SparseShareSplitter) Write(blob coretypes.Blob) error {
 		}
 		sss.shares = append(sss.shares, *share)
 
-		b = NewBuilder(blobNamespace, blob.ShareVersion, false)
-		err = b.Init()
+		b, err = NewBuilder(blobNamespace, blob.ShareVersion, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2157

A separate `Init()` function seems kinda like an anti pattern. If it must always be called after `NewBuilder`, why doesn't `NewBuilder` call it? @mojtaba-esk 