### PR TITLE
ci: add goreleaser-check as a require step for the goreleaser build

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -50,7 +50,7 @@ jobs:
   # If this was a workflow dispatch event, we need to generate and push a tag
   # for goreleaser to grab
   version_bump:
-    needs: [lint, markdown-linter, test]
+    needs: [lint, markdown-linter, test, goreleaser-check]
     runs-on: ubuntu-latest
     permissions: "write-all"
     steps:
@@ -69,7 +69,7 @@ jobs:
 
   # Generate the release with goreleaser to include pre-built binaries
   goreleaser:
-    needs: [goreleaser-check, version_bump]
+    needs: version_bump
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -69,7 +69,7 @@ jobs:
 
   # Generate the release with goreleaser to include pre-built binaries
   goreleaser:
-    needs: version_bump
+    needs: [goreleaser-check, version_bump]
     runs-on: ubuntu-20.04
     if: |
       github.event_name == 'workflow_dispatch' ||


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Minor update I saw when debugging the CI. This will ensure that the goreleaser step won't run if the goreleaser check fails. This will just clean up the error log a little bit. 
