### PR TITLE
test: enables local tracing in e2e benchmark tests

### DIFF
--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -73,8 +73,7 @@ func (b *BenchmarkTest) SetupNodes() error {
 		if pushConfig, err := trace.GetPushConfigFromEnv(); err == nil {
 			log.Print("Setting up trace push config")
 			for _, node := range b.Nodes() {
-				if err = node.Instance.SetEnvironmentVariable(trace.
-					PushBucketName, pushConfig.BucketName); err != nil {
+				if err = node.Instance.SetEnvironmentVariable(trace.PushBucketName, pushConfig.BucketName); err != nil {
 					return fmt.Errorf("failed to set TRACE_PUSH_BUCKET_NAME: %v", err)
 				}
 				if err = node.Instance.SetEnvironmentVariable(trace.PushRegion, pushConfig.Region); err != nil {

--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -54,6 +54,7 @@ func (b *BenchmarkTest) SetupNodes() error {
 	err = b.CreateTxClients(b.manifest.TxClientVersion,
 		b.manifest.BlobSequences,
 		b.manifest.BlobSizes,
+		b.manifest.BlobsPerSeq,
 		b.manifest.TxClientsResource, gRPCEndpoints)
 	testnet.NoError("failed to create tx clients", err)
 

--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -63,6 +63,7 @@ func (b *BenchmarkTest) SetupNodes() error {
 		testnet.WithTimeoutPropose(b.manifest.TimeoutPropose),
 		testnet.WithTimeoutCommit(b.manifest.TimeoutCommit),
 		testnet.WithPrometheus(b.manifest.Prometheus),
+		testnet.WithLocalTracing(b.manifest.LocalTracingType),
 	))
 	return nil
 }

--- a/test/e2e/benchmark/manifest.go
+++ b/test/e2e/benchmark/manifest.go
@@ -69,10 +69,14 @@ type Manifest struct {
 	MaxBlockBytes int64
 
 	// other configs
+	// tracing configs, can be local or noop
+	LocalTracingType string
+	PushTrace        bool
+
+	// other configs
 	UpgradeHeight    int64
 	GovMaxSquareSize int64
 }
-
 func (m *Manifest) GetGenesisModifiers() []genesis.Modifier {
 	ecfg := encoding.MakeConfig(app.ModuleBasics)
 	var modifiers []genesis.Modifier

--- a/test/e2e/benchmark/manifest.go
+++ b/test/e2e/benchmark/manifest.go
@@ -72,11 +72,15 @@ type Manifest struct {
 	// tracing configs, can be local or noop
 	LocalTracingType string
 	PushTrace        bool
+	// download traces from the s3 bucket
+	// only available when PushTrace is enabled
+	DownloadTraces bool
 
 	// other configs
 	UpgradeHeight    int64
 	GovMaxSquareSize int64
 }
+
 func (m *Manifest) GetGenesisModifiers() []genesis.Modifier {
 	ecfg := encoding.MakeConfig(app.ModuleBasics)
 	var modifiers []genesis.Modifier

--- a/test/e2e/benchmark/manifest.go
+++ b/test/e2e/benchmark/manifest.go
@@ -68,15 +68,13 @@ type Manifest struct {
 	// consensus parameters
 	MaxBlockBytes int64
 
-	// other configs
-	// tracing configs, can be local or noop
+	// LocalTracingType can be "local" or "noop"
 	LocalTracingType string
 	PushTrace        bool
 	// download traces from the s3 bucket
 	// only available when PushTrace is enabled
 	DownloadTraces bool
 
-	// other configs
 	UpgradeHeight    int64
 	GovMaxSquareSize int64
 }

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -68,6 +68,13 @@ func E2EThroughput() error {
 	testnet.NoError("failed to run the benchmark test", benchTest.Run())
 
 	// post test data collection and validation
+
+	// if local tracing is enbaled, pull round state traces to confirm tracing is working
+	if benchTest.manifest.LocalTracingType == "local" {
+		if _, err := benchTest.Node(0).PullRoundStateTraces("."); err != nil {
+			return fmt.Errorf("failed to pull round state traces: %w", err)
+		}
+	}
 	log.Println("Reading blockchain")
 	blockchain, err := testnode.ReadBlockchain(context.Background(),
 		benchTest.Node(0).AddressRPC())

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v2/test/e2e/testnet"
 	"github.com/celestiaorg/celestia-app/v2/test/util/testnode"
+	"github.com/tendermint/tendermint/pkg/trace"
 )
 
 const (
@@ -51,6 +52,7 @@ func E2EThroughput() error {
 		MaxBlockBytes:      appconsts.DefaultMaxBytes,
 		LocalTracingType:   "local",
 		PushTrace:          false,
+		DownloadTraces:     false,
 		TestDuration:       30 * time.Second,
 		TxClients:          2,
 	}
@@ -74,6 +76,18 @@ func E2EThroughput() error {
 	if benchTest.manifest.LocalTracingType == "local" {
 		if _, err := benchTest.Node(0).PullRoundStateTraces("."); err != nil {
 			return fmt.Errorf("failed to pull round state traces: %w", err)
+		}
+	}
+
+	// download traces from S3, if enabled
+	if benchTest.manifest.PushTrace && benchTest.manifest.DownloadTraces {
+		// download traces from S3
+		pushConfig, _ := trace.GetPushConfigFromEnv()
+		err := trace.S3Download("./traces/", benchTest.manifest.ChainID,
+			pushConfig)
+		if err != nil {
+			return fmt.Errorf("failed to download traces from S3: %w", err)
+
 		}
 	}
 

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -87,7 +87,6 @@ func E2EThroughput() error {
 			pushConfig)
 		if err != nil {
 			return fmt.Errorf("failed to download traces from S3: %w", err)
-
 		}
 	}
 

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -49,6 +49,8 @@ func E2EThroughput() error {
 		Prometheus:         true,
 		GovMaxSquareSize:   appconsts.DefaultGovMaxSquareSize,
 		MaxBlockBytes:      appconsts.DefaultMaxBytes,
+		LocalTracingType:   "local",
+		PushTrace:          false,
 		TestDuration:       30 * time.Second,
 		TxClients:          2,
 	}

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -69,12 +69,14 @@ func E2EThroughput() error {
 
 	// post test data collection and validation
 
-	// if local tracing is enbaled, pull round state traces to confirm tracing is working
+	// if local tracing is enabled,
+	// pull round state traces to confirm tracing is working as expected.
 	if benchTest.manifest.LocalTracingType == "local" {
 		if _, err := benchTest.Node(0).PullRoundStateTraces("."); err != nil {
 			return fmt.Errorf("failed to pull round state traces: %w", err)
 		}
 	}
+
 	log.Println("Reading blockchain")
 	blockchain, err := testnode.ReadBlockchain(context.Background(),
 		benchTest.Node(0).AddressRPC())

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -52,8 +52,8 @@ type Node struct {
 // PullRoundStateTraces retrieves the round state traces from a node.
 // it will save it to the provided path.
 func (n *Node) PullRoundStateTraces(path string) ([]trace.Event[schema.
-	RoundState], error) {
-
+	RoundState], error,
+) {
 	addr := n.AddressTracing()
 	log.Info().Str("Address", addr).Msg("Pulling round state traces")
 

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -35,23 +35,18 @@ const (
 )
 
 type Node struct {
-	Name                string
-	Version             string
-	StartHeight         int64
-	InitialPeers        []string
-	SignerKey           crypto.PrivKey
-	NetworkKey          crypto.PrivKey
-	SelfDelegation      int64
-	Instance            *knuu.Instance
-	remoteHomeDirectory string
+	Name           string
+	Version        string
+	StartHeight    int64
+	InitialPeers   []string
+	SignerKey      crypto.PrivKey
+	NetworkKey     crypto.PrivKey
+	SelfDelegation int64
+	Instance       *knuu.Instance
 
 	rpcProxyPort   int
 	grpcProxyPort  int
 	traceProxyPort int
-}
-
-func (n *Node) GetRemoteHomeDirectory() string {
-	return n.remoteHomeDirectory
 }
 
 // PullRoundStateTraces retrieves the round state traces from a node.

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -50,12 +50,14 @@ type Node struct {
 }
 
 // PullRoundStateTraces retrieves the round state traces from a node.
-func (n *Node) PullRoundStateTraces() ([]trace.Event[schema.RoundState], error) {
+// it will save it to the provided path.
+func (n *Node) PullRoundStateTraces(path string) ([]trace.Event[schema.
+	RoundState], error) {
 
 	addr := n.AddressTracing()
 	log.Info().Str("Address", addr).Msg("Pulling round state traces")
 
-	err := trace.GetTable(addr, schema.RoundState{}.Table(), ".")
+	err := trace.GetTable(addr, schema.RoundState{}.Table(), path)
 	if err != nil {
 		return nil, fmt.Errorf("getting table: %w", err)
 	}
@@ -143,15 +145,14 @@ func NewNode(
 	}
 
 	return &Node{
-		Name:                name,
-		Instance:            instance,
-		Version:             version,
-		StartHeight:         startHeight,
-		InitialPeers:        peers,
-		SignerKey:           signerKey,
-		NetworkKey:          networkKey,
-		SelfDelegation:      selfDelegation,
-		remoteHomeDirectory: remoteRootDir,
+		Name:           name,
+		Instance:       instance,
+		Version:        version,
+		StartHeight:    startHeight,
+		InitialPeers:   peers,
+		SignerKey:      signerKey,
+		NetworkKey:     networkKey,
+		SelfDelegation: selfDelegation,
 	}, nil
 }
 

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -50,9 +50,9 @@ type Node struct {
 }
 
 // PullRoundStateTraces retrieves the round state traces from a node.
-// it will save it to the provided path.
+// It will save them to the provided path.
 func (n *Node) PullRoundStateTraces(path string) ([]trace.Event[schema.
-	RoundState], error,
+RoundState], error,
 ) {
 	addr := n.AddressTracing()
 	log.Info().Str("Address", addr).Msg("Pulling round state traces")

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -43,7 +43,7 @@ type Node struct {
 	NetworkKey          crypto.PrivKey
 	SelfDelegation      int64
 	Instance            *knuu.Instance
-	RemoteHomeDirectory string
+	remoteHomeDirectory string
 
 	rpcProxyPort   int
 	grpcProxyPort  int
@@ -51,47 +51,7 @@ type Node struct {
 }
 
 func (n *Node) GetRemoteHomeDirectory() string {
-	return n.RemoteHomeDirectory
-}
-
-// GetRoundStateTraces retrieves the round state traces from a node.
-func (n *Node) GetRoundStateTraces() ([]trace.Event[schema.RoundState], error) {
-	tableFileName := fmt.Sprintf("%s.json", schema.RoundState{}.Table())
-	traceFileName := filepath.Join(n.GetRemoteHomeDirectory(), "data",
-		"traces", tableFileName)
-	consensusRoundStateBytes, err := n.Instance.GetFileBytes(traceFileName)
-	if err != nil {
-		return nil, err
-	}
-	tmpFile, err := os.CreateTemp(".", tableFileName)
-	if err != nil {
-		return nil, err
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err = tmpFile.Write(consensusRoundStateBytes); err != nil {
-		return nil, err
-	}
-	events, err := trace.DecodeFile[schema.RoundState](tmpFile)
-	if err != nil {
-		return nil, fmt.Errorf("decoding file: %w", err)
-	}
-	return events, nil
-}
-
-// PullReceivedBytes retrieves the round state traces from a node.
-func (n *Node) PullReceivedBytes() ([]trace.Event[schema.ReceivedBytes],
-	error,
-) {
-
-	addr := n.AddressTracing()
-	log.Info().Str("Address", addr).Msg("Pulling round state traces")
-
-	err := trace.GetTable(addr, schema.ReceivedBytes{}.Table(), ".")
-	if err != nil {
-		return nil, fmt.Errorf("getting table: %w", err)
-	}
-	return nil, nil
+	return n.remoteHomeDirectory
 }
 
 // PullRoundStateTraces retrieves the round state traces from a node.
@@ -196,7 +156,7 @@ func NewNode(
 		SignerKey:           signerKey,
 		NetworkKey:          networkKey,
 		SelfDelegation:      selfDelegation,
-		RemoteHomeDirectory: remoteRootDir,
+		remoteHomeDirectory: remoteRootDir,
 	}, nil
 }
 

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/p2p"
+	"github.com/tendermint/tendermint/pkg/trace"
+	"github.com/tendermint/tendermint/pkg/trace/schema"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/rpc/client/http"
 	"github.com/tendermint/tendermint/types"
@@ -24,6 +26,7 @@ const (
 	p2pPort        = 26656
 	grpcPort       = 9090
 	prometheusPort = 26660
+	tracingPort    = 26661
 	dockerSrcURL   = "ghcr.io/celestiaorg/celestia-app"
 	secp256k1Type  = "secp256k1"
 	ed25519Type    = "ed25519"
@@ -32,17 +35,76 @@ const (
 )
 
 type Node struct {
-	Name           string
-	Version        string
-	StartHeight    int64
-	InitialPeers   []string
-	SignerKey      crypto.PrivKey
-	NetworkKey     crypto.PrivKey
-	SelfDelegation int64
-	Instance       *knuu.Instance
+	Name                string
+	Version             string
+	StartHeight         int64
+	InitialPeers        []string
+	SignerKey           crypto.PrivKey
+	NetworkKey          crypto.PrivKey
+	SelfDelegation      int64
+	Instance            *knuu.Instance
+	RemoteHomeDirectory string
 
-	rpcProxyPort  int
-	grpcProxyPort int
+	rpcProxyPort   int
+	grpcProxyPort  int
+	traceProxyPort int
+}
+
+func (n *Node) GetRemoteHomeDirectory() string {
+	return n.RemoteHomeDirectory
+}
+
+// GetRoundStateTraces retrieves the round state traces from a node.
+func (n *Node) GetRoundStateTraces() ([]trace.Event[schema.RoundState], error) {
+	tableFileName := fmt.Sprintf("%s.json", schema.RoundState{}.Table())
+	traceFileName := filepath.Join(n.GetRemoteHomeDirectory(), "data",
+		"traces", tableFileName)
+	consensusRoundStateBytes, err := n.Instance.GetFileBytes(traceFileName)
+	if err != nil {
+		return nil, err
+	}
+	tmpFile, err := os.CreateTemp(".", tableFileName)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if _, err = tmpFile.Write(consensusRoundStateBytes); err != nil {
+		return nil, err
+	}
+	events, err := trace.DecodeFile[schema.RoundState](tmpFile)
+	if err != nil {
+		return nil, fmt.Errorf("decoding file: %w", err)
+	}
+	return events, nil
+}
+
+// PullReceivedBytes retrieves the round state traces from a node.
+func (n *Node) PullReceivedBytes() ([]trace.Event[schema.ReceivedBytes],
+	error,
+) {
+
+	addr := n.AddressTracing()
+	log.Info().Str("Address", addr).Msg("Pulling round state traces")
+
+	err := trace.GetTable(addr, schema.ReceivedBytes{}.Table(), ".")
+	if err != nil {
+		return nil, fmt.Errorf("getting table: %w", err)
+	}
+	return nil, nil
+}
+
+// PullRoundStateTraces retrieves the round state traces from a node.
+func (n *Node) PullRoundStateTraces() ([]trace.Event[schema.RoundState], error) {
+
+	addr := n.AddressTracing()
+	log.Info().Str("Address", addr).Msg("Pulling round state traces")
+
+	err := trace.GetTable(addr, schema.RoundState{}.Table(), ".")
+	if err != nil {
+		return nil, fmt.Errorf("getting table: %w", err)
+	}
+	return nil, nil
 }
 
 // Resources defines the resource requirements for a Node.
@@ -84,6 +146,10 @@ func NewNode(
 	if err := instance.AddPortTCP(grpcPort); err != nil {
 		return nil, err
 	}
+	if err := instance.AddPortTCP(tracingPort); err != nil {
+		return nil, err
+	}
+
 	if grafana != nil {
 		// add support for metrics
 		if err := instance.SetPrometheusEndpoint(prometheusPort, fmt.Sprintf("knuu-%s", knuu.Scope()), "1m"); err != nil {
@@ -122,14 +188,15 @@ func NewNode(
 	}
 
 	return &Node{
-		Name:           name,
-		Instance:       instance,
-		Version:        version,
-		StartHeight:    startHeight,
-		InitialPeers:   peers,
-		SignerKey:      signerKey,
-		NetworkKey:     networkKey,
-		SelfDelegation: selfDelegation,
+		Name:                name,
+		Instance:            instance,
+		Version:             version,
+		StartHeight:         startHeight,
+		InitialPeers:        peers,
+		SignerKey:           signerKey,
+		NetworkKey:          networkKey,
+		SelfDelegation:      selfDelegation,
+		RemoteHomeDirectory: remoteRootDir,
 	}, nil
 }
 
@@ -251,6 +318,18 @@ func (n Node) RemoteAddressRPC() (string, error) {
 	return fmt.Sprintf("%s:%d", ip, rpcPort), nil
 }
 
+func (n Node) AddressTracing() string {
+	return fmt.Sprintf("http://127.0.0.1:%d", n.traceProxyPort)
+}
+
+func (n Node) RemoteAddressTracing() (string, error) {
+	ip, err := n.Instance.GetIP()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("http://%s:26661", ip), nil
+}
+
 func (n Node) IsValidator() bool {
 	return n.SelfDelegation != 0
 }
@@ -306,8 +385,14 @@ func (n *Node) forwardPorts() error {
 		return fmt.Errorf("forwarding port %d: %w", grpcPort, err)
 	}
 
+	traceProxyPort, err := n.Instance.PortForwardTCP(tracingPort)
+	if err != nil {
+		return fmt.Errorf("forwarding port %d: %w", tracingPort, err)
+	}
+
 	n.rpcProxyPort = rpcProxyPort
 	n.grpcProxyPort = grpcProxyPort
+	n.traceProxyPort = traceProxyPort
 
 	return nil
 }

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -51,8 +51,7 @@ type Node struct {
 
 // PullRoundStateTraces retrieves the round state traces from a node.
 // It will save them to the provided path.
-func (n *Node) PullRoundStateTraces(path string) ([]trace.Event[schema.
-RoundState], error,
+func (n *Node) PullRoundStateTraces(path string) ([]trace.Event[schema.RoundState], error,
 ) {
 	addr := n.AddressTracing()
 	log.Info().Str("Address", addr).Msg("Pulling round state traces")

--- a/test/e2e/testnet/setup.go
+++ b/test/e2e/testnet/setup.go
@@ -1,10 +1,7 @@
 package testnet
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -13,7 +10,6 @@ import (
 	"github.com/tendermint/tendermint/config"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/p2p/pex"
-	"github.com/tendermint/tendermint/pkg/trace"
 )
 
 func MakeConfig(node *Node, opts ...Option) (*config.Config, error) {
@@ -97,24 +93,4 @@ func MakeAppConfig(_ *Node) (*serverconfig.Config, error) {
 	srvCfg := serverconfig.DefaultConfig()
 	srvCfg.MinGasPrices = fmt.Sprintf("0.001%s", app.BondDenom)
 	return srvCfg, srvCfg.ValidateBasic()
-}
-
-// MakeTracePushConfig creates a trace push config file "s3.json" in the given config path
-// with the trace push config from the environment variables.
-func MakeTracePushConfig(configPath string) error {
-	traceConfigFile, err := os.OpenFile(filepath.Join(configPath, "s3.json"), os.O_CREATE|os.O_RDWR, 0o777)
-	if err != nil {
-		return err
-	}
-	defer traceConfigFile.Close()
-	traceConfig, err := trace.GetPushConfigFromEnv()
-	if err != nil {
-		return err
-	}
-	err = json.NewEncoder(traceConfigFile).Encode(traceConfig)
-	if err != nil {
-		return err
-	}
-	traceConfigFile.Close()
-	return nil
 }

--- a/test/e2e/testnet/setup.go
+++ b/test/e2e/testnet/setup.go
@@ -75,8 +75,6 @@ func WithLocalTracing(localTracingType string) Option {
 		cfg.Instrumentation.TraceType = localTracingType
 		cfg.Instrumentation.TraceBufferSize = 1000
 		cfg.Instrumentation.TracePullAddress = ":26661"
-		//cfg.Instrumentation.TracingTables = "consensus_round_state,received_bytes"
-		// cfg.Instrumentation.TracePushConfig = "s3.json"
 	}
 }
 func WriteAddressBook(peers []string, file string) error {

--- a/test/e2e/testnet/setup.go
+++ b/test/e2e/testnet/setup.go
@@ -73,6 +73,7 @@ func WithLocalTracing(localTracingType string) Option {
 		cfg.Instrumentation.TracePullAddress = ":26661"
 	}
 }
+
 func WriteAddressBook(peers []string, file string) error {
 	book := pex.NewAddrBook(file, false)
 	for _, peer := range peers {

--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -69,7 +69,9 @@ func (t *Testnet) SetConsensusMaxBlockSize(size int64) {
 func (t *Testnet) CreateGenesisNode(version string, selfDelegation, upgradeHeight int64, resources Resources) error {
 	signerKey := t.keygen.Generate(ed25519Type)
 	networkKey := t.keygen.Generate(ed25519Type)
-	node, err := NewNode(fmt.Sprintf("val%d", len(t.nodes)), version, 0, selfDelegation, nil, signerKey, networkKey, upgradeHeight, resources, t.grafana)
+	node, err := NewNode(fmt.Sprintf("val%d", len(t.nodes)), version, 0,
+		selfDelegation, nil, signerKey, networkKey, upgradeHeight, resources,
+		t.grafana)
 	if err != nil {
 		return err
 	}
@@ -98,7 +100,7 @@ func (t *Testnet) CreateTxClients(version string,
 	for i, grpcEndpoint := range grpcEndpoints {
 		name := fmt.Sprintf("txsim%d", i)
 		err := t.CreateTxClient(name, version, sequences,
-			blobRange, resources, grpcEndpoint)
+			blobRange, blobPerSequence, resources, grpcEndpoint)
 		if err != nil {
 			log.Err(err).Str("name", name).
 				Str("grpc endpoint", grpcEndpoint).
@@ -127,6 +129,7 @@ func (t *Testnet) CreateTxClient(name,
 	version string,
 	sequences int,
 	blobRange string,
+	blobPerSequence int,
 	resources Resources,
 	grpcEndpoint string,
 ) error {
@@ -144,7 +147,7 @@ func (t *Testnet) CreateTxClient(name,
 
 	// Create a txsim node using the key stored in the txsimKeyringDir
 	txsim, err := CreateTxClient(name, version, grpcEndpoint, t.seed,
-		sequences, blobRange, 1, resources, txsimRootDir)
+		sequences, blobRange, blobPerSequence, 1, resources, txsimRootDir)
 	if err != nil {
 		log.Err(err).
 			Str("name", name).
@@ -235,7 +238,9 @@ func (t *Testnet) CreateAccount(name string, tokens int64, txsimKeyringDir strin
 func (t *Testnet) CreateNode(version string, startHeight, upgradeHeight int64, resources Resources) error {
 	signerKey := t.keygen.Generate(ed25519Type)
 	networkKey := t.keygen.Generate(ed25519Type)
-	node, err := NewNode(fmt.Sprintf("val%d", len(t.nodes)), version, startHeight, 0, nil, signerKey, networkKey, upgradeHeight, resources, t.grafana)
+	node, err := NewNode(fmt.Sprintf("val%d", len(t.nodes)), version,
+		startHeight, 0, nil, signerKey, networkKey, upgradeHeight, resources,
+		t.grafana)
 	if err != nil {
 		return err
 	}

--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -94,6 +94,7 @@ func (t *Testnet) CreateGenesisNodes(num int, version string, selfDelegation, up
 func (t *Testnet) CreateTxClients(version string,
 	sequences int,
 	blobRange string,
+	blobPerSequence int,
 	resources Resources,
 	grpcEndpoints []string,
 ) error {

--- a/test/e2e/testnet/txsimNode.go
+++ b/test/e2e/testnet/txsimNode.go
@@ -26,6 +26,7 @@ func CreateTxClient(
 	seed int64,
 	sequences int,
 	blobRange string,
+	blobsPerSeq int,
 	pollTime int,
 	resources Resources,
 	volumePath string,
@@ -65,7 +66,7 @@ func CreateTxClient(
 		fmt.Sprintf("-t %ds", pollTime),
 		fmt.Sprintf("-b %d ", sequences),
 		fmt.Sprintf("-d %d ", seed),
-		fmt.Sprintf("-a %d ", 5),
+		fmt.Sprintf("-a %d ", blobsPerSeq),
 		fmt.Sprintf("-s %s ", blobRange),
 	}
 

--- a/test/e2e/testnet/util.go
+++ b/test/e2e/testnet/util.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"os"
 
+	"github.com/rs/zerolog/log"
 	"github.com/tendermint/tendermint/crypto"
 	"github.com/tendermint/tendermint/crypto/ed25519"
 	"github.com/tendermint/tendermint/crypto/secp256k1"
@@ -44,12 +45,16 @@ type GrafanaInfo struct {
 }
 
 func GetGrafanaInfoFromEnvVar() *GrafanaInfo {
+	log.Info().Msg("Checking Grafana environment variables")
 	if os.Getenv("GRAFANA_ENDPOINT") == "" ||
 		os.Getenv("GRAFANA_USERNAME") == "" ||
 		os.Getenv("GRAFANA_TOKEN") == "" {
+
+		log.Info().Msg("No Grafana environment variables found")
 		return nil
 	}
 
+	log.Info().Msg("Grafana environment variables found")
 	return &GrafanaInfo{
 		Endpoint: os.Getenv("GRAFANA_ENDPOINT"),
 		Username: os.Getenv("GRAFANA_USERNAME"),


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3318
It enables 1) local tracing in validators knuu instances 2) pushing locally traced data from validators to a S3 bucket, given that proper configs are passed via environment vars.

Additionally, it includes changes that:
- Allow specifying the number of blobs per sequence parameter for TX clients (previously fixed at `5`).
- Log information about the presence of Grafana environment variables.


## How to run
The `E2EThroughput` has been tested and I confirm both local tracing and pushing traces work correctly in knuu instances. To run the test:
```
go run ./test/e2e/benchmark  -v
```
You will see the `consensus_round_state.jsonl` file added to the root directory of the project, indicating the local tracing is operational in the validators' knuu instances.

In order to push traces to a S3 bucket, you would need to  pass S3 bucket push configs as env variables. I also tested this feature, and it works fine. It downloads the traced data and places them under `./traces/` folder in the project root.