### PR TITLE
feat: add support for v2

### DIFF
--- a/pkg/appconsts/v2/app_consts.go
+++ b/pkg/appconsts/v2/app_consts.go
@@ -1,0 +1,7 @@
+package v2
+
+const (
+	Version              uint64 = 2
+	SquareSizeUpperBound int    = 128
+	SubtreeRootThreshold int    = 64
+)

--- a/pkg/appconsts/versioned_consts.go
+++ b/pkg/appconsts/versioned_consts.go
@@ -2,10 +2,11 @@ package appconsts
 
 import (
 	v1 "github.com/celestiaorg/celestia-app/pkg/appconsts/v1"
+	v2 "github.com/celestiaorg/celestia-app/pkg/appconsts/v2"
 )
 
 const (
-	LatestVersion = v1.Version
+	LatestVersion = v2.Version
 )
 
 // SubtreeRootThreshold works as a target upper bound for the number of subtree


### PR DESCRIPTION
Adds v2 package. For now this is just the same as v1 but might change in the future. 

We will need at least the version number for a versioned state machine