### PR TITLE
chore: resolve loopclosure warning

### DIFF
--- a/app/test/priority_test.go
+++ b/app/test/priority_test.go
@@ -80,6 +80,7 @@ func (s *PriorityTestSuite) TestPriorityByGasPrice() {
 	wg := &sync.WaitGroup{}
 	for _, signer := range s.signers {
 		wg.Add(1)
+		signer := signer // new variable per iteration
 		go func() {
 			defer wg.Done()
 			// ensure that it is greater than the min gas price


### PR DESCRIPTION
Fixes this warning

![Screenshot 2024-04-16 at 11 45 35 AM](https://github.com/celestiaorg/celestia-app/assets/3699047/285fde0e-076d-42b6-ba91-dcda317ef210)

Ref: https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/loopclosure

Note: since we're already on Go 1.22, the loop already creates a new variable per loop iteration so we don't technically need to merge this but idk how to inform the warning generator that we're already on Go 1.22 and the warning doesn't apply to us.