### PR TITLE
feat: backport addrbook command (backport #2623 and #2783)

### DIFF
--- a/cmd/celestia-appd/cmd/addrbook.go
+++ b/cmd/celestia-appd/cmd/addrbook.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/celestiaorg/celestia-app/app"
+	"github.com/spf13/cobra"
+	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/p2p/pex"
+)
+
+func addrbookCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "addrbook peers.txt addrbook.json",
+		Short: "Convert a list of peers into an address book",
+		Long: "Convert a list of peers into an address book.\n" +
+			"The first argument (peers.txt) should contain a new line separated list of peers. The format for a peer is `id@ip:port` or `id@domain:port`.\n" +
+			"The second argument (addrbook.json) should contain the complete file path, including both the directory path and the desired output file name, in the following format: `path/to/filename`. The address book is saved to the output file in JSON format.\n",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			inputFile := args[0]
+			outputFile := args[1]
+
+			data, err := os.ReadFile(inputFile)
+			if err != nil {
+				return err
+			}
+			lines := strings.Split(string(data), "\n")
+
+			routabilityStrict := app.DefaultConsensusConfig().P2P.AddrBookStrict
+			book := pex.NewAddrBook(outputFile, routabilityStrict)
+			for _, line := range lines {
+				if line == "" {
+					continue
+				}
+				address, err := p2p.NewNetAddressString(line)
+				if err != nil {
+					return err
+				}
+				err = book.AddAddress(address, address)
+				if err != nil {
+					return err
+				}
+			}
+
+			book.Save()
+			fmt.Printf("Converted %s into %s\n", inputFile, outputFile)
+			return nil
+		},
+	}
+
+	return cmd
+}

--- a/cmd/celestia-appd/cmd/addrbook.go
+++ b/cmd/celestia-appd/cmd/addrbook.go
@@ -37,11 +37,13 @@ func addrbookCommand() *cobra.Command {
 				}
 				address, err := p2p.NewNetAddressString(line)
 				if err != nil {
-					return err
+					fmt.Printf("Error parsing %s: %s\n", line, err)
+					continue
 				}
 				err = book.AddAddress(address, address)
 				if err != nil {
-					return err
+					fmt.Printf("Error adding %s: %s\n", address, err)
+					continue
 				}
 			}
 

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -128,6 +128,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig encoding.Config) {
 		debugCmd,
 		config.Cmd(),
 		commands.CompactGoLevelDBCmd,
+		addrbookCommand(),
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, NewAppServer, createAppAndExport, addModuleInitFlags)


### PR DESCRIPTION
Backports https://github.com/celestiaorg/celestia-app/pull/2623 and https://github.com/celestiaorg/celestia-app/pull/2783

## Testing

```
$ ./build/celestia-appd addrbook ~/git/rootulp/celestia/networks/celestia/peers.txt ~/Downloads/addrbook.json
Error adding b751ffe713e3e5d80e8f45c3bd5e640ee9a91cb9@10.129.127.95:26656: Cannot add non-routable address b751ffe713e3e5d80e8f45c3bd5e640ee9a91cb9@10.129.127.95:26656
Converted /Users/rootulp/git/rootulp/celestia/networks/celestia/peers.txt into /Users/rootulp/Downloads/addrbook.json

$ head -n 10  /Users/rootulp/Downloads/addrbook.json
{
	"key": "8957397890a66cd0f716cbc9",
	"addrs": [
		{
			"addr": {
				"id": "a41b4bc451b1b71d537aa1018226e08d7fa7e44e",
				"ip": "5.255.77.44",
				"port": 26656
			},
			"src": {
```

