### PR TITLE
feat: make the signers keyring public

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -300,6 +300,11 @@ func (s *Signer) ForceSetSequence(seq uint64) {
 	s.lastSignedSequence = seq
 }
 
+// Keyring exposes the signers underlying keyring
+func (s *Signer) Keyring() keyring.Keyring {
+	return s.keys
+}
+
 func (s *Signer) signTransaction(builder client.TxBuilder) error {
 	signers := builder.GetTx().GetSigners()
 	if len(signers) != 1 {


### PR DESCRIPTION
As this is likely to be valuable to clients who want more manual control of signing