### PR TITLE
fix: InitUnlockedBalance unlocked from the vesting balance

### DIFF
--- a/pkg/genesis/vesting_accounts.go
+++ b/pkg/genesis/vesting_accounts.go
@@ -32,6 +32,8 @@ func NewGenesisRegularAccount(
 // NewGenesisDelayedVestingAccount creates a new DelayedVestingAccount with the
 // specified parameters. It returns the created account converted to genesis
 // account type and the account balance.
+// The final vesting balance is calculated by subtracting the initial unlocked coins
+// from the vesting balance.
 func NewGenesisDelayedVestingAccount(
 	address string,
 	vestingBalance,
@@ -55,6 +57,8 @@ func NewGenesisDelayedVestingAccount(
 	return authtypes.GenesisAccount(vAccount), balance, nil
 }
 
+// The final vesting balance is calculated by subtracting the initial unlocked coins
+// from the vesting balance.
 func NewGenesisPeriodicVestingAccount(
 	address string,
 	vestingBalance,
@@ -79,6 +83,8 @@ func NewGenesisPeriodicVestingAccount(
 	return authtypes.GenesisAccount(vAccount), balance, nil
 }
 
+// The final vesting balance is calculated by subtracting the initial unlocked coins
+// from the vesting balance.
 func NewGenesisContinuousVestingAccount(
 	address string,
 	vestingBalance,

--- a/pkg/genesis/vesting_accounts.go
+++ b/pkg/genesis/vesting_accounts.go
@@ -45,8 +45,9 @@ func NewGenesisDelayedVestingAccount(
 
 	balance = banktypes.Balance{
 		Address: address,
-		Coins:   initUnlockedCoins.Add(vestingBalance...),
+		Coins:   vestingBalance,
 	}
+	vestingBalance = vestingBalance.Sub(initUnlockedCoins...)
 
 	bAccount := authtypes.NewBaseAccountWithAddress(sdkAddr)
 	vAccount := vestingtypes.NewDelayedVestingAccount(bAccount, vestingBalance, endTime.Unix())
@@ -68,8 +69,9 @@ func NewGenesisPeriodicVestingAccount(
 
 	balance = banktypes.Balance{
 		Address: address,
-		Coins:   initUnlockedCoins.Add(vestingBalance...),
+		Coins:   vestingBalance,
 	}
+	vestingBalance = vestingBalance.Sub(initUnlockedCoins...)
 
 	bAccount := authtypes.NewBaseAccountWithAddress(sdkAddr)
 	vAccount := vestingtypes.NewPeriodicVestingAccount(bAccount, vestingBalance, startTime.Unix(), periods)
@@ -90,8 +92,9 @@ func NewGenesisContinuousVestingAccount(
 
 	balance = banktypes.Balance{
 		Address: address,
-		Coins:   initUnlockedCoins.Add(vestingBalance...),
+		Coins:   vestingBalance,
 	}
+	vestingBalance = vestingBalance.Sub(initUnlockedCoins...)
 
 	bAccount := authtypes.NewBaseAccountWithAddress(sdkAddr)
 	vAccount := vestingtypes.NewContinuousVestingAccount(bAccount, vestingBalance, startTime.Unix(), endTime.Unix())


### PR DESCRIPTION
closes #2295 
more context in the issue.
A short summary: To install a vesting account in the genesis file, allocate the desired amount to `OriginalVestingBalance` and the banking module. For instance, to lock a `total_allocation` and unlock `1TIA`, follow these steps:

    Set `account.OriginalVestingBalance = total_allocation`.
    Set `account.BalanceInBankModule = total_allocation + 1TIA`.

However, to avoid donating extra funds, a new approach is adopted: unlock `1TIA` from the vested amount. This is achieved by subtracting `1TIA` from the `OriginalVestingBalance`:

    Update `account.OriginalVestingBalance = total_allocation - 1TIA`.
    Keep `account.BalanceInBankModule = total_allocation`.

This achieves the same goal without additional donations.
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
