### PR TITLE
feat(cmd): snapshots command

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/keys"
 	"github.com/cosmos/cosmos-sdk/client/rpc"
+	"github.com/cosmos/cosmos-sdk/client/snapshot"
 	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -148,6 +149,9 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig encoding.Config) {
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
 		bscmd.VerifyCmd(),
+	)
+	rootCmd.AddCommand(
+		snapshot.Cmd(NewAppServer),
 	)
 }
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2824

## Testing

I verified the snapshots command was added

```shell
$ ./build/celestia-appd snapshots
Manage local snapshots

Usage:
  celestia-appd snapshots [command]

Available Commands:
  delete      Delete a local snapshot
  dump        Dump the snapshot as portable archive format
  export      Export app state to snapshot store
  list        List local snapshots
  load        Load a snapshot archive file (.tar.gz) into snapshot store
  restore     Restore app state from local snapshot

Flags:
  -h, --help   help for snapshots

```