### PR TITLE
fix(scripts): single-node.sh chain ID

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -11,7 +11,7 @@ then
     exit 1
 fi
 
-CHAIN_ID="private"
+CHAIN_ID="test"
 KEY_NAME="validator"
 KEYRING_BACKEND="test"
 COINS="1000000000000000utia"


### PR DESCRIPTION
celestia-node no longer accepts a chain ID of `private` but it does accept `test` instead.

```
2024-08-12T13:59:08.549-0400	ERROR	core	core/listener.go:183	listener: received block with unexpected chain ID: expected test, received private
```

This modifies the `single-node.sh` scripts so that it can be used in conjunction with a local celestia node.