### PR TITLE
docs: Updated namespace_id to namespaces in EventPayForBob doc. Fixes…

### DIFF
--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -185,7 +185,7 @@ The blob module emits the following events:
 
 ### Blob Events
 
-#### `EventPayForBlob`
+#### `EventPayForBlobs`
 
 | Attribute Key | Attribute Value                               |
 |---------------|-----------------------------------------------|

--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -191,7 +191,7 @@ The blob module emits the following events:
 |---------------|-----------------------------------------------|
 | signer        | {bech32 encoded signer address}               |
 | blob_sizes    | {sizes of blobs in bytes}                     |
-| namespace_ids | {namespaces the blobs should be published to} |
+| namespaces    | {namespaces the blobs should be published to} |
 
 ## Parameters
 


### PR DESCRIPTION
… #2349



## Overview
The docs for EventPayForBlob are slightly out of date. namespace_ids was renamed to namespaces.

Fixes #2349
