### PR TITLE
chore: move BondDenom to appconsts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -86,6 +86,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/app/ante"
 	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/pkg/proof"
 	blobmodule "github.com/celestiaorg/celestia-app/x/blob"
 	blobmodulekeeper "github.com/celestiaorg/celestia-app/x/blob/keeper"
@@ -104,7 +105,7 @@ const (
 	AccountAddressPrefix = "celestia"
 	Name                 = "celestia-app"
 	// BondDenom defines the native staking token denomination.
-	BondDenom = "utia"
+	BondDenom = appconsts.BondDenom
 	// BondDenomAlias defines an alias for BondDenom.
 	BondDenomAlias = "microtia"
 	// DisplayDenom defines the name, symbol, and display value of the Celestia token.

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -180,7 +180,7 @@ func (s *SquareSizeIntegrationTest) setBlockSizeParams(t *testing.T, squareSize,
 	msg, err := oldgov.NewMsgSubmitProposal(
 		content,
 		sdk.NewCoins(
-			sdk.NewCoin(app.BondDenom, sdk.NewInt(1000000000))),
+			sdk.NewCoin(appconsts.BondDenom, sdk.NewInt(1000000000))),
 		addr,
 	)
 	require.NoError(t, err)

--- a/pkg/appconsts/global_consts.go
+++ b/pkg/appconsts/global_consts.go
@@ -71,6 +71,9 @@ const (
 
 	// MaxShareVersion is the maximum value a share version can be.
 	MaxShareVersion = 127
+
+	// BondDenom defines the native staking denomination
+	BondDenom = "utia"
 )
 
 var (

--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
@@ -180,13 +179,13 @@ func (am *AccountManager) Submit(ctx context.Context, op Operation) error {
 
 	if op.GasLimit == 0 {
 		builder.SetGasLimit(DefaultGasLimit)
-		builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(defaultFee))))
+		builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(appconsts.BondDenom, int64(defaultFee))))
 	} else {
 		builder.SetGasLimit(op.GasLimit)
 		if op.GasPrice > 0 {
-			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(math.Ceil(float64(op.GasLimit)*op.GasPrice)))))
+			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(appconsts.BondDenom, int64(math.Ceil(float64(op.GasLimit)*op.GasPrice)))))
 		} else {
-			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(math.Ceil(float64(op.GasLimit)*appconsts.DefaultMinGasPrice)))))
+			builder.SetFeeAmount(types.NewCoins(types.NewInt64Coin(appconsts.BondDenom, int64(math.Ceil(float64(op.GasLimit)*appconsts.DefaultMinGasPrice)))))
 		}
 	}
 
@@ -235,7 +234,7 @@ func (am *AccountManager) GenerateAccounts(ctx context.Context) error {
 			return fmt.Errorf("master account has insufficient funds")
 		}
 
-		bankMsg := bank.NewMsgSend(am.masterAccount.Address, acc.Address, types.NewCoins(types.NewInt64Coin(app.BondDenom, acc.Balance)))
+		bankMsg := bank.NewMsgSend(am.masterAccount.Address, acc.Address, types.NewCoins(types.NewInt64Coin(appconsts.BondDenom, acc.Balance)))
 		msgs = append(msgs, bankMsg)
 	}
 
@@ -388,7 +387,7 @@ func (am *AccountManager) updateAccount(ctx context.Context, account *Account) e
 func (am *AccountManager) getBalance(ctx context.Context, address types.AccAddress) (int64, error) {
 	balanceResp, err := am.query.Bank().Balance(ctx, &bank.QueryBalanceRequest{
 		Address: address.String(),
-		Denom:   app.BondDenom,
+		Denom:   appconsts.BondDenom,
 	})
 	if err != nil {
 		return 0, fmt.Errorf("error getting balance for %s: %w", address.String(), err)

--- a/test/txsim/send.go
+++ b/test/txsim/send.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"math/rand"
 
-	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -60,7 +59,7 @@ func (s *SendSequence) Next(_ context.Context, _ grpc.ClientConn, rand *rand.Ran
 	}
 	op := Operation{
 		Msgs: []types.Msg{
-			bank.NewMsgSend(s.accounts[s.index%s.numAccounts], s.accounts[(s.index+1)%s.numAccounts], types.NewCoins(types.NewInt64Coin(app.BondDenom, int64(s.sendAmount)))),
+			bank.NewMsgSend(s.accounts[s.index%s.numAccounts], s.accounts[(s.index+1)%s.numAccounts], types.NewCoins(types.NewInt64Coin(appconsts.BondDenom, int64(s.sendAmount)))),
 		},
 		Delay:    rand.Int63n(int64(s.maxHeightDelay)),
 		GasLimit: SendGasLimit,

--- a/test/txsim/stake.go
+++ b/test/txsim/stake.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"math/rand"
 
-	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/cosmos/cosmos-sdk/types"
 	distribution "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -57,7 +57,7 @@ func (s *StakeSequence) Next(ctx context.Context, querier grpc.ClientConn, rand 
 				&staking.MsgDelegate{
 					DelegatorAddress: s.account.String(),
 					ValidatorAddress: s.delegatedTo,
-					Amount:           types.NewInt64Coin(app.BondDenom, int64(s.initialStake)),
+					Amount:           types.NewInt64Coin(appconsts.BondDenom, int64(s.initialStake)),
 				},
 			},
 		}, nil
@@ -77,7 +77,7 @@ func (s *StakeSequence) Next(ctx context.Context, querier grpc.ClientConn, rand 
 						ValidatorSrcAddress: s.delegatedTo,
 						ValidatorDstAddress: val.OperatorAddress,
 						// NOTE: only the initial stake is redelgated (not the entire balance)
-						Amount: types.NewInt64Coin(app.BondDenom, int64(s.initialStake)),
+						Amount: types.NewInt64Coin(appconsts.BondDenom, int64(s.initialStake)),
 					},
 				},
 			}

