### PR TITLE
feat(ci): use release tracking workflow to notify devops

### DIFF
--- a/.github/workflows/create_release_tracking_epic.yml
+++ b/.github/workflows/create_release_tracking_epic.yml
@@ -1,0 +1,14 @@
+name: Create Release Tracking Epic
+
+# This workflow creates an EPIC in the devops repo and notifies the devops team
+# on slack for tracking the deployment of a release to testnets and mainnet.
+on:
+  release:
+    types: [published]
+jobs:
+  trigger_issue:
+    uses: celestiaorg/.github/.github/workflows/reusable_create_release_tracking_epic.yml@v0.4.0
+    secrets: inherit
+    with:
+      release-repo: ${{ github.repository }}
+      release-version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
I created a reusable workflow to help with tracking release deployments to testnets and mainnet. 
This action calls the reusable workflow that creates an issue in the devops repo and notifies the devops team on slack. 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
