### PR TITLE
chore: remove unnecessary go mod tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ build: mod
 	@cd ./cmd/celestia-appd
 	@mkdir -p build/
 	@go build $(BUILD_FLAGS) -o build/ ./cmd/celestia-appd
-	@go mod tidy
 .PHONY: build
 
 ## install: Build and install the celestia-appd binary into the $GOPATH/bin directory.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The makefile target is already depending on `mod` before building the binary. Thus, we can remove the extra go mod tidy

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
