### PR TITLE
fix: download celestia-app-maintainers key in verify signature script

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,12 @@ If you use a pre-built binary, you may also want to verify the checksums and sig
     You should see output like this:
 
     ```shell
-    gpg: Signature made Thu Sep 21 14:39:26 2023 EDT
+    gpg: Signature made Tue Oct 10 13:25:06 2023 UTC
     gpg:                using EDDSA key BF02F32CC36864560B90B764D469F859693DC3FA
-    gpg: Good signature from "celestia-app-maintainers <celestia-app-maintainers@celestia.org>" [ultimate]
+    gpg: Good signature from "celestia-app-maintainers <celestia-app-maintainers@celestia.org>" [unknown]
+    gpg: WARNING: This key is not certified with a trusted signature!
+    gpg:          There is no indication that the signature belongs to the owner.
+    Primary key fingerprint: BF02 F32C C368 6456 0B90  B764 D469 F859 693D C3FA
     ```
 
 ### Ledger Support

--- a/scripts/signing/verify-signature.sh
+++ b/scripts/signing/verify-signature.sh
@@ -13,8 +13,17 @@ fi
 # PGP Key
 # celestia-app-maintainers <celestia-app-maintainers@celestia.org>
 # BF02F32CC36864560B90B764D469F859693DC3FA
-echo "Importing the celestia-app-maintainers public key..."
-gpg --keyserver keys.openpgp.org --recv-keys BF02F32CC36864560B90B764D469F859693DC3FA
+KEY_FILENAME="celestia-app-maintainers.asc"
+GITHUB_URL="https://raw.githubusercontent.com/celestiaorg/celestia-app/main/scripts/signing/${KEY_FILENAME}"
+
+echo "Downloading the celestia-app-maintainers public key"
+curl -L ${GITHUB_URL} -o ${KEY_FILENAME}
+
+echo "Importing ${KEY_FILENAME}"
+gpg --import ${KEY_FILENAME}
+
+echo "Deleting ${KEY_FILENAME}"
+rm ${KEY_FILENAME}
 
 echo "Verifying the signature of "$1" with "$2""
 gpg --verify $1 $2


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2664

## Testing

On a Digital Ocean droplet that has no keys,

```
root@rootulp-quicksync:~# ./verify-signature.sh checksums.txt.sig checksums.txt
Downloading the celestia-app-maintainers public key...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   689  100   689    0     0   6270      0 --:--:-- --:--:-- --:--:--  6321
Importing celestia-app-maintainers.asc
gpg: key D469F859693DC3FA: public key "celestia-app-maintainers <celestia-app-maintainers@celestia.org>" imported
gpg: Total number processed: 1
gpg:               imported: 1
Deleting celestia-app-maintainers.asc
Verifying the signature of checksums.txt.sig with checksums.txt
gpg: Signature made Tue Oct 10 13:25:06 2023 UTC
gpg:                using EDDSA key BF02F32CC36864560B90B764D469F859693DC3FA
gpg: Good signature from "celestia-app-maintainers <celestia-app-maintainers@celestia.org>" [unknown]
gpg: WARNING: This key is not certified with a trusted signature!
gpg:          There is no indication that the signature belongs to the owner.
Primary key fingerprint: BF02 F32C C368 6456 0B90  B764 D469 F859 693D C3FA
```