### PR TITLE
feat: add a default ttl to the mempool config

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -218,7 +218,8 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	// TODO: make TimeoutBroadcastTx configurable per https://github.com/celestiaorg/celestia-app/issues/1034
 	cfg.RPC.TimeoutBroadcastTxCommit = 50 * time.Second
 	cfg.RPC.MaxBodyBytes = int64(8388608) // 8 MiB
-	cfg.Mempool.TTLNumBlocks = 10
+	cfg.Mempool.TTLNumBlocks = 5
+	cfg.Mempool.TTLDuration = time.Duration(cfg.Mempool.TTLNumBlocks) * appconsts.GoalBlockTime
 	// Given that there is a stateful transaction size check in CheckTx,
 	// We set a loose upper bound on what we expect the transaction to
 	// be based on the upper bound size of the entire block for the given

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"time"
 
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	qgbcmd "github.com/celestiaorg/celestia-app/x/qgb/client"
@@ -37,7 +36,6 @@ import (
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
 	"github.com/spf13/cast"
 	"github.com/spf13/cobra"
-	tmcfg "github.com/tendermint/tendermint/config"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
 	"github.com/tendermint/tendermint/libs/log"
 	dbm "github.com/tendermint/tm-db"
@@ -84,19 +82,7 @@ func NewRootCmd() *cobra.Command {
 			}
 
 			// Override the default tendermint config for celestia-app
-			tmCfg := tmcfg.DefaultConfig()
-
-			// Set broadcast timeout to be 50 seconds in order to avoid timeouts for long block times
-			// TODO: make TimeoutBroadcastTx configurable per https://github.com/celestiaorg/celestia-app/issues/1034
-			tmCfg.RPC.TimeoutBroadcastTxCommit = 50 * time.Second
-			tmCfg.RPC.MaxBodyBytes = int64(8388608) // 8 MiB
-			tmCfg.Mempool.TTLNumBlocks = 10
-			tmCfg.Mempool.MaxTxBytes = 2 * 1024 * 1024 // 2 MiB
-			tmCfg.Mempool.Version = "v1"               // prioritized mempool
-			tmCfg.Consensus.TimeoutPropose = appconsts.TimeoutPropose
-			tmCfg.Consensus.TimeoutCommit = appconsts.TimeoutCommit
-			tmCfg.Consensus.SkipTimeoutCommit = false
-
+			tmCfg := app.DefaultConsensusConfig()
 			customAppTemplate, customAppConfig := initAppConfig()
 
 			err = server.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, tmCfg)


### PR DESCRIPTION
After merging https://github.com/celestiaorg/celestia-core/pull/1088, it makes sense to add a default time based TTL to the mempool. This PR reduced the block TTL to 5 (instead of 10) and the time to 5 * 15 seconds = 75 seconds

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
