### PR TITLE
fix: uses the specified volume amount for the genesis nodes

### DIFF
--- a/test/e2e/node.go
+++ b/test/e2e/node.go
@@ -105,7 +105,7 @@ func NewNode(
 	if err != nil {
 		return nil, err
 	}
-	err = instance.AddVolumeWithOwner(remoteRootDir, "1Gi", 10001)
+	err = instance.AddVolumeWithOwner(remoteRootDir, resources.Volume, 10001)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR implements a correction to utilize the disk space amount specified in the resources for genesis nodes, instead of the default `1Gi`.