### PR TITLE
feat(upgrade): register legacy amino json

### DIFF
--- a/x/upgrade/types/codec.go
+++ b/x/upgrade/types/codec.go
@@ -3,6 +3,7 @@ package types
 import (
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
@@ -10,9 +11,13 @@ import (
 // RegisterLegacyAminoCodec registers the upgrade types on the LegacyAmino codec.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(upgradetypes.Plan{}, "cosmos-sdk/Plan", nil)
+	cdc.RegisterConcrete(&MsgTryUpgrade{}, "/celestia.upgrade.v1.Msg/TryUpgrade", nil)
+	cdc.RegisterConcrete(&MsgSignalVersion{}, "/celestia.upgrade.v1.Msg/SignalVersion", nil)
 }
 
 // RegisterInterfaces registers the upgrade module types.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgTryUpgrade{})
+	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgSignalVersion{})
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/upgrade/types/codec.go
+++ b/x/upgrade/types/codec.go
@@ -5,6 +5,7 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
@@ -19,5 +20,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgTryUpgrade{})
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgSignalVersion{})
+	registry.RegisterInterface("cosmos.auth.v1beta1.BaseAccount", (*authtypes.AccountI)(nil))
+	registry.RegisterImplementations((*authtypes.AccountI)(nil), &authtypes.BaseAccount{})
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/upgrade/types/codec.go
+++ b/x/upgrade/types/codec.go
@@ -5,22 +5,19 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
-	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
 // RegisterLegacyAminoCodec registers the upgrade types on the LegacyAmino codec.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(upgradetypes.Plan{}, "cosmos-sdk/Plan", nil)
-	cdc.RegisterConcrete(&MsgTryUpgrade{}, "/celestia.upgrade.v1.Msg/TryUpgrade", nil)
-	cdc.RegisterConcrete(&MsgSignalVersion{}, "/celestia.upgrade.v1.Msg/SignalVersion", nil)
+	cdc.RegisterConcrete(&MsgTryUpgrade{}, URLMsgTryUpgrade, nil)
+	cdc.RegisterConcrete(&MsgSignalVersion{}, URLMsgSignalVersion, nil)
 }
 
 // RegisterInterfaces registers the upgrade module types.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgTryUpgrade{})
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgSignalVersion{})
-	registry.RegisterInterface("cosmos.auth.v1beta1.BaseAccount", (*authtypes.AccountI)(nil))
-	registry.RegisterImplementations((*authtypes.AccountI)(nil), &authtypes.BaseAccount{})
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }

--- a/x/upgrade/types/msgs.go
+++ b/x/upgrade/types/msgs.go
@@ -1,7 +1,10 @@
 package types
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
@@ -13,12 +16,22 @@ const (
 
 	// QuerierRoute defines the module's query routing key
 	QuerierRoute = ModuleName
+
+	// RouterKey defines the module's message routing key
+	RouterKey = ModuleName
+
+	URLMsgSignalVersion = "/celestia.upgrade.v1.Msg/SignalVersion"
+	URLMsgTryUpgrade    = "/celestia.upgrade.v1.Msg/TryUpgrade"
 )
 
 var (
-	_ sdk.Msg = &MsgSignalVersion{}
-	_ sdk.Msg = &MsgTryUpgrade{}
+	_ sdk.Msg            = &MsgSignalVersion{}
+	_ sdk.Msg            = &MsgTryUpgrade{}
+	_ legacytx.LegacyMsg = &MsgSignalVersion{}
+	_ legacytx.LegacyMsg = &MsgTryUpgrade{}
 )
+
+var ModuleCdc = codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
 
 func NewMsgSignalVersion(valAddress sdk.ValAddress, version uint64) *MsgSignalVersion {
 	return &MsgSignalVersion{
@@ -40,6 +53,21 @@ func (msg *MsgSignalVersion) ValidateBasic() error {
 	return err
 }
 
+// GetSignBytes implements legacytx.LegacyMsg.
+func (msg *MsgSignalVersion) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// Route implements legacytx.LegacyMsg.
+func (msg *MsgSignalVersion) Route() string {
+	return RouterKey
+}
+
+// Type implements legacytx.LegacyMsg.
+func (msg *MsgSignalVersion) Type() string {
+	return URLMsgSignalVersion
+}
+
 func NewMsgTryUpgrade(signer sdk.AccAddress) *MsgTryUpgrade {
 	return &MsgTryUpgrade{
 		Signer: signer.String(),
@@ -57,4 +85,19 @@ func (msg *MsgTryUpgrade) GetSigners() []sdk.AccAddress {
 func (msg *MsgTryUpgrade) ValidateBasic() error {
 	_, err := sdk.AccAddressFromBech32(msg.Signer)
 	return err
+}
+
+// GetSignBytes implements legacytx.LegacyMsg.
+func (msg *MsgTryUpgrade) GetSignBytes() []byte {
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(msg))
+}
+
+// Route implements legacytx.LegacyMsg.
+func (msg *MsgTryUpgrade) Route() string {
+	return RouterKey
+}
+
+// Type implements legacytx.LegacyMsg.
+func (msg *MsgTryUpgrade) Type() string {
+	return URLMsgTryUpgrade
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2876

## Testing

I was able to sign a signal tx with a Ledger

```
$ celestia-appd tx upgrade signal 1 --from $LEDGER --ledger --fees 420utia --yes
Default sign-mode 'direct' not supported by Ledger, using sign-mode 'amino-json'.
code: 0
codespace: ""
data: ""
events: []
gas_used: "0"
gas_wanted: "0"
height: "0"
info: ""
logs: []
raw_log: '[]'
timestamp: ""
tx: null
txhash: B512CED67CEF2EF951DEA71C231E583EEE7340BB28EA39ADFF0771EC21AA25B2
```

Ideally we have an automated test for this