### PR TITLE
chore: revive max blob size decorator

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -64,9 +64,11 @@ func NewAnteHandler(
 		// Note: does not consume gas from the gas meter.
 		blobante.NewMinGasPFBDecorator(blobKeeper),
 		// Ensure that the tx's total blob size is <= the max blob size.
+		// Only applies to app version == 1.
 		blobante.NewMaxBlobSizeDecorator(blobKeeper),
 		// Ensure that the blob shares occupied by the tx <= the max shares
-		// available to blob data in a data square.
+		// available to blob data in a data square. Only applies to app version
+		// >= 2.
 		blobante.NewBlobShareDecorator(blobKeeper),
 		// Ensure that tx's with a MsgSubmitProposal have at least one proposal
 		// message.

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -65,7 +65,7 @@ func NewAnteHandler(
 		blobante.NewMinGasPFBDecorator(blobKeeper),
 		// Ensure that the tx's total blob size is <= the max blob size.
 		// Only applies to app version == 1.
-		blobante.NewMaxBlobSizeDecorator(blobKeeper),
+		blobante.NewMaxTotalBlobSizeDecorator(blobKeeper),
 		// Ensure that the blob shares occupied by the tx <= the max shares
 		// available to blob data in a data square. Only applies to app version
 		// >= 2.

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -63,6 +63,8 @@ func NewAnteHandler(
 		// Contract: must be called after all decorators that consume gas.
 		// Note: does not consume gas from the gas meter.
 		blobante.NewMinGasPFBDecorator(blobKeeper),
+		// Ensure that the tx's total blob size is <= the max blob size.
+		blobante.NewMaxBlobSizeDecorator(blobKeeper),
 		// Ensure that the blob shares occupied by the tx <= the max shares
 		// available to blob data in a data square.
 		blobante.NewBlobShareDecorator(blobKeeper),

--- a/x/blob/ante/blob_share_decorator.go
+++ b/x/blob/ante/blob_share_decorator.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
+	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
 	blobtypes "github.com/celestiaorg/celestia-app/v2/x/blob/types"
 	"github.com/celestiaorg/go-square/shares"
 
@@ -25,6 +26,10 @@ func NewBlobShareDecorator(k BlobKeeper) BlobShareDecorator {
 // the PFB exceeds the max number of shares in a data square.
 func (d BlobShareDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	if !ctx.IsCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	if ctx.BlockHeader().Version.App == v1.Version {
 		return next(ctx, tx, simulate)
 	}
 

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -5,12 +5,16 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v2/app"
 	"github.com/celestiaorg/celestia-app/v2/app/encoding"
+	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
+	v2 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v2"
 	ante "github.com/celestiaorg/celestia-app/v2/x/blob/ante"
 	blob "github.com/celestiaorg/celestia-app/v2/x/blob/types"
 	"github.com/celestiaorg/go-square/shares"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	version "github.com/tendermint/tendermint/proto/tendermint/version"
 )
 
 const (
@@ -20,29 +24,40 @@ const (
 
 func TestBlobShareDecorator(t *testing.T) {
 	type testCase struct {
-		name    string
-		pfb     *blob.MsgPayForBlobs
-		wantErr error
+		name       string
+		pfb        *blob.MsgPayForBlobs
+		appVersion uint64
+		wantErr    error
 	}
 
 	testCases := []testCase{
+		{
+			name: "want no error if appVersion v1 and 8 MiB blob",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{8 * mebibyte},
+			},
+			appVersion: v1.Version,
+		},
 		{
 			name: "PFB with 1 blob that is 1 byte",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{1},
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with 1 blob that is 1 MiB",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{mebibyte},
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with 1 blob that is 2 MiB",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{2 * mebibyte},
 			},
+			appVersion: v2.Version,
 			// This test case should return an error because a square size of 64
 			// has exactly 2 MiB of total capacity so the total blob capacity
 			// will be slightly smaller than 2 MiB.
@@ -53,12 +68,14 @@ func TestBlobShareDecorator(t *testing.T) {
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{1, 1},
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with 2 blobs that are 1 MiB each",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{mebibyte, mebibyte},
 			},
+			appVersion: v2.Version,
 			// This test case should return an error for the same reason a
 			// single blob that is 2 MiB returns an error.
 			wantErr: blob.ErrBlobsTooLarge,
@@ -71,6 +88,7 @@ func TestBlobShareDecorator(t *testing.T) {
 				// blob shares so we don't expect an error for this test case.
 				BlobSizes: repeat(4095, 1),
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with too many single byte blobs should not fit",
@@ -80,25 +98,29 @@ func TestBlobShareDecorator(t *testing.T) {
 				// blob shares so we expect an error for this test case.
 				BlobSizes: repeat(4096, 1),
 			},
-			wantErr: blob.ErrBlobsTooLarge,
+			appVersion: v2.Version,
+			wantErr:    blob.ErrBlobsTooLarge,
 		},
 		{
 			name: "PFB with 1 blob that is 1 share",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1))},
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with 1 blob that occupies total square - 1",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares((squareSize * squareSize) - 1))},
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with 1 blob that occupies total square",
 			pfb: &blob.MsgPayForBlobs{
 				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(squareSize * squareSize))},
 			},
+			appVersion: v2.Version,
 			// This test case should return an error because if the blob
 			// occupies the total square, there is no space for the PFB tx
 			// share.
@@ -112,6 +134,7 @@ func TestBlobShareDecorator(t *testing.T) {
 					uint32(shares.AvailableBytesFromSparseShares(1)),
 				},
 			},
+			appVersion: v2.Version,
 		},
 		{
 			name: "PFB with 2 blobs that occupy half the square each",
@@ -121,22 +144,21 @@ func TestBlobShareDecorator(t *testing.T) {
 					uint32(shares.AvailableBytesFromSparseShares(squareSize * squareSize / 2)),
 				},
 			},
-			wantErr: blob.ErrBlobsTooLarge,
+			appVersion: v2.Version,
+			wantErr:    blob.ErrBlobsTooLarge,
 		},
 	}
 
 	txConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...).TxConfig
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := sdk.Context{}.WithIsCheckTx(true)
-
 			txBuilder := txConfig.NewTxBuilder()
 			require.NoError(t, txBuilder.SetMsgs(tc.pfb))
 			tx := txBuilder.GetTx()
 
