### PR TITLE
docs: fix typo in environment variable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ celestia-appd --help
 
 | Variable        | Explanation                        | Default value                                            | Required |
 | --------------- | ---------------------------------- | -------------------------------------------------------- | -------- |
-| `CELESITA_HOME` | Home directory for the application | User home dir. [Ref](https://pkg.go.dev/os#UserHomeDir). | Optional |
+| `CELESTIA_HOME` | Home directory for the application | User home dir. [Ref](https://pkg.go.dev/os#UserHomeDir). | Optional |
 
 ### Create your own single node devnet
 


### PR DESCRIPTION
There is a typo in this environment variable name. The correct spelling is: https://github.com/celestiaorg/celestia-app/blob/8b0decb6e9a4c7aa426192344f6d91f7bb729c08/app/app.go#L181
