### PR TITLE
chore: add (start share == end share) check in parse namespace

### DIFF
--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -151,6 +151,13 @@ func TestNewShareInclusionProof(t *testing.T) {
 			expectErr:     true,
 		},
 		{
+			name:          "ending share is equal to the starting share",
+			startingShare: 1,
+			endingShare:   1,
+			namespaceID:   appns.TxNamespace,
+			expectErr:     true,
+		},
+		{
 			name:          "ending share higher than number of shares available in square size of 32",
 			startingShare: 0,
 			endingShare:   4097,

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -130,6 +130,7 @@ func QueryShareInclusionProof(_ sdk.Context, path []string, req abci.RequestQuer
 
 // ParseNamespace validates the share range, checks if it only contains one namespace and returns
 // that namespace ID.
+// The provided range, defined by startShare and endShare, is end-exclusive.
 func ParseNamespace(rawShares []shares.Share, startShare int, endShare int) (appns.Namespace, error) {
 	if startShare < 0 {
 		return appns.Namespace{}, fmt.Errorf("start share %d should be positive", startShare)

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -139,8 +139,8 @@ func ParseNamespace(rawShares []shares.Share, startShare int, endShare int) (app
 		return appns.Namespace{}, fmt.Errorf("end share %d should be positive", endShare)
 	}
 
-	if endShare < startShare {
-		return appns.Namespace{}, fmt.Errorf("end share %d cannot be lower than starting share %d", endShare, startShare)
+	if endShare <= startShare {
+		return appns.Namespace{}, fmt.Errorf("end share %d cannot be lower or equal to the starting share %d", endShare, startShare)
 	}
 
 	if endShare > len(rawShares) {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The start share shouldn't be equal to the end share because the range is end-exclusive. This PR adds this check.
