### PR TITLE
feat: add decorator to wrap panic messages with the transaction that caused them

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -21,8 +21,10 @@ func NewAnteHandler(
 	channelKeeper *ibckeeper.Keeper,
 ) sdk.AnteHandler {
 	return sdk.ChainAnteDecorators(
+		// Wraps the panic with the string format of the transaction
+		NewHandlePanicDecorator(),
 		// Set up the context with a gas meter.
-		// Contract: must be called first.
+		// Must be called before gas consumption occurs in any other decorator.
 		ante.NewSetUpContextDecorator(),
 		// Ensure the tx does not contain any extension options.
 		ante.NewExtensionOptionsDecorator(nil),

--- a/app/ante/panic.go
+++ b/app/ante/panic.go
@@ -24,7 +24,7 @@ func (d HandlePanicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 }
 
 func FormatTx(tx sdk.Tx) string {
-	output := fmt.Sprintf("\ncaused by transaction:\n")
+	output := "\ncaused by transaction:\n"
 	for _, msg := range tx.GetMsgs() {
 		output += fmt.Sprintf("%T{%s}\n", msg, msg)
 	}

--- a/app/ante/panic.go
+++ b/app/ante/panic.go
@@ -1,0 +1,24 @@
+package ante
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// HandlePanicDecorator that catches panics and wraps them in the transaction that caused the panic
+type HandlePanicDecorator struct{}
+
+func NewHandlePanicDecorator() HandlePanicDecorator {
+	return HandlePanicDecorator{}
+}
+
+func (d HandlePanicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			panic(fmt.Sprint(r, tx))
+		}
+	}()
+
+	return next(newCtx, tx, simulate)
+}

--- a/app/ante/panic.go
+++ b/app/ante/panic.go
@@ -16,9 +16,17 @@ func NewHandlePanicDecorator() HandlePanicDecorator {
 func (d HandlePanicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			panic(fmt.Sprint(r, tx))
+			panic(fmt.Sprint(r, FormatTx(tx)))
 		}
 	}()
 
-	return next(newCtx, tx, simulate)
+	return next(ctx, tx, simulate)
+}
+
+func FormatTx(tx sdk.Tx) string {
+	output := fmt.Sprintf("\ncaused by transaction:\n")
+	for _, msg := range tx.GetMsgs() {
+		output += fmt.Sprintf("%T{%s}\n", msg, msg)
+	}
+	return output
 }

--- a/app/ante/panic_test.go
+++ b/app/ante/panic_test.go
@@ -1,0 +1,36 @@
+package ante_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/celestiaorg/celestia-app/app/ante"
+	"github.com/celestiaorg/celestia-app/app/encoding"
+	"github.com/celestiaorg/celestia-app/test/util/testnode"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPanicHandlerDecorator(t *testing.T) {
+	decorator := ante.NewHandlePanicDecorator()
+	anteHandler := sdk.ChainAnteDecorators(decorator, mockPanicDecorator{})
+	ctx := sdk.Context{}
+	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	builder := encCfg.TxConfig.NewTxBuilder()
+	builder.SetMsgs(banktypes.NewMsgSend(testnode.RandomAddress().(sdk.AccAddress), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 10))))
+	tx := builder.GetTx()
+	defer func() {
+		r := recover()
+		require.NotNil(t, r)
+		require.Equal(t, fmt.Sprint("mock panic", ante.FormatTx(tx)), r)
+	}()
+	_, _ = anteHandler(ctx, tx, false)
+}
+
+type mockPanicDecorator struct{}
+
+func (d mockPanicDecorator) AnteHandle(_ sdk.Context, _ sdk.Tx, _ bool, _ sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	panic("mock panic")
+}

--- a/app/ante/panic_test.go
+++ b/app/ante/panic_test.go
@@ -19,7 +19,8 @@ func TestPanicHandlerDecorator(t *testing.T) {
 	ctx := sdk.Context{}
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	builder := encCfg.TxConfig.NewTxBuilder()
-	builder.SetMsgs(banktypes.NewMsgSend(testnode.RandomAddress().(sdk.AccAddress), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 10))))
+	err := builder.SetMsgs(banktypes.NewMsgSend(testnode.RandomAddress().(sdk.AccAddress), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 10))))
+	require.NoError(t, err)
 	tx := builder.GetTx()
 	defer func() {
 		r := recover()


### PR DESCRIPTION
Closes: #2557

This will allow us to understand when a panic happens, which transaction caused it.

As an example here is a mock panic:

```
mock panic
caused by transaction:
*types.MsgSend{from_address:"celestia15v4r83er48zfrm7u6uuqs3lytwxc63c34ltdgn" to_address:"celestia1t5m2f2m000twkmsgaa777rty36wd254292am6c" amount:<denom:"utia" amount:"10" > }
```