### PR TITLE
chore: extends single-node.sh script to support local tracing and traced data retrieval

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -101,7 +101,7 @@ if [[ $response == "y" ]]; then
   sed -i.bak -e "s/^trace_pull_address *=.*/trace_pull_address = \"$trace_pull_address\"/" ${CELESTIA_APP_HOME}/config/config.toml
   trace_push_batch_size=1000
   sed -i.bak -e "s/^trace_push_batch_size *=.*/trace_push_batch_size = \"$trace_push_batch_size\"/" ${CELESTIA_APP_HOME}/config/config.toml
-  echo "Tracing is set up with the ability to pull traced data from the node on the address http://127.0.0.1:${trace_pull_address}"
+  echo "Tracing is set up with the ability to pull traced data from the node on the address http://127.0.0.1${trace_pull_address}"
 fi
 
 # Start celestia-app

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -91,6 +91,19 @@ sed -i'.bak' 's#"604800s"#"60s"#g' "${CELESTIA_APP_HOME}"/config/genesis.json
 # Override the genesis to use app version 1 and then upgrade to app version 2 later.
 sed -i'.bak' 's#"app_version": "2"#"app_version": "1"#g' "${CELESTIA_APP_HOME}"/config/genesis.json
 
+
+echo "Do you want to set up local tracing with the ability to pull traced data? [y/n]"
+read -r response
+if [[ $response == "y" ]]; then
+  trace_type="local"
+  sed -i.bak -e "s/^trace_type *=.*/trace_type = \"$trace_type\"/" ${CELESTIA_APP_HOME}/config/config.toml
+  trace_pull_address=":26661"
+  sed -i.bak -e "s/^trace_pull_address *=.*/trace_pull_address = \"$trace_pull_address\"/" ${CELESTIA_APP_HOME}/config/config.toml
+  trace_push_batch_size=1000
+  sed -i.bak -e "s/^trace_push_batch_size *=.*/trace_push_batch_size = \"$trace_push_batch_size\"/" ${CELESTIA_APP_HOME}/config/config.toml
+  echo "Tracing is set up with the ability to pull traced data from the node on the address localhost:${trace_pull_address}"
+fi
+
 # Start celestia-app
 echo "Starting celestia-app..."
 celestia-appd start \

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -101,7 +101,7 @@ if [[ $response == "y" ]]; then
   sed -i.bak -e "s/^trace_pull_address *=.*/trace_pull_address = \"$trace_pull_address\"/" ${CELESTIA_APP_HOME}/config/config.toml
   trace_push_batch_size=1000
   sed -i.bak -e "s/^trace_push_batch_size *=.*/trace_push_batch_size = \"$trace_push_batch_size\"/" ${CELESTIA_APP_HOME}/config/config.toml
-  echo "Tracing is set up with the ability to pull traced data from the node on the address localhost:${trace_pull_address}"
+  echo "Tracing is set up with the ability to pull traced data from the node on the address http://127.0.0.1:${trace_pull_address}"
 fi
 
 # Start celestia-app


### PR DESCRIPTION
This PR extends the single-node.sh script by providing an option for the user to enable local tracing and retrieve traced data.

**How to test**
1. Run `single-node.sh` under the `scripts` folder
2. Respond `y` to `Do you want to set up local tracing with the ability to pull traced data? [y/n]`
3. Once the node starts, navigate to ./celestia-app/data/traces folder and you will find the locally traced files.

Also, the trace package from celestia-core has a method to pull the traced data which can be found  [here](https://github.com/celestiaorg/celestia-core/blob/a281e871c70f4c8bd4f6ab7c7e39e28c715d65b2/pkg/trace/fileserver.go#L102).