### PR TITLE
refactor: extract init and denom from app.go

### DIFF
--- a/app/address.go
+++ b/app/address.go
@@ -1,0 +1,20 @@
+package app
+
+import sdk "github.com/cosmos/cosmos-sdk/types"
+
+const AccountAddressPrefix = "celestia"
+
+var (
+	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address.
+	Bech32PrefixAccAddr = AccountAddressPrefix
+	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key.
+	Bech32PrefixAccPub = AccountAddressPrefix + sdk.PrefixPublic
+	// Bech32PrefixValAddr defines the Bech32 prefix of a validator's operator address.
+	Bech32PrefixValAddr = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixOperator
+	// Bech32PrefixValPub defines the Bech32 prefix of a validator's operator public key.
+	Bech32PrefixValPub = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixOperator + sdk.PrefixPublic
+	// Bech32PrefixConsAddr defines the Bech32 prefix of a consensus node address.
+	Bech32PrefixConsAddr = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixConsensus
+	// Bech32PrefixConsPub defines the Bech32 prefix of a consensus node public key.
+	Bech32PrefixConsPub = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixConsensus + sdk.PrefixPublic
+)

--- a/app/app.go
+++ b/app/app.go
@@ -2,8 +2,6 @@ package app
 
 import (
 	"io"
-	"os"
-	"path/filepath"
 
 	"github.com/celestiaorg/celestia-app/x/mint"
 	mintkeeper "github.com/celestiaorg/celestia-app/x/mint/keeper"
@@ -85,7 +83,6 @@ import (
 
 	"github.com/celestiaorg/celestia-app/app/ante"
 	"github.com/celestiaorg/celestia-app/app/encoding"
-	"github.com/celestiaorg/celestia-app/pkg/appconsts"
 	v1 "github.com/celestiaorg/celestia-app/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/pkg/proof"
@@ -101,39 +98,7 @@ import (
 	ibctestingtypes "github.com/cosmos/ibc-go/v6/testing/types"
 )
 
-const (
-	AccountAddressPrefix = "celestia"
-	Name                 = "celestia-app"
-	// BondDenom defines the native staking token denomination.
-	BondDenom = appconsts.BondDenom
-	// BondDenomAlias defines an alias for BondDenom.
-	BondDenomAlias = "microtia"
-	// DisplayDenom defines the name, symbol, and display value of the Celestia token.
-	DisplayDenom = "TIA"
-)
-
-// These constants are derived from the above variables.
-// These are the ones we will want to use in the code, based on
-// any overrides above.
 var (
-	// Bech32PrefixAccAddr defines the Bech32 prefix of an account's address.
-	Bech32PrefixAccAddr = AccountAddressPrefix
-	// Bech32PrefixAccPub defines the Bech32 prefix of an account's public key.
-	Bech32PrefixAccPub = AccountAddressPrefix + sdk.PrefixPublic
-	// Bech32PrefixValAddr defines the Bech32 prefix of a validator's operator address.
-	Bech32PrefixValAddr = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixOperator
-	// Bech32PrefixValPub defines the Bech32 prefix of a validator's operator public key.
-	Bech32PrefixValPub = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixOperator + sdk.PrefixPublic
-	// Bech32PrefixConsAddr defines the Bech32 prefix of a consensus node address.
-	Bech32PrefixConsAddr = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixConsensus
-	// Bech32PrefixConsPub defines the Bech32 prefix of a consensus node public key.
-	Bech32PrefixConsPub = AccountAddressPrefix + sdk.PrefixValidator + sdk.PrefixConsensus + sdk.PrefixPublic
-)
-
-var (
-	// DefaultNodeHome default home directories for the application daemon
-	DefaultNodeHome string
-
 	// ModuleBasics defines the module BasicManager is in charge of setting up basic,
 	// non-dependant module elements, such as codec registration
 	// and genesis verification.
@@ -177,20 +142,6 @@ var (
 )
 
 var _ servertypes.Application = (*App)(nil)
-
-func init() {
-	userHomeDir := os.Getenv("CELESTIA_HOME")
-
-	if userHomeDir == "" {
-		var err error
-		userHomeDir, err = os.UserHomeDir()
-		if err != nil {
-			panic(err)
-		}
-	}
-
-	DefaultNodeHome = filepath.Join(userHomeDir, "."+Name)
-}
 
 // App extends an ABCI application, but with most of its parameters exported.
 // They are exported for convenience in creating helper functions, as object

--- a/app/denom.go
+++ b/app/denom.go
@@ -1,0 +1,12 @@
+package app
+
+import "github.com/celestiaorg/celestia-app/pkg/appconsts"
+
+const (
+	// BondDenom defines the native staking token denomination.
+	BondDenom = appconsts.BondDenom
+	// BondDenomAlias defines an alias for BondDenom.
+	BondDenomAlias = "microtia"
+	// DisplayDenom defines the name, symbol, and display value of the Celestia token.
+	DisplayDenom = "TIA"
+)

--- a/app/init.go
+++ b/app/init.go
@@ -1,0 +1,34 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Name is the name of the application.
+const Name = "celestia-app"
+
+// CelestiaHome is the environment variable for the home directory of the application daemon.
+// If not set, the default user home directory will be used.
+const CelestiaHome = "CELESTIA_HOME"
+
+// DefaultNodeHome is the default home directory for the application daemon.
+// This gets set as a side-effect of the init() function.
+var DefaultNodeHome string
+
+func init() {
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+	celestiaHome := os.Getenv(CelestiaHome)
+	DefaultNodeHome = getDefaultNodeHome(userHome, celestiaHome)
+}
+
+func getDefaultNodeHome(userHome string, celestiaHome string) string {
+	appDir := "." + Name
+	if celestiaHome != "" {
+		return filepath.Join(celestiaHome, appDir)
+	}
+	return filepath.Join(userHome, appDir)
+}

--- a/app/init.go
+++ b/app/init.go
@@ -8,9 +8,13 @@ import (
 // Name is the name of the application.
 const Name = "celestia-app"
 
-// CelestiaHome is the environment variable for the home directory of the application daemon.
-// If not set, the default user home directory will be used.
-const CelestiaHome = "CELESTIA_HOME"
+// appDirectory is the name of the application directory. This directory is used
+// to store configs, data, keyrings, etc.
+const appDirectory = ".celestia-app"
+
+// celestiaHome is an environment variable that sets where appDirectory will be placed.
+// If celestiaHome isn't specified, the default user home directory will be used.
+const celestiaHome = "CELESTIA_HOME"
 
 // DefaultNodeHome is the default home directory for the application daemon.
 // This gets set as a side-effect of the init() function.
@@ -21,17 +25,18 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	celestiaHome := os.Getenv(CelestiaHome)
+	celestiaHome := os.Getenv(celestiaHome)
 	DefaultNodeHome = getDefaultNodeHome(userHome, celestiaHome)
 }
 
-// getDefaultNodeHome computes the default node home directory based on the provided userHome and celestiaHome.
-// If celestiaHome is provided, it takes precedence and constructs the path by appending the application directory.
-// Otherwise, it falls back to using the userHome with the application directory appended.
+// getDefaultNodeHome computes the default node home directory based on the
+// provided userHome and celestiaHome. If celestiaHome is provided, it takes
+// precedence and constructs the path by appending the application directory.
+// Otherwise, it falls back to using the userHome with the application directory
+// appended.
 func getDefaultNodeHome(userHome string, celestiaHome string) string {
-	appDir := "." + Name
 	if celestiaHome != "" {
-		return filepath.Join(celestiaHome, appDir)
+		return filepath.Join(celestiaHome, appDirectory)
 	}
-	return filepath.Join(userHome, appDir)
+	return filepath.Join(userHome, appDirectory)
 }

--- a/app/init.go
+++ b/app/init.go
@@ -25,6 +25,9 @@ func init() {
 	DefaultNodeHome = getDefaultNodeHome(userHome, celestiaHome)
 }
 
+// getDefaultNodeHome computes the default node home directory based on the provided userHome and celestiaHome.
+// If celestiaHome is provided, it takes precedence and constructs the path by appending the application directory.
+// Otherwise, it falls back to using the userHome with the application directory appended.
 func getDefaultNodeHome(userHome string, celestiaHome string) string {
 	appDir := "." + Name
 	if celestiaHome != "" {

--- a/app/init_test.go
+++ b/app/init_test.go
@@ -1,0 +1,50 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getDefaultNodeHome(t *testing.T) {
+	type testCase struct {
+		name         string
+		userHome     string
+		celestiaHome string
+		want         string
+	}
+
+	testCases := []testCase{
+		{
+			name:         "want .celestia-app when userHome is empty and celestiaHome is empty",
+			userHome:     "",
+			celestiaHome: "",
+			want:         ".celestia-app",
+		},
+		{
+			name:         "want celestia-home/.celestia-app when userHome is empty and celestiaHome is not empty",
+			userHome:     "",
+			celestiaHome: "celestia-home",
+			want:         "celestia-home/.celestia-app",
+		},
+		{
+			name:         "want user-home/.celestia-app when userHome is not empty and celestiaHome is empty",
+			userHome:     "user-home",
+			celestiaHome: "",
+			want:         "user-home/.celestia-app",
+		},
+		{
+			name:         "want celestiaHome to take precedence if both are not empty",
+			userHome:     "user-home",
+			celestiaHome: "celestia-home",
+			want:         "celestia-home/.celestia-app",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getDefaultNodeHome(tc.userHome, tc.celestiaHome)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}


### PR DESCRIPTION
A small refactor to extract some of the contents of `app.go`. Motivated by a separate PR that tried to modify app.go which is currently at 700+ line file with very little consistency.