### PR TITLE
docs: remove comments about "counter" in NMT cacher

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -939,5 +939,11 @@ google.golang.org/grpc v1.59.0/go.mod h1:aUPDwccQo6OTjy7Hct4AfBPD1GptF4fyUjIkQ9Y
 google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
+honnef.co/go/tools v0.4.3/go.mod h1:36ZgoUOrqOk1GxwHhyryEkq8FQWkUO2xGuSMhUCcdvA=
+k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
+mvdan.cc/gofumpt v0.4.0/go.mod h1:PljLOHDeZqgS8opHRKLzp2It2VBuSdteAgqUfzMTxlQ=
+mvdan.cc/interfacer v0.0.0-20180901003855-c20040233aed/go.mod h1:Xkxe497xwlCKkIaQYRfC7CSLworTXY9RMqwhhCm+8Nc=
+mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b/go.mod h1:2odslEg/xrtNQqCYg2/jCoyKnw3vv5biOc3JnIcYfL4=
+mvdan.cc/unparam v0.0.0-20221223090309-7455f1af531d/go.mod h1:IeHQjmn6TOD+e4Z3RFiZMMsLVL+A96Nvptar8Fj71is=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=

--- a/pkg/inclusion/nmt_caching.go
+++ b/pkg/inclusion/nmt_caching.go
@@ -74,8 +74,7 @@ func (strc subTreeRootCacher) walk(root []byte, path []WalkInstruction) ([]byte,
 }
 
 // EDSSubTreeRootCacher caches the inner nodes for each row so that we can
-// traverse it later to check for blob inclusion. NOTE: Currently this has to
-// use a leaky abstraction (see docs on counter field below), and is not
+// traverse it later to check for blob inclusion. NOTE: Currently this is not
 // threadsafe, but with a future refactor, we could simply read from rsmt2d and
 // not use the tree constructor which would fix both of these issues.
 type EDSSubTreeRootCacher struct {
@@ -95,9 +94,6 @@ func NewSubtreeCacher(squareSize uint64) *EDSSubTreeRootCacher {
 // Constructor fulfills the rsmt2d.TreeCreatorFn by keeping a pointer to the
 // cache and embedding it as a nmt.NodeVisitor into a new wrapped nmt.
 func (stc *EDSSubTreeRootCacher) Constructor(axis rsmt2d.Axis, axisIndex uint) rsmt2d.Tree {
-	// see docs of counter field for more
-	// info. if the counter is even or == 0, then we make the assumption that we
-	// are creating a tree for a row
 	var newTree wrapper.ErasuredNamespacedMerkleTree
 	switch axis {
 	case rsmt2d.Row:


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3070

There are no instances of counter in `nmt_caching.go`. `paths.go` has a counter field but that doesn't seem immediately relevant to where these comments are so proposal to remove them.