### PR TITLE
docs: improve `x/upgrade` docs

### DIFF
--- a/proto/celestia/upgrade/v1/query.proto
+++ b/proto/celestia/upgrade/v1/query.proto
@@ -7,20 +7,18 @@ option go_package = "github.com/celestiaorg/celestia-app/x/upgrade/types";
 
 // Query defines the upgrade Query service.
 service Query {
-  // VersionTally allows the querying of the tally of voting power by all
-  // validators that have signalled for each version
+  // VersionTally enables a client to query for the tally of voting power has
+  // signalled for a particular version.
   rpc VersionTally(QueryVersionTallyRequest)
       returns (QueryVersionTallyResponse) {
     option (google.api.http).get = "/upgrade/v1/tally/{version}";
   }
 }
 
-// QueryVersionTallyRequest is the request type for the UpgradeStatus RPC
-// method.
+// QueryVersionTallyRequest is the request type for the VersionTally query.
 message QueryVersionTallyRequest { uint64 version = 1; }
 
-// QueryVersionTallyResponse is the response type for the UpgradeStatus RPC
-// method.
+// QueryVersionTallyResponse is the response type for the VersionTally query.
 message QueryVersionTallyResponse {
   uint64 voting_power = 1;
   uint64 threshold_power = 2;

--- a/proto/celestia/upgrade/v1/tx.proto
+++ b/proto/celestia/upgrade/v1/tx.proto
@@ -7,30 +7,29 @@ option go_package = "github.com/celestiaorg/celestia-app/x/upgrade/types";
 
 // Msg defines the upgrade Msg service.
 service Msg {
-  // SignalVersion allows the validator to signal for an upgrade
+  // SignalVersion allows a validator to signal for an upgrade.
   rpc SignalVersion(MsgSignalVersion) returns (MsgSignalVersionResponse) {
     option (google.api.http).post = "/upgrade/v1/signal";
   }
 
   // TryUpgrade tallies all the votes and if a quorum is reached, it will
-  // trigger an upgrade for the following height
+  // trigger an upgrade for the following height.
   rpc TryUpgrade(MsgTryUpgrade) returns (MsgTryUpgradeResponse) {
     option (google.api.http).post = "/upgrade/v1/upgrade";
   }
 }
 
-// MsgSignalVersion signals for an upgrade
+// MsgSignalVersion signals for an upgrade.
 message MsgSignalVersion {
   string validator_address = 1;
   uint64 version = 2;
 }
 
-// MsgSignalVersionResponse describes the response returned after the submission
-// of a SignalVersion
+// MsgSignalVersionResponse is the response type for the SignalVersion method.
 message MsgSignalVersionResponse {}
 
-// MsgTryUpgrade tries to upgrade the chain
+// MsgTryUpgrade tries to upgrade the chain.
 message MsgTryUpgrade { string signer = 1; }
 
-// MsgTryUpgradeResponse describes the response returned after the submission
+// MsgTryUpgradeResponse is the response type for the TryUpgrade method.
 message MsgTryUpgradeResponse {}

--- a/specs/src/specs/params.md
+++ b/specs/src/specs/params.md
@@ -66,5 +66,4 @@ are blocked by the `x/paramfilter` module.
 | staking.MinCommissionRate                     | 0.05 (5%)                                   | Minimum commission rate used by all validators.                                                                                                                                                 | True                      |
 | staking.UnbondingTime                         | 1814400 (21 days)                           | Duration of time for unbonding in seconds.                                                                                                                                                      | False                     |
 
-
 Note: none of the mint module parameters are governance modifiable because they have been converted into hardcoded constants. See the x/mint README.md for more details.

--- a/x/upgrade/README.md
+++ b/x/upgrade/README.md
@@ -21,22 +21,6 @@ The map from validator address to version is updated when a validator signals fo
 
 See [types/msgs.go](./types/msgs.go) for the message types.
 
-## Begin Block
-
-N/A
-
-## End Block
-
-N/A
-
-## Hooks
-
-N/A
-
-## Events
-
-N/A
-
 ## Client
 
 ### CLI
@@ -56,18 +40,6 @@ celestia.upgrade.v1.Query/VersionTally
 ```shell
 grpcurl -plaintext localhost:9090 celestia.upgrade.v1.Query/VersionTally
 ```
-
-## Params - list all module parameters, their types (in JSON) and examples
-
-N/A
-
-## Future Improvements
-
-N/A
-
-## Tests
-
-N/A
 
 ## Appendix
 

--- a/x/upgrade/README.md
+++ b/x/upgrade/README.md
@@ -1,23 +1,77 @@
 # `x/upgrade`
 
-## Abstract
+This upgrade module is a fork of the cosmos-sdk's [x/upgrade](https://github.com/cosmos/cosmos-sdk/tree/main/x/upgrade) module. The primary purpose of this module is to allow for rolling network upgrades as proposed in [ADR-018](../../docs/architecture/adr-018-network-upgrades.md) and [CIP-10](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md).
 
-This upgrade module is a fork of the cosmos-sdk's
-[x/upgrade](https://github.com/cosmos/cosmos-sdk/tree/main/x/upgrade) module
-that removes the entrypoints to the standard upgrade module by not registering a
-message server.
+Note: this module won't be used for upgrading from app version v1 to v2 but will be used for upgrading from v2 to v3 and onwards.
 
-The goal of this approach is to force social consensus to reach an upgrade
-instead of relying on token voting. It works by simply removing the ability of
-the gov module to schedule an upgrade. This way, the only way to upgrade the
-chain is to agree on the upgrade logic and the upgrade height offchain.
+## Concepts
 
-This fork registers the standard upgrade module types to preserve the ability to
-marshal them. Additionally the keeper of the standard upgrade module is still
-added to the application.
+- Total voting power: The sum of voting power for all validators.
+- Voting power threshold: The amount of voting power that needs to signal for a particular version for an upgrade to take place. This is a percentage of the total voting power (usually 5/6).
 
-## Resources
+## State
 
-1. <https://github.com/celestiaorg/celestia-app/pull/1491>
+This module persists a map in state from validator address to version that they are signalling for.
+
+## State Transitions
+
+The map from validator address to version is updated when a validator signals for a version (`SignalVersion`) and after an upgrade takes place (`ResetTally`).
+
+## Messages
+
+See [types/msgs.go](./types/msgs.go) for the message types.
+
+## Begin Block
+
+N/A
+
+## End Block
+
+N/A
+
+## Hooks
+
+N/A
+
+## Events
+
+N/A
+
+## Client
+
+### CLI
+
+```shell
+celestia-appd query upgrade tally
+celestia-appd tx upgrade signal
+celestia-appd tx upgrade try-upgrade
+```
+
+### gRPC
+
+```api
+celestia.upgrade.v1.Query/VersionTally
+```
+
+```shell
+grpcurl -plaintext localhost:9090 celestia.upgrade.v1.Query/VersionTally
+```
+
+## Params - list all module parameters, their types (in JSON) and examples
+
+N/A
+
+## Future Improvements
+
+N/A
+
+## Tests
+
+N/A
+
+## Appendix
+
+1. <https://github.com/celestiaorg/celestia-app/blob/main/docs/architecture/adr-018-network-upgrades.md>
+1. <https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md>
 1. <https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/x/upgrade/README.md>
 1. <https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/x/gov/README.md>

--- a/x/upgrade/cli/cli_test.go
+++ b/x/upgrade/cli/cli_test.go
@@ -23,7 +23,7 @@ type CLITestSuite struct {
 }
 
 func (s *CLITestSuite) SetupSuite() {
-	s.T().Log("setting up integration test suite")
+	s.T().Log("setting up CLI test suite")
 	ctx, _, _ := testnode.NewNetwork(s.T(), testnode.DefaultConfig())
 	s.ctx = ctx
 	_, err := s.ctx.WaitForHeight(1)

--- a/x/upgrade/cli/query.go
+++ b/x/upgrade/cli/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// GetQueryCmd returns the CLI query commands for this module
+// GetQueryCmd returns the CLI query commands for this module.
 func GetQueryCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
@@ -21,15 +21,15 @@ func GetQueryCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(CmdQueryTally())
-
 	return cmd
 }
 
 func CmdQueryTally() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "tally version",
-		Short: "Query the tally of signal votes for a given version",
-		Args:  cobra.ExactArgs(1),
+		Use:     "tally version",
+		Short:   "Query for the tally of voting power that has signalled for a particular version",
+		Args:    cobra.ExactArgs(1),
+		Example: "tally 3",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			clientCtx, err := client.GetClientQueryContext(cmd)
 			if err != nil {
@@ -42,7 +42,6 @@ func CmdQueryTally() *cobra.Command {
 			}
 
 			upgradeQueryClient := types.NewQueryClient(clientCtx)
-
 			resp, err := upgradeQueryClient.VersionTally(cmd.Context(), &types.QueryVersionTallyRequest{Version: version})
 			if err != nil {
 				return err

--- a/x/upgrade/cli/tx.go
+++ b/x/upgrade/cli/tx.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// GetTxCmd returns the transaction commands for this module
+// GetTxCmd returns the transaction commands for this module.
 func GetTxCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                        types.ModuleName,
@@ -24,7 +24,6 @@ func GetTxCmd() *cobra.Command {
 
 	cmd.AddCommand(CmdSignalVersion())
 	cmd.AddCommand(CmdTryUpgrade())
-
 	return cmd
 }
 
@@ -46,9 +45,7 @@ func CmdSignalVersion() *cobra.Command {
 
 			addr := clientCtx.GetFromAddress().Bytes()
 			valAddr := sdk.ValAddress(addr)
-
 			msg := types.NewMsgSignalVersion(valAddr, version)
-
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}
@@ -70,9 +67,7 @@ to the signalled version at the following height.
 			if err != nil {
 				return err
 			}
-
 			msg := types.NewMsgTryUpgrade(clientCtx.GetFromAddress())
-
 			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
 		},
 	}

--- a/x/upgrade/ibc.go
+++ b/x/upgrade/ibc.go
@@ -7,17 +7,17 @@ import (
 )
 
 // We need compatibility with the way that IBC uses the upgrade module. This file
-// ensures that we comply to the interface that IBC expects
+// ensures that we comply to the interface that IBC expects.
 var _ ibctypes.UpgradeKeeper = (*Keeper)(nil)
 
-// ScheduleUpgrade implements the ibc upgrade keeper interface. This is a noop as
+// ScheduleUpgrade implements the IBC upgrade keeper interface. This is a noop as
 // no other process is allowed to schedule an upgrade but the upgrade keeper itself.
 // This is kept around to support the interface.
 func (k Keeper) ScheduleUpgrade(_ sdk.Context, _ types.Plan) error {
 	return nil
 }
 
-// GetUpgradePlan implements the ibc upgrade keeper interface. This is used in BeginBlock
+// GetUpgradePlan implements the IBC upgrade keeper interface. This is used in BeginBlock
 // to know when to write the upgraded consensus state. The IBC module needs to sign over
 // the next consensus state to ensure a smooth transition for counterparty chains. This
 // is implemented as a noop. Any IBC breaking change would be invoked by this upgrade module
@@ -26,14 +26,16 @@ func (k Keeper) GetUpgradePlan(_ sdk.Context) (plan types.Plan, havePlan bool) {
 	return types.Plan{}, false
 }
 
-// SetUpgradedClient sets the expected upgraded client for the next version of this chain at the last height the current chain will commit.
+// SetUpgradedClient sets the expected upgraded client for the next version of
+// this chain at the last height the current chain will commit.
 func (k Keeper) SetUpgradedClient(ctx sdk.Context, planHeight int64, bz []byte) error {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.UpgradedClientKey(planHeight), bz)
 	return nil
 }
 
-// GetUpgradedClient gets the expected upgraded client for the next version of this chain
+// GetUpgradedClient gets the expected upgraded client for the next version of
+// this chain.
 func (k Keeper) GetUpgradedClient(ctx sdk.Context, height int64) ([]byte, bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.UpgradedClientKey(height))
@@ -44,15 +46,16 @@ func (k Keeper) GetUpgradedClient(ctx sdk.Context, height int64) ([]byte, bool) 
 	return bz, true
 }
 
