### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/proto/celestia/core/v1/da/data_availability_header.pb.go
+++ b/proto/celestia/core/v1/da/data_availability_header.pb.go
@@ -5,6 +5,7 @@ package da
 
 import (
 	fmt "fmt"
+	errors "errors"
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
@@ -385,7 +386,7 @@ func skipDataAvailabilityHeader(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthDataAvailabilityHeader        = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowDataAvailabilityHeader          = fmt.Errorf("proto: integer overflow")
-	ErrUnexpectedEndOfGroupDataAvailabilityHeader = fmt.Errorf("proto: unexpected end of group")
+	ErrInvalidLengthDataAvailabilityHeader        = errors.New("proto: negative length found during unmarshaling")
+	ErrIntOverflowDataAvailabilityHeader          = errors.New("proto: integer overflow")
+	ErrUnexpectedEndOfGroupDataAvailabilityHeader = errors.New("proto: unexpected end of group")
 )

--- a/proto/celestia/core/v1/da/data_availability_header.pb.go
+++ b/proto/celestia/core/v1/da/data_availability_header.pb.go
@@ -5,7 +5,6 @@ package da
 
 import (
 	fmt "fmt"
-	errors "errors"
 	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
@@ -386,7 +385,7 @@ func skipDataAvailabilityHeader(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthDataAvailabilityHeader        = errors.New("proto: negative length found during unmarshaling")
-	ErrIntOverflowDataAvailabilityHeader          = errors.New("proto: integer overflow")
-	ErrUnexpectedEndOfGroupDataAvailabilityHeader = errors.New("proto: unexpected end of group")
+	ErrInvalidLengthDataAvailabilityHeader        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowDataAvailabilityHeader          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupDataAvailabilityHeader = fmt.Errorf("proto: unexpected end of group")
 )

--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -57,7 +57,7 @@ func NewAccountManager(
 	}
 
 	if len(records) == 0 {
-		return nil, fmt.Errorf("no accounts found in keyring")
+		return nil, errors.New("no accounts found in keyring")
 	}
 
 	am := &AccountManager{
@@ -118,7 +118,7 @@ func (am *AccountManager) findWealthiestAccount(ctx context.Context) (string, er
 	}
 
 	if wealthiestAddress == "" {
-		return "", fmt.Errorf("no suitable master account found")
+		return "", errors.New("no suitable master account found")
 	}
 
 	return wealthiestAddress, nil

--- a/test/util/genesis/accounts.go
+++ b/test/util/genesis/accounts.go
@@ -1,6 +1,7 @@
 package genesis
 
 import (
+	"errors"
 	"fmt"
 	mrand "math/rand"
 	"time"
@@ -40,10 +41,10 @@ func NewKeyringAccounts(initBal int64, names ...string) []KeyringAccount {
 
 func (ga *KeyringAccount) ValidateBasic() error {
 	if ga.Name == "" {
-		return fmt.Errorf("name cannot be empty")
+		return errors.New("name cannot be empty")
 	}
 	if ga.InitialTokens <= 0 {
-		return fmt.Errorf("initial tokens must be positive")
+		return errors.New("initial tokens must be positive")
 	}
 	return nil
 }
@@ -76,13 +77,13 @@ func (v *Validator) ValidateBasic() error {
 		return err
 	}
 	if v.Stake <= 0 {
-		return fmt.Errorf("stake must be positive")
+		return errors.New("stake must be positive")
 	}
 	if v.ConsensusKey == nil {
-		return fmt.Errorf("consensus key cannot be empty")
+		return errors.New("consensus key cannot be empty")
 	}
 	if v.Stake > v.InitialTokens {
-		return fmt.Errorf("stake cannot be greater than initial tokens")
+		return errors.New("stake cannot be greater than initial tokens")
 	}
 	return nil
 }


### PR DESCRIPTION
If you don't need to format the string, it is recommended to use error.New()