### PR TITLE
feat(cli): add experimental-compact-goleveldb

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/simapp/simd/cmd"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
+	"github.com/tendermint/tendermint/cmd/cometbft/commands"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
@@ -149,6 +150,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig encoding.Config) {
 		tmcli.NewCompletionCmd(rootCmd, true),
 		debugCmd,
 		config.Cmd(),
+		commands.CompactGoLevelDBCmd,
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, NewAppServer, createAppAndExport, addModuleInitFlags)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2380

## Testing

I synced a node to arabica-10. 

### Before

```
$ du -h ~/.celestia-app/data
7.8M	/Users/rootulp/.celestia-app/data/state.db
 11M	/Users/rootulp/.celestia-app/data/blockstore.db
```

### Run compaction

Stop the node then run compaction. Note: I had to run this from the CELESTIA_APP home directory in order for the compaction output to overwrite the existing `data/state.db`.

```shell
$ cd ~/.celestia-app
$ celestia-appd experimental-compact-goleveldb
I[2023-08-31|14:24:39.819] starting compaction...                       db=data/blockstore.db
I[2023-08-31|14:24:39.828] starting compaction...                       db=data/state.db
```

### After

```shell
6.3M	/Users/rootulp/.celestia-app/data/state.db
 11M	/Users/rootulp/.celestia-app/data/blockstore.db
```

Start the node again.