### PR TITLE
chore: remove make test-interchain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -163,13 +163,6 @@ test-fuzz:
 	bash -x scripts/test_fuzz.sh
 .PHONY: test-fuzz
 
-## test-interchain: Run interchain tests in verbose mode. Requires Docker.
-test-interchain:
-	@echo "Reminder: this test uses the latest celestia-app Docker image. If you would like to test recent code changes, re-build the Docker image by running: make build-docker"
-	@echo "--> Running interchain tests"
-	@cd ./test/interchain && go test . -v
-.PHONY: test-interchain
-
 ## txsim-install: Install the tx simulator.
 txsim-install:
 	@echo "--> Installing tx simulator"


### PR DESCRIPTION
I forgot to remove this Makefile target in https://github.com/celestiaorg/celestia-app/pull/3776