### PR TITLE
fix: markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/celestiaorg/celestia-app)](https://goreportcard.com/report/github.com/celestiaorg/celestia-app)
 [![GitPOAP Badge](https://public-api.gitpoap.io/v1/repo/celestiaorg/celestia-app/badge)](https://www.gitpoap.io/gh/celestiaorg/celestia-app)
 
-celestia-app is the software used by [validators](https://docs.celestia.org/nodes/validator-node) and [full consensus nodes](https://docs.celestia.org/nodes/full-consensus-node) on the Celestia consensus network. celestia-app is a blockchain application built using parts of the Cosmos stack:
+celestia-app is the software used by [validators](https://docs.celestia.org/nodes/validator-node) and [consensus nodes](https://docs.celestia.org/nodes/consensus-node) on the Celestia consensus network. celestia-app is a blockchain application built using parts of the Cosmos stack:
 
 - [celestiaorg/cosmos-sdk](https://github.com/celestiaorg/cosmos-sdk) a fork of [cosmos/cosmos-sdk](https://github.com/cosmos/cosmos-sdk)
 - [celestiaorg/celestia-core](https://github.com/celestiaorg/celestia-core) a fork of [cometbft/cometbft](https://github.com/cometbft/cometbft)

--- a/specs/src/specs/namespace.md
+++ b/specs/src/specs/namespace.md
@@ -94,7 +94,7 @@ Among the potential consequences is the _Woods Attack_, as elaborated in this fo
 
 ## Implementation
 
-See the [namespace implementation in go-square](https://github.com/celestiaorg/go-square/v2/share/be3c2801e902a0f90f694c062b9c4e6a7e01154e/namespace/namespace.go).
+See the [namespace implementation in go-square](https://github.com/celestiaorg/go-square/blob/4209e67d30fef7de29af2f2712104871c173543a/share/namespace.go).
 For the most recent version, which may not reflect the current specifications, refer to [the latest namespace code](https://github.com/celestiaorg/go-square/blob/main/share/namespace.go).
 
 ## Go Definition

--- a/tools/blocktime/readme.md
+++ b/tools/blocktime/readme.md
@@ -2,7 +2,7 @@
 
 `blocktime` is a simple tool to analyze block production rates of a chain. It scrapes the latest headers through the RPC endpoint of a provided node and calculates the average, min, max and standard deviation of the intervals between the last `n` blocks (default: 100).
 
-To read up on starting a node and exposing the RPC endpoint go to the docs [here](https://docs.celestia.org/nodes/full-consensus-node)
+To start a consensus node and expose the RPC endpoint, see the [docs](https://docs.celestia.org/nodes/consensus-node).
 
 ## Usage
 


### PR DESCRIPTION
Fixes a few broken links. See [failing CI](https://github.com/celestiaorg/celestia-app/actions/runs/10354113554/job/28658603156).

## Testing

`make markdown-link-check` passes locally