### PR TITLE
docs: add namespace Go definition to specs

### DIFF
--- a/specs/src/specs/namespace.md
+++ b/specs/src/specs/namespace.md
@@ -91,9 +91,14 @@ Applications MUST refrain from using the [reserved namespaces](#reserved-namespa
 
 See [pkg/namespace](../../../pkg/namespace).
 
-## Protobuf Definition
+## Go Definition
 
-<!-- TODO: Add protobuf definition for namespace -->
+```go
+type Namespace struct {
+	Version uint8
+	ID      []byte
+}
+```
 
 ## References
 


### PR DESCRIPTION
I was linking to specs and noticed that the Protobuf section was empty. We don't have a Protobuf definition for namespace but we do have a Go definition.

Ref: https://github.com/celestiaorg/celestia-app/blob/34c98b96fee6e5aaf0ce9cb7b0ec03ee47f24774/pkg/namespace/namespace.go#L8-L11
