### PR TITLE
chore: updates the upgrade module link to the signal module

### DIFF
--- a/specs/src/specs/state_machine_modules.md
+++ b/specs/src/specs/state_machine_modules.md
@@ -9,7 +9,7 @@ Celestia app is built using the cosmos-sdk, and follows standard cosmos-sdk modu
 - [minfee](https://github.com/celestiaorg/celestia-app/blob/main/x/minfee/README.md)
 - [mint](https://github.com/celestiaorg/celestia-app/blob/main/x/mint/README.md)
 - [paramfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/paramfilter/README.md)
-- [upgrade](https://github.com/celestiaorg/celestia-app/blob/main/x/upgrade/README.md)
+- [signal](https://github.com/celestiaorg/celestia-app/blob/main/x/signal/README.md)
 - [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/tokenfilter/README.md)
 
 ## Standard `cosmos-sdk` Modules


### PR DESCRIPTION
The markdown linter keeps failing for a broken link in CIs, and this PR fixes the issue. 