### PR TITLE
chore: expose prometheus port in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /opt/entrypoint.sh
 
 USER ${USER_NAME}
 
-# p2p, rpc and prometheus port
-EXPOSE 26656 26657 1317 9090
+# p2p, rpc,  prometheus, api and grpc ports
+EXPOSE 26656 26657 26660 1317 9090
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]


### PR DESCRIPTION
This PR exposes the port 26660 which is needed to support metrics which we want access to for knuu and testground
