### PR TITLE
chore: update deafult mempool size to match ttl and block size

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -225,6 +225,7 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	// version. This acts as a first line of DoS protection
 	upperBoundBytes := appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound * appconsts.ContinuationSparseShareContentSize
 	cfg.Mempool.MaxTxBytes = upperBoundBytes
+	cfg.Mempool.MaxTxsBytes = appconsts.DefaultMaxBytes * cfg.Mempool.TTLNumBlocks
 
 	cfg.Mempool.Version = "v1" // prioritized mempool
 	cfg.Consensus.TimeoutPropose = appconsts.TimeoutPropose

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -225,7 +225,7 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	// version. This acts as a first line of DoS protection
 	upperBoundBytes := appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound * appconsts.ContinuationSparseShareContentSize
 	cfg.Mempool.MaxTxBytes = upperBoundBytes
-	cfg.Mempool.MaxTxsBytes = appconsts.DefaultMaxBytes * cfg.Mempool.TTLNumBlocks
+	cfg.Mempool.MaxTxsBytes = int64(upperBoundBytes) * cfg.Mempool.TTLNumBlocks
 
 	cfg.Mempool.Version = "v1" // prioritized mempool
 	cfg.Consensus.TimeoutPropose = appconsts.TimeoutPropose


### PR DESCRIPTION
## Overview

The default mempool size should match that of the default TTL and block size.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
