### PR TITLE
fix: removes redundant attempts to start tx clients in the BenchmarkTest's Run method

### DIFF
--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -113,13 +113,6 @@ func (b *BenchmarkTest) Run() error {
 		}
 	}
 
-	// once the testnet is up, start tx clients
-	log.Println("Starting tx clients")
-	err = b.StartTxClients()
-	if err != nil {
-		return fmt.Errorf("failed to start tx clients: %v", err)
-	}
-
 	// wait some time for the tx clients to submit transactions
 	time.Sleep(b.manifest.TestDuration)
 


### PR DESCRIPTION
Closes #3589
Remnant of #3505 

With the changes in this PR, the benchamrk test runs successfully. 