### PR TITLE
chore(deps): Bump go version to 1.21.1

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -67,7 +67,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v4
         with:
-          go-version: 1.21
+          go-version: 1.21.1
       # Generate the binaries and release
       - uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.21.1'
 
 jobs:
   golangci-lint:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,7 +5,7 @@ on:
     - cron: "0 6 * * *"
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.21.1'
 
 jobs:
   e2e-tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
 
 env:
-  GO_VERSION: '1.21'
+  GO_VERSION: '1.21.1'
 
 jobs:
   test-short:

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ node            |  |                               |  |
 
 ## Install
 
-1. [Install Go](https://go.dev/doc/install) 1.21
+1. [Install Go](https://go.dev/doc/install) 1.21.1
 1. Clone this repo
 1. Install the celestia-app CLI
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/celestiaorg/celestia-app
 
-go 1.21
-
-toolchain go1.21.0
+go 1.21.1
 
 require (
 	github.com/celestiaorg/nmt v0.20.0


### PR DESCRIPTION
Bump Go version to 1.21.1 because QGB repo can't depend on celestia-app due to:

```
go: module github.com/celestiaorg/quantum-gravity-bridge/v2@v2.1.1 requires go >= 1.21.1; switching to go1.21.1
```