### PR TITLE
feat: add metrics to prepare and process proposal

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -1,10 +1,13 @@
 package app
 
 import (
+	"time"
+
 	"github.com/celestiaorg/celestia-app/app/ante"
 	"github.com/celestiaorg/celestia-app/pkg/da"
 	"github.com/celestiaorg/celestia-app/pkg/shares"
 	"github.com/celestiaorg/celestia-app/pkg/square"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	abci "github.com/tendermint/tendermint/abci/types"
 	core "github.com/tendermint/tendermint/proto/tendermint/types"
 )
@@ -16,6 +19,7 @@ import (
 // tendermint via the BlockData. Panics indicate a developer error and should
 // immediately halt the node for visibility and so they can be quickly resolved.
 func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+	defer telemetry.MeasureSince(time.Now(), "prepare_proposal")
 	// create a context using a branch of the state and loaded using the
 	// proposal height and chain-id
 	sdkCtx := app.NewProposalContext(core.Header{

--- a/app/validate_txs.go
+++ b/app/validate_txs.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	"github.com/tendermint/tendermint/libs/log"
@@ -54,6 +55,7 @@ func filterStdTxs(logger log.Logger, dec sdk.TxDecoder, ctx sdk.Context, handler
 				"error", err,
 				"msgs", msgTypes(sdkTx),
 			)
+			telemetry.IncrCounter(1, "prepare_proposal", "invalid_std_txs")
 			continue
 		}
 		txs[n] = tx
@@ -83,6 +85,7 @@ func filterBlobTxs(logger log.Logger, dec sdk.TxDecoder, ctx sdk.Context, handle
 			logger.Error(
 				"filtering already checked blob transaction", "tx", tmbytes.HexBytes(coretypes.Tx(tx.Tx).Hash()), "error", err,
 			)
+			telemetry.IncrCounter(1, "prepare_proposal", "invalid_blob_txs")
 			continue
 		}
 		txs[n] = tx


### PR DESCRIPTION
Closes: https://github.com/celestiaorg/celestia-app/issues/2517

This PR adds metrics to track:
- The amount of times process proposal recovers from a panic
- The amount of invalid transactions that get filtered in prepare proposal
- The time it takes for prepare proposal and process proposal to execute