### PR TITLE
chore: disable API, GRPC, and GRPC web by default

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -253,7 +253,9 @@ func DefaultConsensusConfig() *tmcfg.Config {
 
 func DefaultAppConfig() *serverconfig.Config {
 	cfg := serverconfig.DefaultConfig()
-	cfg.API.Enable = true
+	cfg.API.Enable = false
+	cfg.GRPC.Enable = false
+	cfg.GRPCWeb.Enable = false
 
 	// the default snapshot interval was determined by picking a large enough
 	// value as to not dramatically increase resource requirements while also

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -51,3 +51,15 @@ func TestDefaultGenesis(t *testing.T) {
 	assert.Equal(t, distributiontypes.DefaultParams().WithdrawAddrEnabled, distributionGenesisState.Params.WithdrawAddrEnabled)
 	assert.Equal(t, distributiontypes.DefaultParams().CommunityTax, distributionGenesisState.Params.CommunityTax)
 }
+
+func TestDefaultAppConfig(t *testing.T) {
+	cfg := DefaultAppConfig()
+
+	assert.False(t, cfg.API.Enable)
+	assert.False(t, cfg.GRPC.Enable)
+	assert.False(t, cfg.GRPCWeb.Enable)
+
+	assert.Equal(t, uint64(1500), cfg.StateSync.SnapshotInterval)
+	assert.Equal(t, uint32(2), cfg.StateSync.SnapshotKeepRecent)
+	assert.Equal(t, "0.1utia", cfg.MinGasPrices)
+}

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -91,4 +91,6 @@ sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' "${CELESTIA_APP
 echo "Starting celestia-app..."
 celestia-appd start \
   --home ${CELESTIA_APP_HOME} \
-  --api.enable
+  --api.enable \
+  --grpc.enable \
+  --grpc-web.enable


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2758

## Testing
```
./scripts/single-node.sh
cat ~/.celestia-app/config/app.toml
```

Verified that 

```toml
[api]

# Enable defines if the API server should be enabled.
enable = false
```

```toml
[grpc]

# Enable defines if the gRPC server should be enabled.
enable = false
```

```toml
[grpc-web]

# GRPCWebEnable defines if the gRPC-web should be enabled.
# NOTE: gRPC must also be enabled, otherwise, this configuration is a no-op.
enable = false
```