-			mbsd := ante.NewBlobShareDecorator(mockBlobKeeper{})
-			_, err := mbsd.AnteHandle(ctx, tx, false, mockNext)
+			decorator := ante.NewBlobShareDecorator(mockBlobKeeper{})
+			ctx := sdk.Context{}.WithIsCheckTx(true).WithBlockHeader(tmproto.Header{Version: version.Consensus{App: tc.appVersion}})
+			_, err := decorator.AnteHandle(ctx, tx, false, mockNext)
 			assert.ErrorIs(t, tc.wantErr, err)
 		})
 	}

--- a/x/blob/ante/max_total_blob_size_ante.go
+++ b/x/blob/ante/max_total_blob_size_ante.go
@@ -1,0 +1,84 @@
+package ante
+
+import (
+	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
+	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
+	blobtypes "github.com/celestiaorg/celestia-app/v2/x/blob/types"
+	"github.com/celestiaorg/go-square/shares"
+
+	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// MaxTotalBlobSizeDecorator helps to prevent a PFB from being included in a
+// block but not fitting in a data square.
+type MaxTotalBlobSizeDecorator struct {
+	k BlobKeeper
+}
+
+func NewMaxBlobSizeDecorator(k BlobKeeper) MaxTotalBlobSizeDecorator {
+	return MaxTotalBlobSizeDecorator{k}
+}
+
+// AnteHandle implements the Cosmos SDK AnteHandler function signature. It
+// returns an error if tx contains a MsgPayForBlobs where the total blob size is
+// greater than the max total blob size.
+func (d MaxTotalBlobSizeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	if !ctx.IsCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	if ctx.BlockHeader().Version.App != v1.Version {
+		return next(ctx, tx, simulate)
+	}
+
+	max := d.maxTotalBlobSize(ctx)
+	for _, m := range tx.GetMsgs() {
+		if pfb, ok := m.(*blobtypes.MsgPayForBlobs); ok {
+			if total := getTotal(pfb.BlobSizes); total > max {
+				return ctx, errors.Wrapf(blobtypes.ErrTotalBlobSizeTooLarge, "total blob size %d exceeds max %d", total, max)
+			}
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}
+
+// maxTotalBlobSize returns the max the number of bytes available for blobs in a
+// data square based on the max square size. Note it is possible that txs with a
+// total blob size less than this max still fail to be included in a block due
+// to overhead from the PFB tx and/or padding shares.
+func (d MaxTotalBlobSizeDecorator) maxTotalBlobSize(ctx sdk.Context) int {
+	squareSize := d.getMaxSquareSize(ctx)
+	totalShares := squareSize * squareSize
+	// The PFB tx share must occupy at least one share so the # of blob shares
+	// is at least one less than totalShares.
+	blobShares := totalShares - 1
+	return shares.AvailableBytesFromSparseShares(blobShares)
+}
+
+// getMaxSquareSize returns the maximum square size based on the current values
+// for the relevant governance parameter and the versioned constant.
+func (d MaxTotalBlobSizeDecorator) getMaxSquareSize(ctx sdk.Context) int {
+	// TODO: fix hack that forces the max square size for the first height to
+	// 64. This is due to our fork of the sdk not initializing state before
+	// BeginBlock of the first block. This is remedied in versions of the sdk
+	// and comet that have full support of PreparePropsoal, although
+	// celestia-app does not currently use those. see this PR for more details
+	// https://github.com/cosmos/cosmos-sdk/pull/14505
+	if ctx.BlockHeader().Height <= 1 {
+		return int(appconsts.DefaultGovMaxSquareSize)
+	}
+
+	upperBound := appconsts.SquareSizeUpperBound(ctx.BlockHeader().Version.App)
+	govParam := d.k.GovMaxSquareSize(ctx)
+	return min(upperBound, int(govParam))
+}
+
+// getTotal returns the sum of the given sizes.
+func getTotal(sizes []uint32) (sum int) {
+	for _, size := range sizes {
+		sum += int(size)
+	}
+	return sum
+}

--- a/x/blob/ante/max_total_blob_size_ante.go
+++ b/x/blob/ante/max_total_blob_size_ante.go
@@ -1,12 +1,11 @@
 package ante
 
 import (
+	"cosmossdk.io/errors"
 	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
 	blobtypes "github.com/celestiaorg/celestia-app/v2/x/blob/types"
 	"github.com/celestiaorg/go-square/shares"
-
-	"cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 

--- a/x/blob/ante/max_total_blob_size_ante.go
+++ b/x/blob/ante/max_total_blob_size_ante.go
@@ -43,7 +43,7 @@ func (d MaxTotalBlobSizeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 	return next(ctx, tx, simulate)
 }
 
-// maxTotalBlobSize returns the max the number of bytes available for blobs in a
+// maxTotalBlobSize returns the max number of bytes available for blobs in a
 // data square based on the max square size. Note it is possible that txs with a
 // total blob size less than this max still fail to be included in a block due
 // to overhead from the PFB tx and/or padding shares.

--- a/x/blob/ante/max_total_blob_size_ante.go
+++ b/x/blob/ante/max_total_blob_size_ante.go
@@ -15,7 +15,7 @@ type MaxTotalBlobSizeDecorator struct {
 	k BlobKeeper
 }
 
-func NewMaxBlobSizeDecorator(k BlobKeeper) MaxTotalBlobSizeDecorator {
+func NewMaxTotalBlobSizeDecorator(k BlobKeeper) MaxTotalBlobSizeDecorator {
 	return MaxTotalBlobSizeDecorator{k}
 }
 

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -1,0 +1,133 @@
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v2/app"
+	"github.com/celestiaorg/celestia-app/v2/app/encoding"
+	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
+	ante "github.com/celestiaorg/celestia-app/v2/x/blob/ante"
+	blob "github.com/celestiaorg/celestia-app/v2/x/blob/types"
+	"github.com/celestiaorg/go-square/shares"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	version "github.com/tendermint/tendermint/proto/tendermint/version"
+)
+
+func TestMaxTotalBlobSizeAnteHandler(t *testing.T) {
+	type testCase struct {
+		name    string
+		pfb     *blob.MsgPayForBlobs
+		wantErr bool
+	}
+
+	testCases := []testCase{
+		// tests based on bytes
+		{
+			name: "PFB with 1 blob that is 1 byte",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{1},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PFB with 1 blob that is 1 MiB",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{mebibyte},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PFB with 1 blob that is 2 MiB",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{2 * mebibyte},
+			},
+			// This test case should return an error because a square size of 64
+			// has exactly 2 MiB of total capacity so the total blob capacity
+			// will be slightly smaller than 2 MiB.
+			wantErr: true,
+		},
+		{
+			name: "PFB with 2 blobs that are 1 byte each",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{1, 1},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PFB with 2 blobs that are 1 MiB each",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{mebibyte, mebibyte},
+			},
+			// This test case should return an error for the same reason a
+			// single blob that is 2 MiB returns an error.
+			wantErr: true,
+		},
+		// tests based on shares
+		{
+			name: "PFB with 1 blob that is 1 share",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(1))},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PFB with 1 blob that occupies total square - 1",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares((squareSize * squareSize) - 1))},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PFB with 1 blob that occupies total square",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{uint32(shares.AvailableBytesFromSparseShares(squareSize * squareSize))},
+			},
+			// This test case should return an error because if the blob
+			// occupies the total square, there is no space for the PFB tx
+			// share.
+			wantErr: true,
+		},
+		{
+			name: "PFB with 2 blobs that are 1 share each",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{
+					uint32(shares.AvailableBytesFromSparseShares(1)),
+					uint32(shares.AvailableBytesFromSparseShares(1)),
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "PFB with 2 blobs that occupy half the square each",
+			pfb: &blob.MsgPayForBlobs{
+				BlobSizes: []uint32{
+					uint32(shares.AvailableBytesFromSparseShares(squareSize * squareSize / 2)),
+					uint32(shares.AvailableBytesFromSparseShares(squareSize * squareSize / 2)),
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	txConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...).TxConfig
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := sdk.Context{}.WithIsCheckTx(true).WithBlockHeader(tmproto.Header{Version: version.Consensus{App: v1.Version}})
+			txBuilder := txConfig.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.pfb))
+			tx := txBuilder.GetTx()
+
+			mbsd := ante.NewMaxBlobSizeDecorator(mockBlobKeeper{})
+			_, err := mbsd.AnteHandle(ctx, tx, false, mockNext)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -130,7 +130,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 			require.NoError(t, txBuilder.SetMsgs(tc.pfb))
 			tx := txBuilder.GetTx()
 
-			decorator := ante.NewMaxBlobSizeDecorator(mockBlobKeeper{})
+			decorator := ante.NewMaxTotalBlobSizeDecorator(mockBlobKeeper{})
 			ctx := sdk.Context{}.WithIsCheckTx(true).WithBlockHeader(tmproto.Header{Version: version.Consensus{App: tc.appVersion}})
 			_, err := decorator.AnteHandle(ctx, tx, false, mockNext)
 			assert.ErrorIs(t, tc.wantErr, err)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3468 by reviving the max blob size decorator and making both decorators version aware so that:
- v1 uses max blob size decorator
- v2 uses max blob share decorator