### PR TITLE
test: TestGasConsumption

### DIFF
--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -111,8 +110,8 @@ func (s *SignerTestSuite) TestGasConsumption() {
 }
 
 func (s *SignerTestSuite) queryCurrentBalance(t *testing.T) int64 {
-	balanceQuery := banktypes.NewQueryClient(s.ctx.GRPCClient)
-	balanceResp, err := balanceQuery.AllBalances(s.ctx.GoContext(), &banktypes.QueryAllBalancesRequest{Address: s.signer.Address().String()})
+	balanceQuery := bank.NewQueryClient(s.ctx.GRPCClient)
+	balanceResp, err := balanceQuery.AllBalances(s.ctx.GoContext(), &bank.QueryAllBalancesRequest{Address: s.signer.Address().String()})
 	require.NoError(t, err)
 	return balanceResp.Balances.AmountOf(app.BondDenom).Int64()
 }

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -12,8 +12,10 @@ import (
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/rand"
 )
 
@@ -73,4 +75,44 @@ func (s *SignerTestSuite) ConfirmTxTimeout() {
 	_, err := s.signer.ConfirmTx(ctx, string("E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728"))
 	require.Error(s.T(), err)
 	require.Equal(s.T(), err, context.DeadlineExceeded)
+}
+
+// TestGasConsumption verifies that the amount deducted from a user's balance is
+// based on the fee provided in the tx instead of the gas used by the tx. This
+// behavior leads to poor UX because tx submitters must over-estimate the amount
+// of gas that their tx will consume and they are not refunded for the excess.
+func (s *SignerTestSuite) TestGasConsumption() {
+	t := s.T()
+
+	utiaToSend := int64(1)
+	msg := bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, utiaToSend)))
+
+	gasPrice := int64(1)
+	gasLimit := uint64(1e6)
+	fee := uint64(1e6)
+	// Note: gas price * gas limit = fee amount. So by setting gasLimit and fee
+	// to the same value, these options set a gas price of 1utia.
+	options := []user.TxOption{user.SetGasLimit(gasLimit), user.SetFee(fee)}
+
+	balanceBefore := s.queryCurrentBalance(t)
+	resp, err := s.signer.SubmitTx(s.ctx.GoContext(), []sdk.Msg{msg}, options...)
+	require.NoError(t, err)
+
+	require.EqualValues(t, abci.CodeTypeOK, resp.Code)
+	balanceAfter := s.queryCurrentBalance(t)
+
+	// verify that the amount deducted depends on the fee set in the tx.
+	amountDeducted := balanceBefore - balanceAfter - utiaToSend
+	require.EqualValues(t, int64(fee), amountDeducted)
+
+	// verify that the amount deducted does not depend on the actual gas used.
+	gasUsedBasedDeduction := resp.GasUsed * gasPrice
+	require.NotEqual(t, gasUsedBasedDeduction, amountDeducted)
+}
+
+func (s *SignerTestSuite) queryCurrentBalance(t *testing.T) int64 {
+	balanceQuery := banktypes.NewQueryClient(s.ctx.GRPCClient)
+	balanceResp, err := balanceQuery.AllBalances(s.ctx.GoContext(), &banktypes.QueryAllBalancesRequest{Address: s.signer.Address().String()})
+	require.NoError(t, err)
+	return balanceResp.Balances.AmountOf(app.BondDenom).Int64()
 }

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	abci "github.com/tendermint/tendermint/abci/types"
@@ -102,11 +103,11 @@ func (s *SignerTestSuite) TestGasConsumption() {
 
 	// verify that the amount deducted depends on the fee set in the tx.
 	amountDeducted := balanceBefore - balanceAfter - utiaToSend
-	require.EqualValues(t, int64(fee), amountDeducted)
+	assert.Equal(t, int64(fee), amountDeducted)
 
 	// verify that the amount deducted does not depend on the actual gas used.
 	gasUsedBasedDeduction := resp.GasUsed * gasPrice
-	require.NotEqual(t, gasUsedBasedDeduction, amountDeducted)
+	assert.NotEqual(t, gasUsedBasedDeduction, amountDeducted)
 }
 
 func (s *SignerTestSuite) queryCurrentBalance(t *testing.T) int64 {

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -89,7 +89,7 @@ func (s *SignerTestSuite) TestGasConsumption() {
 
 	gasPrice := int64(1)
 	gasLimit := uint64(1e6)
-	fee := uint64(1e6)
+	fee := uint64(1e6) // 1 TIA
 	// Note: gas price * gas limit = fee amount. So by setting gasLimit and fee
 	// to the same value, these options set a gas price of 1utia.
 	options := []user.TxOption{user.SetGasLimit(gasLimit), user.SetFee(fee)}
@@ -108,6 +108,8 @@ func (s *SignerTestSuite) TestGasConsumption() {
 	// verify that the amount deducted does not depend on the actual gas used.
 	gasUsedBasedDeduction := resp.GasUsed * gasPrice
 	assert.NotEqual(t, gasUsedBasedDeduction, amountDeducted)
+	// The gas used based deduction should be less than the fee because the fee is 1 TIA.
+	assert.Less(t, gasUsedBasedDeduction, int64(fee))
 }
 
 func (s *SignerTestSuite) queryCurrentBalance(t *testing.T) int64 {


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/1944

Note: we don't strictly need to merge this. I opted to write a test for the existing behavior so that we have a straight-forward way to verify the behavior change after we implement gas refunds.