### PR TITLE
feat: updates docker file by exposing the tracing port 26661

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,5 +65,6 @@ WORKDIR ${CELESTIA_HOME}
 # 26656 is the default node p2p port.
 # 26657 is the default RPC port.
 # 26660 is the port used for Prometheus.
-EXPOSE 1317 9090 26656 26657 26660
+# 26661 is the port used for tracing.
+EXPOSE 1317 9090 26656 26657 26660 26661
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]

--- a/docker/Dockerfile_txsim
+++ b/docker/Dockerfile_txsim
@@ -56,7 +56,7 @@ USER ${USER_NAME}
 # Set the working directory to the home directory.
 WORKDIR ${CELESTIA_HOME}
 
-# grpc, rpc, api ports (26661 for pull based tracing)
-EXPOSE 26657 1317 9090 26661
+# grpc, rpc, api ports
+EXPOSE 26657 1317 9090
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]

--- a/docker/Dockerfile_txsim
+++ b/docker/Dockerfile_txsim
@@ -56,7 +56,7 @@ USER ${USER_NAME}
 # Set the working directory to the home directory.
 WORKDIR ${CELESTIA_HOME}
 
-# grpc, rpc, api ports
-EXPOSE 26657 1317 9090
+# grpc, rpc, api ports (26661 for pull based tracing)
+EXPOSE 26657 1317 9090 26661
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]


### PR DESCRIPTION
The port `:26661` needs to be exposed in order to access traced data. Please see https://github.com/celestiaorg/celestia-core/tree/main/pkg/trace#pull-based-event-collection. 
Part of #3318