### PR TITLE
chore: removes the log info related to the number of txs in mempool when preparing the first block

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -48,15 +48,6 @@ func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePr
 	// first block is expected to contain no transaction, so is the first block.
 	if app.LastBlockHeight() == 0 {
 		txs = make([][]byte, 0)
-		if len(req.BlockData.Txs) != 0 {
-			// if the consensus layer sends non-empty set of transactions for
-			// block height 1, log it
-			app.Logger().Info(
-				"non-empty txs received from the consensus layer for block height 1",
-				"numberOfTransactions",
-				len(req.BlockData.Txs),
-			)
-		}
 	} else {
 		txs = FilterTxs(sdkCtx, handler, app.txConfig, req.BlockData.Txs)
 	}


### PR DESCRIPTION
## Overview
Following a question raised by @cmwaters in this [comment](https://github.com/celestiaorg/celestia-app/pull/2233#discussion_r1289992252), I have opted to eliminate the logged information pertaining to the number of transactions in the mempool at height 1.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
