### PR TITLE
docs: how to add a new chain-id to download genesis

### DIFF
--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// chainIDToSha256 is a map of chainID to the SHA-256 hash of the genesis file for that chain ID.
+// To add a new chain-id, download the genesis file from the networks repo and compute the SHA-256 hash.
+// Add the chain-id and hash to this map.
 var chainIDToSha256 = map[string]string{
 	"celestia":   "9727aac9bbfb021ce7fc695a92f901986421283a891b89e0af97bc9fad187793",
 	"mocha-4":    "0846b99099271b240b638a94e17a6301423b5e4047f6558df543d6e91db7e575",
@@ -75,11 +78,7 @@ func getChainIDOrDefault(args []string) string {
 
 // isKnownChainID returns true if the chainID is known.
 func isKnownChainID(chainID string) bool {
-	knownChainIDs := []string{
-		"arabica-10", // testnet
-		"mocha-4",    // testnet
-		"celestia",   // mainnet
-	}
+	knownChainIDs := getKeys(chainIDToSha256)
 	return contains(knownChainIDs, chainID)
 }
 
@@ -125,4 +124,11 @@ func computeSha256(filepath string) (string, error) {
 	}
 
 	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+func getKeys(m map[string]string) (result []string) {
+	for key := range m {
+		result = append(result, key)
+	}
+	return result
 }

--- a/cmd/celestia-appd/cmd/download_genesis_test.go
+++ b/cmd/celestia-appd/cmd/download_genesis_test.go
@@ -1,0 +1,27 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_isKnownChainID(t *testing.T) {
+	type testCase struct {
+		chainID string
+		want    bool
+	}
+	testCases := []testCase{
+		{"celestia", true},
+		{"mocha-4", true},
+		{"arabica-10", true},
+		{"foo", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.chainID, func(t *testing.T) {
+			got := isKnownChainID(tc.chainID)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2792

## Testing

```go
$ ./build/celestia-appd download-genesis
Downloading genesis file for celestia to /Users/rootulp/.celestia-app/config/genesis.json
Downloaded genesis file for celestia to /Users/rootulp/.celestia-app/config/genesis.json
SHA-256 hash verified for celestia

$ cat ~/.celestia-app/config/genesis.json | jq ."chain_id"
"celestia"

$ ./build/celestia-appd download-genesis mocha-4
Downloading genesis file for mocha-4 to /Users/rootulp/.celestia-app/config/genesis.json
Downloaded genesis file for mocha-4 to /Users/rootulp/.celestia-app/config/genesis.json
SHA-256 hash verified for mocha-4

$ cat ~/.celestia-app/config/genesis.json | jq ."chain_id"
"mocha-4"
```