### PR TITLE
fix: end exclusive parse namespace end share range

### DIFF
--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -225,12 +225,11 @@ func TestNewShareInclusionProof(t *testing.T) {
 // TestAllSharesInclusionProof creates proof for all the shares in a block.
 // Since we can't prove multiple namespaces at the moment, the block will contain all the shares with the same namespace.
 func TestAllSharesInclusionProof(t *testing.T) {
-	txs := testfactory.GenerateRandomTxs(64, 500)
+	txs := testfactory.GenerateRandomTxs(243, 500)
 
-	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.LatestVersion, appconsts.SquareSizeUpperBound(appconsts.LatestVersion))
-	if err != nil {
-		panic(err)
-	}
+	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.LatestVersion, 128)
+	require.NoError(t, err)
+	assert.Equal(t, 256, len(dataSquare))
 
 	// erasure the data square which we use to create the data root.
 	eds, err := da.ExtendShares(shares.ToBytes(dataSquare))
@@ -242,13 +241,13 @@ func TestAllSharesInclusionProof(t *testing.T) {
 	require.NoError(t, err)
 	dataRoot := dah.Hash()
 
-	actualNID, err := proof.ParseNamespace(dataSquare, 0, 64)
+	actualNID, err := proof.ParseNamespace(dataSquare, 0, 256)
 	require.NoError(t, err)
 	require.Equal(t, appns.TxNamespace, actualNID)
 	proof, err := proof.NewShareInclusionProof(
 		dataSquare,
 		appns.TxNamespace,
-		shares.NewRange(0, 64),
+		shares.NewRange(0, 256),
 	)
 	require.NoError(t, err)
 	assert.NoError(t, proof.Validate(dataRoot))

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -222,8 +222,9 @@ func TestNewShareInclusionProof(t *testing.T) {
 	}
 }
 
-// TestAllSharesInclusionProof creates proof for all the shares in a block.
-// Since we can't prove multiple namespaces at the moment, the block will contain all the shares with the same namespace.
+// TestAllSharesInclusionProof creates a proof for all shares in the data
+// square. Since we can't prove multiple namespaces at the moment, all the
+// shares use the same namespace.
 func TestAllSharesInclusionProof(t *testing.T) {
 	txs := testfactory.GenerateRandomTxs(243, 500)
 

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -241,9 +241,9 @@ func TestAllSharesInclusionProof(t *testing.T) {
 	require.NoError(t, err)
 	dataRoot := dah.Hash()
 
-	actualNID, err := proof.ParseNamespace(dataSquare, 0, 256)
+	actualNamespace, err := proof.ParseNamespace(dataSquare, 0, 256)
 	require.NoError(t, err)
-	require.Equal(t, appns.TxNamespace, actualNID)
+	require.Equal(t, appns.TxNamespace, actualNamespace)
 	proof, err := proof.NewShareInclusionProof(
 		dataSquare,
 		appns.TxNamespace,

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -133,7 +133,7 @@ func ParseNamespace(rawShares []shares.Share, startShare, endShare int) (appns.N
 		return appns.Namespace{}, fmt.Errorf("end share %d cannot be lower than starting share %d", endShare, startShare)
 	}
 
-	if endShare >= len(rawShares) {
+	if endShare > len(rawShares) {
 		return appns.Namespace{}, fmt.Errorf("end share %d is higher than block shares %d", endShare, len(rawShares))
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fixes the range to support end exclusive share ranges 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
