### PR TITLE
test: skip TestMaxTotalBlobSizeSuite during test-race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ test-race:
 # TODO: Remove the -skip flag once the following tests no longer contain data races.
 # https://github.com/celestiaorg/celestia-app/issues/1369
 	@echo "--> Running tests in race mode"
-	@go test -mod=readonly ./... -v -race -skip "TestPrepareProposalConsistency|TestIntegrationTestSuite|TestQGBRPCQueries|TestSquareSizeIntegrationTest|TestStandardSDKIntegrationTestSuite|TestTxsimCommandFlags|TestTxsimCommandEnvVar|TestMintIntegrationTestSuite|TestQGBCLI|TestUpgrade|TestMaliciousTestNode|TestVestingModule"
+	@go test -mod=readonly ./... -v -race -skip "TestPrepareProposalConsistency|TestIntegrationTestSuite|TestQGBRPCQueries|TestSquareSizeIntegrationTest|TestStandardSDKIntegrationTestSuite|TestTxsimCommandFlags|TestTxsimCommandEnvVar|TestMintIntegrationTestSuite|TestQGBCLI|TestUpgrade|TestMaliciousTestNode|TestVestingModule|TestMaxTotalBlobSizeSuite"
 .PHONY: test-race
 
 ## test-bench: Run unit tests in bench mode.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2276

Note: doesn't need to be backported to v1.x because v1.x skips tests via `-short`
https://github.com/celestiaorg/celestia-app/blob/53b5dbf2438a085ded2952a0250829213eb77f55/Makefile#L114-L118