-// SetUpgradedConsensusState set the expected upgraded consensus state for the next version of this chain
-// using the last height committed on this chain.
+// SetUpgradedConsensusState sets the expected upgraded consensus state for the
+// next version of this chain using the last height committed on this chain.
 func (k Keeper) SetUpgradedConsensusState(ctx sdk.Context, planHeight int64, bz []byte) error {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(types.UpgradedConsStateKey(planHeight), bz)
 	return nil
 }
 
-// GetUpgradedConsensusState get the expected upgraded consensus state for the next version of this chain
+// GetUpgradedConsensusState gets the expected upgraded consensus state for the
+// next version of this chain.
 func (k Keeper) GetUpgradedConsensusState(ctx sdk.Context, lastHeight int64) ([]byte, bool) {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get(types.UpgradedConsStateKey(lastHeight))
@@ -63,7 +66,7 @@ func (k Keeper) GetUpgradedConsensusState(ctx sdk.Context, lastHeight int64) ([]
 	return bz, true
 }
 
-// ClearIBCState clears any planned IBC state
+// ClearIBCState clears any planned IBC state.
 func (k Keeper) ClearIBCState(ctx sdk.Context, lastHeight int64) {
 	// delete IBC client and consensus state from store if this is IBC plan
 	store := ctx.KVStore(k.storeKey)

--- a/x/upgrade/keeper.go
+++ b/x/upgrade/keeper.go
@@ -34,21 +34,22 @@ func SignalThreshold(_ uint64) Fraction {
 }
 
 type Keeper struct {
-	// we use the same upgrade store key so existing IBC client state can
-	// safely be ported over without any migration
+	// storeKey uses the same key as the Cosmos SDK x/upgrade module so that
+	// existing IBC client state can safely be ported over without any
+	// migration.
 	storeKey storetypes.StoreKey
 
 	// quorumVersion is the version that has received a quorum of validators
 	// to signal for it. This variable is relevant just for the scope of the
-	// lifetime of the block
+	// lifetime of the block.
 	quorumVersion uint64
 
-	// staking keeper is used to fetch validators to calculate the total power
-	// signalled to a version
+	// stakingKeeper is used to fetch validators to calculate the total power
+	// signalled to a version.
 	stakingKeeper StakingKeeper
 }
 
-// NewKeeper constructs an upgrade keeper
+// NewKeeper returns an upgrade keeper.
 func NewKeeper(
 	storeKey storetypes.StoreKey,
 	stakingKeeper StakingKeeper,
@@ -59,7 +60,7 @@ func NewKeeper(
 	}
 }
 
-// SignalVersion is a method required by the MsgServer interface
+// SignalVersion is a method required by the MsgServer interface.
 func (k Keeper) SignalVersion(ctx context.Context, req *types.MsgSignalVersion) (*types.MsgSignalVersionResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	valAddr, err := sdk.ValAddressFromBech32(req.ValidatorAddress)
@@ -67,14 +68,13 @@ func (k Keeper) SignalVersion(ctx context.Context, req *types.MsgSignalVersion) 
 		return nil, err
 	}
 
-	// the signalled version must be either the current version (for cancelling an upgrade)
-	// or the very next version (for accepting an upgrade)
+	// The signalled version must be either the current version or the next
+	// version.
 	currentVersion := sdkCtx.BlockHeader().Version.App
 	if req.Version != currentVersion && req.Version != currentVersion+1 {
 		return nil, types.ErrInvalidVersion
 	}
 
-	// check that the validator exists
 	_, found := k.stakingKeeper.GetValidator(sdkCtx, valAddr)
 	if !found {
 		return nil, stakingtypes.ErrNoValidatorFound
@@ -84,7 +84,7 @@ func (k Keeper) SignalVersion(ctx context.Context, req *types.MsgSignalVersion) 
 	return &types.MsgSignalVersionResponse{}, nil
 }
 
-// TryUpgrade is a method required by the MsgServer interface
+// TryUpgrade is a method required by the MsgServer interface.
 // It tallies the voting power that has voted on each version.
 // If one version has quorum, it is set as the quorum version
 // which the application can use as signal to upgrade to that version.
@@ -98,7 +98,8 @@ func (k *Keeper) TryUpgrade(ctx context.Context, _ *types.MsgTryUpgrade) (*types
 	return &types.MsgTryUpgradeResponse{}, nil
 }
 
-// VersionTally is a method required by the QueryServer interface
+// VersionTally enables a client to query for the tally of voting power has
+// signalled for a particular version.
 func (k Keeper) VersionTally(ctx context.Context, req *types.QueryVersionTallyRequest) (*types.QueryVersionTallyResponse, error) {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	totalVotingPower := k.stakingKeeper.GetLastTotalPower(sdkCtx)
@@ -122,22 +123,23 @@ func (k Keeper) VersionTally(ctx context.Context, req *types.QueryVersionTallyRe
 	}, nil
 }
 
-// SetValidatorVersion saves a signalled version for a validator using the keeper's store key
+// SetValidatorVersion saves a signalled version for a validator.
 func (k Keeper) SetValidatorVersion(ctx sdk.Context, valAddress sdk.ValAddress, version uint64) {
 	store := ctx.KVStore(k.storeKey)
 	store.Set(valAddress, VersionToBytes(version))
 }
 
-// DeleteValidatorVersion deletes a signalled version for a validator using the keeper's store key
+// DeleteValidatorVersion deletes a signalled version for a validator.
 func (k Keeper) DeleteValidatorVersion(ctx sdk.Context, valAddress sdk.ValAddress) {
 	store := ctx.KVStore(k.storeKey)
 	store.Delete(valAddress)
 }
 
-// TallyVotingPower tallies the voting power for each version and returns true if
-// any version has reached the quorum in voting power
+// TallyVotingPower tallies the voting power for each version and returns true
+// and the version if any version has reached the quorum in voting power.
+// Returns false and 0 otherwise.
 func (k Keeper) TallyVotingPower(ctx sdk.Context, threshold int64) (bool, uint64) {
-	output := make(map[uint64]int64)
+	versionToPower := make(map[uint64]int64)
 	store := ctx.KVStore(k.storeKey)
 	iterator := store.Iterator(nil, nil)
 	defer iterator.Close()
@@ -155,12 +157,12 @@ func (k Keeper) TallyVotingPower(ctx sdk.Context, threshold int64) (bool, uint64
 		}
 		power := k.stakingKeeper.GetLastValidatorPower(ctx, valAddress)
 		version := VersionFromBytes(iterator.Value())
-		if _, ok := output[version]; !ok {
-			output[version] = power
+		if _, ok := versionToPower[version]; !ok {
+			versionToPower[version] = power
 		} else {
-			output[version] += power
+			versionToPower[version] += power
 		}
-		if output[version] >= threshold {
+		if versionToPower[version] >= threshold {
 			return true, version
 		}
 	}

--- a/x/upgrade/legacy_test.go
+++ b/x/upgrade/legacy_test.go
@@ -37,9 +37,9 @@ func TestLegacyUpgrade(t *testing.T) {
 // proposals.
 func TestRemoval(t *testing.T) {
 	app, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams())
-	sftwrUpgrd := types.MsgSoftwareUpgrade{}
+	msgSoftwareUpgrade := types.MsgSoftwareUpgrade{}
 	router := app.MsgServiceRouter()
-	handler := router.Handler(&sftwrUpgrd)
+	handler := router.Handler(&msgSoftwareUpgrade)
 	require.Nil(t, handler)
 }
 

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -50,17 +50,28 @@ func (AppModuleBasic) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *r
 	}
 }
 
-// GetQueryCmd returns the cli query commands for this module
+// GetQueryCmd returns the CLI query commands for this module.
 func (AppModuleBasic) GetQueryCmd() *cobra.Command {
 	return cli.GetQueryCmd()
 }
 
-// GetTxCmd returns the transaction commands for this module
+// GetTxCmd returns the CLI transaction commands for this module.
 func (AppModuleBasic) GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
 
-func (b AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
+// DefaultGenesis returns an empty object.
+func (AppModuleBasic) DefaultGenesis(_ codec.JSONCodec) json.RawMessage {
+	return []byte("{}")
+}
+
+// ValidateGenesis is always successful, as we ignore the value.
+func (AppModuleBasic) ValidateGenesis(_ codec.JSONCodec, _ client.TxEncodingConfig, _ json.RawMessage) error {
+	return nil
+}
+
+// RegisterInterfaces registers the module's interface types on the InterfaceRegistry.
+func (AppModuleBasic) RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	types.RegisterInterfaces(registry)
 }
 
@@ -78,19 +89,22 @@ func NewAppModule(keeper Keeper) AppModule {
 	}
 }
 
-// RegisterInvariants does nothing, there are no invariants to enforce
+// RegisterInvariants does nothing because there are no invariants to enforce.
 func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
-// Deprecated: Route returns the message routing key for the upgrade module.
+// Route returns an empty route for this module.
+// Deprecated in favor of RegisterServices.
 func (AppModule) Route() sdk.Route {
 	return sdk.Route{}
 }
 
-// QuerierRoute returns the route we respond to for abci queries
-func (AppModule) QuerierRoute() string { return types.QuerierRoute }
+// QuerierRoute returns the query routing key used for ABCI queries.
+func (AppModule) QuerierRoute() string {
+	return types.QuerierRoute
+}
 
-// LegacyQuerierHandler registers a query handler to respond to the module-specific queries
-func (am AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
+// LegacyQuerierHandler returns nil because there are no legacy queriers.
+func (AppModule) LegacyQuerierHandler(_ *codec.LegacyAmino) sdk.Querier {
 	return nil
 }
 
@@ -100,25 +114,15 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 }
 
-// InitGenesis is ignored, no sense in serializing future upgrades
-func (am AppModule) InitGenesis(_ sdk.Context, _ codec.JSONCodec, _ json.RawMessage) []abci.ValidatorUpdate {
+// InitGenesis does nothing because there is no sense in serializing future upgrades.
+func (AppModule) InitGenesis(_ sdk.Context, _ codec.JSONCodec, _ json.RawMessage) []abci.ValidatorUpdate {
 	return []abci.ValidatorUpdate{}
 }
 
-// DefaultGenesis is an empty object
-func (AppModuleBasic) DefaultGenesis(_ codec.JSONCodec) json.RawMessage {
-	return []byte("{}")
-}
-
-// ValidateGenesis is always successful, as we ignore the value
-func (AppModuleBasic) ValidateGenesis(_ codec.JSONCodec, _ client.TxEncodingConfig, _ json.RawMessage) error {
-	return nil
-}
-
-// ExportGenesis is always empty, as InitGenesis does nothing either
+// ExportGenesis is always empty, as InitGenesis does nothing either.
 func (am AppModule) ExportGenesis(_ sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	return am.DefaultGenesis(cdc)
 }
 
-// ConsensusVersion implements AppModule/ConsensusVersion.
+// ConsensusVersion returns the consensus version of this module.
 func (AppModule) ConsensusVersion() uint64 { return consensusVersion }

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -22,6 +22,7 @@ func init() {
 }
 
 const (
+	// consensusVersion defines the current x/upgrade module consensus version.
 	consensusVersion uint64 = 3
 )
 

--- a/x/upgrade/module.go
+++ b/x/upgrade/module.go
@@ -94,7 +94,6 @@ func NewAppModule(keeper Keeper) AppModule {
 func (AppModule) RegisterInvariants(_ sdk.InvariantRegistry) {}
 
 // Route returns an empty route for this module.
-// Deprecated in favor of RegisterServices.
 func (AppModule) Route() sdk.Route {
 	return sdk.Route{}
 }

--- a/x/upgrade/tally_test.go
+++ b/x/upgrade/tally_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/store"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	testutil "github.com/celestiaorg/celestia-app/test/util"
@@ -22,36 +23,45 @@ import (
 func TestSignalVersion(t *testing.T) {
 	upgradeKeeper, ctx, _ := setup(t)
 	goCtx := sdk.WrapSDKContext(ctx)
-	_, err := upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
-		ValidatorAddress: testutil.ValAddrs[0].String(),
-		Version:          0,
+	t.Run("should return an error if the signal version is less than the current version", func(t *testing.T) {
+		_, err := upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
+			ValidatorAddress: testutil.ValAddrs[0].String(),
+			Version:          0,
+		})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, types.ErrInvalidVersion)
 	})
-	require.Error(t, err)
-	_, err = upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
-		ValidatorAddress: testutil.ValAddrs[0].String(),
-		Version:          3,
+	t.Run("should return an error if the signal version is greater than the next version", func(t *testing.T) {
+		_, err := upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
+			ValidatorAddress: testutil.ValAddrs[0].String(),
+			Version:          3,
+		})
+		assert.Error(t, err)
+		assert.ErrorIs(t, err, types.ErrInvalidVersion)
 	})
