### PR TITLE
ci: PRs titles must have a conventional commit prefix

### DIFF
--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -1,0 +1,20 @@
+name: lint-pull-request
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-pull-request.yml
+++ b/.github/workflows/lint-pull-request.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   main:
-    name: Validate PR title
+    name: conventional-commit-pr-title
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v5


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/1539 by validating that PR titles have a conventional commit prefix

## Testing
1. https://github.com/rootulp/celestia-app/pull/42
2. https://github.com/rootulp/celestia-app/pull/43