### PR TITLE
fix(ci): update from published to released trigger for deployment epic

### DIFF
--- a/.github/workflows/create_release_tracking_epic.yml
+++ b/.github/workflows/create_release_tracking_epic.yml
@@ -4,7 +4,7 @@ name: Create Release Tracking Epic
 # on slack for tracking the deployment of a release to testnets and mainnet.
 on:
   release:
-    types: [published]
+    types: [released]
 jobs:
   trigger_issue:
     uses: celestiaorg/.github/.github/workflows/reusable_create_release_tracking_epic.yml@v0.4.1


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
I realized that the `published` event is triggered by pre-releases too.
The `released` event is only triggered when we set the release to the latest release, which is what we want to track for deployments.