### PR TITLE
refactor: remove ValidateBasic in cli

### DIFF
--- a/x/blobstream/client/tx.go
+++ b/x/blobstream/client/tx.go
@@ -46,9 +46,6 @@ send a new message overriding the previous one.
 				ValidatorAddress: valAddress,
 				EvmAddress:       evmAddress,
 			}
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},

--- a/x/upgrade/cli/tx.go
+++ b/x/upgrade/cli/tx.go
@@ -48,9 +48,6 @@ func CmdSignalVersion() *cobra.Command {
 			valAddr := sdk.ValAddress(addr)
 
 			msg := types.NewMsgSignalVersion(valAddr, version)
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
@@ -75,9 +72,6 @@ to the signalled version at the following height.
 			}
 
 			msg := types.NewMsgTryUpgrade(clientCtx.GetFromAddress())
-			if err := msg.ValidateBasic(); err != nil {
-				return err
-			}
 
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},


### PR DESCRIPTION
## Overview
The `ValidateBasic` function has been called in the `GenerateOrBroadcastTxWithFactory` function, so we no longer need to add the `ValidateBasic` function when writing Cli. Related PRs can be viewed at: https://github.com/cosmos/cosmos-sdk/pull/9236#discussion_r623803504

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
