### PR TITLE
test: resolve flakes for application.db

### DIFF
--- a/test/util/testnode/full_node.go
+++ b/test/util/testnode/full_node.go
@@ -19,7 +19,9 @@ import (
 // already initialized and saved to the baseDir.
 func NewCometNode(baseDir string, cfg *UniversalTestingConfig) (*node.Node, srvtypes.Application, error) {
 	logger := newLogger(cfg)
-	dbPath := filepath.Join(cfg.TmConfig.RootDir, "data")
+	// Put the database in a new directory called "database" instead of "data"
+	// because "data" will be managed by CometBFT.
+	dbPath := filepath.Join(cfg.TmConfig.RootDir, "database")
 	db, err := dbm.NewGoLevelDB("application", dbPath)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2918 by moving `application.db` to a distinct directory. Since the default config of CometBFT uses `data` ([ref](https://github.com/celestiaorg/celestia-core/blob/51600002aa445e26f52dfddf661c8e06c03ad57c/config/config.go#L257)), this PR uses a new directory: `database`.