### PR TITLE
chore!: bump sdk fork to v1.17.0

### DIFF
--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"math/big"
 	"sync"
 	"testing"
 
@@ -19,7 +18,6 @@ import (
 	oldgov "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	"github.com/cosmos/cosmos-sdk/x/params/types/proposal"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -132,7 +130,6 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 				account := s.unusedAccount()
 				valopAccAddr := getAddress(account, s.cctx.Keyring)
 				valopAddr := sdk.ValAddress(valopAccAddr)
-				evmAddr := common.BigToAddress(big.NewInt(420))
 				msg, err := stakingtypes.NewMsgCreateValidator(
 					valopAddr,
 					pv.PrivKey.PubKey(),
@@ -140,7 +137,6 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 					stakingtypes.NewDescription("taco tuesday", "my keybase", "www.celestia.org", "ping @celestiaorg on twitter", "fake validator"),
 					stakingtypes.NewCommissionRates(sdk.NewDecWithPrec(6, 0o2), sdk.NewDecWithPrec(12, 0o2), sdk.NewDecWithPrec(1, 0o2)),
 					sdk.NewInt(1000000),
-					evmAddr,
 				)
 				require.NoError(t, err)
 				return []sdk.Msg{msg}, account

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	cosmossdk.io/math v1.0.0-rc.0
 	github.com/celestiaorg/rsmt2d v0.10.0
 	github.com/cosmos/cosmos-proto v1.0.0-alpha8
-	github.com/cosmos/cosmos-sdk v0.46.13
+	github.com/cosmos/cosmos-sdk v0.46.14
 	github.com/cosmos/gogoproto v1.4.10
 	github.com/cosmos/ibc-go/v6 v6.2.0
 	github.com/rs/zerolog v1.30.0
@@ -233,7 +233,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.16.1-sdk-v0.46.13
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.17.0-sdk-v0.46.14
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.26.2-tm-v0.34.28

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,8 @@ github.com/c-bata/go-prompt v0.2.2/go.mod h1:VzqtzE2ksDBcdln8G7mk2RX9QyGjH+OVqOC
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v1.26.2-tm-v0.34.28 h1:2efXQaggLFknz0wQufr4nUEz5G7pSVHS1j7NuJDsvII=
 github.com/celestiaorg/celestia-core v1.26.2-tm-v0.34.28/go.mod h1:++dNzzzjP9jYg+NopN9G8sg1HEZ58lv1TPtg71evZ0E=
-github.com/celestiaorg/cosmos-sdk v1.16.1-sdk-v0.46.13 h1:CxEQDQEQR1ypB+VUmCISIqFVmHfb+mx8x+zh7rHbyU8=
-github.com/celestiaorg/cosmos-sdk v1.16.1-sdk-v0.46.13/go.mod h1:xpBZc/OYZ736hp0IZlBGNUhEgCD9C+bKs8yNLZibyv0=
+github.com/celestiaorg/cosmos-sdk v1.17.0-sdk-v0.46.14 h1:PckXGxLJjXv97VO3xS8NPHN5oO83X5nvJLbc/4s8jUM=
+github.com/celestiaorg/cosmos-sdk v1.17.0-sdk-v0.46.14/go.mod h1:70Go8qNy7YAb1PUcHCChRHNX2ke7c9jgUIEklUX+Mac=
 github.com/celestiaorg/knuu v0.8.2 h1:x63nYTO46j293VkNP7VcRHtYHSize6dM/h7xME2Vgi0=
 github.com/celestiaorg/knuu v0.8.2/go.mod h1:zBrMXhFl7irCPOVJyHS8sBg7K9Hux5dLy9VChA40LTo=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -17,9 +17,7 @@ import (
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	slashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/tendermint/tendermint/config"
-	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/p2p/pex"
 	"github.com/tendermint/tendermint/types"
@@ -61,7 +59,6 @@ func MakeGenesis(nodes []*Node, accounts []*GenesisAccount) (types.GenesisDoc, e
 		if err != nil {
 			return types.GenesisDoc{}, err
 		}
-		evmAddress := common.HexToAddress(crypto.CRandHex(common.AddressLength))
 
 		validators = append(validators, staking.Validator{
 			OperatorAddress: sdk.ValAddress(addr).String(),
@@ -75,7 +72,6 @@ func MakeGenesis(nodes []*Node, accounts []*GenesisAccount) (types.GenesisDoc, e
 			// 5% commission
 			Commission:        staking.NewCommission(sdk.NewDecWithPrec(5, 2), sdk.OneDec(), sdk.OneDec()),
 			MinSelfDelegation: sdk.ZeroInt(),
-			EvmAddress:        evmAddress.Hex(),
 		})
 		totalBonded += node.SelfDelegation
 		consensusAddr := pk.Address()

--- a/test/tokenfilter/setup.go
+++ b/test/tokenfilter/setup.go
@@ -11,7 +11,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
-	"github.com/ethereum/go-ethereum/common"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
@@ -20,7 +19,6 @@ import (
 	ibctesting "github.com/cosmos/ibc-go/v6/testing"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
-	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmtypes "github.com/tendermint/tendermint/types"
@@ -159,7 +157,6 @@ func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs 
 		require.NoError(t, err)
 		pkAny, err := codectypes.NewAnyWithValue(pk)
 		require.NoError(t, err)
-		evmAddress := common.HexToAddress(crypto.CRandHex(common.AddressLength))
 		validator := stakingtypes.Validator{
 			OperatorAddress:   sdk.ValAddress(val.Address).String(),
 			ConsensusPubkey:   pkAny,
@@ -172,7 +169,6 @@ func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs 
 			UnbondingTime:     time.Unix(0, 0).UTC(),
 			Commission:        stakingtypes.NewCommission(sdk.ZeroDec(), sdk.ZeroDec(), sdk.ZeroDec()),
 			MinSelfDelegation: sdk.ZeroInt(),
-			EvmAddress:        evmAddress.Hex(),
 		}
 
 		validators = append(validators, validator)

--- a/test/util/testnode/node_init.go
+++ b/test/util/testnode/node_init.go
@@ -1,7 +1,6 @@
 package testnode
 
 import (
-	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -22,16 +21,11 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/genutil"
 	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/tendermint/tendermint/config"
 	tmos "github.com/tendermint/tendermint/libs/os"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	"github.com/tendermint/tendermint/types"
 )
-
-// NodeEVMPrivateKey the key used to initialize the test node validator.
-// Its corresponding address is: "0x9c2B12b5a07FC6D719Ed7646e5041A7E85758329".
-var NodeEVMPrivateKey, _ = crypto.HexToECDSA("64a1d6f0e760a8d62b4afdde4096f16f51b401eaaecc915740f71770ea76a8ad")
 
 func collectGenFiles(tmCfg *config.Config, encCfg encoding.Config, pubKey cryptotypes.PubKey, nodeID, rootDir string) error {
 	gentxsDir := filepath.Join(rootDir, "gentxs")
@@ -126,8 +120,6 @@ func createValidator(
 	if err != nil {
 		return err
 	}
-	orchEVMPublicKey := NodeEVMPrivateKey.Public().(*ecdsa.PublicKey)
-	evmAddr := crypto.PubkeyToAddress(*orchEVMPublicKey)
 
 	createValMsg, err := stakingtypes.NewMsgCreateValidator(
 		sdk.ValAddress(addr),
@@ -136,7 +128,6 @@ func createValidator(
 		stakingtypes.NewDescription("test", "", "", "", ""),
 		stakingtypes.NewCommissionRates(commission, sdk.OneDec(), sdk.OneDec()),
 		sdk.OneInt(),
-		evmAddr,
 	)
 	if err != nil {
 		return err

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -94,7 +94,8 @@ func TestValsetCreationWhenEditingEVMAddr(t *testing.T) {
 	qgb.EndBlocker(ctx, *pk)
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 10)
 
-	assert.Equal(t, currentAttestationNonce+1, pk.GetLatestAttestationNonce(ctx))
+	// FIXME: this needs to change to 2 once we have a proper implementation of editing the EVM address
+	assert.Equal(t, currentAttestationNonce, pk.GetLatestAttestationNonce(ctx))
 }
 
 func TestSetValset(t *testing.T) {

--- a/x/qgb/abci_test.go
+++ b/x/qgb/abci_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/x/qgb/types"
 
-	"github.com/cosmos/cosmos-sdk/x/staking/teststaking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	testutil "github.com/celestiaorg/celestia-app/test/util"
@@ -83,16 +82,13 @@ func TestValsetCreationWhenEditingEVMAddr(t *testing.T) {
 	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + 1)
 	msgServer := stakingkeeper.NewMsgServerImpl(input.StakingKeeper)
 
-	newEVMAddr, err := teststaking.RandomEVMAddress()
-	require.NoError(t, err)
 	editMsg := stakingtypes.NewMsgEditValidator(
 		testutil.ValAddrs[1],
 		stakingtypes.Description{},
 		nil,
 		nil,
-		newEVMAddr,
 	)
-	_, err = msgServer.EditValidator(ctx, editMsg)
+	_, err := msgServer.EditValidator(ctx, editMsg)
 	require.NoError(t, err)
 	staking.EndBlocker(ctx, input.StakingKeeper)
 	qgb.EndBlocker(ctx, *pk)

--- a/x/qgb/keeper/keeper.go
+++ b/x/qgb/keeper/keeper.go
@@ -11,7 +11,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/tendermint/tendermint/libs/log"
 )
 
@@ -66,7 +65,6 @@ type StakingKeeper interface {
 	GetLastValidatorPower(ctx sdk.Context, valAddr sdk.ValAddress) int64
 	GetParams(ctx sdk.Context) stakingtypes.Params
 	ValidatorQueueIterator(ctx sdk.Context, endTime time.Time, endHeight int64) sdk.Iterator
-	GetValidatorByEVMAddress(ctx sdk.Context, addr common.Address) (validator stakingtypes.Validator, found bool)
 }
 
 func (k Keeper) Logger(ctx sdk.Context) log.Logger {

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -6,8 +6,8 @@ import (
 
 	cosmosmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/x/qgb/types"
-	gethcommon "github.com/ethereum/go-ethereum/common"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	gethcommon "github.com/ethereum/go-ethereum/common"
 
 	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -6,7 +6,7 @@ import (
 
 	cosmosmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/x/qgb/types"
-
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	"cosmossdk.io/errors"
@@ -95,7 +95,8 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 		p := sdk.NewInt(k.StakingKeeper.GetLastValidatorPower(ctx, val))
 
 		// FIXME @cmwaters fix this by adding a mapping from val address to evm address
-		bv := types.BridgeValidator{Power: p.Uint64(), EvmAddress: val.String()}
+		evmAddrs := gethcommon.BytesToAddress(val)
+		bv := types.BridgeValidator{Power: p.Uint64(), EvmAddress: evmAddrs.String()}
 		ibv, err := types.NewInternalBridgeValidator(bv)
 		if err != nil {
 			return types.Valset{}, errors.Wrapf(err, types.ErrInvalidEVMAddress.Error(), val)

--- a/x/qgb/keeper/keeper_valset.go
+++ b/x/qgb/keeper/keeper_valset.go
@@ -94,8 +94,8 @@ func (k Keeper) GetCurrentValset(ctx sdk.Context) (types.Valset, error) {
 
 		p := sdk.NewInt(k.StakingKeeper.GetLastValidatorPower(ctx, val))
 
-		// TODO make sure this  is always the case
-		bv := types.BridgeValidator{Power: p.Uint64(), EvmAddress: validator.EvmAddress}
+		// FIXME @cmwaters fix this by adding a mapping from val address to evm address
+		bv := types.BridgeValidator{Power: p.Uint64(), EvmAddress: val.String()}
 		ibv, err := types.NewInternalBridgeValidator(bv)
 		if err != nil {
 			return types.Valset{}, errors.Wrapf(err, types.ErrInvalidEVMAddress.Error(), val)

--- a/x/qgb/keeper/keeper_valset_test.go
+++ b/x/qgb/keeper/keeper_valset_test.go
@@ -80,7 +80,6 @@ func TestCheckingEarliestAvailableAttestationNonceInValsets(t *testing.T) {
 		testutil.ValAddrs[0],
 		testutil.ConsPubKeys[0],
 		testutil.StakingAmount,
-		testutil.EVMAddrs[0],
 	)
 	// Run the staking endblocker to ensure valset is correct in state
 	staking.EndBlocker(input.Context, input.StakingKeeper)
@@ -131,7 +130,6 @@ func TestCheckingAttestationNonceInValsets(t *testing.T) {
 		testutil.ValAddrs[0],
 		testutil.ConsPubKeys[0],
 		testutil.StakingAmount,
-		testutil.EVMAddrs[0],
 	)
 	// Run the staking endblocker to ensure valset is correct in state
 	staking.EndBlocker(input.Context, input.StakingKeeper)

--- a/x/qgb/types/query.pb.go
+++ b/x/qgb/types/query.pb.go
@@ -6,8 +6,8 @@ package types
 import (
 	context "context"
 	fmt "fmt"
-	types "github.com/cosmos/cosmos-sdk/codec/types"
 	_ "github.com/cosmos/cosmos-proto"
+	types "github.com/cosmos/cosmos-sdk/codec/types"
 	_ "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"

--- a/x/qgb/types/query.pb.go
+++ b/x/qgb/types/query.pb.go
@@ -6,8 +6,8 @@ package types
 import (
 	context "context"
 	fmt "fmt"
-	_ "github.com/cosmos/cosmos-proto"
 	types "github.com/cosmos/cosmos-sdk/codec/types"
+	_ "github.com/cosmos/cosmos-proto"
 	_ "github.com/cosmos/cosmos-sdk/types/query"
 	_ "github.com/cosmos/gogoproto/gogoproto"
 	grpc1 "github.com/gogo/protobuf/grpc"

--- a/x/qgb/types/validator.go
+++ b/x/qgb/types/validator.go
@@ -2,12 +2,11 @@ package types
 
 import (
 	"bytes"
+	"fmt"
 	math "math"
 	"sort"
 
 	"github.com/ethereum/go-ethereum/common"
-
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 
 	"cosmossdk.io/errors"
 )
@@ -42,7 +41,8 @@ type InternalBridgeValidator struct {
 
 func NewInternalBridgeValidator(bridgeValidator BridgeValidator) (*InternalBridgeValidator, error) {
 	if !common.IsHexAddress(bridgeValidator.EvmAddress) {
-		return nil, stakingtypes.ErrEVMAddressNotHex
+		// TODO @cmwaters add appropriate QGB error type for this
+		return nil, fmt.Errorf("bridge validator evm address (%s) is not HEX formatted", bridgeValidator.EvmAddress)
 	}
 	validatorEVMAddr := common.HexToAddress(bridgeValidator.EvmAddress)
 	i := &InternalBridgeValidator{


### PR DESCRIPTION
Bumps to the latest version of the SDK. Note that this deactivates the use of the EVM address. To fulfill that functionality we will need to reintroduce a mapping in https://github.com/celestiaorg/celestia-app/pull/2169

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
