### PR TITLE
docs: clarify that `MaxSquareSize` is a versioned constant

### DIFF
--- a/docs/architecture/adr-021-restricted-block-size.md
+++ b/docs/architecture/adr-021-restricted-block-size.md
@@ -18,7 +18,7 @@ will determine what the protocol considers to be a valid block size.
 |------------------|--------|--------|--------------|---------------|
 | `MaxBlockSizeBytes` | 100 | MiB | Maximum total size of the protobuf encoded block, a hard coded constant acting as a cap for `MaxBytes`. | Hard coded |
 | `MaxBytes`     |  21 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBlockSizeBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
-| `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Hard coded |
+| `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Modifiable (versioned constant) |
 
 Using the currently set/default values, `MaxSquareSize` is limiting the block
 size because it is the smallest value in terms of bytes. However if the
@@ -79,7 +79,7 @@ Option 2: Introduce a new parameter, `GovMaxSquareSize`. After implemented, the 
 |------------------|--------|--------|--------------|---------------|
 | `MaxBlockSizeBytes` | 100 | MiB | Maximum total size of the protobuf encoded block, a hard coded constant acting as a cap for `MaxBytes`. | Hard coded |
 | `MaxBytes`     |  ~1.8 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBlockSizeBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
-| `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Modifiable(Versioned constant) |
+| `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Modifiable (versioned constant) |
 | `GovMaxSquareSize`     |  ~1.8 | MiB | Governance modifiable parameter that determines valid square sizes. Must be smaller than the `MaxSquareSize`. Default set to 64. | Modifiable |
 
 ## Detailed Design

--- a/docs/architecture/adr-021-restricted-block-size.md
+++ b/docs/architecture/adr-021-restricted-block-size.md
@@ -79,7 +79,7 @@ Option 2: Introduce a new parameter, `GovMaxSquareSize`. After implemented, the 
 |------------------|--------|--------|--------------|---------------|
 | `MaxBlockSizeBytes` | 100 | MiB | Maximum total size of the protobuf encoded block, a hard coded constant acting as a cap for `MaxBytes`. | Hard coded |
 | `MaxBytes`     |  ~1.8 | MiB | Determines the valid size of the entire protobuf encoded block. Is a governance modifiable parameter and is capped by `MaxBlockSizeBytes`. Used to regulate the amount of data gossiped in the consensus portion of the network (using the current block gossiping mechanism). | Modifiable |
-| `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Hard coded |
+| `MaxSquareSize` | ~7.5 | MiB | Determines the maximum size of the original data square. Used to regulate storage requirements for celestia-node, and the size of the data availability header. Default set to 128. | Modifiable(Versioned constant) |
 | `GovMaxSquareSize`     |  ~1.8 | MiB | Governance modifiable parameter that determines valid square sizes. Must be smaller than the `MaxSquareSize`. Default set to 64. | Modifiable |
 
 ## Detailed Design


### PR DESCRIPTION
Closes #2186 