### PR TITLE
feat: add overwrite confirmation when genesis file is existed

### DIFF
--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -82,7 +82,7 @@ func downloadGenesisCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolP(flagYes, "y", false, "Skip overwrite confirmation prompt when genesis.json is existed")
+	cmd.Flags().BoolP(flagYes, "y", false, "Skip overwrite confirmation prompt when genesis.json already exists")
 
 	return cmd
 }

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -15,8 +15,7 @@ import (
 )
 
 const (
-	flagYes   = "yes"
-	flagForce = "force"
+	flagYes = "yes"
 )
 
 // chainIDToSha256 is a map of chainID to the SHA-256 hash of the genesis file for that chain ID.
@@ -42,7 +41,7 @@ func downloadGenesisCommand() *cobra.Command {
 				return fmt.Errorf("unknown chain-id: %s. Must be: celestia, mocha-4, or arabica-10", chainID)
 			}
 			outputFile := server.GetServerContextFromCmd(cmd).Config.GenesisFile()
-			// confirm cover, unless -y is passed
+			// confirm covering, unless -y is passed
 			if skip, _ := cmd.Flags().GetBool(flagYes); !skip {
 				// if file is existed
 				if _, err := os.Stat(outputFile); err == nil {

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -41,7 +41,7 @@ func downloadGenesisCommand() *cobra.Command {
 				return fmt.Errorf("unknown chain-id: %s. Must be: celestia, mocha-4, or arabica-10", chainID)
 			}
 			outputFile := server.GetServerContextFromCmd(cmd).Config.GenesisFile()
-			// confirm covering, unless -y is passed
+			// confirm overwrite, unless -y is passed
 			if skip, _ := cmd.Flags().GetBool(flagYes); !skip {
 				// if file is existed
 				if _, err := os.Stat(outputFile); err == nil {

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -41,7 +41,7 @@ func downloadGenesisCommand() *cobra.Command {
 				return fmt.Errorf("unknown chain-id: %s. Must be: celestia, mocha-4, or arabica-10", chainID)
 			}
 			outputFile := server.GetServerContextFromCmd(cmd).Config.GenesisFile()
-			// confirm overwrite, unless -y is passed
+			// confirm overwrite if --yes is not provided
 			if skip, _ := cmd.Flags().GetBool(flagYes); !skip {
 				// if file already exists
 				if _, err := os.Stat(outputFile); err == nil {

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -82,7 +82,7 @@ func downloadGenesisCommand() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().BoolP(flagYes, "y", false, "Skip covering confirmation prompt when genesis.json is existed")
+	cmd.Flags().BoolP(flagYes, "y", false, "Skip overwrite confirmation prompt when genesis.json is existed")
 
 	return cmd
 }

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -46,7 +46,7 @@ func downloadGenesisCommand() *cobra.Command {
 				// if file is existed
 				if _, err := os.Stat(outputFile); err == nil {
 					buf := bufio.NewReader(cmd.InOrStdin())
-					if yes, err := input.GetConfirmation(fmt.Sprintf("Genesis file in %s is existed. Continue covering?", outputFile), buf, cmd.ErrOrStderr()); err != nil {
+					if yes, err := input.GetConfirmation(fmt.Sprintf("A genesis file already exists at %s. Do you want to overwrite it?", outputFile), buf, cmd.ErrOrStderr()); err != nil {
 						return fmt.Errorf("get confirmation error: %w", err)
 					} else if !yes {
 						return nil

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -43,7 +43,7 @@ func downloadGenesisCommand() *cobra.Command {
 			outputFile := server.GetServerContextFromCmd(cmd).Config.GenesisFile()
 			// confirm overwrite, unless -y is passed
 			if skip, _ := cmd.Flags().GetBool(flagYes); !skip {
-				// if file is existed
+				// if file already exists
 				if _, err := os.Stat(outputFile); err == nil {
 					buf := bufio.NewReader(cmd.InOrStdin())
 					if yes, err := input.GetConfirmation(fmt.Sprintf("A genesis file already exists at %s. Do you want to overwrite it?", outputFile), buf, cmd.ErrOrStderr()); err != nil {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
This PR add support for displaying cover confirmation prompt to user when genesis file is existed

- **New Features**
  - Addition of displaying overwrite confirmation prompt to user when genesis file is existed
  - Addition of a new bool flag `yes`, used to Skip overwrite confirmation prompt when genesis.json is existed(in order to compatible with some old scripts)

----
## Screenshots

![image](https://github.com/celestiaorg/celestia-app/assets/25278203/86528005-8ec7-4e16-8bf1-09af3df06e73)

