### PR TITLE
test: prepare proposal block data size

### DIFF
--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -242,7 +242,10 @@ func TestPrepareProposalBlockDataSize(t *testing.T) {
 		accounts[numBlobTxs:],
 		testutil.ChainID,
 	)
-	txs := append(blobTxs, coretypes.Txs(normalTxs).ToSliceOfBytes()...)
+
+	txs := blobTxs
+	txs = append(txs, coretypes.Txs(normalTxs).ToSliceOfBytes()...)
+
 	request := abci.RequestPrepareProposal{
 		BlockData: &tmproto.Data{
 			Txs: txs,


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3573

Note: we could add an explicit conditional at the end of prepare proposal like: 

```go
	if getSize(txs) > req.BlockDataSize {
		panic("the size of the proposal block data exceeds the block data size")
	}
```

but I'm not sure that actually gets us much. Instead of panic'ing in celestia-core (like it does currently), it'll panic in celestia-app. Since this is a change to prepare proposal which has already been audited, I'm hesitant to add the conditional unless reviewers feel strongly that it is helpful.