### PR TITLE
docs: fix broken links to docs.celestia.org

### DIFF
--- a/tools/blocktime/readme.md
+++ b/tools/blocktime/readme.md
@@ -2,7 +2,7 @@
 
 `blocktime` is a simple tool to analyze block production rates of a chain. It scrapes the latest headers through the RPC endpoint of a provided node and calculates the average, min, max and standard deviation of the intervals between the last `n` blocks (default: 100).
 
-To read up on starting a node and exposing the RPC endpoint go to the docs [here](https://docs.celestia.org/nodes/full-consensus-node/)
+To read up on starting a node and exposing the RPC endpoint go to the docs [here](https://docs.celestia.org/nodes/consensus-node)
 
 ## Usage
 

--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -203,7 +203,7 @@ celestia-app tx blob PayForBlobs <hex encoded namespace> <hex encoded data> [fla
 ```
 
 For submitting PFB transaction via a light client's rpc, see [celestia-node's
-documention](https://docs.celestia.org/developers/node-tutorial/#submitting-data ).
+documention](https://docs.celestia.org/developers/node-tutorial#command-formatting).
 
 The steps in the
 [`SubmitPayForBlobs`](https://github.com/celestiaorg/celestia-app/blob/v1.0.0-rc2/x/blob/payforblob.go#L15-L54)

--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -203,7 +203,7 @@ celestia-app tx blob PayForBlobs <hex encoded namespace> <hex encoded data> [fla
 ```
 
 For submitting PFB transaction via a light client's rpc, see [celestia-node's
-documention](https://docs.celestia.org/developers/node-tutorial#command-formatting).
+documention](https://docs.celestia.org/developers/node-tutorial#submitting-data).
 
 The steps in the
 [`SubmitPayForBlobs`](https://github.com/celestiaorg/celestia-app/blob/v1.0.0-rc2/x/blob/payforblob.go#L15-L54)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2762

## Testing

`make markdown-link-check` passes locally