### PR TITLE
ci(goreleaser): fix release candidate suffix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -118,4 +118,5 @@ changelog:
 release:
   prerelease: auto
 git:
-  prerelease_suffix: "-rc*"
+  prerelease_suffix: "-"
+  tag_sort: semver

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -118,5 +118,5 @@ changelog:
 release:
   prerelease: auto
 git:
-  prerelease_suffix: "-"
+  prerelease_suffix: "-rc"
   tag_sort: semver

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,4 +119,3 @@ release:
   prerelease: auto
 git:
   prerelease_suffix: "-rc"
-  tag_sort: -version:refname

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -119,4 +119,4 @@ release:
   prerelease: auto
 git:
   prerelease_suffix: "-rc"
-  tag_sort: semver
+  tag_sort: -version:refname

--- a/docs/maintainers/prebuilt-binaries.md
+++ b/docs/maintainers/prebuilt-binaries.md
@@ -1,0 +1,49 @@
+# Prebuilt binaries
+
+Prebuilt binaries are attached to each release via [GoReleaser](https://goreleaser.com/) which runs in Github Actions. If GoReleaser failed to attach prebuilt binaries, you may want to attach them manually by following the steps below.
+
+## Prerequisites
+
+1. Create a Github token (classic) that has `repo:public_repo` scope via: <https://github.com/settings/tokens/new>
+
+    ```shell
+    export GORELEASER_ACCESS_TOKEN=<your-github-token>
+    echo "GITHUB_TOKEN=${GORELEASER_ACCESS_TOKEN}" >> .release-env
+    ```
+
+## Steps
+
+1. [Optional] If you need to make any code changes to fix the issue that occured when CI tried to generate and attach the prebuilt binaries, then you likely need to skip validation when running GoReleaser locally. To skip validation, modify the Makefile command like so:
+
+    ```diff
+    ## prebuilt-binary: Create prebuilt binaries and attach them to GitHub release. Requires Docker.
+    prebuilt-binary:
+        @if [ ! -f ".release-env" ]; then \
+            echo "A .release-env file was not found but is required to create prebuilt binaries. This command is expected to be run in CI where a .release-env file exists. If you need to run this command locally to attach binaries to a release, you need to create a .release-env file with a Github token (classic) that has repo:public_repo scope."; \
+            exit 1;\
+        fi
+        docker run \
+            --rm \
+            -e CGO_ENABLED=1 \
+            --env-file .release-env \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v `pwd`:/go/src/$(PACKAGE_NAME) \
+            -w /go/src/$(PACKAGE_NAME) \
+            ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+    -       release --clean
+    +       release --clean --skip=validate
+    .PHONY: prebuilt-binary
+    ```
+
+1. Before proceeding, test your change by running `make prebuilt-binary` and verifying that prebuilt binaries are attached to a release on your Github fork.
+1. Modify `.goreleaser.yaml` so that you can upload assets to the main repository:
+
+    ```diff
+    release:
+    +  github:
+    +    owner: celestiaorg
+    +    name: celestia-app
+    ```
+
+1. Run `make prebuilt-binary` to generate and attach the prebuilt binaries.
+1. Verify the assets were attached to the release on the main repository.


### PR DESCRIPTION
Prevents https://github.com/celestiaorg/celestia-app/issues/3819 from happening again. Also adds a document so other maintainers can generate + upload prebuilt binaries if they don't work again in the future.

The current `-rc*` [prerelease_suffix](https://goreleaser.com/customization/git/#git) was not working because goreleaser treated v2.1.2-rc1 as more recent than v2.1.2 in the [failing workflow](https://github.com/celestiaorg/celestia-app/actions/runs/10523365886/job/29157983992#step:6:68). This resolves by removing the `*`.

## Testing

1. Worked on my fork: https://github.com/rootulp/celestia-app/releases/tag/v2.1.2
2. Worked on this repo: https://github.com/celestiaorg/celestia-app/releases/tag/v2.1.2

### Before

```
    • git state                                      commit=48173df3dc78f9348eedb3796f29ef9e9e5dc584 branch=HEAD current_tag=v2.1.2-rc1 previous_tag=v2.1.2-rc0 dirty=true
```
### After

```
    • git state                                      commit=48173df3dc78f9348eedb3796f29ef9e9e5dc584 branch=HEAD current_tag=v2.1.2 previous_tag=v2.1.2-rc0 dirty=true
```

It is curious that it thinks the previous tag is v2.1.2-rc0 and not v2.1.2-rc1 but I couldn't fix with various [tag_sort](https://goreleaser.com/customization/git/?h=tag_sort#git) options. I think this only impacts Goreleaser changelog generation which we don't use b/c we use Github's auto generate release notes feature.