### PR TITLE
chore: remove "start celestia app" from CLI docs

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -65,8 +65,7 @@ func NewRootCmd() *cobra.Command {
 		WithViper(EnvPrefix)
 
 	rootCmd := &cobra.Command{
-		Use:   "celestia-appd",
-		Short: "Start celestia app",
+		Use: "celestia-appd",
 		PersistentPreRunE: func(cmd *cobra.Command, _ []string) error {
 			initClientCtx, err := client.ReadPersistentCommandFlags(initClientCtx, cmd.Flags())
 			if err != nil {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3716

## Testing

```
$ celestia-appd
Usage:
  celestia-appd [command]

Available Commands:
// ...
```