### PR TITLE
docs(x/signal): replace upgrade with signal in comments

### DIFF
--- a/x/signal/keeper.go
+++ b/x/signal/keeper.go
@@ -30,9 +30,8 @@ func Threshold(_ uint64) sdk.Dec {
 }
 
 type Keeper struct {
-	// storeKey uses the same key as the Cosmos SDK x/upgrade module so that
-	// existing IBC client state can safely be ported over without any
-	// migration.
+	// storeKey is key that is used to fetch the signal store from the multi
+	// store.
 	storeKey storetypes.StoreKey
 
 	// quorumVersion is the version that has received a quorum of validators
@@ -45,7 +44,7 @@ type Keeper struct {
 	stakingKeeper StakingKeeper
 }
 
-// NewKeeper returns an upgrade keeper.
+// NewKeeper returns a signal keeper.
 func NewKeeper(
 	storeKey storetypes.StoreKey,
 	stakingKeeper StakingKeeper,

--- a/x/signal/module.go
+++ b/x/signal/module.go
@@ -22,7 +22,7 @@ func init() {
 }
 
 const (
-	// consensusVersion defines the current x/upgrade module consensus version.
+	// consensusVersion defines the current x/signal module consensus version.
 	consensusVersion uint64 = 3
 )
 


### PR DESCRIPTION
Follow up to https://github.com/celestiaorg/celestia-app/pull/3290 which fixes a few comments that still say "upgrade" when they should say "signal".