### PR TITLE
refactor(x/blobstream): remove unnecessary code

### DIFF
--- a/x/blobstream/abci.go
+++ b/x/blobstream/abci.go
@@ -143,23 +143,17 @@ func pruneAttestations(ctx sdk.Context, k keeper.Keeper) {
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return
 	}
-	earliestAttestation, found, err := k.GetAttestationByNonce(ctx, k.GetEarliestAvailableAttestationNonce(ctx))
-	if err != nil {
-		ctx.Logger().Error("error getting earliest attestation for pruning", "err", err.Error())
-		return
-	}
+	found := k.CheckEarliestAvailableAttestationNonce(ctx)
 	if !found {
 		ctx.Logger().Error("couldn't find earliest attestation for pruning")
 		return
 	}
-	if earliestAttestation == nil {
-		ctx.Logger().Error("nil earliest attestation")
-		return
-	}
+
 	currentBlockTime := ctx.BlockTime()
 	latestAttestationNonce := k.GetLatestAttestationNonce(ctx)
+	earliestNounce := k.GetEarliestAvailableAttestationNonce(ctx)
 	var newEarliestAvailableNonce uint64
-	for newEarliestAvailableNonce = earliestAttestation.GetNonce(); newEarliestAvailableNonce < latestAttestationNonce; newEarliestAvailableNonce++ {
+	for newEarliestAvailableNonce = earliestNounce; newEarliestAvailableNonce < latestAttestationNonce; newEarliestAvailableNonce++ {
 		newEarliestAttestation, found, err := k.GetAttestationByNonce(ctx, newEarliestAvailableNonce)
 		if err != nil {
 			ctx.Logger().Error("error getting attestation for pruning", "nonce", newEarliestAvailableNonce, "err", err.Error())
@@ -181,13 +175,13 @@ func pruneAttestations(ctx sdk.Context, k keeper.Keeper) {
 		}
 		k.DeleteAttestation(ctx, newEarliestAvailableNonce)
 	}
-	if newEarliestAvailableNonce > earliestAttestation.GetNonce() {
+	if newEarliestAvailableNonce > earliestNounce {
 		// some attestations were pruned and we need to update the state for it
 		k.SetEarliestAvailableAttestationNonce(ctx, newEarliestAvailableNonce)
 		ctx.Logger().Debug(
 			"pruned attestations from Blobstream store",
 			"count",
-			newEarliestAvailableNonce-earliestAttestation.GetNonce(),
+			newEarliestAvailableNonce-earliestNounce,
 			"new_earliest_available_nonce",
 			newEarliestAvailableNonce,
 			"latest_attestation_nonce",

--- a/x/blobstream/abci.go
+++ b/x/blobstream/abci.go
@@ -143,17 +143,16 @@ func pruneAttestations(ctx sdk.Context, k keeper.Keeper) {
 	if !k.CheckLatestAttestationNonce(ctx) {
 		return
 	}
-	found := k.CheckEarliestAvailableAttestationNonce(ctx)
-	if !found {
+	if !k.CheckEarliestAvailableAttestationNonce(ctx) {
 		ctx.Logger().Error("couldn't find earliest attestation for pruning")
 		return
 	}
 
 	currentBlockTime := ctx.BlockTime()
 	latestAttestationNonce := k.GetLatestAttestationNonce(ctx)
-	earliestNounce := k.GetEarliestAvailableAttestationNonce(ctx)
+	earliestNonce := k.GetEarliestAvailableAttestationNonce(ctx)
 	var newEarliestAvailableNonce uint64
-	for newEarliestAvailableNonce = earliestNounce; newEarliestAvailableNonce < latestAttestationNonce; newEarliestAvailableNonce++ {
+	for newEarliestAvailableNonce = earliestNonce; newEarliestAvailableNonce < latestAttestationNonce; newEarliestAvailableNonce++ {
 		newEarliestAttestation, found, err := k.GetAttestationByNonce(ctx, newEarliestAvailableNonce)
 		if err != nil {
 			ctx.Logger().Error("error getting attestation for pruning", "nonce", newEarliestAvailableNonce, "err", err.Error())
@@ -175,13 +174,13 @@ func pruneAttestations(ctx sdk.Context, k keeper.Keeper) {
 		}
 		k.DeleteAttestation(ctx, newEarliestAvailableNonce)
 	}
-	if newEarliestAvailableNonce > earliestNounce {
+	if newEarliestAvailableNonce > earliestNonce {
 		// some attestations were pruned and we need to update the state for it
 		k.SetEarliestAvailableAttestationNonce(ctx, newEarliestAvailableNonce)
 		ctx.Logger().Debug(
 			"pruned attestations from Blobstream store",
 			"count",
-			newEarliestAvailableNonce-earliestNounce,
+			newEarliestAvailableNonce-earliestNonce,
 			"new_earliest_available_nonce",
 			newEarliestAvailableNonce,
 			"latest_attestation_nonce",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Closes: [#2765](https://github.com/celestiaorg/celestia-app/issues/2765)

## Changes

- Call `CheckEarliestAvailableAttestationNonce ` to check if Nonce is available
- Use `GetEarliestAvailableAttestationNonce ` to fetch the nonce use in [`newEarliestAvailableNonce`](https://github.com/celestiaorg/celestia-app/blob/2335d2b7d8d9463abc85f79b430926380dd41001/x/qgb/abci.go#L161) and logging in [here](https://github.com/celestiaorg/celestia-app/blob/2335d2b7d8d9463abc85f79b430926380dd41001/x/qgb/abci.go#L183) and [here](https://github.com/celestiaorg/celestia-app/blob/2335d2b7d8d9463abc85f79b430926380dd41001/x/qgb/abci.go#L189)
