### PR TITLE
chore(deps): pin to govulncheck v1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,5 +197,5 @@ prebuilt-binary:
 
 ## govulncheck: Check for vulnerabilities in dependencies.
 govulncheck:
-	@go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+	@go run golang.org/x/vuln/cmd/govulncheck@v1.0.1 ./...
 .PHONY: govulncheck

--- a/go.work.sum
+++ b/go.work.sum
@@ -723,6 +723,7 @@ github.com/golangci/unconvert v0.0.0-20180507085042-28b1c447d1f4/go.mod h1:Izgrg
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/flatbuffers v2.0.8+incompatible/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-containerregistry v0.13.0/go.mod h1:J9FQ+eSS4a1aC2GNZxvNpbWhgp0487v+cgiilB4FqDo=
+github.com/google/go-pkcs11 v0.2.1-0.20230907215043-c6f79328ddf9/go.mod h1:6eQoGcuNJpa7jnd5pMGdkSaQpNDYvPlXWMcjXXThLlY=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/go-querystring v1.1.0/go.mod h1:Kcdr2DB4koayq7X8pmAG4sNG59So17icRSOU623lUBU=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3018

Will fix CI too because CI just calls `make govulncheck`. I kinda like that pattern b/c then we don't have to keep two versions in sync (one in Makefile and one in CI workflow file)