### PR TITLE
feat: add workdir to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,8 @@ COPY --from=builder /celestia-app/build/celestia-appd /bin/celestia-appd
 COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /opt/entrypoint.sh
 # Set the user to celestia.
 USER ${USER_NAME}
+# Set the working directory to the home directory.
+WORKDIR ${CELESTIA_HOME}
 # Expose ports:
 # 1317 is the default API server port.
 # 9090 is the default GRPC server port.

--- a/docker/Dockerfile_txsim
+++ b/docker/Dockerfile_txsim
@@ -53,6 +53,9 @@ COPY --chown=${USER_NAME}:${USER_NAME} docker/txsim.sh /opt/entrypoint.sh
 
 USER ${USER_NAME}
 
+# Set the working directory to the home directory.
+WORKDIR ${CELESTIA_HOME}
+
 # grpc, rpc, api ports
 EXPOSE 26657 1317 9090
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This should be a non-breaking change.

This only changes the work directory when the container is started. This means that if you want to execute a command in a running container, it will be automatically in that directory instead of '/'. This improves maintaining and debugging our environments.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
