### PR TITLE
fix: usage of default address and account in tx client

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -50,15 +50,22 @@ func WithDefaultAddress(address sdktypes.AccAddress) Option {
 			panic(err)
 		}
 		c.defaultAccount = record.Name
+		c.defaultAddress = address
 	}
 }
 
 func WithDefaultAccount(name string) Option {
 	return func(c *TxClient) {
-		if _, err := c.signer.keys.Key(name); err != nil {
+		rec, err := c.signer.keys.Key(name)
+		if err != nil {
+			panic(err)
+		}
+		addr, err := rec.GetAddress()
+		if err != nil {
 			panic(err)
 		}
 		c.defaultAccount = name
+		c.defaultAddress = addr
 	}
 }
 


### PR DESCRIPTION
This ports a bug that was caught in `main` whereby setting either the default address or default account name in the tx client does not automatically set the other leading in a potential incoherence between the two