### PR TITLE
test(testnode): query for events on v1.x

### DIFF
--- a/app/test/testnode_test.go
+++ b/app/test/testnode_test.go
@@ -48,7 +48,6 @@ func Test_testnode(t *testing.T) {
 			select {
 			case evt := <-eventChan:
 				h := evt.Data.(types.EventDataSignedBlock).Header.Height
-				fmt.Printf("Block height: %d\n", h)
 				block, err := client.Block(ctx, &h)
 				require.NoError(t, err)
 				require.GreaterOrEqual(t, block.Block.Height, int64(i))


### PR DESCRIPTION
Here's another test that passes on v1.x but fails on v2.x and main because there were regressions to testnode when we refactored it. This PR should prevent future regressions even though we don't plan on modifying v1.x much in the future.