### PR TITLE
chore: stop registering EVM address in scripts

### DIFF
--- a/scripts/build-run-single-node.sh
+++ b/scripts/build-run-single-node.sh
@@ -31,20 +31,5 @@ ${BIN_PATH} collect-gentxs --home ${HOME_DIR}
 sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ${HOME_DIR}/config/config.toml
 sed -i'.bak' 's#"null"#"kv"#g' ${HOME_DIR}/config/config.toml
 
-# Register the validator EVM address
-{
-  # wait for block 1
-  sleep 20
-
-  # private key: da6ed55cb2894ac2c9c10209c09de8e8b9d109b910338d5bf3d747a7e1fc9eb9
-  ${BIN_PATH} tx qgb register \
-    "$(${BIN_PATH} keys show validator --home "${HOME_DIR}" --bech val -a)" \
-    0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488 \
-    --from validator \
-    --home "${HOME_DIR}" \
-    --fees 30000utia -b block \
-    -y
-} &
-
 # Start the celestia-app
 ${BIN_PATH} start --home ${HOME_DIR} --api.enable

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -72,27 +72,6 @@ sed -i'.bak' 's#"null"#"kv"#g' "${CELESTIA_APP_HOME}"/config/config.toml
 # Override the VotingPeriod from 1 week to 1 minute
 sed -i'.bak' 's#"604800s"#"60s"#g' "${CELESTIA_APP_HOME}"/config/genesis.json
 
-# Register the validator EVM address
-{
-  # Wait for block 1
-  sleep 20
-
-  VALIDATOR_ADDRESS=$(celestia-appd keys show ${KEY_NAME} --home "${CELESTIA_APP_HOME}" --bech val --address)
-  EVM_ADDRESS=0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488 # private key: da6ed55cb2894ac2c9c10209c09de8e8b9d109b910338d5bf3d747a7e1fc9eb9
-  echo "Registering an EVM address for validator..."
-  celestia-appd tx qgb register \
-    ${VALIDATOR_ADDRESS} \
-    ${EVM_ADDRESS} \
-    --from ${KEY_NAME} \
-    --home "${CELESTIA_APP_HOME}" \
-    --fees 30000utia \
-    --broadcast-mode block \
-    --yes \
-    &> /dev/null # Hide output to reduce terminal noise
-
-  echo "Registered EVM address."
-} &
-
 # Start celestia-app
 echo "Starting celestia-app..."
 celestia-appd start \


### PR DESCRIPTION
I think we no longer expect validators to register EVM addresses so this PR removes a command from the scripts in `scripts/`.

cc: @rach-id 