### PR TITLE
chore: remove unnecessary conversions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,7 @@ linters:
     - revive
     - prealloc
     - stylecheck
+    - unconvert
 
 linters-settings:
   nakedret:

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -174,7 +174,7 @@ type govModule struct {
 // DefaultGenesis returns custom x/gov module genesis state.
 func (govModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	genState := govtypes.DefaultGenesisState()
-	day := time.Duration(time.Hour * 24)
+	day := time.Hour * 24
 	oneWeek := day * 7
 
 	genState.DepositParams.MinDeposit = sdk.NewCoins(sdk.NewCoin(BondDenom, sdk.NewInt(10_000_000_000))) // 10,000 TIA

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -16,7 +16,7 @@ import (
 // overridden.
 func Test_newGovModule(t *testing.T) {
 	encCfg := encoding.MakeConfig(ModuleEncodingRegisters...)
-	day := time.Duration(time.Hour * 24)
+	day := time.Hour * 24
 	oneWeek := day * 7
 
 	govModule := newGovModule()

--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -137,7 +137,7 @@ func NewShareInclusionProof(
 		}
 
 		rawShares = append(rawShares, shares.ToBytes(row[startLeafPos:endLeafPos+1])...)
-		proof, err := tree.ProveRange(int(startLeafPos), int(endLeafPos+1))
+		proof, err := tree.ProveRange(startLeafPos, endLeafPos+1)
 		if err != nil {
 			return types.ShareProof{}, err
 		}

--- a/pkg/shares/info_byte.go
+++ b/pkg/shares/info_byte.go
@@ -38,6 +38,6 @@ func (i InfoByte) IsSequenceStart() bool {
 
 func ParseInfoByte(i byte) (InfoByte, error) {
 	isSequenceStart := i%2 == 1
-	version := uint8(i) >> 1
+	version := i >> 1
 	return NewInfoByte(version, isSequenceStart)
 }

--- a/pkg/shares/shares.go
+++ b/pkg/shares/shares.go
@@ -239,7 +239,7 @@ func (s *Share) rawDataStartIndexUsingReserved() (int, error) {
 func ToBytes(shares []Share) (bytes [][]byte) {
 	bytes = make([][]byte, len(shares))
 	for i, share := range shares {
-		bytes[i] = []byte(share.data)
+		bytes[i] = share.data
 	}
 	return bytes
 }

--- a/pkg/square/square_test.go
+++ b/pkg/square/square_test.go
@@ -43,12 +43,12 @@ func TestSquareConstruction(t *testing.T) {
 	t.Run("not enough space to append transactions", func(t *testing.T) {
 		_, err := square.Construct(coretypes.Txs(sendTxs).ToSliceOfBytes(), appconsts.LatestVersion, 2)
 		require.Error(t, err)
-		_, err = square.Construct(coretypes.Txs(pfbTxs).ToSliceOfBytes(), appconsts.LatestVersion, 2)
+		_, err = square.Construct(pfbTxs.ToSliceOfBytes(), appconsts.LatestVersion, 2)
 		require.Error(t, err)
 	})
 	t.Run("construction should fail if a single PFB tx contains a blob that is too large to fit in the square", func(t *testing.T) {
 		pfbTxs := blobfactory.RandBlobTxs(signer, rand, 1, 1, 2*mebibyte)
-		_, err := square.Construct(coretypes.Txs(pfbTxs).ToSliceOfBytes(), appconsts.LatestVersion, 64)
+		_, err := square.Construct(pfbTxs.ToSliceOfBytes(), appconsts.LatestVersion, 64)
 		require.Error(t, err)
 	})
 }

--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -212,7 +212,7 @@ func (am *AccountManager) Submit(ctx context.Context, op Operation) error {
 	// If a delay is set, wait for that many blocks to have been produced
 	// before continuing
 	if op.Delay != 0 {
-		if err := am.waitDelay(ctx, uint64(op.Delay)); err != nil {
+		if err := am.waitDelay(ctx, op.Delay); err != nil {
 			return fmt.Errorf("error delaying tx submission: %w", err)
 		}
 	}

--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -37,7 +37,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	//
 	// Note: if TimeIotaMs is removed from CometBFT, this technique will no
 	// longer work.
-	cparams.Block.TimeIotaMs = int64(sixMonths.Milliseconds())
+	cparams.Block.TimeIotaMs = sixMonths.Milliseconds()
 
 	cfg := testnode.DefaultConfig().
 		WithConsensusParams(cparams)

--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -12,7 +12,7 @@ const (
 	// https://en.wikipedia.org/wiki/Year
 	DaysPerYear        = 365.2425
 	SecondsPerYear     = int64(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
-	NanosecondsPerYear = int64(NanosecondsPerSecond * SecondsPerYear)                         // 31,556,952,000,000,000
+	NanosecondsPerYear = NanosecondsPerSecond * SecondsPerYear                                // 31,556,952,000,000,000
 
 	// InitialInflationRate is the inflation rate that the network starts at.
 	InitialInflationRate = 0.08

--- a/x/upgrade/types/msgs.go
+++ b/x/upgrade/types/msgs.go
@@ -51,7 +51,7 @@ func (msg *MsgTryUpgrade) GetSigners() []sdk.AccAddress {
 	if err != nil {
 		panic(err)
 	}
-	return []sdk.AccAddress{sdk.AccAddress(valAddr)}
+	return []sdk.AccAddress{valAddr}
 }
 
 func (msg *MsgTryUpgrade) ValidateBasic() error {


### PR DESCRIPTION
Use linter to detect unnecessary type conversions
https://github.com/mdempsky/unconvert