### PR TITLE
chore: describe manual usage and remove unneccesary env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ test-short:
 ## test-e2e: Run end to end tests via knuu. This command requires a kube/config file to configure kubernetes.
 test-e2e:
 	@echo "--> Running end to end tests"
-	@KNUU_NAMESPACE=test KNUU_TIMEOUT=20m E2E_LATEST_VERSION=$(shell git rev-parse --short main) E2E_VERSIONS="$(ALL_VERSIONS)" E2E=true go test ./test/e2e/... -timeout 20m -v
+	@KNUU_NAMESPACE=test KNUU_TIMEOUT=20m E2E_LATEST_VERSION=$(shell git rev-parse --short main) E2E_VERSIONS="$(ALL_VERSIONS)" go test ./test/e2e/... -timeout 20m -v
 .PHONY: test-e2e
 
 ## test-race: Run tests in race mode.

--- a/test/e2e/readme.md
+++ b/test/e2e/readme.md
@@ -2,12 +2,14 @@
 
 Celestia uses the [knuu](https://github.com/celestiaorg/knuu) framework to orchestrate clusters of nodes in a network for end to end testing. This relies on Docker and a kubeconfig (in `~/.kube/config`) to access the Kubernetes cluster.
 
+End to end tests pull docker images from ghcr.io/celestiaorg/celestia-app. These are automatically published when tagging a new release or when opening a pull request. If you wish to manually test a specific commit, you can manually publish the image by first running `make build-ghcr-docker` (from the root directory) and then running `make publish-ghcr-docker`. You must have permission to push to the ghcr.io/celestiaorg/celestia-app repository.
+
 ## Usage
 
 E2E tests can be simply run through go tests. They are distinguished from unit tets through an environment variable. To run all e2e tests run:
 
 ```shell
-E2E=true KNUU_NAMESPACE=test E2E_LATEST_VERSION="$(git rev-parse --short main)" E2E_VERSIONS="$(git tag -l)"  go test ./test/e2e/... -timeout 30m -v
+KNUU_NAMESPACE=test E2E_LATEST_VERSION="$(git rev-parse --short main)" E2E_VERSIONS="$(git tag -l)"  go test ./test/e2e/... -timeout 30m -v
 ```
 
 You can optionally set a global timeout using `KNUU_TIMEOUT` (default is 60m).

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -23,7 +23,7 @@ var latestVersion = "latest"
 // and MsgSends over 30 seconds and then asserts that at least 10 transactions were
 // committed.
 func TestE2ESimple(t *testing.T) {
-	if os.Getenv("E2E") != "true" {
+	if os.Getenv("KNUU_NAMESPACE") != "test" {
 		t.Skip("skipping e2e test")
 	}
 

--- a/test/e2e/upgrade_test.go
+++ b/test/e2e/upgrade_test.go
@@ -23,7 +23,7 @@ import (
 const MajorVersion = 1
 
 func TestMinorVersionCompatibility(t *testing.T) {
-	if os.Getenv("E2E") != "true" {
+	if os.Getenv("KNUU_NAMESPACE") != "test" {
 		t.Skip("skipping e2e test")
 	}
 


### PR DESCRIPTION
A previous PR added the ability to manually build and publish docker images (which are needed to run e2e tests).

This PR adds documentation to explain how to do it.

It also removes the environment variable `E2E` which is redundant and can be replaced by `KNUU_NAMESPACE` which is required