### PR TITLE
refactor: fork the markdown linter from .github and use our own config

### DIFF
--- a/.github/markdown-link-check-config.json
+++ b/.github/markdown-link-check-config.json
@@ -1,0 +1,15 @@
+{
+    "ignorePatterns": [
+        {
+            "pattern": "https://crypto.stackexchange.com/questions/54852/what-happens-if-a-sha-256-input-is-too-long-longer-than-512-bits"
+        }
+    ],
+    "timeout": "20s",
+    "retryOn429": true,
+    "retryCount": 5,
+    "fallbackRetryDelay": "30s",
+    "aliveStatusCodes": [
+        200,
+        206
+    ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,8 +42,3 @@ jobs:
       - uses: actions/checkout@v4
       - uses: celestiaorg/.github/.github/actions/yamllint@v0.2.3
 
-  markdown-lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: celestiaorg/.github/.github/actions/markdown-lint@v0.2.3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,4 +41,3 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: celestiaorg/.github/.github/actions/yamllint@v0.2.3
-

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -1,0 +1,35 @@
+name: "markdown-linter"
+on:
+  push:
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install markdownlint-cli
+        run: npm install -g markdownlint-cli@0.32.1
+        shell: bash
+
+      - name: Run markdownlint
+        run: markdownlint --config .markdownlint.yaml **/*.md
+        shell: bash
+
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Run markdown link check
+        uses: gaurav-nelson/github-action-markdown-link-check@1.0.15
+        with:
+          config-file: '.github/markdown-link-check-config.json'
+          folder-path: '.'


### PR DESCRIPTION
… to ignore false positive link check failures

forks the .github markdown linter so that we can use our own config to ignore false positive link checks. front ported from v1.x

## Overview


## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
