### PR TITLE
chore: allow locally publishing docker images to ghcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,11 +77,24 @@ proto-format:
 	@$(DOCKER_PROTO_BUILDER) find . -name '*.proto' -path "./proto/*" -exec clang-format -i {} \;
 .PHONY: proto-format
 
-## build-docker: Build the celestia-appd docker image. Requires docker.
+## build-docker: Build the celestia-appd docker image from the current branch. Requires docker.
 build-docker:
 	@echo "--> Building Docker image"
 	$(DOCKER) build -t celestiaorg/celestia-app -f Dockerfile .
 .PHONY: build-docker
+
+## build-ghcr-docker: Build the celestia-appd docker image from the last commit. Requires docker.
+build-ghcr-docker:
+	@echo "--> Building Docker image"
+	$(DOCKER) build -t ghcr.io/celestiaorg/celestia-app:$(GH_COMMIT) -f Dockerfile .
+.PHONY: build-ghcr-docker
+
+## publish-ghcr-docker: Publish the celestia-appd docker image. Requires docker. 
+## Make sure you are logged in and authenticated to the ghcr.io registry.
+publish-ghcr-docker:
+	@echo "--> Publishing Docker image"
+	$(DOCKER) push ghcr.io/celestiaorg/celestia-app:$(GH_COMMIT)
+.PHONY: publish-ghcr-docker
 
 ## lint: Run all linters; golangci-lint, markdownlint, hadolint, yamllint.
 lint:


### PR DESCRIPTION
This adds two commands in the makefile to make it easy to build and publish the last commit to the ghcr.io registry. This is convenient with the e2e tests which depend on a published commit to run off. 

If you want to use this you need to setup a personal access token with github and login to docker with ghcr else you won't have the requisite permissions