### PR TITLE
feat: add the ability to specifiy the txsim master account

### DIFF
--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -136,6 +136,7 @@ func (s *SquareSizeIntegrationTest) fillBlocks(blobSize, blobsPerPFB, pfbsPerBlo
 		[]string{s.rpcAddr},
 		[]string{s.grpcAddr},
 		s.cctx.Keyring,
+		"",
 		rand.Int63(),
 		time.Second,
 		seqs...,

--- a/test/cmd/txsim/cli.go
+++ b/test/cmd/txsim/cli.go
@@ -22,22 +22,23 @@ import (
 
 // A set of environment variables that can be used instead of flags
 const (
-	TxsimGRPC     = "TXSIM_GRPC"
-	TxsimRPC      = "TXSIM_RPC"
-	TxsimSeed     = "TXSIM_SEED"
-	TxsimPoll     = "TXSIM_POLL"
-	TxsimKeypath  = "TXSIM_KEYPATH"
-	TxsimMnemonic = "TXSIM_MNEMONIC"
+	TxsimGRPC          = "TXSIM_GRPC"
+	TxsimRPC           = "TXSIM_RPC"
+	TxsimSeed          = "TXSIM_SEED"
+	TxsimPoll          = "TXSIM_POLL"
+	TxsimKeypath       = "TXSIM_KEYPATH"
+	TxsimMasterAccName = "TXSIM_MASTER_ACC_NAME"
+	TxsimMnemonic      = "TXSIM_MNEMONIC"
 )
 
 // Values for all flags
 var (
-	keyPath, keyMnemonic, rpcEndpoints, grpcEndpoints string
-	blobSizes, blobAmounts                            string
-	seed                                              int64
-	pollTime                                          time.Duration
-	send, sendIterations, sendAmount                  int
-	stake, stakeValue, blob                           int
+	keyPath, masterAccName, keyMnemonic, rpcEndpoints, grpcEndpoints string
+	blobSizes, blobAmounts                                           string
+	seed                                                             int64
+	pollTime                                                         time.Duration
+	send, sendIterations, sendAmount                                 int
+	stake, stakeValue, blob                                          int
 )
 
 func main() {
@@ -101,6 +102,10 @@ well funded account that can act as the master account. The command runs until a
 				}
 			}
 
+			if masterAccName == "" {
+				masterAccName = os.Getenv(TxsimMasterAccName)
+			}
+
 			if stake == 0 && send == 0 && blob == 0 {
 				return errors.New("no sequences specified. Use --stake, --send or --blob")
 			}
@@ -154,6 +159,7 @@ well funded account that can act as the master account. The command runs until a
 				strings.Split(rpcEndpoints, ","),
 				strings.Split(grpcEndpoints, ","),
 				keys,
+				masterAccName,
 				seed,
 				pollTime,
 				sequences...,
@@ -172,6 +178,7 @@ well funded account that can act as the master account. The command runs until a
 func flags() *flag.FlagSet {
 	flags := &flag.FlagSet{}
 	flags.StringVar(&keyPath, "key-path", "", "path to the keyring")
+	flags.StringVar(&masterAccName, "master", "", "the account name of the master account. Leaving empty will result in using the account with the most funds.")
 	flags.StringVar(&keyMnemonic, "key-mnemonic", "", "space separated mnemonic for the keyring. The hdpath used is an empty string")
 	flags.StringVar(&rpcEndpoints, "rpc-endpoints", "", "comma separated list of rpc endpoints")
 	flags.StringVar(&grpcEndpoints, "grpc-endpoints", "", "comma separated list of grpc endpoints")

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -41,7 +41,7 @@ func TestE2ESimple(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
-	err = txsim.Run(ctx, testnet.RPCEndpoints(), testnet.GRPCEndpoints(), kr, seed, 3*time.Second, sequences...)
+	err = txsim.Run(ctx, testnet.RPCEndpoints(), testnet.GRPCEndpoints(), kr, "", seed, 3*time.Second, sequences...)
 	require.True(t, errors.Is(err, context.DeadlineExceeded), err.Error())
 
 	blockchain, err := testnode.ReadBlockchain(context.Background(), testnet.Node(0).AddressRPC())

--- a/test/txsim/run.go
+++ b/test/txsim/run.go
@@ -27,6 +27,7 @@ func Run(
 	ctx context.Context,
 	rpcEndpoints, grpcEndpoints []string,
 	keys keyring.Keyring,
+	masterAccName string,
 	seed int64,
 	pollTime time.Duration,
 	sequences ...Sequence,
@@ -45,7 +46,7 @@ func Run(
 	defer queryClient.Close()
 
 	// Create the account manager to handle account transactions.
-	manager, err := NewAccountManager(ctx, keys, txClient, queryClient)
+	manager, err := NewAccountManager(ctx, keys, masterAccName, txClient, queryClient)
 	if err != nil {
 		return err
 	}

--- a/test/txsim/run_test.go
+++ b/test/txsim/run_test.go
@@ -90,6 +90,7 @@ func TestTxSimulator(t *testing.T) {
 				[]string{rpcAddr},
 				[]string{grpcAddr},
 				keyring,
+				"",
 				9001,
 				time.Second,
 				tc.sequences...,


### PR DESCRIPTION
## Overview

This PR adds the ability to specify a specific account to use as master for txsim. This is useful for when we don't want to always use the account with the most funds in our wallet.

closes #2286
kinda sorta blocking #2197 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
