### PR TITLE
fix: TestLegacyGovUpgradeFailure flakiness

### DIFF
--- a/x/upgrade/test/integration_test.go
+++ b/x/upgrade/test/integration_test.go
@@ -112,10 +112,9 @@ func (s *UpgradeTestSuite) TestLegacyGovUpgradeFailure() {
 	res, err := testnode.SignAndBroadcastTx(s.ecfg, s.cctx.Context, acc, msg)
 	require.NoError(t, err)
 	require.Equal(t, abci.CodeTypeOK, res.Code) // we're only submitting the tx, so we expect everything to work
-	require.NoError(t, s.cctx.WaitForNextBlock())
 
 	// compare the result after the tx has been executed.
-	finalResult, err := testnode.QueryTx(s.cctx.Context, res.TxHash, false)
+	finalResult, err := s.cctx.WaitForTx(res.TxHash, 100)
 	require.NoError(t, err)
 	require.NotNil(t, finalResult)
 	assert.Contains(t, finalResult.TxResult.Log, "no handler exists for proposal type")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This fixes the flakiness of the upgrade test sometimes perceived in CI and also locally.

The CI might fail if https://github.com/celestiaorg/celestia-app/pull/2251 is still not merged.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
