### PR TITLE
fix(goreleaser): do not mark rcs as latest release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -115,5 +115,7 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+release:
+  prerelease: auto
 git:
-  prerelease_suffix: "-"
+  prerelease_suffix: "-rc*"


### PR DESCRIPTION
There is an issue with goreleaser where it will automatically mark release candidates as the latest release.

Motivated by https://github.com/celestiaorg/celestia-node/pull/3569

Thanks @ramin!