### PR TITLE
feat: adds functionality to read the blockchain headers into a csv file

### DIFF
--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -68,7 +68,10 @@ func E2EThroughput() error {
 	blockchain, err := testnode.ReadBlockchain(context.Background(), testNet.Node(0).AddressRPC())
 	testnet.NoError("failed to read blockchain", err)
 
-	SaveToCSV(extractHeaders(blockchain), "./blockchain.csv")
+	err = SaveToCSV(extractHeaders(blockchain), "./blockchain.csv")
+	if err != nil {
+		log.Println("failed to save blockchain data to CSV", err)
+	}
 
 	totalTxs := 0
 	for _, block := range blockchain {

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -68,7 +68,7 @@ func E2EThroughput() error {
 	blockchain, err := testnode.ReadBlockchain(context.Background(), testNet.Node(0).AddressRPC())
 	testnet.NoError("failed to read blockchain", err)
 
-	SaveToCSV(extractHeaders(blockchain), "blockchain.csv")
+	SaveToCSV(extractHeaders(blockchain), "./blockchain.csv")
 
 	totalTxs := 0
 	for _, block := range blockchain {

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -68,6 +68,8 @@ func E2EThroughput() error {
 	blockchain, err := testnode.ReadBlockchain(context.Background(), testNet.Node(0).AddressRPC())
 	testnet.NoError("failed to read blockchain", err)
 
+	SaveToCSV(extractHeaders(blockchain), "blockchain.csv")
+
 	totalTxs := 0
 	for _, block := range blockchain {
 		if appconsts.LatestVersion != block.Version.App {

--- a/test/e2e/benchmark/utils.go
+++ b/test/e2e/benchmark/utils.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"encoding/csv"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/tendermint/tendermint/types"
+)
+
+func extractHeaders(blockchain []*types.Block) []BlockHeader {
+	blockData := make([]BlockHeader, 0, len(blockchain))
+	for _, block := range blockchain {
+		blockData = append(blockData, BlockHeader{
+			Time:   block.Header.Time,
+			Size:   float64(block.Size()),
+			Height: int(block.Height),
+		})
+	}
+	return blockData
+
+}
+
+type BlockHeader struct {
+	Time   time.Time // Use time.Time for the Time field
+	Size   float64   // in bytes
+	Height int
+}
+
+// SaveToCSV saves slice of BlockHeader to a CSV file at the given path.
+func SaveToCSV(blockData []BlockHeader, filePath string) error {
+	// Create a new file
+	file, err := os.Create(filePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	// Create a CSV writer
+	writer := csv.NewWriter(file)
+	defer writer.Flush()
+
+	// Write the header
+	header := []string{"Time", "Size", "Height"}
+	if err := writer.Write(header); err != nil {
+		return err
+	}
+
+	// Iterate over the slice and write each element as a row in the CSV
+	for _, data := range blockData {
+		row := []string{
+			data.Time.Format(time.RFC3339), // Format the time using RFC3339 standard
+			strconv.FormatFloat(data.Size, 'f', -1, 64),
+			strconv.Itoa(data.Height),
+		}
+		if err := writer.Write(row); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/test/e2e/benchmark/utils.go
+++ b/test/e2e/benchmark/utils.go
@@ -19,7 +19,6 @@ func extractHeaders(blockchain []*types.Block) []BlockHeader {
 		})
 	}
 	return blockData
-
 }
 
 type BlockHeader struct {

--- a/test/e2e/benchmark/utils.go
+++ b/test/e2e/benchmark/utils.go
@@ -23,34 +23,32 @@ func extractHeaders(blockchain []*types.Block) []BlockHeader {
 }
 
 type BlockHeader struct {
-	Time   time.Time // Use time.Time for the Time field
-	Size   float64   // in bytes
+	Time   time.Time
+	Size   float64 // in bytes
 	Height int
 }
 
 // SaveToCSV saves slice of BlockHeader to a CSV file at the given path.
 func SaveToCSV(blockData []BlockHeader, filePath string) error {
-	// Create a new file
 	file, err := os.Create(filePath)
 	if err != nil {
 		return err
 	}
 	defer file.Close()
 
-	// Create a CSV writer
 	writer := csv.NewWriter(file)
 	defer writer.Flush()
 
-	// Write the header
 	header := []string{"Time", "Size", "Height"}
 	if err := writer.Write(header); err != nil {
 		return err
 	}
 
-	// Iterate over the slice and write each element as a row in the CSV
+	// iterates over the slice and write each element as a row in the CSV
 	for _, data := range blockData {
 		row := []string{
-			data.Time.Format(time.RFC3339), // Format the time using RFC3339 standard
+			// format the time using RFC3339 standard
+			data.Time.Format(time.RFC3339),
 			strconv.FormatFloat(data.Size, 'f', -1, 64),
 			strconv.Itoa(data.Height),
 		}


### PR DESCRIPTION
While we can obtain traced data and use it to calculate block time, size, and throughput, this is merely an alternative approach. We can achieve the same results at the end of the test using Python scripts and without analyzing the traced data.