### PR TITLE
fix: make test-interchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ test-fuzz:
 ## test-interchain: Run interchain tests in verbose mode. Requires Docker.
 test-interchain:
 	@echo "--> Running interchain tests"
-	@go test ./test/interchain -v
+	@cd ./test/interchain && go test . -v
 .PHONY: test-interchain
 
 ## txsim-install: Install the tx simulator.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3587

## Testing

```
$ make test-interchain
--> Running interchain tests
=== RUN   TestInterChainAccounts
    setup.go:203: Pruned 3 volumes, reclaiming approximately 5.0 MB
...
```