--- a/test/util/blobfactory/payforblob_factory.go
+++ b/test/util/blobfactory/payforblob_factory.go
@@ -99,7 +99,7 @@ func RandBlobTxsRandomlySized(enc sdk.TxEncoder, rand *tmrand.Rand, count, maxSi
 	}
 
 	coin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(10),
 	}
 
@@ -155,7 +155,7 @@ func RandBlobTxsWithAccounts(
 	accounts []string,
 ) []coretypes.Tx {
 	coin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(10),
 	}
 
@@ -229,7 +229,7 @@ func RandBlobTxs(enc sdk.TxEncoder, rand *tmrand.Rand, count, blobsPerTx, size i
 	}
 
 	coin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(10),
 	}
 
@@ -359,7 +359,7 @@ func MultiBlobTx(
 	require.NoError(t, err)
 
 	coin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(10),
 	}
 	msg, err := blobtypes.NewMsgPayForBlobs(addr.String(), blobs...)
@@ -401,7 +401,7 @@ func IndexWrappedTxWithInvalidNamespace(
 	require.NoError(t, err)
 
 	coin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(10),
 	}
 	opts := []blobtypes.TxBuilderOption{
@@ -443,7 +443,7 @@ func RandBlobTxsWithNamespacesAndSigner(
 	}
 
 	coin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(10),
 	}
 
@@ -482,7 +482,7 @@ func ComplexBlobTxWithOtherMsgs(t *testing.T, rand *tmrand.Rand, kr keyring.Keyr
 	pfb, blobs := RandMsgPayForBlobsWithSigner(rand, signerAddr.String(), 100, 1)
 
 	opts := []blobtypes.TxBuilderOption{
-		blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(bondDenom, sdk.NewInt(10)))),
+		blobtypes.SetFeeAmount(sdk.NewCoins(sdk.NewCoin(appconsts.BondDenom, sdk.NewInt(10)))),
 		blobtypes.SetGasLimit(100000000000000),
 	}
 

--- a/test/util/blobfactory/test_util.go
+++ b/test/util/blobfactory/test_util.go
@@ -1,6 +1,7 @@
 package blobfactory
 
 import (
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/util/testfactory"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -8,12 +9,6 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
 	coretypes "github.com/tendermint/tendermint/types"
-)
-
-const (
-	// bondDenom should match app.BondDenom. We copy it here so that we don't
-	// have to import the application, causing an import cycle
-	bondDenom = "utia"
 )
 
 func GenerateManyRawSendTxs(txConfig client.TxConfig, count int) []coretypes.Tx {
@@ -33,7 +28,7 @@ func GenerateManyRawSendTxs(txConfig client.TxConfig, count int) []coretypes.Tx 
 // the same account signing the transaction.
 func GenerateRawSendTx(txConfig client.TxConfig, signer *blobtypes.KeyringSigner, amount int64) (rawTx []byte) {
 	feeCoin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(1),
 	}
 
@@ -43,7 +38,7 @@ func GenerateRawSendTx(txConfig client.TxConfig, signer *blobtypes.KeyringSigner
 	}
 
 	amountCoin := sdk.Coin{
-		Denom:  bondDenom,
+		Denom:  appconsts.BondDenom,
 		Amount: sdk.NewInt(amount),
 	}
 


### PR DESCRIPTION
This moves BondDemon to the appconsts package. This is a commonly used constant especially for clients submitting messages. They shouldn't need to import the entire app package just to use this constant. By doing this we also remove a duplicate bondDenom that was created to avoid import cycles