### PR TITLE
fix: lint suggestions

### DIFF
--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -303,17 +303,12 @@ func (n *Node) Start() error {
 	if err := n.StartAsync(); err != nil {
 		return err
 	}
-	if err := n.WaitUntilStartedAndForwardPorts(); err != nil {
-		return err
-	}
-	return nil
+
+	return n.WaitUntilStartedAndForwardPorts()
 }
 
 func (n *Node) StartAsync() error {
-	if err := n.Instance.StartAsync(); err != nil {
-		return err
-	}
-	return nil
+	return n.Instance.StartAsync()
 }
 
 func (n *Node) WaitUntilStartedAndForwardPorts() error {
@@ -360,10 +355,7 @@ func (n *Node) Upgrade(version string) error {
 		return err
 	}
 
-	if err := n.Instance.WaitInstanceIsRunning(); err != nil {
-		return err
-	}
-	return nil
+	return n.Instance.WaitInstanceIsRunning()
 }
 
 func DockerImageName(version string) string {


### PR DESCRIPTION
## Overview

There were non-blocking lint suggestions shown on every run. This pr addresses those suggestions so we don't have to keep seeing the red lines.
