### PR TITLE
ci: use Go version from go.mod

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,9 +17,6 @@ on:
   schedule:
     - cron: '24 20 * * 4'
 
-env:
-  GO_VERSION: '1.22.0'
-
 jobs:
   analyze:
     name: Analyze
@@ -59,7 +56,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Build binary
         run: |

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -5,9 +5,6 @@ on:
       GORELEASER_ACCESS_TOKEN:
         required: true
 
-env:
-  GO_VERSION: '1.22.0'
-
 jobs:
   goreleaser-check:
     runs-on: ubuntu-latest
@@ -32,7 +29,7 @@ jobs:
       - run: git fetch --force --tags
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - name: Create .release-env file
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' >> .release-env

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -10,9 +10,9 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v4
       - name: make govulncheck
         run: make govulncheck

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -6,16 +6,13 @@ name: govulncheck
 on:
   pull_request:
 
-env:
-  GO_VERSION: '1.22.0'
-
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v4
       - name: make govulncheck
         run: make govulncheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,6 @@ name: lint
 on:
   workflow_call:
 
-env:
-  GO_VERSION: '1.22.0'
-
 jobs:
   golangci-lint:
     name: golangci-lint
@@ -14,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
       - uses: technote-space/get-diff-action@v6.1.2
         with:
           # This job will pass without running if go.mod, go.sum, and *.go

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -5,9 +5,6 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
-env:
-  GO_VERSION: '1.22.0'
-
 jobs:
   test-e2e:
     runs-on: ubuntu-latest
@@ -16,7 +13,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Setup kubeconfig
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,6 @@ name: test
 on:
   workflow_call:
 
-env:
-  GO_VERSION: '1.22.0'
-
 jobs:
   test-short:
     runs-on: ubuntu-latest
@@ -13,7 +10,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run tests in short mode
         run: make test-short
@@ -26,7 +23,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run tests
         run: make test
@@ -38,7 +35,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Generate coverage.txt
         run: make test-coverage
@@ -55,7 +52,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run tests in race mode
         run: make test-race
@@ -67,7 +64,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version-file: 'go.mod'
 
       - name: Run fuzz tests
         run: make test-fuzz


### PR DESCRIPTION
This should make it slightly easier to bump Go versions in the future because there will be fewer places to update. 
 
Thanks for the tip @ramin! See https://github.com/celestiaorg/celestia-core/pull/1242/files#r1511342490
