### PR TITLE
docs(x/mint): explain `TargetInflationRate`

### DIFF
--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -16,7 +16,10 @@ const (
 
 	InitialInflationRate = 0.08
 	DisinflationRate     = 0.1
-	TargetInflationRate  = 0.015
+	// TargetInflationRate is the inflation rate that the network aims to
+	// stabalize at. In practice, TargetInflationRate acts as a minimum so that
+	// the inflation rate doesn't decrease after reaching it.
+	TargetInflationRate = 0.015
 )
 
 func InitialInflationRateAsDec() sdk.Dec {


### PR DESCRIPTION
Addresses finding 004 of binary builders preliminary audit report. 

I don't think it's necessary to rename the variable to `MinimumTargetInflationRate` but can do if reviewers feel strongly that renaming is preferred over this comment.