### PR TITLE
feat(tools): blockheight

### DIFF
--- a/tools/blockheight/README.md
+++ b/tools/blockheight/README.md
@@ -1,0 +1,15 @@
+# blockheight
+
+blockheight is a small tool to help predict the block height of a chain at a given time.
+
+## Usage
+
+Update values in `main.go` and then run it:
+
+```go
+$ go run main.go
+Now: 2024-06-27 16:03:31 -0400 EDT
+Target: 2024-07-03 12:00:00 -0400 EDT
+Diff in seconds: 503789
+Diff in block heights: 42477
+```

--- a/tools/blockheight/main.go
+++ b/tools/blockheight/main.go
@@ -18,13 +18,18 @@ func main() {
 		panic(err)
 	}
 
-	now := time.Now().Truncate(time.Second)
-	target := time.Date(2024, 7, 3, 12, 0, 0, 0, location).Truncate(time.Second)
-	diffInSeconds := target.Sub(now).Seconds()
-	diffInBlockHeight := math.Floor(diffInSeconds / blockTime)
+	currentHeight := 5627
+	currentTime := time.Now().Truncate(time.Second)
+	targetTime := time.Date(2024, 7, 4, 12, 30, 0, 0, location).Truncate(time.Second) // July 4th, 2024 @ 12:30PM ET
 
-	fmt.Printf("Now: %v\n", now.String())
-	fmt.Printf("Target: %v\n", target.String())
-	fmt.Printf("Diff in seconds: %v\n", diffInSeconds)
-	fmt.Printf("Diff in block heights: %v\n", diffInBlockHeight)
+	diffInSeconds := targetTime.Sub(currentTime).Seconds()
+	diffInBlockHeight := math.Floor(diffInSeconds / blockTime)
+	targetHeight := currentHeight + int(diffInBlockHeight)
+
+	fmt.Printf("currentHeight: %v\n", currentHeight)
+	fmt.Printf("currentTime: %v\n", currentTime.String())
+	fmt.Printf("targetTime: %v\n", targetTime.String())
+	fmt.Printf("diffInSeconds: %v\n", diffInSeconds)
+	fmt.Printf("diffInBlockHeight: %v\n", diffInBlockHeight)
+	fmt.Printf("targetHeight: %v\n", targetHeight)
 }

--- a/tools/blockheight/main.go
+++ b/tools/blockheight/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+// blockTime is the observed average time between blocks. You can update this
+// value based on the block time on https://www.mintscan.io/celestia/block/. The
+// accuracy of the block height prediction depends on the accuracy of this
+// value.
+var blockTime = 11.86 // seconds between blocks
+
+func main() {
+	location, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		panic(err)
+	}
+
+	now := time.Now().Truncate(time.Second)
+	target := time.Date(2024, 7, 3, 12, 0, 0, 0, location).Truncate(time.Second)
+	diffInSeconds := target.Sub(now).Seconds()
+	diffInBlockHeight := math.Floor(diffInSeconds / blockTime)
+
+	fmt.Printf("Now: %v\n", now.String())
+	fmt.Printf("Target: %v\n", target.String())
+	fmt.Printf("Diff in seconds: %v\n", diffInSeconds)
+	fmt.Printf("Diff in block heights: %v\n", diffInBlockHeight)
+}


### PR DESCRIPTION
Extremely optional tool I used to determine the block height that a Robusta chain should use for `--v2-upgrade-height`. We may want to use a variation of this for testnets when we roll-out v2 there.

## Testing

```
$ go run main.go
currentHeight: 5627
currentTime: 2024-06-28 10:42:03 -0400 EDT
targetTime: 2024-07-04 12:30:00 -0400 EDT
diffInSeconds: 524877
diffInBlockHeight: 44256
targetHeight: 49883
```