### PR TITLE
ci: disable CodeRabbit high level summary

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,7 +2,7 @@
 language: "en" # English
 early_access: false
 reviews:
-  high_level_summary: true
+  high_level_summary: false # Disable the high level summary because this feature modifies the original PR description. Ideally this feature would add a new comment to the PR instead of modifying the original PR description.
   poem: false # Disable the poem feature because it adds noise and doesn't improve the review process.
   review_status: false
   collapse_walkthrough: true


### PR DESCRIPTION
Based on [Slack thread](https://celestia-team.slack.com/archives/C02PFFCGMNW/p1700507951358399). 

Consider re-enabling if CodeRabbit modifies this feature so that the high level summary gets included in a comment on the PR rather than modifying the original PR description.
