### PR TITLE
fix: update e2e test

### DIFF
--- a/test/e2e/readme.md
+++ b/test/e2e/readme.md
@@ -7,7 +7,7 @@ Celestia uses the [knuu](https://github.com/celestiaorg/knuu) framework to orche
 E2E tests can be simply run through go tests. They are distinguished from unit tets through an environment variable. To run all e2e tests run:
 
 ```shell
-E2E=true KNUU_NAMESPACE=celestia-app go test ./test/e2e/... -timeout 30m
+E2E=true KNUU_NAMESPACE=knuu-app go test ./test/e2e/... -timeout 30m
 ```
 
 ## Observation

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -14,10 +14,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	latestVersion = "v1.0.0-rc9"
-	seed          = 42 // the meaning of life
-)
+const seed          = 42
+
+var latestVersion = "v1.0.0-rc12"
 
 // This test runs a simple testnet with 4 validators. It submits both MsgPayForBlobs
 // and MsgSends over 30 seconds and then asserts that at least 10 transactions were
@@ -25,6 +24,10 @@ const (
 func TestE2ESimple(t *testing.T) {
 	if os.Getenv("E2E") == "" {
 		t.Skip("skipping e2e test")
+	}
+
+	if os.Getenv("E2E_VERSION") != "" {
+		latestVersion = os.Getenv("E2E_VERSION")
 	}
 
 	testnet, err := New(t.Name(), seed)

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const seed          = 42
+const seed = 42
 
 var latestVersion = "v1.0.0-rc12"
 


### PR DESCRIPTION
Our e2e tests were failing because we made a breaking change and didn't update thr RC. We should probably come up with a more clever way of working out the latest release and running that