### PR TITLE
chore(makefile): add PHONY for markdown-link-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,13 +103,13 @@ lint:
 	@hadolint Dockerfile
 	@echo "--> Running yamllint"
 	@yamllint --no-warnings . -c .yamllint.yml
-
 .PHONY: lint
 
 ## markdown-link-check: Check all markdown links.
 markdown-link-check:
 	@echo "--> Running markdown-link-check"
 	@find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check
+.PHONY: markdown-link-check
 
 
 ## fmt: Format files per linters golangci-lint and markdownlint.


### PR DESCRIPTION
I was copying this command to celestia-stack-internal and noticed that it is missing a `PHONY`