### PR TITLE
chore: update the default per peer bandwidth limits

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -28,6 +28,14 @@ import (
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
+const (
+	// oneGigabit 1Gbit == 1 billion bits
+	oneGigabit = 1_000_000_000
+	// defaultBandwidth is the symetric bandwidth a node is assumed to have in
+	// bytes (not bits!)
+	defaultBandwidth = oneGigabit / 8
+)
+
 // bankModule defines a custom wrapper around the x/bank module's AppModuleBasic
 // implementation to provide custom default genesis state.
 type bankModule struct {
@@ -175,6 +183,9 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	cfg.Consensus.TimeoutCommit = appconsts.TimeoutCommit
 	cfg.Consensus.SkipTimeoutCommit = false
 	cfg.TxIndex.Indexer = "null"
+
+	cfg.P2P.SendRate = int64(defaultBandwidth / cfg.P2P.MaxNumInboundPeers)
+	cfg.P2P.RecvRate = int64(defaultBandwidth / cfg.P2P.MaxNumInboundPeers)
 	return cfg
 }
 


### PR DESCRIPTION
## Overview

part of #2387 

fair warning, this is technically using the metric versions of bandwidth, so 1 Gigabit = 1_000_000_000 bytes (power of 10 instead of a power of 2)

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
