### PR TITLE
fix: fixes e2e test failure by adjusting commit hash length in version recognition

### DIFF
--- a/test/e2e/readme.md
+++ b/test/e2e/readme.md
@@ -6,7 +6,7 @@ End to end tests pull docker images from ghcr.io/celestiaorg/celestia-app. These
 
 ## Usage
 
-E2E tests can be simply run through go tests. They are distinguished from unit tets through an environment variable. To run all e2e tests run:
+E2E tests can be simply run through go tests. They are distinguished from unit tests through an environment variable. To run all e2e tests run:
 
 ```shell
 KNUU_NAMESPACE=test E2E_LATEST_VERSION="$(git rev-parse --short main)" E2E_VERSIONS="$(git tag -l)"  go test ./test/e2e/... -timeout 30m -v

--- a/test/e2e/simple_test.go
+++ b/test/e2e/simple_test.go
@@ -34,7 +34,7 @@ func TestE2ESimple(t *testing.T) {
 		case isSemVer:
 		case latestVersion == "latest":
 		case len(latestVersion) == 7:
-		case len(latestVersion) == 8:
+		case len(latestVersion) >= 8:
 			// assume this is a git commit hash (we need to trim the last digit to match the docker image tag)
 			latestVersion = latestVersion[:7]
 		default:


### PR DESCRIPTION
When I attempted to run e2e tests from the root directory of celestia-app, the `simple_test` failed due to an unrecognized version of the application: `unrecognized version: 91603c49c`. However, this version seems to be available at [https://github.com/celestiaorg/celestia-app/pkgs/container/celestia-app/191141043?tag=91603c4](https://github.com/celestiaorg/celestia-app/pkgs/container/celestia-app/191141043?tag=91603c4). See the details below:

```
 KNUU_NAMESPACE=test E2E_LATEST_VERSION="$(git rev-parse --short main)" E2E_VERSIONS="$(git tag -l)" go test ./test/e2e/... -timeout 30m -v
=== RUN   TestE2ESimple
    simple_test.go:41: unrecognized version: 91603c49c
--- FAIL: TestE2ESimple (0.00s)
=== RUN   TestMinorVersionCompatibility
    upgrade_test.go:37: skipping e2e test: no versions to test
--- SKIP: TestMinorVersionCompatibility (0.00s)
=== RUN   TestMajorUpgradeToV2
    upgrade_test.go:129: skipping e2e test
--- SKIP: TestMajorUpgradeToV2 (0.00s)
=== RUN   TestVersionParsing
--- PASS: TestVersionParsing (0.00s)
=== RUN   TestFilterMajorVersions
--- PASS: TestFilterMajorVersions (0.00s)
=== RUN   TestOrder
--- PASS: TestOrder (0.00s)
=== RUN   TestOrderOfReleaseCandidates
--- PASS: TestOrderOfReleaseCandidates (0.00s)
FAIL
FAIL    github.com/celestiaorg/celestia-app/test/e2e    0.550s
FAIL
```

Upon further investigation, realized that the command `git rev-parse --short main` returns a commit hash with varying lengths depending on the git configurations and versions. In contrast, the code assumes that only a maximum of 8 characters is returned by this command. In this PR, the limitation is removed; instead, any length will be trimmed to 7 characters.

This fix has resolved the error. 