### PR TITLE
feat: enable querying state through grpc

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -679,7 +679,7 @@ func (app *App) RegisterTxService(clientCtx client.Context) {
 
 // RegisterTendermintService implements the Application.RegisterTendermintService method.
 func (app *App) RegisterTendermintService(clientCtx client.Context) {
-	tmservice.RegisterTendermintService(clientCtx, app.BaseApp.GRPCQueryRouter(), app.interfaceRegistry, nil)
+	tmservice.RegisterTendermintService(clientCtx, app.BaseApp.GRPCQueryRouter(), app.interfaceRegistry, app.Query)
 }
 
 func (app *App) RegisterNodeService(clientCtx client.Context) {


### PR DESCRIPTION
We seemed to have forgotten to add the query function which means `ABCIQuery` wasn't working even although the grpc endpoint was exposed  