### PR TITLE
fix: rename remaining instances of GlobalMinGasPrice to NetworkMinGasPrice 

### DIFF
--- a/x/minfee/grpc_query.go
+++ b/x/minfee/grpc_query.go
@@ -30,5 +30,5 @@ func (q *QueryServerImpl) NetworkMinGasPrice(ctx context.Context, _ *QueryNetwor
 		return nil, status.Errorf(codes.NotFound, "subspace not found for minfee. Minfee is only active in app version 2 and onwards")
 	}
 	subspace.GetParamSet(sdkCtx, &params)
-	return &QueryNetworkMinGasPriceResponse{NetworkMinGasPrice: params.GlobalMinGasPrice}, nil
+	return &QueryNetworkMinGasPriceResponse{NetworkMinGasPrice: params.NetworkMinGasPrice}, nil
 }

--- a/x/minfee/grpc_query_test.go
+++ b/x/minfee/grpc_query_test.go
@@ -24,5 +24,5 @@ func TestQueryNetworkMinGasPrice(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check the response
-	require.Equal(t, v2.GlobalMinGasPrice, resp.NetworkMinGasPrice.MustFloat64())
+	require.Equal(t, v2.NetworkMinGasPrice, resp.NetworkMinGasPrice.MustFloat64())
 }


### PR DESCRIPTION
Closes #3582  