### PR TITLE
chore(deps): upgrade to celestiaorg/.github v0.3.1

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.8 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.3.1
     with:
       dockerfile: Dockerfile
 
@@ -28,7 +28,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.2.8
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.3.1
     with:
       dockerfile: docker/Dockerfile_txsim
       packageName: txsim

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,10 +32,10 @@ jobs:
 
   # hadolint lints the Dockerfile
   hadolint:
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@v0.2.8 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_lint.yml@v0.3.1
 
   yamllint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: celestiaorg/.github/.github/actions/yamllint@v0.2.8
+      - uses: celestiaorg/.github/.github/actions/yamllint@v0.3.1

--- a/.github/workflows/pr-review-requester.yml
+++ b/.github/workflows/pr-review-requester.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   auto-request-review:
     name: Auto request reviews
-    uses: celestiaorg/.github/.github/workflows/reusable_housekeeping.yml@v0.2.8 # yamllint disable-line rule:line-length
+    uses: celestiaorg/.github/.github/workflows/reusable_housekeeping.yml@v0.3.1
     secrets: inherit
     # write access for issues and pull requests is needed because the called
     # workflow requires write access to issues and pull requests and the


### PR DESCRIPTION
Supersedes https://github.com/celestiaorg/celestia-app/pull/3024. We expect CI to pass on this PR.