### PR TITLE
test: extend minor version compat to test v2

### DIFF
--- a/test/e2e/check_upgrades.go
+++ b/test/e2e/check_upgrades.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"os/exec"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,7 +26,7 @@ func MinorVersionCompatibility(logger *log.Logger) error {
 	testnet.NoError("failed to get versions", err)
 	versions1 := testnet.ParseVersions(versionStr).FilterMajor(v1.Version).FilterOutReleaseCandidates()
 	versions2 := testnet.ParseVersions(versionStr).FilterMajor(v2.Version) // include release candidates for v2 because there isn't an official release yet.
-	versions := append(versions1, versions2...)
+	versions := slices.Concat(versions1, versions2)
 
 	if len(versions) == 0 {
 		logger.Fatal("no versions to test")

--- a/test/e2e/check_upgrades.go
+++ b/test/e2e/check_upgrades.go
@@ -23,7 +23,9 @@ import (
 func MinorVersionCompatibility(logger *log.Logger) error {
 	versionStr, err := getAllVersions()
 	testnet.NoError("failed to get versions", err)
-	versions := testnet.ParseVersions(versionStr).FilterMajor(MajorVersion).FilterOutReleaseCandidates()
+	versions1 := testnet.ParseVersions(versionStr).FilterMajor(v1.Version).FilterOutReleaseCandidates()
+	versions2 := testnet.ParseVersions(versionStr).FilterMajor(v2.Version) // include release candidates for v2 because there isn't an official release yet.
+	versions := append(versions1, versions2...)
 
 	if len(versions) == 0 {
 		logger.Fatal("no versions to test")

--- a/test/e2e/main.go
+++ b/test/e2e/main.go
@@ -4,13 +4,10 @@ import (
 	"log"
 	"os"
 	"strings"
-
-	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
 )
 
 const (
-	MajorVersion = v1.Version
-	seed         = 42
+	seed = 42
 )
 
 type TestFunc func(*log.Logger) error


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3298

## Testing

Relevant logs

```
$ make test-e2e MinorVersionCompatibility

test-e2e2024/05/09 15:47:37 Running minor version compatibility test versions v1.0.0	v1.1.0	v1.2.0	v1.3.0	v1.4.0	v1.5.0	v1.6.0	v1.7.0	v1.8.0	v1.9.0	v2.0.0-rc0

test-e2e2024/05/09 15:49:38 Starting testnet
test-e2e2024/05/09 15:50:53 Upgrading node node 2 version v1.0.0
test-e2e2024/05/09 15:51:16 Upgrading node node 3 version v1.2.0
test-e2e2024/05/09 15:51:34 Upgrading node node 4 version v2.0.0-rc0
test-e2e2024/05/09 15:52:05 Upgrading node node 2 version v1.3.0
test-e2e2024/05/09 15:52:32 Upgrading node node 3 version v1.5.0
test-e2e2024/05/09 15:53:03 Upgrading node node 4 version v1.2.0
test-e2e2024/05/09 15:53:29 Upgrading node node 2 version v1.8.0
test-e2e2024/05/09 15:53:57 Upgrading node node 3 version v1.2.0
test-e2e2024/05/09 15:54:24 Upgrading node node 4 version v1.4.0
test-e2e2024/05/09 15:54:54 Upgrading node node 2 version v1.6.0
test-e2e2024/05/09 15:55:14 Upgrading node node 3 version v1.3.0
test-e2e2024/05/09 15:55:42 Upgrading node node 4 version v1.5.0
test-e2e2024/05/09 15:56:07 Upgrading node node 2 version v1.6.0

test-e2e2024/05/09 15:58:01 checking that all nodes are at the same height
test-e2e2024/05/09 15:58:07 --- ✅ PASS: MinorVersionCompatibility
```