### PR TITLE
fix: round up when calculating fee in txsim

### DIFF
--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -3,6 +3,7 @@ package txsim
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 
@@ -183,9 +184,9 @@ func (am *AccountManager) Submit(ctx context.Context, op Operation) error {
 	} else {
 		builder.SetGasLimit(op.GasLimit)
 		if op.GasPrice > 0 {
-			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(float64(op.GasLimit)*op.GasPrice))))
+			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(math.Ceil(float64(op.GasLimit)*op.GasPrice)))))
 		} else {
-			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(float64(op.GasLimit)*appconsts.DefaultMinGasPrice))))
+			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(math.Ceil(float64(op.GasLimit)*appconsts.DefaultMinGasPrice)))))
 		}
 	}
 


### PR DESCRIPTION
## Overview

this is a quick bug fix that rounds up when calculating fees in txsim. Without doing this, the fees used are too low by a single utia

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
