### PR TITLE
refactor: Imporve signer confirm tx

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -215,8 +215,8 @@ func (s *Signer) ConfirmTx(ctx context.Context, txHash string) (*sdktypes.TxResp
 	pollTime := s.pollTime
 	s.mtx.RUnlock()
 
-	poolTicker := time.NewTicker(pollTime)
-	defer poolTicker.Stop()
+	pollTicker := time.NewTicker(pollTime)
+	defer pollTicker.Stop()
 
 	for {
 		resp, err := txClient.GetTx(ctx, &tx.GetTxRequest{Hash: txHash})
@@ -234,7 +234,7 @@ func (s *Signer) ConfirmTx(ctx context.Context, txHash string) (*sdktypes.TxResp
 		select {
 		case <-ctx.Done():
 			return &sdktypes.TxResponse{}, ctx.Err()
-		case <-poolTicker.C:
+		case <-pollTicker.C:
 		}
 	}
 }

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -206,8 +206,9 @@ func (s *Signer) BroadcastTx(ctx context.Context, txBytes []byte) (*sdktypes.TxR
 	return resp.TxResponse, nil
 }
 
-// ConfirmTx waits for tx to be confirmed on the blockchain.
-// It stops waiting when the context is canceled.
+// ConfirmTx periodically pings the provided node for the commitment of a transaction by its
+// hash. It will continually loop until the context is cancelled, the tx is found or an error
+// is encountered.
 func (s *Signer) ConfirmTx(ctx context.Context, txHash string) (*sdktypes.TxResponse, error) {
 	txClient := tx.NewServiceClient(s.grpc)
 

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -211,7 +211,11 @@ func (s *Signer) BroadcastTx(ctx context.Context, txBytes []byte) (*sdktypes.TxR
 func (s *Signer) ConfirmTx(ctx context.Context, txHash string) (*sdktypes.TxResponse, error) {
 	txClient := tx.NewServiceClient(s.grpc)
 
-	poolTicker := time.NewTicker(s.pollTime)
+	s.mtx.RLock()
+	pollTime := s.pollTime
+	s.mtx.RUnlock()
+
+	poolTicker := time.NewTicker(pollTime)
 	defer poolTicker.Stop()
 
 	for {
@@ -253,6 +257,8 @@ func (s *Signer) Address() sdktypes.AccAddress {
 
 // SetPollTime sets how often the signer should poll for the confirmation of the transaction
 func (s *Signer) SetPollTime(pollTime time.Duration) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
 	s.pollTime = pollTime
 }
 

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -153,7 +153,8 @@ func (s *Signer) SubmitPayForBlob(ctx context.Context, blobs []*blob.Blob, opts 
 		return nil, err
 	}
 	if resp.Code != 0 {
-		return nil, fmt.Errorf("tx failed with code %d: %s", resp.Code, resp.RawLog)
+		// TODO(htienv): Should return nil here? 
+		return resp, fmt.Errorf("tx failed with code %d: %s", resp.Code, resp.RawLog)
 	}
 
 	return s.ConfirmTx(ctx, resp.TxHash)

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/celestiaorg/celestia-app/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/test/util/testnode"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -157,7 +156,7 @@ func (s *SignerTestSuite) queryCurrentBalance(t *testing.T) int64 {
 	return balanceResp.Balances.AmountOf(app.BondDenom).Int64()
 }
 
-func (s *SignerTestSuite) submitTxWithoutConfirm(msgs []sdktypes.Msg, opts ...user.TxOption) (*sdktypes.TxResponse, error) {
+func (s *SignerTestSuite) submitTxWithoutConfirm(msgs []sdk.Msg, opts ...user.TxOption) (*sdk.TxResponse, error) {
 	txBytes, err := s.signer.CreateTx(msgs, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -74,40 +74,45 @@ func (s *SignerTestSuite) TestSubmitTx() {
 func (s *SignerTestSuite) TestConfirmTx() {
 	t := s.T()
 
-	// 1. ConfirmTx returns an error when the context times out
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	_, err := s.signer.ConfirmTx(ctx, "E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
-
-	// 2. ConfirmTx returns an error when tx is not found
-	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_, err = s.signer.ConfirmTx(ctx, "not found tx")
-	assert.Error(t, err)
-
-	// 3. ConfirmTx returns no error if tx is found immediately
 	fee := user.SetFee(1e6)
 	gas := user.SetGasLimit(1e6)
-	msg := bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 10)))
-	resp, err := s.submitTxWithoutConfirm([]sdk.Msg{msg}, fee, gas)
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	resp, err = s.signer.ConfirmTx(s.ctx.GoContext(), resp.TxHash)
-	assert.NoError(t, err)
-	assert.Equal(t, abci.CodeTypeOK, resp.Code)
 
-	// 4. ConfirmTx returns error if the tx is found with a non-zero error code
-	balance := s.queryCurrentBalance(t)
-	// Create a msg send with out of balance, ensure this tx fails
-	msg = bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 1+balance)))
-	resp, err = s.submitTxWithoutConfirm([]sdk.Msg{msg}, fee, gas)
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	resp, err = s.signer.ConfirmTx(s.ctx.GoContext(), resp.TxHash)
-	assert.Error(t, err)
-	assert.NotEqual(t, abci.CodeTypeOK, resp.Code)
+	t.Run("deadline exceeded when the context times out", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		_, err := s.signer.ConfirmTx(ctx, "E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
+	})
+
+	t.Run("should error when tx is not found", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		_, err := s.signer.ConfirmTx(ctx, "not found tx")
+		assert.Error(t, err)
+	})
+
+	t.Run("should success when tx is found immediately", func(t *testing.T) {
+		msg := bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 10)))
+		resp, err := s.submitTxWithoutConfirm([]sdk.Msg{msg}, fee, gas)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		resp, err = s.signer.ConfirmTx(s.ctx.GoContext(), resp.TxHash)
+		assert.NoError(t, err)
+		assert.Equal(t, abci.CodeTypeOK, resp.Code)
+	})
+
+	t.Run("should error when tx is found with a non-zero error code", func(t *testing.T) {
+		balance := s.queryCurrentBalance(t)
+		// Create a msg send with out of balance, ensure this tx fails
+		msg := bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 1+balance)))
+		resp, err := s.submitTxWithoutConfirm([]sdk.Msg{msg}, fee, gas)
+		assert.NoError(t, err)
+		assert.NotNil(t, resp)
+		resp, err = s.signer.ConfirmTx(s.ctx.GoContext(), resp.TxHash)
+		assert.Error(t, err)
+		assert.NotEqual(t, abci.CodeTypeOK, resp.Code)
+	})
 }
 
 // TestGasConsumption verifies that the amount deducted from a user's balance is

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -69,11 +69,13 @@ func (s *SignerTestSuite) TestSubmitTx() {
 	require.EqualValues(t, 0, resp.Code)
 }
 
