### PR TITLE
chore: remove import hack for protobuf any

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -23,11 +23,6 @@ done
 
 cd ..
 
-# temporary import hack to use cosmos-sdk implementation of Any type.
-# check https://github.com/celestiaorg/celestia-app/issues/507 for more information.
-sed -i 's/types "github.com\/celestiaorg\/celestia-app\/codec\/types"/types "github.com\/cosmos\/cosmos-sdk\/codec\/types"/g' \
- github.com/celestiaorg/celestia-app/x/blobstream/types/query.pb.go
-
 # move proto files to the right places
 cp -r github.com/celestiaorg/celestia-app/* ./
 rm -rf github.com


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/744

This import hack doesn't seem necessary b/c it doesn't actually modify `x/blobstream/types/query.pb.go`

## Testing

```
$ rm x/blobstream/types/query.pb.go
$ make proto-gen
```

and then observe that there is no `git diff` so no changes to the already checked in `x/blobstream/types/query.pb.go` and the generated one.

Also proto-gen passes in CI: https://github.com/celestiaorg/celestia-app/actions/runs/6881660922/job/18718509598?pr=2846