### PR TITLE
feat: check if the celestia binary is installed in single-node.sh

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -5,6 +5,12 @@ set -o errexit
 # Stop script execution if an undefined variable is used
 set -o nounset
 
+if ! [ -x "$(command -v celestia-appd)" ]
+then
+    echo "celestia-appd could not be found. Please install the celestia-appd binary using 'make install' and make sure the PATH contains the directory where the binary exists. By default, go will install the binary under '~/go/bin'"
+    exit 1
+fi
+
 CHAIN_ID="private"
 KEY_NAME="validator"
 KEYRING_BACKEND="test"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Given that we're using `set -o errexit` in the `single-node.sh` script, and we're setting the variable `CELESTIA_APP_VERSION=$(celestia-appd version 2>&1)`, if `celestia-appd` is not in the path, the execution will return nothing and just exist, and users can be confused why the script is not doing anything. This PR adds a check whether the celestia-appd binary is in the PATH and is executable, and returns an error otherwise to help users.
