### PR TITLE
ci: remove markdown-linter as prerequisite to version bump

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -50,7 +50,7 @@ jobs:
   # If this was a workflow dispatch event, we need to generate and push a tag
   # for goreleaser to grab
   version_bump:
-    needs: [lint, markdown-linter, test]
+    needs: [lint, test]
     runs-on: ubuntu-latest
     permissions: "write-all"
     steps:


### PR DESCRIPTION
Forward ports https://github.com/celestiaorg/celestia-app/pull/2751 to main

FYI: may introduce merge conflicts with https://github.com/celestiaorg/celestia-app/pull/2772 cc: @MSevey 