### PR TITLE
chore: remove checkboxes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -36,14 +36,3 @@ body:
         What commands in order should someone run to reproduce your problem?
     validations:
       required: true
-
-  - type: checkboxes
-    id: admin
-    attributes:
-      label: For Admin Use
-      description: (do not edit)
-      options:
-        - label: Not duplicate issue
-        - label: Appropriate labels applied
-        - label: Appropriate contributors tagged
-        - label: Contributor assigned/self-assigned

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -39,14 +39,3 @@ body:
       description: Detailed description of requirements of implementation.
     validations:
       required: true
-
-  - type: checkboxes
-    id: admin
-    attributes:
-      label: For Admin Use
-      description: (do not edit)
-      options:
-        - label: Not duplicate issue
-        - label: Appropriate labels applied
-        - label: Appropriate contributors tagged
-        - label: Contributor assigned/self-assigned


### PR DESCRIPTION
We basically never use the checkboxes on issues so they're just visual noise. Proposal to delete them from the issue templates.