### PR TITLE
fix: address serialization in PayForBlobs event

### DIFF
--- a/x/blob/keeper/keeper.go
+++ b/x/blob/keeper/keeper.go
@@ -54,7 +54,7 @@ func (k Keeper) PayForBlobs(goCtx context.Context, msg *types.MsgPayForBlobs) (*
 	ctx.GasMeter().ConsumeGas(gasToConsume, payForBlobGasDescriptor)
 
 	err := ctx.EventManager().EmitTypedEvent(
-		types.NewPayForBlobsEvent(sdk.AccAddress(msg.Signer).String(), msg.BlobSizes, msg.Namespaces),
+		types.NewPayForBlobsEvent(msg.Signer, msg.BlobSizes, msg.Namespaces),
 	)
 	if err != nil {
 		return &types.MsgPayForBlobsResponse{}, err

--- a/x/blob/keeper/keeper_test.go
+++ b/x/blob/keeper/keeper_test.go
@@ -16,6 +16,7 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 )
 
+// TestPayForBlobs verifies the attributes on the emitted event.
 func TestPayForBlobs(t *testing.T) {
 	k, stateStore := keeper(t)
 	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, nil)
@@ -36,9 +37,9 @@ func TestPayForBlobs(t *testing.T) {
 	// verify that an event was emitted
 	events = ctx.EventManager().Events().ToABCIEvents()
 	assert.Len(t, events, 1)
-	parsedEvent, err := sdk.ParseTypedEvent(events[0])
+	protoEvent, err := sdk.ParseTypedEvent(events[0])
 	require.NoError(t, err)
-	event, err := ConvertToEventPayForBlobs(parsedEvent)
+	event, err := convertToEventPayForBlobs(protoEvent)
 	require.NoError(t, err)
 
 	// verify the attributes of the event
@@ -47,8 +48,7 @@ func TestPayForBlobs(t *testing.T) {
 	assert.Equal(t, blobSizes, event.BlobSizes)
 }
 
-func ConvertToEventPayForBlobs(message proto.Message) (*types.EventPayForBlobs, error) {
-	// Type assertion to convert proto.Message to *EventPayForBlobs
+func convertToEventPayForBlobs(message proto.Message) (*types.EventPayForBlobs, error) {
 	if event, ok := message.(*types.EventPayForBlobs); ok {
 		return event, nil
 	}

--- a/x/blob/keeper/keeper_test.go
+++ b/x/blob/keeper/keeper_test.go
@@ -32,7 +32,8 @@ func TestPayForBlobs(t *testing.T) {
 
 	// emit an event by submitting a PayForBlob
 	msg := createMsgPayForBlob(t, signer, namespace, blobData)
-	k.PayForBlobs(ctx, msg)
+	_, err := k.PayForBlobs(ctx, msg)
+	require.NoError(t, err)
 
 	// verify that an event was emitted
 	events = ctx.EventManager().Events().ToABCIEvents()

--- a/x/blob/keeper/keeper_test.go
+++ b/x/blob/keeper/keeper_test.go
@@ -1,0 +1,63 @@
+package keeper
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/pkg/blob"
+	appns "github.com/celestiaorg/celestia-app/pkg/namespace"
+	"github.com/celestiaorg/celestia-app/x/blob/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	proto "github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestPayForBlobs(t *testing.T) {
+	k, stateStore := keeper(t)
+	ctx := sdk.NewContext(stateStore, tmproto.Header{}, false, nil)
+	signer := "celestia15drmhzw5kwgenvemy30rqqqgq52axf5wwrruf7"
+	namespace := appns.MustNewV0(bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))
+	namespaces := [][]byte{namespace.Bytes()}
+	blobData := []byte("blob")
+	blobSizes := []uint32{uint32(len(blobData))}
+
+	// verify no events exist yet
+	events := ctx.EventManager().Events().ToABCIEvents()
+	assert.Len(t, events, 0)
+
+	// emit an event by submitting a PayForBlob
+	msg := createMsgPayForBlob(t, signer, namespace, blobData)
+	k.PayForBlobs(ctx, msg)
+
+	// verify that an event was emitted
+	events = ctx.EventManager().Events().ToABCIEvents()
+	assert.Len(t, events, 1)
+	parsedEvent, err := sdk.ParseTypedEvent(events[0])
+	require.NoError(t, err)
+	event, err := ConvertToEventPayForBlobs(parsedEvent)
+	require.NoError(t, err)
+
+	// verify the attributes of the event
+	assert.Equal(t, signer, event.Signer)
+	assert.Equal(t, namespaces, event.Namespaces)
+	assert.Equal(t, blobSizes, event.BlobSizes)
+}
+
+func ConvertToEventPayForBlobs(message proto.Message) (*types.EventPayForBlobs, error) {
+	// Type assertion to convert proto.Message to *EventPayForBlobs
+	if event, ok := message.(*types.EventPayForBlobs); ok {
+		return event, nil
+	}
+	return nil, fmt.Errorf("message is not of type EventPayForBlobs")
+}
+
+func createMsgPayForBlob(t *testing.T, signer string, namespace appns.Namespace, blobData []byte) *types.MsgPayForBlobs {
+	blob := blob.New(namespace, blobData, appconsts.ShareVersionZero)
+	msg, err := types.NewMsgPayForBlobs(signer, blob)
+	require.NoError(t, err)
+	return msg
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2781

Note this _shouldn't_ be consensus breaking b/c the ABCI response results hash shouldn't depend on events. [`deterministicResponseDeliverTx`](https://github.com/celestiaorg/celestia-core/blob/ffdb652634fb1b6b6426c0f1a2c5adec8af80253/types/results.go#L45-L55) filters events from the response. Thanks @cmwaters for identifying.

Draft PR because
- [x] Needs a unit test
- [ ] Confirm this isn't consensus breaking. Run a two node local devnet. One pre this change. One post this change. Submit a PFB.

