### PR TITLE
fix: override proposer rewards to 0%

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -141,7 +141,7 @@ var (
 		capability.AppModuleBasic{},
 		stakingModule{},
 		mintModule{},
-		distr.AppModuleBasic{},
+		distributionModule{},
 		newGovModule(),
 		params.AppModuleBasic{},
 		crisisModule{},

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -15,7 +15,9 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	crisistypes "github.com/cosmos/cosmos-sdk/x/crisis/types"
+	distribution "github.com/cosmos/cosmos-sdk/x/distribution"
 	distrclient "github.com/cosmos/cosmos-sdk/x/distribution/client"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/cosmos/cosmos-sdk/x/gov"
 	govclient "github.com/cosmos/cosmos-sdk/x/gov/client"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
@@ -114,6 +116,20 @@ type crisisModule struct {
 func (crisisModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	return cdc.MustMarshalJSON(&crisistypes.GenesisState{
 		ConstantFee: sdk.NewCoin(BondDenom, sdk.NewInt(1000)),
+	})
+}
+
+type distributionModule struct {
+	distribution.AppModuleBasic
+}
+
+// DefaultGenesis returns custom x/distribution module genesis state.
+func (distributionModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
+	params := distributiontypes.DefaultParams()
+	params.BaseProposerReward = sdk.ZeroDec()  // 0%
+	params.BonusProposerReward = sdk.ZeroDec() // 0%
+	return cdc.MustMarshalJSON(&distributiontypes.GenesisState{
+		Params: params,
 	})
 }
 

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -128,7 +128,9 @@ func (distributionModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	params := distributiontypes.DefaultParams()
 	params.BaseProposerReward = sdk.ZeroDec()  // 0%
 	params.BonusProposerReward = sdk.ZeroDec() // 0%
-	return cdc.MustMarshalJSON(&distributiontypes.GenesisState{})
+	return cdc.MustMarshalJSON(&distributiontypes.GenesisState{
+		Params: params,
+	})
 }
 
 type ibcModule struct {

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -128,9 +128,7 @@ func (distributionModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	params := distributiontypes.DefaultParams()
 	params.BaseProposerReward = sdk.ZeroDec()  // 0%
 	params.BonusProposerReward = sdk.ZeroDec() // 0%
-	return cdc.MustMarshalJSON(&distributiontypes.GenesisState{
-		Params: params,
-	})
+	return cdc.MustMarshalJSON(&distributiontypes.GenesisState{})
 }
 
 type ibcModule struct {

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/celestiaorg/celestia-app/app/encoding"
 	"github.com/cosmos/cosmos-sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/stretchr/testify/assert"
 )
@@ -31,4 +33,22 @@ func Test_newGovModule(t *testing.T) {
 	assert.Equal(t, want, govGenesisState.DepositParams.MinDeposit)
 	assert.Equal(t, oneWeek, *govGenesisState.DepositParams.MaxDepositPeriod)
 	assert.Equal(t, oneWeek, *govGenesisState.VotingParams.VotingPeriod)
+}
+
+// TestDefaultGenesis verifies that the distribution module's genesis state has
+// defaults overriden.
+func TestDefaultGenesis(t *testing.T) {
+	encCfg := encoding.MakeConfig(ModuleEncodingRegisters...)
+	dm := distributionModule{}
+	raw := dm.DefaultGenesis(encCfg.Codec)
+	distributionGenesisState := distributiontypes.GenesisState{}
+	encCfg.Codec.MustUnmarshalJSON(raw, &distributionGenesisState)
+
+	// Verify that BaseProposerReward and BonusProposerReward were overriden to 0%.
+	assert.Equal(t, sdk.ZeroDec(), distributionGenesisState.Params.BaseProposerReward)
+	assert.Equal(t, sdk.ZeroDec(), distributionGenesisState.Params.BonusProposerReward)
+
+	// Verify that other params weren't overriden.
+	assert.Equal(t, distributiontypes.DefaultParams().WithdrawAddrEnabled, distributionGenesisState.Params.WithdrawAddrEnabled)
+	assert.Equal(t, distributiontypes.DefaultParams().CommunityTax, distributionGenesisState.Params.CommunityTax)
 }

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/app/encoding"
 	"github.com/cosmos/cosmos-sdk/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
 	"github.com/stretchr/testify/assert"
@@ -36,7 +35,7 @@ func Test_newGovModule(t *testing.T) {
 }
 
 // TestDefaultGenesis verifies that the distribution module's genesis state has
-// defaults overriden.
+// defaults overridden.
 func TestDefaultGenesis(t *testing.T) {
 	encCfg := encoding.MakeConfig(ModuleEncodingRegisters...)
 	dm := distributionModule{}
@@ -44,11 +43,11 @@ func TestDefaultGenesis(t *testing.T) {
 	distributionGenesisState := distributiontypes.GenesisState{}
 	encCfg.Codec.MustUnmarshalJSON(raw, &distributionGenesisState)
 
-	// Verify that BaseProposerReward and BonusProposerReward were overriden to 0%.
-	assert.Equal(t, sdk.ZeroDec(), distributionGenesisState.Params.BaseProposerReward)
-	assert.Equal(t, sdk.ZeroDec(), distributionGenesisState.Params.BonusProposerReward)
+	// Verify that BaseProposerReward and BonusProposerReward were overridden to 0%.
+	assert.Equal(t, types.ZeroDec(), distributionGenesisState.Params.BaseProposerReward)
+	assert.Equal(t, types.ZeroDec(), distributionGenesisState.Params.BonusProposerReward)
 
-	// Verify that other params weren't overriden.
+	// Verify that other params weren't overridden.
 	assert.Equal(t, distributiontypes.DefaultParams().WithdrawAddrEnabled, distributionGenesisState.Params.WithdrawAddrEnabled)
 	assert.Equal(t, distributiontypes.DefaultParams().CommunityTax, distributionGenesisState.Params.CommunityTax)
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2716

## Testing

```bash
./scripts/single-node.sh
cat ~/.celestia-app/config/genesis.json
```

### Before

```genesis.json
    "distribution": {
      "params": {
        "community_tax": "0.020000000000000000",
        "base_proposer_reward": "0.010000000000000000",
        "bonus_proposer_reward": "0.040000000000000000",
        "withdraw_addr_enabled": true
      },
```

### After

```genesis.json
    "distribution": {
      "params": {
        "community_tax": "0.020000000000000000",
        "base_proposer_reward": "0.000000000000000000",
        "bonus_proposer_reward": "0.000000000000000000",
        "withdraw_addr_enabled": true
      },
```