### PR TITLE
build: Goreleaser

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
+      (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     permissions: "write-all"
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -28,23 +28,51 @@ on:
           - major
 
 jobs:
-
   lint:
     uses: ./.github/workflows/lint.yml
 
   test:
     uses: ./.github/workflows/test.yml
 
-  # Make a release if this is a manually trigger job, i.e. workflow_dispatch
-  release:
+  # If this was a workflow dispatch event, we need to generate and push a tag
+  # for goreleaser to grab
+  version_bump:
     needs: [lint, test]
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
     permissions: "write-all"
     steps:
       - uses: actions/checkout@v4
-      - name: Version Release
-        uses: celestiaorg/.github/.github/actions/version-release@v0.2.2
+      - name: Bump version and push tag
+        # Placing the if condition here is a workaround for needing to block
+        # on this step during workflow dispatch events but the step not
+        # needing to run on tags. If we had the if condition on the full
+        # version_bump section, it would skip and not run, which would result
+        # in goreleaser not running either.
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        uses: mathieudutour/github-tag-action@v6.0
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          version-bump: ${{inputs.version}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: ${{ inputs.version }}
+
+  # Generate the release with goreleaser to include pre-built binaries
+  goreleaser:
+    needs: version_bump
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && contains(github.ref, 'refs/tags/')) }}
+    permissions: "write-all"
+    steps:
+      - uses: actions/checkout@v3
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v4
+        with:
+          go-version: 1.21
+      # Generate the binaries and release
+      - uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,57 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# NOTE: CGO is required for ledger support to work, however goreleaser
+# technically doesn't support CGO. But it seems to work so that's cool. This
+# only seems to work because we are building for a single binary. Cross
+# compiling binaries for multiple distributions might be problematic and a
+# proper workaround might be needed.
+#
+# REF: https://goreleaser.com/limitations/cgo/
+
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./cmd/celestia-appd
+    binary: celestia-appd
+    env:
+      - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
+    goarch:
+      - amd64
+    goos:
+      - linux
+    tags:
+      - ledger
+    ldflags:
+      # Ref: https://goreleaser.com/customization/templates/#common-fields
+      #
+      # .FullCommit is git commit hash goreleaser is using for the release
+      #
+      # .Version is the version being released
+      - -X "{{ .Env.SDKPath }}.Name=celestia-app"
+      - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
+      - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
+      - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
+dist: ./build/goreleaser
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of
+    # uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,8 +4,8 @@
 # NOTE: CGO is required for ledger support to work, however goreleaser
 # technically doesn't support CGO. But it seems to work so that's cool. This
 # only seems to work because we are building for a single binary. Cross
-# compiling binaries for multiple distributions might be problematic and a
-# proper workaround might be needed.
+# compiling binaries for multiple distributions doesn't work and a proper
+# workaround will be needed.
 #
 # REF: https://goreleaser.com/limitations/cgo/
 

--- a/Makefile
+++ b/Makefile
@@ -213,7 +213,6 @@ goreleaser-build:
 .PHONY: goreleaser-build
 
 ## goreleaser-release: Builds the release celestia-appd binary as defined in .goreleaser.yaml. This requires there be a git tag for the release in the local git history.
-# TODO: update to build the binary that is published with the Github release.
 goreleaser-release:
 	goreleaser release --clean --fail-fast --skip-publish
 .PHONY: goreleaser-release

--- a/Makefile
+++ b/Makefile
@@ -199,3 +199,24 @@ adr-gen:
 	@echo "--> Downloading ADR template"
 	@curl -sSL https://raw.githubusercontent.com/celestiaorg/.github/main/adr-template.md > docs/architecture/adr-template.md
 .PHONY: adr-gen
+
+## goreleaser: list goreleaser options and checks if goreleaser is installed
+goreleaser: Makefile
+	@echo " Choose a goreleaser command to run:"
+	@sed -n 's/^## goreleaser/goreleaser/p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@goreleaser --version
+.PHONY: goreleaser
+
+## goreleaser-build: builds the celestia-appd binary using goreleaser for your
+# local OS
+goreleaser-build:
+	goreleaser build --snapshot --clean --single-target
+.PHONY: goreleaser-build
+
+## goreleaser-release: builds the release celestia-appd binary as defined in
+# .goreleaser.yaml, this requires there be a git tag for the release in the
+# local git history.
+# TODO - update to build the binary that is published with the github release
+goreleaser-release:
+	goreleaser release --clean --fail-fast --skip-publish
+.PHONY: goreleaser-release

--- a/Makefile
+++ b/Makefile
@@ -200,23 +200,20 @@ adr-gen:
 	@curl -sSL https://raw.githubusercontent.com/celestiaorg/.github/main/adr-template.md > docs/architecture/adr-template.md
 .PHONY: adr-gen
 
-## goreleaser: list goreleaser options and checks if goreleaser is installed
+## goreleaser: List Goreleaser commands and checks if GoReleaser is installed.
 goreleaser: Makefile
 	@echo " Choose a goreleaser command to run:"
 	@sed -n 's/^## goreleaser/goreleaser/p' $< | column -t -s ':' |  sed -e 's/^/ /'
 	@goreleaser --version
 .PHONY: goreleaser
 
-## goreleaser-build: builds the celestia-appd binary using goreleaser for your
-# local OS
+## goreleaser-build: Builds the celestia-appd binary using GoReleaser for your local OS.
 goreleaser-build:
 	goreleaser build --snapshot --clean --single-target
 .PHONY: goreleaser-build
 
