### PR TITLE
ci: remove markdown-linter as prerequisite to version bump

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -40,7 +40,7 @@ jobs:
   # If this was a workflow dispatch event, we need to generate and push a tag
   # for goreleaser to grab
   version_bump:
-    needs: [lint, markdown-linter, test]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     permissions: "write-all"
     steps:


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/2749

The markdown-linter job contains markdown-link-check which is super flakey. If it fails on a release then the pre-built binaries won't be generated and attached to the release.