### PR TITLE
chore(deps): bump .github version for release tracking epic

### DIFF
--- a/.github/workflows/create_release_tracking_epic.yml
+++ b/.github/workflows/create_release_tracking_epic.yml
@@ -7,7 +7,7 @@ on:
     types: [published]
 jobs:
   trigger_issue:
-    uses: celestiaorg/.github/.github/workflows/reusable_create_release_tracking_epic.yml@v0.4.0
+    uses: celestiaorg/.github/.github/workflows/reusable_create_release_tracking_epic.yml@v0.4.1
     secrets: inherit
     with:
       release-repo: ${{ github.repository }}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

`main` is on this version. the bump somehow was missed for v1 branch. 
patch fixes a variable name for the slack notification. 