### PR TITLE
docs: improve docs for max square size

### DIFF
--- a/app/square_size.go
+++ b/app/square_size.go
@@ -5,8 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// GovSquareSizeUpperBound returns the maximum square size that can be used for a block
-// using the governance parameter blob.GovMaxSquareSize.
+// GovSquareSizeUpperBound returns the max effective square size.
 func (app *App) GovSquareSizeUpperBound(ctx sdk.Context) int {
 	// TODO: fix hack that forces the max square size for the first height to
 	// 64. This is due to our fork of the sdk not initializing state before

--- a/pkg/appconsts/versioned_consts.go
+++ b/pkg/appconsts/versioned_consts.go
@@ -28,9 +28,7 @@ func GlobalMinGasPrice(_ uint64) float64 {
 	return v2.GlobalMinGasPrice
 }
 
-// SquareSizeUpperBound is the maximum original square width possible
-// for a version of the state machine. The maximum is decided through
-// governance. See `DefaultGovMaxSquareSize`.
+// SquareSizeUpperBound imposes an upper bound on the max effective square size.
 func SquareSizeUpperBound(v uint64) int {
 	switch v {
 	case testground.Version:

--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -52,9 +52,8 @@ value is set below that of normal transaction gas consumption, which is 10.
 
 #### `GovMaxSquareSize`
 
-`GovMaxSquareSize` is the maximum size of a data square that is considered valid
-by the validator set. This value is superseded by the `MaxSquareSize`, which is
-hardcoded and cannot change without hardforking the chain. See
+`GovMaxSquareSize` is a governance modifiable parameter that is used to
+determine the max effective square size. See
 [ADR021](../../docs/architecture/adr-021-restricted-block-size.md) for more
 details.
 
@@ -197,7 +196,7 @@ function can be reverse engineered to submit blobs programmatically.
 
 Q: Why do the PFB transactions in the response from Comet BFT API endpoints fail to decode to valid transaction hashes?
 
-The response of CometBFT API endpoints (e.g. `/cosmos/base/tendermint/v1beta1/blocks/{block_number}`) will contain a field called `txs` with base64 encoded transactions. In Celestia, transactions may have one of the two possible types of `sdk.Tx` or `BlobTx` (which wraps around a `sdk.Tx`). As such, each transaction should be first decoded and then gets unmarshalled according to its type, as explained below: 
+The response of CometBFT API endpoints (e.g. `/cosmos/base/tendermint/v1beta1/blocks/{block_number}`) will contain a field called `txs` with base64 encoded transactions. In Celestia, transactions may have one of the two possible types of `sdk.Tx` or `BlobTx` (which wraps around a `sdk.Tx`). As such, each transaction should be first decoded and then gets unmarshalled according to its type, as explained below:
 
 1. Base64 decode the transaction
 1. Check to see if the transaction is a `BlobTx` by unmarshalling it into a `BlobTx` type.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/2241

We may consider renaming `GovSquareSizeUpperBound` => `MaxEffectiveSquareSize` in a future PR but that's API breaking. 