### PR TITLE
feat(cli): addr-conversion

### DIFF
--- a/cmd/celestia-appd/cmd/addr_converter.go
+++ b/cmd/celestia-appd/cmd/addr_converter.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/spf13/cobra"
+)
+
+// addrConversionCmd returns a command that converts between celestia1xxx and
+// celestiavaloper1xxx addresses.
+func addrConversionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "addr-conversion [celestia address]",
+		Short: "Convert between celestia1xxx address and validator operator address celestiavaloper1xxx",
+		Long:  `Reads a celestia1xxx or celestiavaloper1xxx address and converts it to the other type.`,
+		Example: "celestia-appd addr-conversion celestia1grvklux2yjsln7ztk6slv538396qatckqhs86z\n" +
+			"celestia-appd addr-conversion celestiavaloper1grvklux2yjsln7ztk6slv538396qatck9gj7vy\n",
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			converted, err := convertAccountValidatorAddress(args[0])
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write([]byte(converted + "\n"))
+			if err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	return cmd
+}
+
+// convertAccountValidatorAddress converts an account address into a valoper
+// address, or a valoper address into an account address.
+func convertAccountValidatorAddress(original string) (string, error) {
+	if accAddr, err := sdk.AccAddressFromBech32(original); err == nil {
+		return sdk.ValAddress(accAddr.Bytes()).String(), nil
+	}
+	if valAddr, err := sdk.ValAddressFromBech32(original); err == nil {
+		return sdk.AccAddress(valAddr.Bytes()).String(), nil
+	}
+	return "", fmt.Errorf("invalid address: %s", original)
+}

--- a/cmd/celestia-appd/cmd/addr_converter_test.go
+++ b/cmd/celestia-appd/cmd/addr_converter_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddrConversionCmd(t *testing.T) {
+	accAddr := "celestia1grvklux2yjsln7ztk6slv538396qatckqhs86z"
+	valAddr := "celestiavaloper1grvklux2yjsln7ztk6slv538396qatck9gj7vy"
+	t.Run("converts an account address", func(t *testing.T) {
+		output, err := executeCmd(addrConversionCmd(), accAddr)
+		assert.NoError(t, err)
+		assert.Equal(t, valAddr+"\n", output)
+	})
+	t.Run("converts a valoper address", func(t *testing.T) {
+		output, err := executeCmd(addrConversionCmd(), valAddr)
+		assert.NoError(t, err)
+		assert.Equal(t, accAddr+"\n", output)
+	})
+	t.Run("returns an error for an invalid account address", func(t *testing.T) {
+		invalidAddr := "celestia1xxxxxxxxxxxx"
+		_, err := executeCmd(addrConversionCmd(), invalidAddr)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "invalid address")
+	})
+	t.Run("returns an error for an invalid valoper address", func(t *testing.T) {
+		invalidAddr := "celestiavaloper1xxxxxxxxxxxx"
+		_, err := executeCmd(addrConversionCmd(), invalidAddr)
+		assert.Error(t, err)
+		assert.ErrorContains(t, err, "invalid address")
+	})
+}
+
+func executeCmd(cmd *cobra.Command, args ...string) (string, error) {
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -125,8 +125,6 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig encoding.Config) {
 	cfg := sdk.GetConfig()
 	cfg.Seal()
 
-	debugCmd := debug.Cmd()
-
 	rootCmd.AddCommand(
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
@@ -135,11 +133,12 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig encoding.Config) {
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		tmcli.NewCompletionCmd(rootCmd, true),
-		debugCmd,
+		debug.Cmd(),
 		config.Cmd(),
 		commands.CompactGoLevelDBCmd,
 		addrbookCommand(),
 		downloadGenesisCommand(),
+		addrConversionCmd(),
 	)
 
 	server.AddCommands(rootCmd, app.DefaultNodeHome, NewAppServer, createAppAndExport, addModuleInitFlags)


### PR DESCRIPTION
## Motivation

This is an adoption of #3249 with feedback addressed and authorship preserved.

## Testing

```shell
$ ./build/celestia-appd addr-conversion --help
Reads a celestia1xxx or celestiavaloper1xxx address and converts it to the other type.

Usage:
  celestia-appd addr-conversion [celestia address] [flags]

Examples:
celestia-appd addr-conversion celestia1grvklux2yjsln7ztk6slv538396qatckqhs86z
celestia-appd addr-conversion celestiavaloper1grvklux2yjsln7ztk6slv538396qatck9gj7vy

$ celestia-appd addr-conversion celestia1grvklux2yjsln7ztk6slv538396qatckqhs86z
celestiavaloper1grvklux2yjsln7ztk6slv538396qatck9gj7vy

$ celestia-appd addr-conversion celestiavaloper1grvklux2yjsln7ztk6slv538396qatck9gj7vy
celestia1grvklux2yjsln7ztk6slv538396qatckqhs86z
```
