### PR TITLE
ci: fix goreleaser check deprecation warning

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -108,7 +108,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3793 by resolving this [deprecation notice](https://goreleaser.com/deprecations/#snapshotname_template)