### PR TITLE
fix(test/e2e): name cannot be empty error

### DIFF
--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -218,6 +218,7 @@ func (t *Testnet) CreateAccount(name string, tokens int64, txsimKeyringDir strin
 	err = t.genesis.AddAccount(genesis.Account{
 		PubKey:  pk,
 		Balance: tokens,
+		Name:    name,
 	})
 	if err != nil {
 		return nil, err

--- a/test/util/genesis/genesis.go
+++ b/test/util/genesis/genesis.go
@@ -122,6 +122,9 @@ func (g *Genesis) WithKeyringAccounts(accs ...KeyringAccount) *Genesis {
 
 // AddAccount adds an existing account to the genesis.
 func (g *Genesis) AddAccount(account Account) error {
+	if err := account.ValidateBasic(); err != nil {
+		return err
+	}
 	for _, acc := range g.accounts {
 		if bytes.Equal(acc.PubKey.Bytes(), account.PubKey.Bytes()) {
 			return fmt.Errorf("account with pubkey %s already exists", account.PubKey.String())


### PR DESCRIPTION
Recent e2e tests failed with:

```
2024/07/18 17:22:08 Failed to setup testnet: converting accounts into sdk types: invalid account 4: name cannot be empty
```

because https://github.com/celestiaorg/celestia-app/pull/3690 merged. Since e2e tests aren't run as part of CI on each PR, I didn't learn about the failure until @ninabarbakadze pinged about it.

## Testing

```
make test-e2e
```

gets past that error locally.