-	require.Error(t, err)
+	t.Run("should return an error if the validator was not found", func(t *testing.T) {
+		_, err := upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
+			ValidatorAddress: testutil.ValAddrs[4].String(),
+			Version:          2,
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, stakingtypes.ErrNoValidatorFound)
+	})
+	t.Run("should not return an error if the signal version and validator are valid", func(t *testing.T) {
+		_, err := upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
+			ValidatorAddress: testutil.ValAddrs[0].String(),
+			Version:          2,
+		})
+		require.NoError(t, err)
 
-	_, err = upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
-		ValidatorAddress: testutil.ValAddrs[4].String(),
-		Version:          2,
+		res, err := upgradeKeeper.VersionTally(goCtx, &types.QueryVersionTallyRequest{
+			Version: 2,
+		})
+		require.NoError(t, err)
+		require.EqualValues(t, 40, res.VotingPower)
+		require.EqualValues(t, 100, res.ThresholdPower)
+		require.EqualValues(t, 120, res.TotalVotingPower)
 	})
-	require.Error(t, err)
-
-	_, err = upgradeKeeper.SignalVersion(goCtx, &types.MsgSignalVersion{
-		ValidatorAddress: testutil.ValAddrs[0].String(),
-		Version:          2,
-	})
-	require.NoError(t, err)
-
-	res, err := upgradeKeeper.VersionTally(goCtx, &types.QueryVersionTallyRequest{
-		Version: 2,
-	})
-	require.NoError(t, err)
-	require.EqualValues(t, 40, res.VotingPower)
-	require.EqualValues(t, 100, res.ThresholdPower)
-	require.EqualValues(t, 120, res.TotalVotingPower)
 }
 
 func TestTallyingLogic(t *testing.T) {

--- a/x/upgrade/types/codec.go
+++ b/x/upgrade/types/codec.go
@@ -8,14 +8,16 @@ import (
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
-// RegisterLegacyAminoCodec registers the upgrade types on the LegacyAmino codec.
+// RegisterLegacyAminoCodec registers the upgrade types on the provided
+// LegacyAmino codec.
 func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(upgradetypes.Plan{}, "cosmos-sdk/Plan", nil)
 	cdc.RegisterConcrete(&MsgTryUpgrade{}, URLMsgTryUpgrade, nil)
 	cdc.RegisterConcrete(&MsgSignalVersion{}, URLMsgSignalVersion, nil)
 }
 
-// RegisterInterfaces registers the upgrade module types.
+// RegisterInterfaces registers the upgrade module types on the provided
+// registry.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgTryUpgrade{})
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgSignalVersion{})

