### PR TITLE
fix: provide a fee in single node script

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -12,6 +12,7 @@ COINS="1000000000000000utia"
 DELEGATION_AMOUNT="5000000000utia"
 CELESTIA_APP_HOME="${HOME}/.celestia-app"
 CELESTIA_APP_VERSION=$(celestia-appd version 2>&1)
+FEES="500utia"
 
 echo "celestia-app home: ${CELESTIA_APP_HOME}"
 echo "celestia-app version: ${CELESTIA_APP_VERSION}"
@@ -51,6 +52,7 @@ celestia-appd add-genesis-account \
 
 echo "Creating a genesis tx..."
 celestia-appd gentx ${KEY_NAME} ${DELEGATION_AMOUNT} \
+  --fees ${FEES} \
   --keyring-backend=${KEYRING_BACKEND} \
   --chain-id ${CHAIN_ID} \
   --home ${CELESTIA_APP_HOME} \


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3205

## Testing

```shell
./scripts/single-node.sh

celestia-app home: /Users/rootulp/.celestia-app
celestia-app version: 1.0.0-rc0-588-g952a455b

Are you sure you want to delete: /Users/rootulp/.celestia-app? [y/n] y
Deleting /Users/rootulp/.celestia-app...
Initializing validator and node config files...
Adding a new key to the keyring...
Adding genesis account...
Creating a genesis tx...
Collecting genesis txs...
Starting celestia-app...

// no error
```