### PR TITLE
ci: separate out PR tests and run fuzzing and race in nightlies

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,5 +1,6 @@
 name: nightly
 on:
+  workflow_dispatch:
   schedule:
     # runs every day at 6am UTC
     - cron: "0 6 * * *"
@@ -26,3 +27,26 @@ jobs:
 
       - name: Run e2e tests
         run: make test-e2e
+
+  race-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Run tests in race mode
+        run: make test-race
+
+  fuzz_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - uses: jidicula/go-fuzz-action@v1.1.0
+        with:
+          packages: './...'
+          fuzz-time: 2m
+          go-version: ${{ env.GO_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,69 +7,69 @@ env:
 
 jobs:
   split-test-files:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-    - name: Create a file with all Celestia pkgs
-      run: go list ./... > pkgs.txt
-    - name: Split pkgs into 4 files
-      run: split -d -n l/4 pkgs.txt pkgs.txt.part.
-    - uses: actions/upload-artifact@v3
-      with:
-        name: "${{ github.sha }}-00"
-        path: ./pkgs.txt.part.00
-    - uses: actions/upload-artifact@v3
-      with:
-        name: "${{ github.sha }}-01"
-        path: ./pkgs.txt.part.01
-    - uses: actions/upload-artifact@v3
-      with:
-        name: "${{ github.sha }}-02"
-        path: ./pkgs.txt.part.02
-    - uses: actions/upload-artifact@v3
-      with:
-        name: "${{ github.sha }}-03"
-        path: ./pkgs.txt.part.03
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Create a file with all Celestia pkgs
+        run: go list ./... > pkgs.txt
+      - name: Split pkgs into 4 files
+        run: split -d -n l/4 pkgs.txt pkgs.txt.part.
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-00"
+          path: ./pkgs.txt.part.00
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-01"
+          path: ./pkgs.txt.part.01
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-02"
+          path: ./pkgs.txt.part.02
+      - uses: actions/upload-artifact@v3
+        with:
+          name: "${{ github.sha }}-03"
+          path: ./pkgs.txt.part.03
 
-tests:
-  runs-on: ubuntu-latest
-  needs: split-test-files
-  strategy:
-    fail-fast: false
-    matrix:
-      part: ["00", "01", "02", "03"]
-  steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-go@v4
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-        cache: true
-        cache-dependency-path: go.sum
-    - uses: technote-space/get-diff-action@v6.1.2
-      id: git_diff
-      with:
-        PATTERNS: |
-          **/*.go
-          go.mod
-          go.sum
-          **/go.mod
-          **/go.sum
-          Makefile
-    - uses: actions/download-artifact@v3
-      with:
-        name: "${{ github.sha }}-${{ matrix.part }}"
-    - name: test & coverage report creation
-      if: env.GIT_DIFF
-      run: |
-        cat pkgs.txt.part.${{ matrix.part }} | xargs go test -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic
-    - uses: actions/upload-artifact@v3
-      if: env.GIT_DIFF
-      with:
-        name: "${{ github.sha }}-${{ matrix.part }}-coverage"
-        path: ./${{ matrix.part }}profile.out
+  tests:
+    runs-on: ubuntu-latest
+    needs: split-test-files
+    strategy:
+      fail-fast: false
+      matrix:
+        part: ["00", "01", "02", "03"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+          cache: true
+          cache-dependency-path: go.sum
+      - uses: technote-space/get-diff-action@v6.1.2
+        id: git_diff
+        with:
+          PATTERNS: |
+            **/*.go
+            go.mod
+            go.sum
+            **/go.mod
+            **/go.sum
+            Makefile
+      - uses: actions/download-artifact@v3
+        with:
+          name: "${{ github.sha }}-${{ matrix.part }}"
+      - name: test & coverage report creation
+        if: env.GIT_DIFF
+        run: |
+          cat pkgs.txt.part.${{ matrix.part }} | xargs go test -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic
+      - uses: actions/upload-artifact@v3
+        if: env.GIT_DIFF
+        with:
+          name: "${{ github.sha }}-${{ matrix.part }}-coverage"
+          path: ./${{ matrix.part }}profile.out
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,4 +72,3 @@ jobs:
         with:
           name: "${{ github.sha }}-${{ matrix.part }}-coverage"
           path: ./${{ matrix.part }}profile.out
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,56 +6,70 @@ env:
   GO_VERSION: '1.21.1'
 
 jobs:
-  test-short:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+  split-test-files:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        check-latest: true
+    - name: Create a file with all Celestia pkgs
+      run: go list ./... > pkgs.txt
+    - name: Split pkgs into 4 files
+      run: split -d -n l/4 pkgs.txt pkgs.txt.part.
+    - uses: actions/upload-artifact@v3
+      with:
+        name: "${{ github.sha }}-00"
+        path: ./pkgs.txt.part.00
+    - uses: actions/upload-artifact@v3
+      with:
+        name: "${{ github.sha }}-01"
+        path: ./pkgs.txt.part.01
+    - uses: actions/upload-artifact@v3
+      with:
+        name: "${{ github.sha }}-02"
+        path: ./pkgs.txt.part.02
+    - uses: actions/upload-artifact@v3
+      with:
+        name: "${{ github.sha }}-03"
+        path: ./pkgs.txt.part.03
 
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
+tests:
+  runs-on: ubuntu-latest
+  needs: split-test-files
+  strategy:
+    fail-fast: false
+    matrix:
+      part: ["00", "01", "02", "03"]
+  steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        check-latest: true
+        cache: true
+        cache-dependency-path: go.sum
+    - uses: technote-space/get-diff-action@v6.1.2
+      id: git_diff
+      with:
+        PATTERNS: |
+          **/*.go
+          go.mod
+          go.sum
+          **/go.mod
+          **/go.sum
+          Makefile
+    - uses: actions/download-artifact@v3
+      with:
+        name: "${{ github.sha }}-${{ matrix.part }}"
+    - name: test & coverage report creation
+      if: env.GIT_DIFF
+      run: |
+        cat pkgs.txt.part.${{ matrix.part }} | xargs go test -timeout 30m -coverprofile=${{ matrix.part }}profile.out -covermode=atomic
+    - uses: actions/upload-artifact@v3
+      if: env.GIT_DIFF
+      with:
+        name: "${{ github.sha }}-${{ matrix.part }}-coverage"
+        path: ./${{ matrix.part }}profile.out
 
-      - name: Run tests in short mode
-        run: make test-short
-        timeout-minutes: 10
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Run tests
-        run: make test
-
-  test-coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Generate coverage.txt
-        run: make test-coverage
-
-      - name: Upload coverage.txt
-        uses: codecov/codecov-action@v3.1.4
-        with:
-          file: ./coverage.txt
-
-  test-race:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v4
-        with:
-          go-version: ${{ env.GO_VERSION }}
-
-      - name: Run tests in race mode
-        run: make test-race


### PR DESCRIPTION
This PR attempts to improve our CI. It breaks up our test suite into 4 parallel test jobs. It doesn't replicate the work by removing `test-short` and `test-coverage`, combining them into a single job.

This PR also moves our race tests to the nightlies and adds fuzzing to the nightlies