-## goreleaser-release: builds the release celestia-appd binary as defined in
-# .goreleaser.yaml, this requires there be a git tag for the release in the
-# local git history.
-# TODO - update to build the binary that is published with the github release
+## goreleaser-release: Builds the release celestia-appd binary as defined in .goreleaser.yaml. This requires there be a git tag for the release in the local git history.
+# TODO: update to build the binary that is published with the Github release.
 goreleaser-release:
 	goreleaser release --clean --fail-fast --skip-publish
 .PHONY: goreleaser-release

--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ make goreleaser-build
 
 ### Publishing a Release
 
+> **NOTE** Due to `goreleaser`'s CGO limitations, cross-compiling the binary does not work. So the binaries must be built on the target platform. This means that the release process must be done on a Linux amd64 machine.
+
 To generate the binaries for the Github release, you can run the following command:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ make goreleaser-build
 
 ### Publishing a Release
 
-To generate the binaries for the github release, you can run the following command:
+To generate the binaries for the Github release, you can run the following command:
 
 ```sh
 make goreleaser-release
@@ -134,7 +134,7 @@ build
     └── metadata.json
 ```
 
-For the Github release, you just need to upload the `checksum.txt` and `celestia-app_Linux_x86_64.tar.gz` files. 
+For the Github release, you just need to upload the `checksums.txt` and `celestia-app_Linux_x86_64.tar.gz` files. 
 
 ### Docs
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,31 @@ make proto-gen
 make goreleaser-build
 ```
 
+### Publishing a Release
+
+To generate the binaries for the github release, you can run the following command:
+
+```sh
+make goreleaser-release
+```
+
+This will generate the binaries as defined in `.goreleaser.yaml` and put them in `build/goreleaser` like so:
+
+```sh
+build
+└── goreleaser
+    ├── CHANGELOG.md
+    ├── artifacts.json
+    ├── celestia-app_Linux_x86_64.tar.gz
+    ├── celestia-app_linux_amd64_v1
+    │   └── celestia-appd
+    ├── checksums.txt
+    ├── config.yaml
+    └── metadata.json
+```
+
+For the Github release, you just need to upload the `checksum.txt` and `celestia-app_Linux_x86_64.tar.gz` files. 
+
 ### Docs
 
 Package-specific READMEs aim to explain implementation details for developers that are contributing to these packages. The [specs](https://celestiaorg.github.io/celestia-app/) aim to explain the protocol as a whole for developers building on top of Celestia.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This repo attempts to conform to [conventional commits](https://www.conventional
 1. Install [hadolint](https://github.com/hadolint/hadolint)
 1. Install [yamllint](https://yamllint.readthedocs.io/en/stable/quickstart.html)
 1. Install [markdown-link-check](https://github.com/tcort/markdown-link-check)
+1. Install [goreleaser](https://goreleaser.com/install/)
 
 ### Helpful Commands
 
@@ -105,6 +106,9 @@ make fmt
 
 # Regenerate Protobuf files (this assumes Docker is running)
 make proto-gen
+
+# Build binaries with goreleaser
+make goreleaser-build
 ```
 
 ### Docs


### PR DESCRIPTION
## Overview

**UPDATE**

This PR adds building binaries to the release process by using [goreleaser](https://goreleaser.com/).

The CI release process is largely unchanged. Releases can be trigger by either manually triggering the `ci_release` workflow, or they can be triggered by pushing a version tag. 

I know the team has not been using the CI to generate releases, so I added a `make goreleaser-release` command to build the linux distro binaries for the release locally so that they can be manually uploaded. 

Result of running `make goreleaser-release`:
```
tree build 
build
└── goreleaser
    ├── CHANGELOG.md
    ├── artifacts.json
    ├── celestia-app_Linux_x86_64.tar.gz
    ├── celestia-app_linux_amd64_v1
    │   └── celestia-appd
    ├── checksums.txt
    ├── config.yaml
    └── metadata.json
```

Since we are just building for `linux amd64`, I hard coded the `ledger` build tag to simplify the changes. 

The `.goreleaser.yaml` file is 90% stock generated from `goreleaser init`. The celestia app specific items are:
```yaml
builds:
  - main: ./cmd/celestia-appd
    binary: celestia-appd
    env:
      - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
    goarch:
      - amd64
    goos:
      - linux
    tags:
      - ledger
    ldflags:
      # Ref: https://goreleaser.com/customization/templates/#common-fields
      #
      # .FullCommit is git commit hash goreleaser is using for the release
      #
      # .Version is the version being released
      - -X "{{ .Env.SDKPath }}.Name=celestia-app"
      - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
      - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
      - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
dist: ./build/goreleaser
```

For building locally, i added a `make goreleaser-build` command. The binaries are put into a `build/goreleaser` directory. The `make goreleaser` command lists the `goreleaser` commands and also checks the version as a way to verify you have `goreleaser` installed.

Result of running `make goreleaser-build`:
```
tree build           
build
└── goreleaser
    ├── artifacts.json
    ├── celestia-app_darwin_amd64_v1
    │   └── celestia-appd
    ├── config.yaml
    └── metadata.json
```

Successful github action run: https://github.com/MSevey/celestia-app/actions/runs/6115034436/job/16597834241
Example release generated: https://github.com/MSevey/celestia-app/releases

Created #2445 as a follow up discussion how to add signing.
