### PR TITLE
Makefile: fix formatting error on help printout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ build-docker:
 	$(DOCKER) build -t celestiaorg/celestia-app -f Dockerfile .
 .PHONY: build-docker
 
-## lint: Run all linters: golangci-lint, markdownlint, hadolint, yamllint.
+## lint: Run all linters; golangci-lint, markdownlint, hadolint, yamllint.
 lint:
 	@echo "--> Running golangci-lint"
 	@golangci-lint run


### PR DESCRIPTION
Small formatting fix for the `lint` command having an extra column. 

See screen shot.

<img width="1392" alt="Screen Shot 2023-09-07 at 4 50 08 PM" src="https://github.com/celestiaorg/celestia-app/assets/15232757/551be1c4-d27e-4013-8a02-ee56086e978f">
