### PR TITLE
ci: check if goreleaser config is valid

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -37,6 +37,16 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: check
+
   # If this was a workflow dispatch event, we need to generate and push a tag
   # for goreleaser to grab
   version_bump:


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2452

## Testing

Tested on my fork

```
/opt/hostedtoolcache/goreleaser-action/1.21.2/x64/goreleaser check
  • checking                                 path=
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

Ref: https://github.com/rootulp/celestia-app/actions/runs/6473546638/job/17576484916?pr=39#step:3:16