### PR TITLE
feat: enables selection and execution of specific e2e benchmark tests

### DIFF
--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -113,13 +113,6 @@ func (b *BenchmarkTest) Run() error {
 		}
 	}
 
-	// once the testnet is up, start tx clients
-	log.Println("Starting tx clients")
-	err = b.StartTxClients()
-	if err != nil {
-		return fmt.Errorf("failed to start tx clients: %v", err)
-	}
-
 	// wait some time for the tx clients to submit transactions
 	time.Sleep(b.manifest.TestDuration)
 

--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -1,0 +1,1 @@
+package main

--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -1,1 +1,61 @@
 package main
+
+import (
+	"log"
+	"os"
+	"strings"
+)
+
+func main() {
+	logger := log.New(os.Stdout, "test-e2e-benchmark", log.LstdFlags)
+
+	tests := []Test{
+		{"TwoNodeSimple", TwoNodeSimple},
+	}
+
+	// check the test name passed as an argument and run it
+	specificTestFound := false
+	for _, arg := range os.Args[1:] {
+		for _, test := range tests {
+			if test.Name == arg {
+				runTest(logger, test)
+				specificTestFound = true
+				break
+			}
+		}
+	}
+
+	if !specificTestFound {
+		logger.Println("No particular test specified. Running all tests.")
+		logger.Println("go run ./test/e2e/benchmark <test_name> to run a specific test")
+		logger.Printf("Valid tests are: %s\n\n", getTestNames(tests))
+		// if no specific test is passed, run all tests
+		for _, test := range tests {
+			runTest(logger, test)
+		}
+	}
+}
+
+type TestFunc func(*log.Logger) error
+
+type Test struct {
+	Name string
+	Func TestFunc
+}
+
+func runTest(logger *log.Logger, test Test) {
+	logger.Printf("=== RUN %s", test.Name)
+	err := test.Func(logger)
+	if err != nil {
+		logger.Fatalf("--- ERROR %s: %v", test.Name, err)
+	}
+	logger.Printf("--- ✅ PASS: %s \n\n", test.Name)
+}
+
+func getTestNames(tests []Test) string {
+	testNames := make([]string, 0, len(tests))
+	for _, test := range tests {
+		testNames = append(testNames, test.Name)
+	}
+	return strings.Join(testNames, ", ")
+}

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -16,14 +16,14 @@ const (
 	seed = 42
 )
 
-func TwoNodeSimple(_ *log.Logger) error {
+func TwoNodeSimple(logger *log.Logger) error {
 	latestVersion, err := testnet.GetLatestVersion()
 	testnet.NoError("failed to get latest version", err)
 
-	log.Println("=== RUN E2EThroughput", "version:", latestVersion)
+	logger.Println("=== RUN TwoNodeSimple", "version:", latestVersion)
 
 	manifest := Manifest{
-		ChainID:            "test-e2e-throughput",
+		ChainID:            "test-e2e-two-node-simple",
 		Validators:         2,
 		ValidatorResource:  testnet.DefaultResources,
 		TxClientsResource:  testnet.DefaultResources,
@@ -99,5 +99,6 @@ func TwoNodeSimple(_ *log.Logger) error {
 	if totalTxs < 10 {
 		return fmt.Errorf("expected at least 10 transactions, got %d", totalTxs)
 	}
+
 	return nil
 }

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -16,13 +16,7 @@ const (
 	seed = 42
 )
 
-func main() {
-	if err := E2EThroughput(); err != nil {
-		log.Fatalf("--- ERROR Throughput test: %v", err.Error())
-	}
-}
-
-func E2EThroughput() error {
+func TwoNodeSimple(_ *log.Logger) error {
 	latestVersion, err := testnet.GetLatestVersion()
 	testnet.NoError("failed to get latest version", err)
 
@@ -105,7 +99,5 @@ func E2EThroughput() error {
 	if totalTxs < 10 {
 		return fmt.Errorf("expected at least 10 transactions, got %d", totalTxs)
 	}
-
-	log.Println("--- PASS ✅: E2EThroughput")
 	return nil
 }


### PR DESCRIPTION
Closes #3588

Now, you can pass the test name as an arument:
```
 go run ./test/e2e/benchmark TwoNodeSimple  -v
```
And at the end you will see
```
test-e2e-benchmark2024/06/18 15:44:38 --- ✅ PASS: TwoNodeSimple 
```