### PR TITLE
chore: disable CodeCov comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,1 @@
+comment: false


### PR DESCRIPTION
During Thursday sync, we agreed to try disabling the CodeCov comments on PRs b/c they can be noisy. Note: the code coverage on PRs still gets uploaded to CodeCov via `make test-coverage`

Ref: https://docs.codecov.com/docs/pull-request-comments#disable-comment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated configuration to disable automated comments from the code coverage tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->