### PR TITLE
fix: check for equal expected size in square size test

### DIFF
--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -98,7 +98,7 @@ func (s *SquareSizeIntegrationTest) TestSquareSizeUpperBound_Flaky() {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s.setBlockSizeParams(t, tt.govMaxSquareSize, tt.maxBytes)
-			start, end := s.fillBlocks(100_000, 100, tt.pfbsPerBlock, 20*time.Second)
+			start, end := s.fillBlocks(100_000, 10, tt.pfbsPerBlock, 20*time.Second)
 
 			// check that we're not going above the specified size and that we hit the specified size
 			actualMaxSize := 0
@@ -111,7 +111,8 @@ func (s *SquareSizeIntegrationTest) TestSquareSizeUpperBound_Flaky() {
 					actualMaxSize = int(block.Block.Data.SquareSize)
 				}
 			}
-			require.Greater(t, tt.expectedMaxSquareSize, actualMaxSize)
+
+			require.Equal(t, tt.expectedMaxSquareSize, actualMaxSize)
 		})
 	}
 }


### PR DESCRIPTION
## Overview

in what appears to be an effort to make the tests more stable, I think we accidently changed the square size test to not work as intended. This PR fixes this by requiring the expected square size to actually get hit.

closes #2034 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
