### PR TITLE
chore(blob): clarifies that hex values should not be 0x prefixed in the PayForBlobs subcommand

### DIFF
--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -36,10 +36,9 @@ func CmdPayForBlob() *cobra.Command {
 		Long: "Pay for a data blob to be published to the Celestia blockchain. " +
 			"[hexNamespaceID] must be a 10 byte hex encoded namespace ID, " +
 			"(for the namespace version 0). " +
-			"The hex string should not include a 0x prefix." +
-			"[hexBlob] can be an arbitrary length hex encoded data blob." +
-			"The hex string should not include a 0x prefix." +
-			" " +
+			"The hex string should not include a 0x prefix. " +
+			"[hexBlob] can be an arbitrary length hex encoded data blob. " +
+			"The hex string should not include a 0x prefix. " +
 			"This command only supports a single blob per invocation. ",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -36,9 +36,8 @@ func CmdPayForBlob() *cobra.Command {
 		Long: "Pay for a data blob to be published to the Celestia blockchain. " +
 			"[hexNamespaceID] must be a 10 byte hex encoded namespace ID, " +
 			"(for the namespace version 0). " +
-			"The hex string should not include a 0x prefix. " +
 			"[hexBlob] can be an arbitrary length hex encoded data blob. " +
-			"The hex string should not include a 0x prefix. " +
+			"Hex strings should not include a 0x prefix. " +
 			"This command only supports a single blob per invocation. ",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -34,8 +34,12 @@ func CmdPayForBlob() *cobra.Command {
 		Use:   "PayForBlobs [hexNamespaceID] [hexBlob]",
 		Short: "Pay for a data blob to be published to the Celestia blockchain",
 		Long: "Pay for a data blob to be published to the Celestia blockchain. " +
-			"[hexNamespaceID] must be a 10 byte hex encoded namespace ID. " +
-			"[hexBlob] can be an arbitrary length hex encoded data blob. " +
+			"[hexNamespaceID] must be a 10 byte hex encoded namespace ID, " +
+			"(for the namespace version 0). " +
+			"The hex string should not include a 0x prefix." +
+			"[hexBlob] can be an arbitrary length hex encoded data blob." +
+			"The hex string should not include a 0x prefix." +
+			" " +
 			"This command only supports a single blob per invocation. ",
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
## Overview

Prefixing hex values with the `0x` prefix is a common convention. Nevertheless, the `blob` module CLI does not have the capability to parse the `0x` prefix. Hence, including this clarification in the command description can greatly assist users.

## Checklist


- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
