### PR TITLE
fix: handle context cancellations in txsim

### DIFF
--- a/test/txsim/run.go
+++ b/test/txsim/run.go
@@ -101,8 +101,15 @@ func Run(
 			log.Info().Err(err).Msg("sequence terminated")
 			continue
 		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			continue
+		}
 		log.Error().Err(err).Msg("sequence failed")
 		finalErr = err
+	}
+
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	return finalErr


### PR DESCRIPTION
I have seen a few CI tests fail because although the context stops the process, it isn't correctly parsed causing the program that called the txsim to think that there was another error and not the context Canceled or DeadlineExceeded errors
