### PR TITLE
feat: allow for hardcoded upgrade schedules

### DIFF
--- a/test/tokenfilter/setup.go
+++ b/test/tokenfilter/setup.go
@@ -140,7 +140,7 @@ func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs 
 	encCdc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	genesisState := app.NewDefaultGenesisState(encCdc.Codec)
 	app := app.New(
-		log.NewNopLogger(), db, nil, true, map[int64]bool{}, app.DefaultNodeHome, 5, encCdc, simapp.EmptyAppOptions{},
+		log.NewNopLogger(), db, nil, true, 5, encCdc, nil, simapp.EmptyAppOptions{},
 	)
 
 	// set genesis accounts

--- a/test/util/malicious/app.go
+++ b/test/util/malicious/app.go
@@ -52,14 +52,12 @@ func New(
 	db dbm.DB,
 	traceStore io.Writer,
 	loadLatest bool,
-	skipUpgradeHeights map[int64]bool,
-	homePath string,
 	invCheckPeriod uint,
 	encodingConfig encoding.Config,
 	appOpts servertypes.AppOptions,
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
-	goodApp := app.New(logger, db, traceStore, loadLatest, skipUpgradeHeights, homePath, invCheckPeriod, encodingConfig, appOpts, baseAppOptions...)
+	goodApp := app.New(logger, db, traceStore, loadLatest, invCheckPeriod, encodingConfig, nil, appOpts, baseAppOptions...)
 	badApp := &App{App: goodApp}
 
 	// set the malicious prepare proposal handler if it is set in the app options

--- a/test/util/malicious/test_app.go
+++ b/test/util/malicious/test_app.go
@@ -60,11 +60,6 @@ func NewAppServer(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts se
 		cache = store.NewCommitKVStoreCacheManager()
 	}
 
-	skipUpgradeHeights := make(map[int64]bool)
-	for _, h := range cast.ToIntSlice(appOpts.Get(server.FlagUnsafeSkipUpgrades)) {
-		skipUpgradeHeights[int64(h)] = true
-	}
-
 	pruningOpts, err := server.GetPruningOptionsFromFlags(appOpts)
 	if err != nil {
 		panic(err)
@@ -83,8 +78,7 @@ func NewAppServer(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts se
 	}
 
 	return New(
-		logger, db, traceStore, true, skipUpgradeHeights,
-		cast.ToString(appOpts.Get(flags.FlagHome)),
+		logger, db, traceStore, true,
 		cast.ToUint(appOpts.Get(server.FlagInvCheckPeriod)),
 		encoding.MakeConfig(app.ModuleEncodingRegisters...), // Ideally, we would reuse the one created by NewRootCmd.
 		appOpts,

--- a/test/util/network/network.go
+++ b/test/util/network/network.go
@@ -77,8 +77,8 @@ func DefaultConfig() network.Config {
 		AccountRetriever:  authtypes.AccountRetriever{},
 		AppConstructor: func(val network.Validator) servertypes.Application {
 			return app.New(
-				val.Ctx.Logger, tmdb.NewMemDB(), nil, true, map[int64]bool{}, val.Ctx.Config.RootDir, 0,
-				encCfg,
+				val.Ctx.Logger, tmdb.NewMemDB(), nil, true, 0,
+				encCfg, nil,
 				simapp.EmptyAppOptions{},
 				baseapp.SetPruning(pruningtypes.NewPruningOptionsFromString(val.AppConfig.Pruning)),
 				baseapp.SetMinGasPrices(val.AppConfig.MinGasPrices),

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -10,7 +10,6 @@ import (
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
-	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
@@ -56,15 +55,14 @@ func SetupTestAppWithGenesisValSet(cparams *tmproto.ConsensusParams, genAccounts
 	emptyOpts := emptyAppOptions{}
 	// var anteOpt = func(bapp *baseapp.BaseApp) { bapp.SetAnteHandler(nil) }
 	db := dbm.NewMemDB()
-	skipUpgradeHeights := make(map[int64]bool)
 
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
 	testApp := app.New(
-		log.NewNopLogger(), db, nil, true, skipUpgradeHeights,
-		cast.ToString(emptyOpts.Get(flags.FlagHome)),
+		log.NewNopLogger(), db, nil, true,
 		cast.ToUint(emptyOpts.Get(server.FlagInvCheckPeriod)),
 		encCfg,
+		nil,
 		emptyOpts,
 	)
 	testApp.GetBaseApp().SetProtocolVersion(appconsts.LatestVersion)

--- a/x/upgrade/keeper.go
+++ b/x/upgrade/keeper.go
@@ -1,0 +1,89 @@
+package upgrade
+
+import (
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/upgrade/types"
+	ibctypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+)
+
+var _ ibctypes.UpgradeKeeper = (*Keeper)(nil)
+
+type Keeper struct {
+	// we use the same upgrade store key so existing IBC client state can
+	// safely be ported over without any migration
+	storeKey storetypes.StoreKey
+
+	// in memory copy of the upgrade schedule if any. This is local per node
+	// and configured from the config.
+	upgradeSchedule Schedule
+}
+
+// NewKeeper constructs an upgrade keeper
+func NewKeeper(storeKey storetypes.StoreKey, upgradeSchedule Schedule) Keeper {
+	return Keeper{
+		storeKey:        storeKey,
+		upgradeSchedule: upgradeSchedule,
+	}
+}
+
+// ScheduleUpgrade implements the ibc upgrade keeper interface. This is a noop as
+// no other process is allowed to schedule an upgrade but the upgrade keeper itself.
+// This is kept around to support the interface.
+func (k Keeper) ScheduleUpgrade(_ sdk.Context, _ types.Plan) error {
+	return nil
+}
+
+// GetUpgradePlan implements the ibc upgrade keeper interface. This is used in BeginBlock
+// to know when to write the upgraded consensus state. The IBC module needs to sign over
+// the next consensus state to ensure a smooth transition for counterparty chains. This
+// is implemented as a noop. Any IBC breaking change would be invoked by this upgrade module
+// in end blocker.
+func (k Keeper) GetUpgradePlan(_ sdk.Context) (plan types.Plan, havePlan bool) {
+	return types.Plan{}, false
+}
+
+// SetUpgradedClient sets the expected upgraded client for the next version of this chain at the last height the current chain will commit.
+func (k Keeper) SetUpgradedClient(ctx sdk.Context, planHeight int64, bz []byte) error {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.UpgradedClientKey(planHeight), bz)
+	return nil
+}
+
+// GetUpgradedClient gets the expected upgraded client for the next version of this chain
+func (k Keeper) GetUpgradedClient(ctx sdk.Context, height int64) ([]byte, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.UpgradedClientKey(height))
+	if len(bz) == 0 {
+		return nil, false
+	}
+
+	return bz, true
+}
+
+// SetUpgradedConsensusState set the expected upgraded consensus state for the next version of this chain
+// using the last height committed on this chain.
+func (k Keeper) SetUpgradedConsensusState(ctx sdk.Context, planHeight int64, bz []byte) error {
+	store := ctx.KVStore(k.storeKey)
+	store.Set(types.UpgradedConsStateKey(planHeight), bz)
+	return nil
+}
+
+// GetUpgradedConsensusState set the expected upgraded consensus state for the next version of this chain
+func (k Keeper) GetUpgradedConsensusState(ctx sdk.Context, lastHeight int64) ([]byte, bool) {
+	store := ctx.KVStore(k.storeKey)
+	bz := store.Get(types.UpgradedConsStateKey(lastHeight))
+	if len(bz) == 0 {
+		return nil, false
+	}
+
+	return bz, true
+}
+
+// ClearIBCState clears any planned IBC state
+func (k Keeper) ClearIBCState(ctx sdk.Context, lastHeight int64) {
+	// delete IBC client and consensus state from store if this is IBC plan
+	store := ctx.KVStore(k.storeKey)
+	store.Delete(types.UpgradedClientKey(lastHeight))
+	store.Delete(types.UpgradedConsStateKey(lastHeight))
+}

--- a/x/upgrade/types.go
+++ b/x/upgrade/types.go
@@ -6,16 +6,19 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
+const (
+	StoreKey   = upgradetypes.StoreKey
+	ModuleName = upgradetypes.ModuleName
+)
+
 // TypeRegister is used to register the upgrade module's types in the encoding
 // config without defining an entire module.
 type TypeRegister struct{}
 
 // RegisterLegacyAminoCodec registers the upgrade types on the LegacyAmino codec.
 func (TypeRegister) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	upgradetypes.RegisterLegacyAminoCodec(cdc)
+	cdc.RegisterConcrete(upgradetypes.Plan{}, "cosmos-sdk/Plan", nil)
 }
 
 // RegisterInterfaces registers the upgrade module types.
-func (TypeRegister) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
-	upgradetypes.RegisterInterfaces(registry)
-}
+func (TypeRegister) RegisterInterfaces(_ codectypes.InterfaceRegistry) {}

--- a/x/upgrade/upgrade.go
+++ b/x/upgrade/upgrade.go
@@ -1,0 +1,34 @@
+package upgrade
+
+type Schedule map[string]map[int64]uint64 // chain-id -> height -> app version
+
+// ShouldUpgradeNextHeight returns true if the network of the given chainID should
+// modify the app version in the following block. This can be used for both upgrading
+// and downgrading. This relies on social consensus to work. At least 2/3+ of the
+// validators must have the same app version and height in their schedule for the
+// upgrade to happen successfully.
+func (k Keeper) ShouldUpgradeNextHeight(chainID string, height int64) bool {
+	if k.upgradeSchedule == nil {
+		return false
+	}
+	if schedule, ok := k.upgradeSchedule[chainID]; ok {
+		if _, ok := schedule[height+1]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// GetAppVersionForNextHeight returns the app version that the network of the given
+// chainID should modify in the following block. This is 0, if none is provided.
+func (k Keeper) GetAppVersionForNextHeight(chainID string, height int64) uint64 {
+	if k.upgradeSchedule == nil {
+		return 0
+	}
+	if schedule, ok := k.upgradeSchedule[chainID]; ok {
+		if appVersion, ok := schedule[height+1]; ok {
+			return appVersion
+		}
+	}
+	return 0
+}


### PR DESCRIPTION
This PR implements the protocol work behind ADR018. It replaces the existing upgrade module with a custom one which is capable of modifying the app version in EndBlock so that the next block is proposed using the new version