### PR TITLE
chore(pkg/user): fix typo

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -267,7 +267,7 @@ func (s *Signer) PubKey() cryptotypes.PubKey {
 	return s.pk
 }
 
-// GetSequence gets the lastest signed sequence and increments the local sequence number
+// GetSequence gets the latest signed sequence and increments the local sequence number
 func (s *Signer) GetSequence() uint64 {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()


### PR DESCRIPTION
very last forgotten typo from #2926 

the repo should now be typo free, quite the feat!
