### PR TITLE
chore(scripts): persist ABCI responses for single-node.sh

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -71,6 +71,9 @@ sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' "${CELESTIA_APP
 # Enable transaction indexing
 sed -i'.bak' 's#"null"#"kv"#g' "${CELESTIA_APP_HOME}"/config/config.toml
 
+# Persist ABCI responses
+sed -i'.bak' 's#discard_abci_responses = true#discard_abci_responses = false#g' "${CELESTIA_APP_HOME}"/config/config.toml
+
 # Override the VotingPeriod from 1 week to 1 minute
 sed -i'.bak' 's#"604800s"#"60s"#g' "${CELESTIA_APP_HOME}"/config/genesis.json
 


### PR DESCRIPTION
I had to do this for an IBC test and an external engineer who is using this script also has to do this b/c they are querying block results. The relevant config:

```
#######################################################
###         Storage Configuration Options           ###
#######################################################
[storage]

# Set to true to discard ABCI responses from the state store, which can save a
# considerable amount of disk space. Set to false to ensure ABCI responses are
# persisted. ABCI responses are required for /block_results RPC queries, and to
# reindex events in the command-line tool.
discard_abci_responses = true
```

Note: this may increase disk space usage but this script is used for dev purposes and every run deletes the previous run's `data/` directory so I'm not concerned about it.