### PR TITLE
chore(e2e benchmark test): allows selection of only one test

### DIFF
--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -14,26 +14,20 @@ func main() {
 	}
 
 	// check the test name passed as an argument and run it
-	specificTestFound := false
-	for _, arg := range os.Args[1:] {
-		for _, test := range tests {
-			if test.Name == arg {
-				runTest(logger, test)
-				specificTestFound = true
-				break
-			}
+	if len(os.Args) < 2 {
+		logger.Println("Usage: go run ./test/e2e/benchmark <test_name>")
+		logger.Printf("Valid tests are: %s\n\n", getTestNames(tests))
+		return
+
+	}
+	testName := os.Args[1]
+	for _, test := range tests {
+		if test.Name == testName {
+			runTest(logger, test)
+			break
 		}
 	}
 
-	if !specificTestFound {
-		logger.Println("No particular test specified. Running all tests.")
-		logger.Println("go run ./test/e2e/benchmark <test_name> to run a specific test")
-		logger.Printf("Valid tests are: %s\n\n", getTestNames(tests))
-		// if no specific test is passed, run all tests
-		for _, test := range tests {
-			runTest(logger, test)
-		}
-	}
 }
 
 type TestFunc func(*log.Logger) error

--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -15,6 +15,7 @@ func main() {
 
 	// check the test name passed as an argument and run it
 	if len(os.Args) < 2 {
+		logger.Println("No test is specified.")
 		logger.Println("Usage: go run ./test/e2e/benchmark <test_name>")
 		logger.Printf("Valid tests are: %s\n\n", getTestNames(tests))
 		return

--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -28,7 +28,6 @@ func main() {
 			break
 		}
 	}
-
 }
 
 type TestFunc func(*log.Logger) error

--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -21,12 +21,20 @@ func main() {
 		return
 
 	}
+	found := false
 	testName := os.Args[1]
 	for _, test := range tests {
 		if test.Name == testName {
+			found = true
 			runTest(logger, test)
 			break
 		}
+	}
+	if !found {
+		logger.Printf("Invalid test name: %s\n", testName)
+		logger.Printf("Valid tests are: %s\n", getTestNames(tests))
+		logger.Println("Usage: go run ./test/e2e/benchmark <test_name>")
+
 	}
 }
 

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -47,7 +47,7 @@ func TwoNodeSimple(logger *log.Logger) error {
 		LocalTracingType:   "local",
 		PushTrace:          false,
 		DownloadTraces:     false,
-		TestDuration:       3 * time.Minute,
+		TestDuration:       2 * time.Minute,
 		TxClients:          2,
 	}
 

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -47,7 +47,7 @@ func TwoNodeSimple(logger *log.Logger) error {
 		LocalTracingType:   "local",
 		PushTrace:          false,
 		DownloadTraces:     false,
-		TestDuration:       2 * time.Minute,
+		TestDuration:       3 * time.Minute,
 		TxClients:          2,
 	}
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3617

Before this PR, you could run:
```
 go run ./test/e2e/benchmark
test-e2e-benchmark2024/06/24 13:02:13 No particular test specified. Running all tests.
test-e2e-benchmark2024/06/24 13:02:13 go run ./test/e2e/benchmark <test_name> to run a specific test
test-e2e-benchmark2024/06/24 13:02:13 Valid tests are: TwoNodeSimple
```
and it would start running all the benchmark tests. However, after this PR, it will require user to specify the test name:
```
go run ./test/e2e/benchmark                       
test-e2e-benchmark2024/06/24 13:26:24 No test is specified.
test-e2e-benchmark2024/06/24 13:26:24 Usage: go run ./test/e2e/benchmark <test_name>
test-e2e-benchmark2024/06/24 13:26:24 Valid tests are: TwoNodeSimple

```