### PR TITLE
refactor!: rename to MaxEffectiveSquareSize

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -64,7 +64,7 @@ func (app *App) PrepareProposal(req abci.RequestPrepareProposal) abci.ResponsePr
 	// build the square from the set of valid and prioritised transactions.
 	// The txs returned are the ones used in the square and block
 	dataSquare, txs, err := square.Build(txs,
-		app.GovSquareSizeUpperBound(sdkCtx),
+		app.MaxEffectiveSquareSize(sdkCtx),
 		appconsts.SubtreeRootThreshold(app.GetBaseApp().AppVersion(sdkCtx)),
 	)
 	if err != nil {

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -119,7 +119,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 	// Construct the data square from the block's transactions
 	dataSquare, err := square.Construct(
 		req.BlockData.Txs,
-		app.GovSquareSizeUpperBound(sdkCtx),
+		app.MaxEffectiveSquareSize(sdkCtx),
 		subtreeRootThreshold,
 	)
 	if err != nil {

--- a/app/square_size.go
+++ b/app/square_size.go
@@ -5,8 +5,8 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// GovSquareSizeUpperBound returns the max effective square size.
-func (app *App) GovSquareSizeUpperBound(ctx sdk.Context) int {
+// MaxEffectiveSquareSize returns the max effective square size.
+func (app *App) MaxEffectiveSquareSize(ctx sdk.Context) int {
 	// TODO: fix hack that forces the max square size for the first height to
 	// 64. This is due to our fork of the sdk not initializing state before
 	// BeginBlock of the first block. This is remedied in versions of the sdk
@@ -17,7 +17,7 @@ func (app *App) GovSquareSizeUpperBound(ctx sdk.Context) int {
 		return int(appconsts.DefaultGovMaxSquareSize)
 	}
 
-	gmax := int(app.BlobKeeper.GovMaxSquareSize(ctx))
+	govMax := int(app.BlobKeeper.GovMaxSquareSize(ctx))
 	hardMax := appconsts.SquareSizeUpperBound(app.AppVersion(ctx))
-	return min(gmax, hardMax)
+	return min(govMax, hardMax)
 }

--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -36,7 +36,7 @@ func (a *App) OutOfOrderPrepareProposal(req abci.RequestPrepareProposal) abci.Re
 
 	// build the square from the set of valid and prioritised transactions.
 	// The txs returned are the ones used in the square and block
-	dataSquare, txs, err := Build(txs, a.GetBaseApp().AppVersion(sdkCtx), a.GovSquareSizeUpperBound(sdkCtx), OutOfOrderExport)
+	dataSquare, txs, err := Build(txs, a.GetBaseApp().AppVersion(sdkCtx), a.MaxEffectiveSquareSize(sdkCtx), OutOfOrderExport)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Motivation: the previous name `GovSquareSizeUpperBound` was easy to mix up with two other related but distinct constants:
- `SquareSizeUpperBound`
- `GovMaxSquareSize`

The new name is a bit easier to visually differentiate from those two. This is technically API breaking but celestia-node doesn't use this method.