### PR TITLE
chore: lower the default mempool min gas price

### DIFF
--- a/pkg/appconsts/initial_consts.go
+++ b/pkg/appconsts/initial_consts.go
@@ -20,7 +20,7 @@ const (
 	// DefaultMinGasPrice is the default min gas price that gets set in the app.toml file.
 	// The min gas price acts as a filter. Transactions below that limit will not pass
 	// a nodes `CheckTx` and thus not be proposed by that node.
-	DefaultMinGasPrice = 0.1
+	DefaultMinGasPrice = 0.01
 
 	// DefaultUnbondingTime is the default time a validator must wait
 	// to unbond in a proof of stake system. Any validator within this


### PR DESCRIPTION
## Overview

The mempool minfee seems too high as the goal of it is just to reduce spam if the blocks are empty. The proper solution will come with a consensus critical dynamic minfee. For now the default should be lowered by an order of magnitude.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
