### PR TITLE
fix: make help format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ install: go.sum
 	@go install $(BUILD_FLAGS) ./cmd/celestia-appd
 .PHONY: install
 
-## Update go.mod
+## mod: Update all go.mod files.
 mod:
 	@echo "--> Syncing workspaces"
 	@go work sync
@@ -71,7 +71,7 @@ proto-check-breaking:
 	@$(DOCKER_BUF) breaking --against $(HTTPS_GIT)#branch=main
 .PHONY: proto-check-breaking
 
-## proto-format: Format protobuf files. Requires docker.
+## proto-format: Format protobuf files. Requires Docker.
 proto-format:
 	@echo "--> Formatting Protobuf files"
 	@$(DOCKER_PROTO_BUILDER) find . -name '*.proto' -path "./proto/*" -exec clang-format -i {} \;
@@ -90,8 +90,8 @@ build-ghcr-docker:
 .PHONY: build-ghcr-docker
 
 ## publish-ghcr-docker: Publish the celestia-appd docker image. Requires docker.
-## Make sure you are logged in and authenticated to the ghcr.io registry.
 publish-ghcr-docker:
+# Make sure you are logged in and authenticated to the ghcr.io registry.
 	@echo "--> Publishing Docker image"
 	$(DOCKER) push ghcr.io/celestiaorg/celestia-app:$(GH_COMMIT)
 .PHONY: publish-ghcr-docker
@@ -185,7 +185,7 @@ txsim-build-docker:
 	docker build -t ghcr.io/celestiaorg/txsim -f docker/Dockerfile_txsim  .
 .PHONY: txsim-build-docker
 
-## adr-gen: Download the ADR template from the celestiaorg/.github repo. Ex. `make adr-gen`
+## adr-gen: Download the ADR template from the celestiaorg/.github repo.
 adr-gen:
 	@echo "--> Downloading ADR template"
 	@curl -sSL https://raw.githubusercontent.com/celestiaorg/.github/main/adr-template.md > docs/architecture/adr-template.md


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3178

## Testing

```
$ make help
 Choose a command run in celestia-app:
  help                   Get more info on make commands.
  build                  Build the celestia-appd binary into the ./build directory.
  install                Build and install the celestia-appd binary into the $GOPATH/bin directory.
  mod                    Update all go.mod files.
  mod-verify             Verify dependencies have expected content.
  proto-gen              Generate protobuf files. Requires docker.
  proto-lint             Lint protobuf files. Requires docker.
  proto-check-breaking   Check if there are any breaking change to protobuf definitions.
  proto-format           Format protobuf files. Requires Docker.
  build-docker           Build the celestia-appd docker image from the current branch. Requires docker.
  build-ghcr-docker      Build the celestia-appd docker image from the last commit. Requires docker.
  publish-ghcr-docker    Publish the celestia-appd docker image. Requires docker.
  lint                   Run all linters; golangci-lint, markdownlint, hadolint, yamllint.
  markdown-link-check    Check all markdown links.
  fmt                    Format files per linters golangci-lint and markdownlint.
  test                   Run tests.
  test-short             Run tests in short mode.
  test-e2e               Run end to end tests via knuu. This command requires a kube/config file to configure kubernetes.
  test-race              Run tests in race mode.
  test-bench             Run unit tests in bench mode.
  test-coverage          Generate test coverage.txt
  txsim-install          Install the tx simulator.
  txsim-build            Build the tx simulator binary into the ./build directory.
  txsim-build-docker     Build the tx simulator Docker image. Requires Docker.
  adr-gen                Download the ADR template from the celestiaorg/.github repo.
  prebuilt-binary        Create prebuilt binaries and attach them to GitHub release. Requires Docker.
  govulncheck            Check for vulnerabilities in dependencies.
```