### PR TITLE
fix: set the protocol version during integration tests

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -108,6 +108,9 @@ const (
 	BondDenomAlias = "microtia"
 	// DisplayDenom defines the name, symbol, and display value of the Celestia token.
 	DisplayDenom = "TIA"
+	// SetProtocolVersionOptionKey is the key used to set the protocol version
+	// to a specific value during tests.
+	SetProtocolVersionOptionKey = "set-protocol-version"
 )
 
 // These constants are derived from the above variables.
@@ -258,6 +261,15 @@ func New(
 	appCodec := encodingConfig.Codec
 	cdc := encodingConfig.Amino
 	interfaceRegistry := encodingConfig.InterfaceRegistry
+
+	// set the protocol version to a specific value if specified. This is used
+	// for testing purposes.
+	if pvo := appOpts.Get(SetProtocolVersionOptionKey); pvo != nil {
+		baseAppOptions = append(baseAppOptions, func(ba *baseapp.BaseApp) {
+			appVersion := pvo.(uint64)
+			ba.SetProtocolVersion(appVersion)
+		})
+	}
 
 	bApp := baseapp.NewBaseApp(Name, logger, db, encodingConfig.TxConfig.TxDecoder(), baseAppOptions...)
 	bApp.SetCommitMultiStoreTracer(traceStore)

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -3,6 +3,7 @@ package testnode
 import (
 	"time"
 
+	"github.com/celestiaorg/celestia-app/app"
 	"github.com/celestiaorg/celestia-app/cmd/celestia-appd/cmd"
 	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/test/util/genesis"
@@ -146,6 +147,7 @@ func (ao *KVAppOptions) Set(o string, v interface{}) {
 func DefaultAppOptions() *KVAppOptions {
 	opts := &KVAppOptions{options: make(map[string]interface{})}
 	opts.Set(server.FlagPruning, pruningtypes.PruningOptionNothing)
+	opts.Set(app.SetProtocolVersionOptionKey, appconsts.LatestVersion)
 	return opts
 }
 

--- a/test/util/testnode/full_node_test.go
+++ b/test/util/testnode/full_node_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-app/test/util/genesis"
 	blobtypes "github.com/celestiaorg/celestia-app/x/blob/types"
 	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
 	tmrand "github.com/tendermint/tendermint/libs/rand"
@@ -131,4 +132,13 @@ func (s *IntegrationTestSuite) Test_FillBlock_InvalidSquareSizeError() {
 			s.Equal(tc.expectedErr, actualErr)
 		})
 	}
+}
+
+// Test_defaultAppVersion tests that the default app version is set correctly in
+// testnode.
+func (s *IntegrationTestSuite) Test_defaultAppVersion() {
+	t := s.T()
+	blockRes, err := s.cctx.Client.Block(s.cctx.GoContext(), nil)
+	require.NoError(t, err)
+	require.Equal(t, appconsts.LatestVersion, blockRes.Block.Version.App)
 }


### PR DESCRIPTION
## Overview

Ever since we implemented upgrades, we moved the baseapp.Option to set the protocol version outside of the app creator. This is a desired property to make v2 compatible for v1, however that also means that we stopped setting the app version in testnode. This PR remedies that by adding an app option to set manually set the protocol version in testnode. This also allows for the testground tooling to set its own app version, which is necessary for extremely large blonks.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the ability to set a specific protocol version for testing purposes.

- **Tests**
  - Added a new test to verify that the default application version matches the latest protocol version.

- **Refactor**
  - Updated default application options to include the latest protocol version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->