--- a/x/upgrade/types/msgs.go
+++ b/x/upgrade/types/msgs.go
@@ -75,11 +75,11 @@ func NewMsgTryUpgrade(signer sdk.AccAddress) *MsgTryUpgrade {
 }
 
 func (msg *MsgTryUpgrade) GetSigners() []sdk.AccAddress {
-	valAddr, err := sdk.AccAddressFromBech32(msg.Signer)
+	addr, err := sdk.AccAddressFromBech32(msg.Signer)
 	if err != nil {
 		panic(err)
 	}
-	return []sdk.AccAddress{valAddr}
+	return []sdk.AccAddress{addr}
 }
 
 func (msg *MsgTryUpgrade) ValidateBasic() error {

--- a/x/upgrade/types/query.pb.go
+++ b/x/upgrade/types/query.pb.go
@@ -28,8 +28,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// QueryVersionTallyRequest is the request type for the UpgradeStatus RPC
-// method.
+// QueryVersionTallyRequest is the request type for the VersionTally query.
 type QueryVersionTallyRequest struct {
 	Version uint64 `protobuf:"varint,1,opt,name=version,proto3" json:"version,omitempty"`
 }
@@ -74,8 +73,7 @@ func (m *QueryVersionTallyRequest) GetVersion() uint64 {
 	return 0
 }
 
-// QueryVersionTallyResponse is the response type for the UpgradeStatus RPC
-// method.
+// QueryVersionTallyResponse is the response type for the VersionTally query.
 type QueryVersionTallyResponse struct {
 	VotingPower      uint64 `protobuf:"varint,1,opt,name=voting_power,json=votingPower,proto3" json:"voting_power,omitempty"`
 	ThresholdPower   uint64 `protobuf:"varint,2,opt,name=threshold_power,json=thresholdPower,proto3" json:"threshold_power,omitempty"`
@@ -180,8 +178,8 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type QueryClient interface {
-	// VersionTally allows the querying of the tally of voting power by all
-	// validators that have signalled for each version
+	// VersionTally enables a client to query for the tally of voting power has
+	// signalled for a particular version.
 	VersionTally(ctx context.Context, in *QueryVersionTallyRequest, opts ...grpc.CallOption) (*QueryVersionTallyResponse, error)
 }
 
@@ -204,8 +202,8 @@ func (c *queryClient) VersionTally(ctx context.Context, in *QueryVersionTallyReq
 
 // QueryServer is the server API for Query service.
 type QueryServer interface {
-	// VersionTally allows the querying of the tally of voting power by all
-	// validators that have signalled for each version
+	// VersionTally enables a client to query for the tally of voting power has
+	// signalled for a particular version.
 	VersionTally(context.Context, *QueryVersionTallyRequest) (*QueryVersionTallyResponse, error)
 }
 

--- a/x/upgrade/types/tx.pb.go
+++ b/x/upgrade/types/tx.pb.go
@@ -28,7 +28,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// MsgSignalVersion signals for an upgrade
+// MsgSignalVersion signals for an upgrade.
 type MsgSignalVersion struct {
 	ValidatorAddress string `protobuf:"bytes,1,opt,name=validator_address,json=validatorAddress,proto3" json:"validator_address,omitempty"`
 	Version          uint64 `protobuf:"varint,2,opt,name=version,proto3" json:"version,omitempty"`
@@ -81,8 +81,7 @@ func (m *MsgSignalVersion) GetVersion() uint64 {
 	return 0
 }
 
-// MsgSignalVersionResponse describes the response returned after the submission
-// of a SignalVersion
+// MsgSignalVersionResponse is the response type for the SignalVersion method.
 type MsgSignalVersionResponse struct {
 }
 
@@ -119,7 +118,7 @@ func (m *MsgSignalVersionResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_MsgSignalVersionResponse proto.InternalMessageInfo
 
-// MsgTryUpgrade tries to upgrade the chain
+// MsgTryUpgrade tries to upgrade the chain.
 type MsgTryUpgrade struct {
 	Signer string `protobuf:"bytes,1,opt,name=signer,proto3" json:"signer,omitempty"`
 }
@@ -164,7 +163,7 @@ func (m *MsgTryUpgrade) GetSigner() string {
 	return ""
 }
 
-// MsgTryUpgradeResponse describes the response returned after the submission
+// MsgTryUpgradeResponse is the response type for the TryUpgrade method.
 type MsgTryUpgradeResponse struct {
 }
 
@@ -248,10 +247,10 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type MsgClient interface {
-	// SignalVersion allows the validator to signal for an upgrade
+	// SignalVersion allows a validator to signal for an upgrade.
 	SignalVersion(ctx context.Context, in *MsgSignalVersion, opts ...grpc.CallOption) (*MsgSignalVersionResponse, error)
 	// TryUpgrade tallies all the votes and if a quorum is reached, it will
-	// trigger an upgrade for the following height
+	// trigger an upgrade for the following height.
 	TryUpgrade(ctx context.Context, in *MsgTryUpgrade, opts ...grpc.CallOption) (*MsgTryUpgradeResponse, error)
 }
 
@@ -283,10 +282,10 @@ func (c *msgClient) TryUpgrade(ctx context.Context, in *MsgTryUpgrade, opts ...g
 
 // MsgServer is the server API for Msg service.
 type MsgServer interface {
-	// SignalVersion allows the validator to signal for an upgrade
+	// SignalVersion allows a validator to signal for an upgrade.
 	SignalVersion(context.Context, *MsgSignalVersion) (*MsgSignalVersionResponse, error)
 	// TryUpgrade tallies all the votes and if a quorum is reached, it will
-	// trigger an upgrade for the following height
+	// trigger an upgrade for the following height.
 	TryUpgrade(context.Context, *MsgTryUpgrade) (*MsgTryUpgradeResponse, error)
 }
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3223

x/upgrade README format inspired by https://docs.cosmos.network/v0.50/build/spec/SPEC_MODULE

## FLUPs
1. Can we move some of the unit tests from tally_test.go to keeper_test.go?
2. Why does ResetTally only delete versions less than the current version? Why not delete all versions in the map?