### PR TITLE
docs: rephrase `MinSignedPerWindow` description

### DIFF
--- a/specs/src/specs/params.md
+++ b/specs/src/specs/params.md
@@ -44,7 +44,7 @@ are blocked by the `x/paramfilter` module.
 | slashing.SignedBlocksWindow | 5000 | The range of blocks used to count for downtime. | True |
 | slashing.MinSignedPerWindow | 0.05 (5%) | Minimum proportion of blocks signed per window to avoid being slashed. | True |
 | slashing.DowntimeJailDuration | 10 mins | Duration of time a validator must stay jailed. | True |
-| slashing.SlashFractionDoubleSign | 5.0% | Percentage slashed after a validator is jailed for downtime. | True |
+| slashing.SlashFractionDoubleSign | 5.0% | Percentage slashed after a validator is jailed for double-signing. | True |
 | slashing.SlashFractionDowntime | 1.0% | Percentage slashed after a validator is jailed for downtime. | True |
 | staking.UnbondingTime | 1814400 (21 days) | Duration of time for unbonding in seconds. | False |
 | staking.MaxValidators | 100 | Maximum number of validators. | False |

--- a/specs/src/specs/params.md
+++ b/specs/src/specs/params.md
@@ -42,7 +42,7 @@ are blocked by the `x/paramfilter` module.
 | ibc.Transfer.SendEnabled | true | Enable sending tokens via IBC. | True |
 | ibc.Transfer.ReceiveEnabled | true | Enable receiving tokens via IBC. | True |
 | slashing.SignedBlocksWindow | 5000 | The range of blocks used to count for downtime. | True |
-| slashing.MinSignedPerWindow | 5 | Minumum signatures in the block. | True |
+| slashing.MinSignedPerWindow | 0.05 (5%) | Minimum proportion of blocks signed per window to avoid being slashed. | True |
 | slashing.DowntimeJailDuration | 10 mins | Duration of time a validator must stay jailed. | True |
 | slashing.SlashFractionDoubleSign | 5.0% | Percentage slashed after a validator is jailed for downtime. | True |
 | slashing.SlashFractionDowntime | 1.0% | Percentage slashed after a validator is jailed for downtime. | True |

--- a/specs/src/specs/params.md
+++ b/specs/src/specs/params.md
@@ -44,7 +44,7 @@ are blocked by the `x/paramfilter` module.
 | slashing.SignedBlocksWindow | 5000 | The range of blocks used to count for downtime. | True |
 | slashing.MinSignedPerWindow | 0.5 (50%) | Minimum proportion of blocks signed per window to avoid being slashed. | True |
 | slashing.DowntimeJailDuration | 10 mins | Duration of time a validator must stay jailed. | True |
-| slashing.SlashFractionDoubleSign | 5.0% | Percentage slashed after a validator is jailed for double-signing. | True |
+| slashing.SlashFractionDoubleSign | 0.05 (5%) | Percentage slashed after a validator is jailed for double-signing. | True |
 | slashing.SlashFractionDowntime | 1.0% | Percentage slashed after a validator is jailed for downtime. | True |
 | staking.UnbondingTime | 1814400 (21 days) | Duration of time for unbonding in seconds. | False |
 | staking.MaxValidators | 100 | Maximum number of validators. | False |

--- a/specs/src/specs/params.md
+++ b/specs/src/specs/params.md
@@ -42,7 +42,7 @@ are blocked by the `x/paramfilter` module.
 | ibc.Transfer.SendEnabled | true | Enable sending tokens via IBC. | True |
 | ibc.Transfer.ReceiveEnabled | true | Enable receiving tokens via IBC. | True |
 | slashing.SignedBlocksWindow | 5000 | The range of blocks used to count for downtime. | True |
-| slashing.MinSignedPerWindow | 0.05 (5%) | Minimum proportion of blocks signed per window to avoid being slashed. | True |
+| slashing.MinSignedPerWindow | 0.5 (50%) | Minimum proportion of blocks signed per window to avoid being slashed. | True |
 | slashing.DowntimeJailDuration | 10 mins | Duration of time a validator must stay jailed. | True |
 | slashing.SlashFractionDoubleSign | 5.0% | Percentage slashed after a validator is jailed for double-signing. | True |
 | slashing.SlashFractionDowntime | 1.0% | Percentage slashed after a validator is jailed for downtime. | True |


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2469

The description is partially inspired by [these docs](https://github.com/gavinly/CosmosParametersWiki/blob/master/Slashing.md#2-minsignedperwindow). The default value is defined [here](https://github.com/cosmos/cosmos-sdk/blob/f1dfe60be9cfd76d6e513117dbd863be360cfd99/x/slashing/types/params.go#L18).