### PR TITLE
docs: move optional step into collapsible details

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ If you'd rather not install from source, you can download a pre-built binary fro
     ./celestia-appd --help
     ```
 
-#### Optional: Verify the pre-built binary checksums and signatures
+<details>
+<summary>
+Optional: Verify the pre-built binary checksums and signatures  
+</summary>
 
 If you use a pre-built binary, you may also want to verify the checksums and signatures.
 
@@ -99,6 +102,7 @@ If you use a pre-built binary, you may also want to verify the checksums and sig
     gpg:          There is no indication that the signature belongs to the owner.
     Primary key fingerprint: BF02 F32C C368 6456 0B90  B764 D469 F859 693D C3FA
     ```
+</details>
 
 ### Ledger Support
 


### PR DESCRIPTION
The optional step for verifying the pre-built binary takes up a large chunk of the README. Since it's a less frequently used procedure, proposal to hide the contents into a collapsible details section.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added instructions for verifying checksums and signatures of pre-built binaries in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->