-func (s *SignerTestSuite) TestConfirmTxTimeout() {
+// TestConfirmTx verifies that the ConfirmTx method returns an error when
+// the context times out.
+func (s *SignerTestSuite) TestConfirmTx() {
 	t := s.T()
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	_, err := s.signer.ConfirmTx(ctx, string("E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728"))
+	_, err := s.signer.ConfirmTx(ctx, "E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
 }

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -69,12 +69,12 @@ func (s *SignerTestSuite) TestSubmitTx() {
 	require.EqualValues(t, 0, resp.Code)
 }
 
-func (s *SignerTestSuite) ConfirmTxTimeout() {
+func (s *SignerTestSuite) TestConfirmTxTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	_, err := s.signer.ConfirmTx(ctx, string("E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728"))
 	require.Error(s.T(), err)
-	require.Equal(s.T(), err, context.DeadlineExceeded)
+	require.Equal(s.T(), context.DeadlineExceeded, err)
 }
 
 // TestGasConsumption verifies that the amount deducted from a user's balance is

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -70,11 +70,12 @@ func (s *SignerTestSuite) TestSubmitTx() {
 }
 
 func (s *SignerTestSuite) TestConfirmTxTimeout() {
+	t := s.T()
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 	_, err := s.signer.ConfirmTx(ctx, string("E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728"))
-	require.Error(s.T(), err)
-	require.Equal(s.T(), context.DeadlineExceeded, err)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), context.DeadlineExceeded.Error())
 }
 
 // TestGasConsumption verifies that the amount deducted from a user's balance is

--- a/pkg/user/signer_test.go
+++ b/pkg/user/signer_test.go
@@ -71,11 +71,10 @@ func (s *SignerTestSuite) TestSubmitTx() {
 	require.EqualValues(t, 0, resp.Code)
 }
 
-// TestConfirmTx verifies that the ConfirmTx method returns the expected results.
 func (s *SignerTestSuite) TestConfirmTx() {
 	t := s.T()
 
-	// 1. ConfirmTx returns an error when the context time out
+	// 1. ConfirmTx returns an error when the context times out
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	_, err := s.signer.ConfirmTx(ctx, "E32BD15CAF57AF15D17B0D63CF4E63A9835DD1CEBB059C335C79586BC3013728")
@@ -88,7 +87,7 @@ func (s *SignerTestSuite) TestConfirmTx() {
 	_, err = s.signer.ConfirmTx(ctx, "not found tx")
 	assert.Error(t, err)
 
-	// 3. ConfirmTx has no error if tx is found immediately
+	// 3. ConfirmTx returns no error if tx is found immediately
 	fee := user.SetFee(1e6)
 	gas := user.SetGasLimit(1e6)
 	msg := bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 10)))
@@ -97,18 +96,18 @@ func (s *SignerTestSuite) TestConfirmTx() {
 	assert.NotNil(t, resp)
 	resp, err = s.signer.ConfirmTx(s.ctx.GoContext(), resp.TxHash)
 	assert.NoError(t, err)
-	assert.Equal(t, resp.Code, uint32(0))
+	assert.Equal(t, abci.CodeTypeOK, resp.Code)
 
 	// 4. ConfirmTx returns error if the tx is found with a non-zero error code
 	balance := s.queryCurrentBalance(t)
-	// Create a msg send with out of balance, ensure this tx is failed
+	// Create a msg send with out of balance, ensure this tx fails
 	msg = bank.NewMsgSend(s.signer.Address(), testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(app.BondDenom, 1+balance)))
 	resp, err = s.submitTxWithoutConfirm([]sdk.Msg{msg}, fee, gas)
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	resp, err = s.signer.ConfirmTx(s.ctx.GoContext(), resp.TxHash)
 	assert.Error(t, err)
-	assert.NotEqual(t, resp.Code, uint32(0))
+	assert.NotEqual(t, abci.CodeTypeOK, resp.Code)
 }
 
 // TestGasConsumption verifies that the amount deducted from a user's balance is


### PR DESCRIPTION
This PR using a `Ticker` for periodically call `GetTx` by given hash instead of a `Timer`. This makes the code clean and avoids calling reset `Timer` multiple times.

It's similar to `WaitMined` in [geth](https://github.com/ethereum/go-ethereum/blob/09e0208029ff96a9cda0c69dbaebfd3f31a39771/accounts/abi/bind/util.go#L32).

Other changes:
* Add lock when get `pollTime`
