### PR TITLE
chore(e2e test): extends the wait time for genesis nodes to produce the first block in e2e tests #3610

### DIFF
--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -367,7 +367,7 @@ func (t *Testnet) Start() error {
 				return fmt.Errorf("failed to start node %s", node.Name)
 			}
 			fmt.Printf("node %s is not synced yet, waiting...\n", node.Name)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(1000 * time.Millisecond)
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #3610