### PR TITLE
chore: The variable name has a typo

### DIFF
--- a/test/util/genesis/document.go
+++ b/test/util/genesis/document.go
@@ -62,8 +62,8 @@ func Document(
 	state[banktypes.ModuleName] = ecfg.Codec.MustMarshalJSON(bankGenState)
 	state[genutiltypes.ModuleName] = ecfg.Codec.MustMarshalJSON(genutilGenState)
 
-	for _, modifer := range mods {
-		state = modifer(state)
+	for _, modifier := range mods {
+		state = modifier(state)
 	}
 
 	stateBz, err := json.MarshalIndent(state, "", "  ")


### PR DESCRIPTION
Overview:

This PR addresses a spelling error in variable names.
The variable names contained a spelling mistake, and this PR corrects that mistake.
