### PR TITLE
refactor: expose CreateShareToRowRootProofs for downstream use

### DIFF
--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -121,56 +121,10 @@ func NewShareInclusionProofFromEDS(
 		rows[i-startRow] = shares
 	}
 
-	var shareProofs []*NMTProof //nolint:prealloc
-	var rawShares [][]byte
-	for i, row := range rows {
-		// create an nmt to generate a proof.
-		// we have to re-create the tree as the eds one is not accessible.
-		tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(squareSize), uint(i))
-		for _, share := range row {
-			err := tree.Push(
-				share.ToBytes(),
-			)
-			if err != nil {
-				return ShareProof{}, err
-			}
-		}
-
-		// make sure that the generated root is the same as the eds row root.
-		root, err := tree.Root()
-		if err != nil {
-			return ShareProof{}, err
-		}
-		if !bytes.Equal(rowRoots[i], root) {
-			return ShareProof{}, errors.New("eds row root is different than tree root")
-		}
-
-		startLeafPos := startLeaf
-		endLeafPos := endLeaf
-
-		// if this is not the first row, then start with the first leaf
-		if i > 0 {
-			startLeafPos = 0
-		}
-		// if this is not the last row, then select for the rest of the row
-		if i != (len(rows) - 1) {
-			endLeafPos = squareSize - 1
-		}
-
-		rawShares = append(rawShares, shares.ToBytes(row[startLeafPos:endLeafPos+1])...)
-		proof, err := tree.ProveRange(startLeafPos, endLeafPos+1)
-		if err != nil {
-			return ShareProof{}, err
-		}
-
-		shareProofs = append(shareProofs, &NMTProof{
-			Start:    int32(proof.Start()),
-			End:      int32(proof.End()),
-			Nodes:    proof.Nodes(),
-			LeafHash: proof.LeafHash(),
-		})
+	shareProofs, rawShares, err := CreateShareToRowRootProofs(squareSize, rows, rowRoots, startLeaf, endLeaf)
+	if err != nil {
+		return ShareProof{}, err
 	}
-
 	return ShareProof{
 		RowProof: &RowProof{
 			RowRoots: rowRoots,
@@ -190,4 +144,59 @@ func safeConvertUint64ToInt(val uint64) (int, error) {
 		return 0, fmt.Errorf("value %d is too large to convert to int", val)
 	}
 	return int(val), nil
+}
+
+// CreateShareToRowRootProofs takes a set of shares and their corresponding row roots, and generates
+// an NMT inclusion proof of a set of shares, defined by startLeaf and endLeaf, to their corresponding row roots.
+func CreateShareToRowRootProofs(squareSize int, rowShares [][]shares.Share, rowRoots [][]byte, startLeaf, endLeaf int) ([]*NMTProof, [][]byte, error) {
+	shareProofs := make([]*NMTProof, 0, len(rowRoots))
+	var rawShares [][]byte
+	for i, row := range rowShares {
+		// create an nmt to generate a proof.
+		// we have to re-create the tree as the eds one is not accessible.
+		tree := wrapper.NewErasuredNamespacedMerkleTree(uint64(squareSize), uint(i))
+		for _, share := range row {
+			err := tree.Push(
+				share.ToBytes(),
+			)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+
+		// make sure that the generated root is the same as the eds row root.
+		root, err := tree.Root()
+		if err != nil {
+			return nil, nil, err
+		}
+		if !bytes.Equal(rowRoots[i], root) {
+			return nil, nil, errors.New("eds row root is different than tree root")
+		}
+
+		startLeafPos := startLeaf
+		endLeafPos := endLeaf
+
+		// if this is not the first row, then start with the first leaf
+		if i > 0 {
+			startLeafPos = 0
+		}
+		// if this is not the last row, then select for the rest of the row
+		if i != (len(rowShares) - 1) {
+			endLeafPos = squareSize - 1
+		}
+
+		rawShares = append(rawShares, shares.ToBytes(row[startLeafPos:endLeafPos+1])...)
+		proof, err := tree.ProveRange(startLeafPos, endLeafPos+1)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		shareProofs = append(shareProofs, &NMTProof{
+			Start:    int32(proof.Start()),
+			End:      int32(proof.End()),
+			Nodes:    proof.Nodes(),
+			LeafHash: proof.LeafHash(),
+		})
+	}
+	return shareProofs, rawShares, nil
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Exposes that functionality so that we don't end up copy-pasting that code in Celestia-node.