### PR TITLE
feat: add support for arabica-11 in download-genesis command

### DIFF
--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -19,6 +19,7 @@ var chainIDToSha256 = map[string]string{
 	"celestia":   "9727aac9bbfb021ce7fc695a92f901986421283a891b89e0af97bc9fad187793",
 	"mocha-4":    "0846b99099271b240b638a94e17a6301423b5e4047f6558df543d6e91db7e575",
 	"arabica-10": "fad0a187669f7a2c11bb07f9dc27140d66d2448b7193e186312713856f28e3e1",
+	"arabica-11": ""
 }
 
 func downloadGenesisCommand() *cobra.Command {

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -19,7 +19,7 @@ var chainIDToSha256 = map[string]string{
 	"celestia":   "9727aac9bbfb021ce7fc695a92f901986421283a891b89e0af97bc9fad187793",
 	"mocha-4":    "0846b99099271b240b638a94e17a6301423b5e4047f6558df543d6e91db7e575",
 	"arabica-10": "fad0a187669f7a2c11bb07f9dc27140d66d2448b7193e186312713856f28e3e1",
-	"arabica-11": ""
+	"arabica-11": "77605cee57ce545b1be22402110d4baacac837bdc7fc3f5c74020abf9a08810f"
 }
 
 func downloadGenesisCommand() *cobra.Command {

--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ var chainIDToSha256 = map[string]string{
 	"celestia":   "9727aac9bbfb021ce7fc695a92f901986421283a891b89e0af97bc9fad187793",
 	"mocha-4":    "0846b99099271b240b638a94e17a6301423b5e4047f6558df543d6e91db7e575",
 	"arabica-10": "fad0a187669f7a2c11bb07f9dc27140d66d2448b7193e186312713856f28e3e1",
-	"arabica-11": "77605cee57ce545b1be22402110d4baacac837bdc7fc3f5c74020abf9a08810f"
+	"arabica-11": "77605cee57ce545b1be22402110d4baacac837bdc7fc3f5c74020abf9a08810f",
 }
 
 func downloadGenesisCommand() *cobra.Command {
@@ -27,13 +28,13 @@ func downloadGenesisCommand() *cobra.Command {
 		Use:   "download-genesis [chain-id]",
 		Short: "Download genesis file from https://github.com/celestiaorg/networks",
 		Long: "Download genesis file from https://github.com/celestiaorg/networks.\n" +
-			"The first argument should be a known chain-id. Ex. celestia, mocha-4, or arabica-10.\n" +
+			fmt.Sprintf("The first argument should be a known chain-id. Ex. %s\n", chainIDs()) +
 			"If no argument is provided, defaults to celestia.\n",
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainID := getChainIDOrDefault(args)
 			if !isKnownChainID(chainID) {
-				return fmt.Errorf("unknown chain-id: %s. Must be: celestia, mocha-4, or arabica-10", chainID)
+				return fmt.Errorf("unknown chain-id: %s. Must be: %s", chainID, chainIDs())
 			}
 			outputFile := server.GetServerContextFromCmd(cmd).Config.GenesisFile()
 			fmt.Printf("Downloading genesis file for %s to %s\n", chainID, outputFile)
@@ -81,6 +82,10 @@ func getChainIDOrDefault(args []string) string {
 func isKnownChainID(chainID string) bool {
 	knownChainIDs := getKeys(chainIDToSha256)
 	return contains(knownChainIDs, chainID)
+}
+
+func chainIDs() string {
+	return strings.Join(getKeys(chainIDToSha256), ", ")
 }
 
 // contains checks if a string is present in a slice.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2976

## Testing

Updated the help and error messages to include arabica-11
```
$ ./build/celestia-appd download-genesis --help
Download genesis file from https://github.com/celestiaorg/networks.
The first argument should be a known chain-id. Ex. celestia, mocha-4, arabica-10, arabica-11

$ ./build/celestia-appd download-genesis arabaica-12
Error: unknown chain-id: arabaica-12. Must be: celestia, mocha-4, arabica-10, arabica-11
```

Downloading arabica-11 genesis works
```
$ ./build/celestia-appd download-genesis arabica-11
Downloading genesis file for arabica-11 to /Users/rootulp/.celestia-app/config/genesis.json
Downloaded genesis file for arabica-11 to /Users/rootulp/.celestia-app/config/genesis.json
SHA-256 hash verified for arabica-11
```