### PR TITLE
ci: goreleaser darwin

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,9 @@ builds:
       - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
     goarch:
       - amd64
+      - arm64
     goos:
+      - darwin
       - linux
     tags:
       - ledger


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2567

## Testing

Testing with binaries on [my fork](https://github.com/rootulp/celestia-app/releases/tag/v1.0.0-rc5).

| os     | arch  | machine       | works | notes                                                                                                                                                                     |
|--------|-------|---------------|-------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| darwin | amd64 | Rootul's MBP  | ✅    | I had to circumvent [Apple can't check app for malicious software](https://support.apple.com/guide/mac-help/apple-cant-check-app-for-malicious-software-mchleab3a043/mac) |
| darwin | arm64 | TBD           |       |                                                                                                                                                                           |
| linux  | amd64 | Digital Ocean |       |                                                                                                                                                                           |
| linux  | arm64 | Digital Ocean |       |                                                                                                                                                                           |