### PR TITLE
fix: PayForBlobs help text for namespace ID

### DIFF
--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -34,7 +34,7 @@ func CmdPayForBlob() *cobra.Command {
 		Use:   "PayForBlobs [hexNamespaceID] [hexBlob]",
 		Short: "Pay for a data blob to be published to the Celestia blockchain",
 		Long: "Pay for a data blob to be published to the Celestia blockchain. " +
-			"[hexNamespaceID] must be a 28 byte hex encoded namespace ID. " +
+			"[hexNamespaceID] must be a 10 byte hex encoded namespace ID. " +
 			"[hexBlob] can be an arbitrary length hex encoded data blob. " +
 			"This command only supports a single blob per invocation. ",
 		Args: cobra.ExactArgs(2),


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2346

## Testing

```
$ ./build/celestia-appd tx blob PayForBlobs --help
Pay for a data blob to be published to the Celestia blockchain. [hexNamespaceID] must be a 10 byte hex encoded namespace ID. [hexBlob] can be an arbitrary length hex encoded data blob. This command only supports a single blob per invocation.
```

