### PR TITLE
feat: expose sequence number correctly to users of the signer

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -300,6 +300,11 @@ func (s *Signer) ForceSetSequence(seq uint64) {
 	s.lastSignedSequence = seq
 }
 
+// Keyring exposes the signers underlying keyring
+func (s *Signer) Keyring() keyring.Keyring {
+	return s.keys
+}
+
 func (s *Signer) signTransaction(builder client.TxBuilder) error {
 	signers := builder.GetTx().GetSigners()
 	if len(signers) != 1 {

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -283,8 +283,8 @@ func (s *Signer) GetSequence() uint64 {
 	return s.lastSignedSequence
 }
 
-// incrementSequence gets the latest signed sequence and increments the local sequence number
-func (s *Signer) incrementSequence() uint64 {
+// getAndIncrementSequence gets the latest signed sequence and increments the local sequence number
+func (s *Signer) getAndIncrementSequence() uint64 {
 	s.mtx.Lock()
 	defer s.mtx.Unlock()
 	defer func() { s.lastSignedSequence++ }()
@@ -315,7 +315,7 @@ func (s *Signer) signTransaction(builder client.TxBuilder) error {
 		return fmt.Errorf("expected signer %s, got %s", s.address.String(), signers[0].String())
 	}
 
-	sequence := s.incrementSequence()
+	sequence := s.getAndIncrementSequence()
 
 	// To ensure we have the correct bytes to sign over we produce
 	// a dry run of the signing data


### PR DESCRIPTION
It's probably misleading that `GetSequence` should not only return the sequence number but increment it. The incrementing sequence should be internal and the user should just be able to use `Sequence` if they wish to query the sequence number of the signer