### PR TITLE
refactor(e2e): stop using deprecated knuu methods

### DIFF
--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -55,11 +55,15 @@ func (b *BenchmarkTest) SetupNodes(ctx context.Context) error {
 	// create tx clients and point them to the validators
 	log.Println("Creating tx clients")
 
-	err = b.CreateTxClients(b.manifest.TxClientVersion,
+	err = b.CreateTxClients(
+		ctx,
+		b.manifest.TxClientVersion,
 		b.manifest.BlobSequences,
 		b.manifest.BlobSizes,
 		b.manifest.BlobsPerSeq,
-		b.manifest.TxClientsResource, gRPCEndpoints)
+		b.manifest.TxClientsResource,
+		gRPCEndpoints,
+	)
 	testnet.NoError("failed to create tx clients", err)
 
 	log.Println("Setting up testnet")
@@ -100,7 +104,7 @@ func (b *BenchmarkTest) SetupNodes(ctx context.Context) error {
 }
 
 // Run runs the benchmark test for the specified duration in the manifest.
-func (b *BenchmarkTest) Run() error {
+func (b *BenchmarkTest) Run(ctx context.Context) error {
 	log.Println("Starting benchmark testnet")
 
 	log.Println("Starting nodes")
@@ -128,7 +132,7 @@ func (b *BenchmarkTest) Run() error {
 
 	// start tx clients
 	log.Println("Starting tx clients")
-	err = b.StartTxClients()
+	err = b.StartTxClients(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to start tx clients: %v", err)
 	}

--- a/test/e2e/benchmark/benchmark.go
+++ b/test/e2e/benchmark/benchmark.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck
 package main
 
 import (
@@ -18,9 +17,9 @@ type BenchmarkTest struct {
 	manifest *Manifest
 }
 
-func NewBenchmarkTest(name string, manifest *Manifest) (*BenchmarkTest, error) {
+func NewBenchmarkTest(ctx context.Context, name string, manifest *Manifest) (*BenchmarkTest, error) {
 	// create a new testnet
-	testNet, err := testnet.New(name, seed,
+	testNet, err := testnet.New(ctx, name, seed,
 		testnet.GetGrafanaInfoFromEnvVar(), manifest.ChainID,
 		manifest.GetGenesisModifiers()...)
 	if err != nil {
@@ -34,9 +33,9 @@ func NewBenchmarkTest(name string, manifest *Manifest) (*BenchmarkTest, error) {
 // SetupNodes creates genesis nodes and tx clients based on the manifest.
 // There will be manifest.Validators validators and manifest.TxClients tx clients.
 // Each tx client connects to one validator. If TxClients are fewer than Validators, some validators will not have a tx client.
-func (b *BenchmarkTest) SetupNodes() error {
+func (b *BenchmarkTest) SetupNodes(ctx context.Context) error {
 	testnet.NoError("failed to create genesis nodes",
-		b.CreateGenesisNodes(b.manifest.Validators,
+		b.CreateGenesisNodes(ctx, b.manifest.Validators,
 			b.manifest.CelestiaAppVersion, b.manifest.SelfDelegation,
 			b.manifest.UpgradeHeight, b.manifest.ValidatorResource))
 

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"time"
 
@@ -90,7 +91,10 @@ func TwoNodeSimple(logger *log.Logger) error {
 		TxClients:          2,
 	}
 
-	benchTest, err := NewBenchmarkTest(testName, &manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	benchTest, err := NewBenchmarkTest(ctx, testName, &manifest)
 	testnet.NoError("failed to create benchmark test", err)
 
 	defer func() {
@@ -98,7 +102,7 @@ func TwoNodeSimple(logger *log.Logger) error {
 		benchTest.Cleanup()
 	}()
 
-	testnet.NoError("failed to setup nodes", benchTest.SetupNodes())
+	testnet.NoError("failed to setup nodes", benchTest.SetupNodes(ctx))
 
 	testnet.NoError("failed to run the benchmark test", benchTest.Run())
 
@@ -107,11 +111,11 @@ func TwoNodeSimple(logger *log.Logger) error {
 	return nil
 }
 
-func runBenchmarkTest(logger *log.Logger, testName string, manifest Manifest) error {
+func runBenchmarkTest(ctx context.Context, logger *log.Logger, testName string, manifest Manifest) error {
 	logger.Println("Running", testName)
 	manifest.ChainID = manifest.summary()
 	log.Println("ChainID: ", manifest.ChainID)
-	benchTest, err := NewBenchmarkTest(testName, &manifest)
+	benchTest, err := NewBenchmarkTest(ctx, testName, &manifest)
 	testnet.NoError("failed to create benchmark test", err)
 
 	defer func() {
@@ -119,7 +123,7 @@ func runBenchmarkTest(logger *log.Logger, testName string, manifest Manifest) er
 		benchTest.Cleanup()
 	}()
 
-	testnet.NoError("failed to setup nodes", benchTest.SetupNodes())
+	testnet.NoError("failed to setup nodes", benchTest.SetupNodes(ctx))
 	testnet.NoError("failed to run the benchmark test", benchTest.Run())
 	expectedBlockSize := int64(0.90 * float64(manifest.MaxBlockBytes))
 	testnet.NoError("failed to check results", benchTest.CheckResults(expectedBlockSize))
@@ -130,7 +134,9 @@ func runBenchmarkTest(logger *log.Logger, testName string, manifest Manifest) er
 func TwoNodeBigBlock8MB(logger *log.Logger) error {
 	manifest := bigBlockManifest
 	manifest.MaxBlockBytes = 8 * testnet.MB
-	return runBenchmarkTest(logger, "TwoNodeBigBlock8MB", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "TwoNodeBigBlock8MB", manifest)
 }
 
 func TwoNodeBigBlock8MBLatency(logger *log.Logger) error {
@@ -138,19 +144,25 @@ func TwoNodeBigBlock8MBLatency(logger *log.Logger) error {
 	manifest.MaxBlockBytes = 8 * testnet.MB
 	manifest.EnableLatency = true
 	manifest.LatencyParams = LatencyParams{70, 0}
-	return runBenchmarkTest(logger, "TwoNodeBigBlock8MBLatency", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "TwoNodeBigBlock8MBLatency", manifest)
 }
 
 func TwoNodeBigBlock32MB(logger *log.Logger) error {
 	manifest := bigBlockManifest
 	manifest.MaxBlockBytes = 32 * testnet.MB
-	return runBenchmarkTest(logger, "TwoNodeBigBlock32MB", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "TwoNodeBigBlock32MB", manifest)
 }
 
 func TwoNodeBigBlock64MB(logger *log.Logger) error {
 	manifest := bigBlockManifest
 	manifest.MaxBlockBytes = 64 * testnet.MB
-	return runBenchmarkTest(logger, "TwoNodeBigBlock64MB", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "TwoNodeBigBlock64MB", manifest)
 }
 
 func LargeNetworkBigBlock8MB(logger *log.Logger) error {
@@ -159,7 +171,9 @@ func LargeNetworkBigBlock8MB(logger *log.Logger) error {
 	manifest.Validators = 50
 	manifest.TxClients = 50
 	manifest.BlobSequences = 2
-	return runBenchmarkTest(logger, "LargeNetworkBigBlock8MB", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "LargeNetworkBigBlock8MB", manifest)
 }
 
 func LargeNetworkBigBlock32MB(logger *log.Logger) error {
@@ -168,7 +182,9 @@ func LargeNetworkBigBlock32MB(logger *log.Logger) error {
 	manifest.Validators = 50
 	manifest.TxClients = 50
 	manifest.BlobSequences = 2
-	return runBenchmarkTest(logger, "LargeNetworkBigBlock32MB", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "LargeNetworkBigBlock32MB", manifest)
 }
 
 func LargeNetworkBigBlock64MB(logger *log.Logger) error {
@@ -177,5 +193,7 @@ func LargeNetworkBigBlock64MB(logger *log.Logger) error {
 	manifest.Validators = 50
 	manifest.TxClients = 50
 	manifest.BlobSequences = 2
-	return runBenchmarkTest(logger, "LargeNetworkBigBlock64MB", manifest)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	return runBenchmarkTest(ctx, logger, "LargeNetworkBigBlock64MB", manifest)
 }

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -99,12 +99,12 @@ func TwoNodeSimple(logger *log.Logger) error {
 
 	defer func() {
 		log.Print("Cleaning up testnet")
-		benchTest.Cleanup()
+		benchTest.Cleanup(ctx)
 	}()
 
 	testnet.NoError("failed to setup nodes", benchTest.SetupNodes(ctx))
 
-	testnet.NoError("failed to run the benchmark test", benchTest.Run())
+	testnet.NoError("failed to run the benchmark test", benchTest.Run(ctx))
 
 	testnet.NoError("failed to check results", benchTest.CheckResults(1*testnet.MB))
 
@@ -120,11 +120,11 @@ func runBenchmarkTest(ctx context.Context, logger *log.Logger, testName string, 
 
 	defer func() {
 		log.Print("Cleaning up testnet")
-		benchTest.Cleanup()
+		benchTest.Cleanup(ctx)
 	}()
 
 	testnet.NoError("failed to setup nodes", benchTest.SetupNodes(ctx))
-	testnet.NoError("failed to run the benchmark test", benchTest.Run())
+	testnet.NoError("failed to run the benchmark test", benchTest.Run(ctx))
 	expectedBlockSize := int64(0.90 * float64(manifest.MaxBlockBytes))
 	testnet.NoError("failed to check results", benchTest.CheckResults(expectedBlockSize))
 

--- a/test/e2e/major_upgrade_v2.go
+++ b/test/e2e/major_upgrade_v2.go
@@ -35,11 +35,14 @@ func MajorUpgradeToV2(logger *log.Logger) error {
 
 	testNet.SetConsensusParams(app.DefaultInitialConsensusParams())
 
-	preloader, err := knuu.NewPreloader()
+	k, err := knuu.New(ctx)
+	testnet.NoError("failed to create knuu", err)
+
+	preloader, err := k.NewPreloader()
 	testnet.NoError("failed to create preloader", err)
 
-	defer func() { _ = preloader.EmptyImages() }()
-	testnet.NoError("failed to add image", preloader.AddImage(testnet.DockerImageName(latestVersion)))
+	defer func() { _ = preloader.EmptyImages(ctx) }()
+	testnet.NoError("failed to add image", preloader.AddImage(ctx, testnet.DockerImageName(latestVersion)))
 
 	logger.Println("Creating genesis nodes")
 	for i := 0; i < numNodes; i++ {

--- a/test/e2e/major_upgrade_v2.go
+++ b/test/e2e/major_upgrade_v2.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck
 package main
 
 import (
@@ -28,7 +27,7 @@ func MajorUpgradeToV2(logger *log.Logger) error {
 	defer cancel()
 
 	logger.Println("Creating testnet")
-	testNet, err := testnet.New("runMajorUpgradeToV2", seed, nil, "test")
+	testNet, err := testnet.New(ctx, "runMajorUpgradeToV2", seed, nil, "test")
 	testnet.NoError("failed to create testnet", err)
 
 	defer testNet.Cleanup()
@@ -46,7 +45,7 @@ func MajorUpgradeToV2(logger *log.Logger) error {
 
 	logger.Println("Creating genesis nodes")
 	for i := 0; i < numNodes; i++ {
-		err := testNet.CreateGenesisNode(latestVersion, 10000000, upgradeHeight, testnet.DefaultResources)
+		err := testNet.CreateGenesisNode(ctx, latestVersion, 10000000, upgradeHeight, testnet.DefaultResources)
 		testnet.NoError("failed to create genesis node", err)
 	}
 

--- a/test/e2e/major_upgrade_v2.go
+++ b/test/e2e/major_upgrade_v2.go
@@ -30,7 +30,7 @@ func MajorUpgradeToV2(logger *log.Logger) error {
 	testNet, err := testnet.New(ctx, "runMajorUpgradeToV2", seed, nil, "test")
 	testnet.NoError("failed to create testnet", err)
 
-	defer testNet.Cleanup()
+	defer testNet.Cleanup(ctx)
 
 	testNet.SetConsensusParams(app.DefaultInitialConsensusParams())
 
@@ -52,13 +52,13 @@ func MajorUpgradeToV2(logger *log.Logger) error {
 	logger.Println("Creating txsim")
 	endpoints, err := testNet.RemoteGRPCEndpoints()
 	testnet.NoError("failed to get remote gRPC endpoints", err)
-	err = testNet.CreateTxClient("txsim", testnet.TxsimVersion, 1, "100-2000", 100, testnet.DefaultResources, endpoints[0])
+	err = testNet.CreateTxClient(ctx, "txsim", testnet.TxsimVersion, 1, "100-2000", 100, testnet.DefaultResources, endpoints[0])
 	testnet.NoError("failed to create tx client", err)
 
 	logger.Println("Setting up testnet")
 	testnet.NoError("Failed to setup testnet", testNet.Setup())
 	logger.Println("Starting testnet")
-	testnet.NoError("Failed to start testnet", testNet.Start())
+	testnet.NoError("Failed to start testnet", testNet.Start(ctx))
 
 	heightBefore := upgradeHeight - 1
 	for i := 0; i < numNodes; i++ {

--- a/test/e2e/minor_version_compatibility.go
+++ b/test/e2e/minor_version_compatibility.go
@@ -37,7 +37,7 @@ func MinorVersionCompatibility(logger *log.Logger) error {
 	testNet, err := testnet.New(ctx, "runMinorVersionCompatibility", seed, nil, "test")
 	testnet.NoError("failed to create testnet", err)
 
-	defer testNet.Cleanup()
+	defer testNet.Cleanup(ctx)
 
 	testNet.SetConsensusParams(app.DefaultInitialConsensusParams())
 
@@ -63,14 +63,14 @@ func MinorVersionCompatibility(logger *log.Logger) error {
 	logger.Println("Creating txsim")
 	endpoints, err := testNet.RemoteGRPCEndpoints()
 	testnet.NoError("failed to get remote gRPC endpoints", err)
-	err = testNet.CreateTxClient("txsim", testnet.TxsimVersion, 1, "100-2000", 100, testnet.DefaultResources, endpoints[0])
+	err = testNet.CreateTxClient(ctx, "txsim", testnet.TxsimVersion, 1, "100-2000", 100, testnet.DefaultResources, endpoints[0])
 	testnet.NoError("failed to create tx client", err)
 
 	// start the testnet
 	logger.Println("Setting up testnet")
 	testnet.NoError("Failed to setup testnet", testNet.Setup())
 	logger.Println("Starting testnet")
-	testnet.NoError("Failed to start testnet", testNet.Start())
+	testnet.NoError("Failed to start testnet", testNet.Start(ctx))
 
 	for i := 0; i < len(versions)*2; i++ {
 		// FIXME: skip the first node because we need them available to

--- a/test/e2e/simple.go
+++ b/test/e2e/simple.go
@@ -20,13 +20,16 @@ func E2ESimple(logger *log.Logger) error {
 
 	logger.Println("Running simple e2e test", "version", latestVersion)
 
-	testNet, err := testnet.New("E2ESimple", seed, nil, "test")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	testNet, err := testnet.New(ctx, "E2ESimple", seed, nil, "test")
 	testnet.NoError("failed to create testnet", err)
 
 	defer testNet.Cleanup()
 
 	logger.Println("Creating testnet validators")
-	testnet.NoError("failed to create genesis nodes", testNet.CreateGenesisNodes(4, latestVersion, 10000000, 0, testnet.DefaultResources))
+	testnet.NoError("failed to create genesis nodes", testNet.CreateGenesisNodes(ctx, 4, latestVersion, 10000000, 0, testnet.DefaultResources))
 
 	logger.Println("Creating txsim")
 	endpoints, err := testNet.RemoteGRPCEndpoints()

--- a/test/e2e/simple.go
+++ b/test/e2e/simple.go
@@ -26,7 +26,7 @@ func E2ESimple(logger *log.Logger) error {
 	testNet, err := testnet.New(ctx, "E2ESimple", seed, nil, "test")
 	testnet.NoError("failed to create testnet", err)
 
-	defer testNet.Cleanup()
+	defer testNet.Cleanup(ctx)
 
 	logger.Println("Creating testnet validators")
 	testnet.NoError("failed to create genesis nodes", testNet.CreateGenesisNodes(ctx, 4, latestVersion, 10000000, 0, testnet.DefaultResources))
@@ -34,7 +34,7 @@ func E2ESimple(logger *log.Logger) error {
 	logger.Println("Creating txsim")
 	endpoints, err := testNet.RemoteGRPCEndpoints()
 	testnet.NoError("failed to get remote gRPC endpoints", err)
-	err = testNet.CreateTxClient("txsim", testnet.TxsimVersion, 10,
+	err = testNet.CreateTxClient(ctx, "txsim", testnet.TxsimVersion, 10,
 		"100-2000", 100, testnet.DefaultResources, endpoints[0])
 	testnet.NoError("failed to create tx client", err)
 
@@ -42,7 +42,7 @@ func E2ESimple(logger *log.Logger) error {
 	testnet.NoError("failed to setup testnets", testNet.Setup())
 
 	logger.Println("Starting testnets")
-	testnet.NoError("failed to start testnets", testNet.Start())
+	testnet.NoError("failed to start testnets", testNet.Start(ctx))
 
 	logger.Println("Waiting for 30 seconds to produce blocks")
 	time.Sleep(30 * time.Second)

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck
 package testnet
 
 import (
@@ -92,6 +91,7 @@ type Resources struct {
 }
 
 func NewNode(
+	ctx context.Context,
 	name, version string,
 	startHeight, selfDelegation int64,
 	peers []string,
@@ -100,7 +100,6 @@ func NewNode(
 	resources Resources,
 	grafana *GrafanaInfo,
 ) (*Node, error) {
-	ctx := context.Background()
 	k, err := knuu.New(ctx)
 	if err != nil {
 		return nil, err
@@ -129,7 +128,7 @@ func NewNode(
 
 	if grafana != nil {
 		// add support for metrics
-		if err := instance.SetPrometheusEndpoint(prometheusPort, fmt.Sprintf("knuu-%s", knuu.Scope()), "1m"); err != nil {
+		if err := instance.SetPrometheusEndpoint(prometheusPort, fmt.Sprintf("knuu-%s", k.Scope()), "1m"); err != nil {
 			return nil, fmt.Errorf("setting prometheus endpoint: %w", err)
 		}
 		if err := instance.SetJaegerEndpoint(14250, 6831, 14268); err != nil {

--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck
 package testnet
 
 import (
@@ -26,14 +25,13 @@ type Testnet struct {
 	keygen    *keyGenerator
 	grafana   *GrafanaInfo
 	txClients []*TxSim
+	knuu      *knuu.Knuu
 }
 
-func New(name string, seed int64, grafana *GrafanaInfo, chainID string,
-	genesisModifiers ...genesis.Modifier) (
-	*Testnet, error,
-) {
+func New(ctx context.Context, name string, seed int64, grafana *GrafanaInfo, chainID string, genesisModifiers ...genesis.Modifier) (*Testnet, error) {
 	identifier := fmt.Sprintf("%s_%s", name, time.Now().Format("20060102_150405"))
-	if err := knuu.InitializeWithScope(identifier); err != nil {
+	k, err := knuu.New(ctx, knuu.WithTestScope(identifier))
+	if err != nil {
 		return nil, err
 	}
 
@@ -43,6 +41,7 @@ func New(name string, seed int64, grafana *GrafanaInfo, chainID string,
 		genesis: genesis.NewDefaultGenesis().WithChainID(chainID).WithModifiers(genesisModifiers...),
 		keygen:  newKeyGenerator(seed),
 		grafana: grafana,
+		knuu:    k,
 	}, nil
 }
 
@@ -54,12 +53,10 @@ func (t *Testnet) SetConsensusMaxBlockSize(size int64) {
 	t.genesis.ConsensusParams.Block.MaxBytes = size
 }
 
-func (t *Testnet) CreateGenesisNode(version string, selfDelegation, upgradeHeight int64, resources Resources) error {
+func (t *Testnet) CreateGenesisNode(ctx context.Context, version string, selfDelegation, upgradeHeight int64, resources Resources) error {
 	signerKey := t.keygen.Generate(ed25519Type)
 	networkKey := t.keygen.Generate(ed25519Type)
-	node, err := NewNode(fmt.Sprintf("val%d", len(t.nodes)), version, 0,
-		selfDelegation, nil, signerKey, networkKey, upgradeHeight, resources,
-		t.grafana)
+	node, err := NewNode(ctx, fmt.Sprintf("val%d", len(t.nodes)), version, 0, selfDelegation, nil, signerKey, networkKey, upgradeHeight, resources, t.grafana)
 	if err != nil {
 		return err
 	}
@@ -70,9 +67,9 @@ func (t *Testnet) CreateGenesisNode(version string, selfDelegation, upgradeHeigh
 	return nil
 }
 
-func (t *Testnet) CreateGenesisNodes(num int, version string, selfDelegation, upgradeHeight int64, resources Resources) error {
+func (t *Testnet) CreateGenesisNodes(ctx context.Context, num int, version string, selfDelegation, upgradeHeight int64, resources Resources) error {
 	for i := 0; i < num; i++ {
-		if err := t.CreateGenesisNode(version, selfDelegation, upgradeHeight, resources); err != nil {
+		if err := t.CreateGenesisNode(ctx, version, selfDelegation, upgradeHeight, resources); err != nil {
 			return err
 		}
 	}
@@ -232,10 +229,10 @@ func (t *Testnet) CreateAccount(name string, tokens int64, txsimKeyringDir strin
 	return kr, nil
 }
 
-func (t *Testnet) CreateNode(version string, startHeight, upgradeHeight int64, resources Resources) error {
+func (t *Testnet) CreateNode(ctx context.Context, version string, startHeight, upgradeHeight int64, resources Resources) error {
 	signerKey := t.keygen.Generate(ed25519Type)
 	networkKey := t.keygen.Generate(ed25519Type)
-	node, err := NewNode(fmt.Sprintf("val%d", len(t.nodes)), version,
+	node, err := NewNode(ctx, fmt.Sprintf("val%d", len(t.nodes)), version,
 		startHeight, 0, nil, signerKey, networkKey, upgradeHeight, resources,
 		t.grafana)
 	if err != nil {

--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -417,7 +417,7 @@ func (t *Testnet) Cleanup() {
 	}
 	// cleanup nodes
 	for _, node := range t.nodes {
-		err := node.Instance.Destroy()
+		err := node.Instance.Destroy(context.Background())
 		if err != nil {
 			log.Err(err).
 				Str("name", node.Name).

--- a/test/e2e/testnet/txsimNode.go
+++ b/test/e2e/testnet/txsimNode.go
@@ -1,4 +1,3 @@
-//nolint:staticcheck
 package testnet
 
 import (

--- a/test/e2e/testnet/txsimNode.go
+++ b/test/e2e/testnet/txsimNode.go
@@ -1,8 +1,10 @@
 package testnet
 
 import (
+	"context"
 	"fmt"
 
+	"github.com/celestiaorg/knuu/pkg/instance"
 	"github.com/celestiaorg/knuu/pkg/knuu"
 	"github.com/rs/zerolog/log"
 )
@@ -17,10 +19,11 @@ func txsimDockerImageName(version string) string {
 
 type TxSim struct {
 	Name     string
-	Instance *knuu.Instance
+	Instance *instance.Instance
 }
 
 func CreateTxClient(
+	ctx context.Context,
 	name, version string,
 	endpoint string,
 	seed int64,
@@ -31,7 +34,11 @@ func CreateTxClient(
 	resources Resources,
 	volumePath string,
 ) (*TxSim, error) {
-	instance, err := knuu.NewInstance(name)
+	k, err := knuu.New(ctx)
+	if err != nil {
+		return nil, err
+	}
+	instance, err := k.NewInstance(name)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +47,7 @@ func CreateTxClient(
 		Str("name", name).
 		Str("image", image).
 		Msg("setting image for tx client")
-	err = instance.SetImage(image)
+	err = instance.SetImage(ctx, image)
 	if err != nil {
 		log.Err(err).
 			Str("name", name).


### PR DESCRIPTION
Attempts to address https://github.com/celestiaorg/celestia-app/issues/3779 by replacing usage of [deprecated](https://github.com/celestiaorg/knuu/blob/32b98ab58d4bd3b3141d95884f963d5da3167af2/pkg/knuu/instance_old.go#L260-L263) Knuu methods with their [non-deprecated](https://github.com/celestiaorg/knuu/blob/32b98ab58d4bd3b3141d95884f963d5da3167af2/pkg/instance/instance.go#L997-L1000) versions. Enables staticcheck in the e2e package so that linters can inform us if deprecated methods are used.

cc: @smuu for awareness