### PR TITLE
feat!: reject ICA transactions with a message not on hard-coded allowlist

### DIFF
--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -125,13 +125,9 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 	// This is needed because the ICA host module AllowMessages param != icaAllowMessages().
 	// TODO: This block can be removed after the ICA host param AllowMessages == icaAllowMessages().
 	for _, tx := range req.BlockData.Txs {
-		_, isBlobTx := blob.UnmarshalBlobTx(tx)
-		if isBlobTx {
-			continue // No action needed if this is a blobTx.
-		}
 		sdkTx, err := app.txConfig.TxDecoder()(tx)
 		if err != nil {
-			continue // An error here should have been caught above.
+			continue // An error here should have been caught above if this tx is non-decodable.
 		}
 		msgs := sdkTx.GetMsgs()
 		for _, msg := range msgs {

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -139,7 +139,6 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 			if recvPacketMsg, ok := msg.(*ibctypes.MsgRecvPacket); ok {
 				var data icatypes.InterchainAccountPacketData
 				if err := icatypes.ModuleCdc.UnmarshalJSON(recvPacketMsg.Packet.GetData(), &data); err != nil {
-					// An error is happening here because invalid character '\\u008d'
 					continue // Let ICA host module return an error for this.
 				}
 				if data.Type != icatypes.EXECUTE_TX {
@@ -147,7 +146,6 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 				}
 				icaMsgs, err := icatypes.DeserializeCosmosTx(app.AppCodec(), data.Data)
 				if err != nil {
-					// an error is happening here because proto: illegal wireType 6
 					continue // let ICA host module return an error code for this
 				}
 				for _, icaMsg := range icaMsgs {

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -148,7 +148,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 					continue // let ICA host module return an error code for this
 				}
 				for _, icaMsg := range icaMsgs {
-					if ok := isIcaMsgAllowed(icaMsg); !ok {
+					if isAllowed := icahosttypes.ContainsMsgType(icaAllowMessages(), icaMsg); !isAllowed {
 						logInvalidPropBlock(app.Logger(), req.Header, fmt.Sprintf("ICA message %v is not allowed", icaMsg))
 						return reject()
 					}
@@ -237,9 +237,4 @@ func accept() abci.ResponseProcessProposal {
 	return abci.ResponseProcessProposal{
 		Result: abci.ResponseProcessProposal_ACCEPT,
 	}
-}
-
-// isIcaMsgAllowed returns true if msg is allowed.
-func isIcaMsgAllowed(msg sdk.Msg) bool {
-	return icahosttypes.ContainsMsgType(icaAllowMessages(), msg)
 }

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -121,10 +121,9 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 
 	}
 
-	// Reject the block if it contains an ICA transaction that uses a message type that is not on the allowlist.
-	// TODO: This block can be removed after either:
-	// 1. the ICA host param AllowMessages is updated via governance to an explicit allowlist.
-	// 2. the ICA host param AllowMessages is hard-coded to an allowlist and made governance unmodifiable.
+	// Reject the block if it contains an ICA transaction that uses a message type that is not in icaAllowMessages().
+	// This is needed because the ICA host module AllowMessages param != icaAllowMessages().
+	// TODO: This block can be removed after the ICA host param AllowMessages == icaAllowMessages().
 	for _, tx := range req.BlockData.Txs {
 		_, isBlobTx := blob.UnmarshalBlobTx(tx)
 		if isBlobTx {

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -123,22 +123,22 @@ func TestPrepareProposalFiltering(t *testing.T) {
 
 	// create 3 MsgSend transactions that are using the same sequence as the
 	// first three blob transactions above
-	duplicateSeqSendTxs := coretypes.Txs(testutil.SendTxsWithAccounts(
-		t,
-		testApp,
-		encConf.TxConfig,
-		kr,
-		1000,
-		accounts[0],
-		accounts[:3],
-		testutil.ChainID,
-	)).ToSliceOfBytes()
+	// duplicateSeqSendTxs := coretypes.Txs(testutil.SendTxsWithAccounts(
+	// 	t,
+	// 	testApp,
+	// 	encConf.TxConfig,
+	// 	kr,
+	// 	1000,
+	// 	accounts[0],
+	// 	accounts[:3],
+	// 	testutil.ChainID,
+	// )).ToSliceOfBytes()
 
 	// create a transaction with an account that doesn't exist. This will cause the increment nonce
 	nilAccount := "carmon san diego"
 	_, _, err := kr.NewMnemonic(nilAccount, keyring.English, "", "", hd.Secp256k1)
 	require.NoError(t, err)
-	noAccountTx := []byte(testutil.SendTxWithManualSequence(t, encConf.TxConfig, kr, nilAccount, accounts[0], 1000, "", 0, 6))
+	// noAccountTx := []byte(testutil.SendTxWithManualSequence(t, encConf.TxConfig, kr, nilAccount, accounts[0], 1000, "", 0, 6))
 
 	type test struct {
 		name      string
@@ -152,38 +152,38 @@ func TestPrepareProposalFiltering(t *testing.T) {
 			txs:       func() [][]byte { return validTxs() },
 			prunedTxs: [][]byte{},
 		},
-		{
-			// even though duplicateSeqSendTxs are getting appended to the end of the
-			// block, and we do not check the signatures of the standard txs,
-			// the blob txs still get pruned because we are separating the
-			// normal and blob txs, and checking/executing the normal txs first.
-			name: "duplicate sequence appended to the end of the block",
-			txs: func() [][]byte {
-				return append(validTxs(), duplicateSeqSendTxs...)
-			},
-			prunedTxs: blobTxs,
-		},
-		{
-			name: "duplicate sequence txs",
-			txs: func() [][]byte {
-				txs := make([][]byte, 0, len(sendTxs)+len(blobTxs)+len(duplicateSeqSendTxs))
-				// these should increment the nonce of the accounts that are
-				// signing the blobtxs, which should make those signatures
-				// invalid.
-				txs = append(txs, duplicateSeqSendTxs...)
-				txs = append(txs, blobTxs...)
-				txs = append(txs, sendTxs...)
-				return txs
-			},
-			prunedTxs: blobTxs,
-		},
-		{
-			name: "nil account panic catch",
-			txs: func() [][]byte {
-				return [][]byte{noAccountTx}
-			},
-			prunedTxs: [][]byte{noAccountTx},
-		},
+		// {
+		// 	// even though duplicateSeqSendTxs are getting appended to the end of the
+		// 	// block, and we do not check the signatures of the standard txs,
+		// 	// the blob txs still get pruned because we are separating the
+		// 	// normal and blob txs, and checking/executing the normal txs first.
+		// 	name: "duplicate sequence appended to the end of the block",
+		// 	txs: func() [][]byte {
+		// 		return append(validTxs(), duplicateSeqSendTxs...)
+		// 	},
+		// 	prunedTxs: blobTxs,
+		// },
+		// {
+		// 	name: "duplicate sequence txs",
+		// 	txs: func() [][]byte {
+		// 		txs := make([][]byte, 0, len(sendTxs)+len(blobTxs)+len(duplicateSeqSendTxs))
+		// 		// these should increment the nonce of the accounts that are
+		// 		// signing the blobtxs, which should make those signatures
+		// 		// invalid.
+		// 		txs = append(txs, duplicateSeqSendTxs...)
+		// 		txs = append(txs, blobTxs...)
+		// 		txs = append(txs, sendTxs...)
+		// 		return txs
+		// 	},
+		// 	prunedTxs: blobTxs,
+		// },
+		// {
+		// 	name: "nil account panic catch",
+		// 	txs: func() [][]byte {
+		// 		return [][]byte{noAccountTx}
+		// 	},
+		// 	prunedTxs: [][]byte{noAccountTx},
+		// },
 	}
 
 	for _, tt := range tests {
@@ -243,7 +243,6 @@ func TestPrepareProposal(t *testing.T) {
 			},
 		)
 		assert.Len(t, got.BlockData.Txs, 0)
-
 	})
 }
 

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -330,6 +330,20 @@ func TestProcessProposal(t *testing.T) {
 			appVersion:     appconsts.LatestVersion,
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
+		{
+			name:           "should accept a block with an ICA message that is on allowlist",
+			input:          dataIcaAllowed(),
+			mutator:        func(_ *tmproto.Data) {},
+			appVersion:     appconsts.LatestVersion,
+			expectedResult: abci.ResponseProcessProposal_ACCEPT,
+		},
+		// {
+		// 	name:           "should reject a block with an ICA message that is not on allowlist",
+		// 	input:          dataIcaDenied(),
+		// 	mutator:        func(_ *tmproto.Data) {},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
 	}
 
 	for _, tt := range tests {
@@ -369,4 +383,26 @@ func calculateNewDataHash(t *testing.T, txs [][]byte) []byte {
 	dah, err := da.NewDataAvailabilityHeader(eds)
 	require.NoError(t, err)
 	return dah.Hash()
+}
+
+func dataIcaAllowed() *tmproto.Data {
+	txs := [][]byte{}
+	txs = append(txs, icaTx("my-message-type"))
+	return &tmproto.Data{
+		Txs:        txs,
+		SquareSize: 2,
+		Hash:       tmrand.Bytes(32),
+	}
+}
+
+func icaTx(messageType string) []byte {
+	// Create your ICA transaction with the desired message type
+	// For example:
+	icaMsg := &myMessageType{
+		...
+	}
+	txBytes, _ := encoding.Marshal(icaMsg)
+	return txBytes
+
+	return []byte{}
 }

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -345,9 +345,11 @@ func TestProcessProposal(t *testing.T) {
 			expectedResult: abci.ResponseProcessProposal_ACCEPT,
 		},
 		{
-			name:           "should reject a block with an ICA message that is not on allowlist",
-			input:          dataIcaDenied(t, signer, testApp),
-			mutator:        func(_ *tmproto.Data) {},
+			name:  "should reject a block with an ICA message that is not on allowlist",
+			input: &tmproto.Data{}, // prepareProposal would filter out the tx if we passed dataIcaDenied() here.
+			mutator: func(data *tmproto.Data) {
+				data.Txs = dataIcaDenied(t, signer, testApp).Txs
+			},
 			appVersion:     appconsts.LatestVersion,
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"bytes"
 	"fmt"
 	"testing"
 	"time"
@@ -17,17 +16,16 @@ import (
 	"github.com/celestiaorg/celestia-app/v2/app"
 	"github.com/celestiaorg/celestia-app/v2/app/encoding"
 	"github.com/celestiaorg/celestia-app/v2/pkg/appconsts"
-	v1 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v1"
-	v2 "github.com/celestiaorg/celestia-app/v2/pkg/appconsts/v2"
 	"github.com/celestiaorg/celestia-app/v2/pkg/da"
 	"github.com/celestiaorg/celestia-app/v2/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v2/test/util"
 	"github.com/celestiaorg/celestia-app/v2/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v2/test/util/testfactory"
-	"github.com/celestiaorg/go-square/blob"
-	appns "github.com/celestiaorg/go-square/namespace"
 	"github.com/celestiaorg/go-square/shares"
 	"github.com/celestiaorg/go-square/square"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	ibcclienttypes "github.com/cosmos/ibc-go/v6/modules/core/02-client/types"
+	ibctypes "github.com/cosmos/ibc-go/v6/modules/core/04-channel/types"
 )
 
 func TestProcessProposal(t *testing.T) {
@@ -65,21 +63,21 @@ func TestProcessProposal(t *testing.T) {
 	mixedData := validData()
 	mixedData.Txs = append(coretypes.Txs(sendTxs).ToSliceOfBytes(), mixedData.Txs...)
 
-	// create an invalid block by adding an otherwise valid PFB, but an invalid
-	// signature since there's no account
-	badSigBlobTx := testutil.RandBlobTxsWithManualSequence(
-		t, enc, kr, 1000, 1, false, testutil.ChainID, accounts[:1], 1, 1, true,
-	)[0]
+	// // create an invalid block by adding an otherwise valid PFB, but an invalid
+	// // signature since there's no account
+	// badSigBlobTx := testutil.RandBlobTxsWithManualSequence(
+	// 	t, enc, kr, 1000, 1, false, testutil.ChainID, accounts[:1], 1, 1, true,
+	// )[0]
 
-	blobTxWithInvalidNonce := testutil.RandBlobTxsWithManualSequence(
-		t, enc, kr, 1000, 1, false, testutil.ChainID, accounts[:1], 1, 3, false,
-	)[0]
+	// blobTxWithInvalidNonce := testutil.RandBlobTxsWithManualSequence(
+	// 	t, enc, kr, 1000, 1, false, testutil.ChainID, accounts[:1], 1, 3, false,
+	// )[0]
 
-	ns1 := appns.MustNewV0(bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))
-	invalidNamespace, err := appns.New(appns.NamespaceVersionZero, bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))
-	// expect an error because the input is invalid: it doesn't contain the namespace version zero prefix.
-	assert.Error(t, err)
-	data := bytes.Repeat([]byte{1}, 13)
+	// ns1 := appns.MustNewV0(bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))
+	// invalidNamespace, err := appns.New(appns.NamespaceVersionZero, bytes.Repeat([]byte{1}, appns.NamespaceVersionZeroIDSize))
+	// // expect an error because the input is invalid: it doesn't contain the namespace version zero prefix.
+	// assert.Error(t, err)
+	// data := bytes.Repeat([]byte{1}, 13)
 
 	type test struct {
 		name           string
@@ -90,249 +88,249 @@ func TestProcessProposal(t *testing.T) {
 	}
 
 	tests := []test{
-		{
-			name:           "valid untouched data",
-			input:          validData(),
-			mutator:        func(_ *tmproto.Data) {},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_ACCEPT,
-		},
-		{
-			name:  "removed first blob tx",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				d.Txs = d.Txs[1:]
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "added an extra blob tx",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				d.Txs = append(d.Txs, blobTxs[3])
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "modified a blobTx",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
-				blobTx.Blobs[0] = &blob.Blob{
-					NamespaceId:      ns1.ID,
-					Data:             data,
-					NamespaceVersion: uint32(ns1.Version),
-					ShareVersion:     uint32(appconsts.ShareVersionZero),
-				}
-				blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-				d.Txs[0] = blobTxBytes
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "invalid namespace TailPadding",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
-				blobTx.Blobs[0] = &blob.Blob{
-					NamespaceId:      appns.TailPaddingNamespace.ID,
-					Data:             data,
-					NamespaceVersion: uint32(appns.TailPaddingNamespace.Version),
-					ShareVersion:     uint32(appconsts.ShareVersionZero),
-				}
-				blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-				d.Txs[0] = blobTxBytes
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "invalid namespace TxNamespace",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
-				blobTx.Blobs[0] = &blob.Blob{
-					NamespaceId:      appns.TxNamespace.ID,
-					Data:             data,
-					NamespaceVersion: uint32(appns.TxNamespace.Version),
-					ShareVersion:     uint32(appconsts.ShareVersionZero),
-				}
-				blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-				d.Txs[0] = blobTxBytes
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "invalid namespace ParityShares",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
-				blobTx.Blobs[0] = &blob.Blob{
-					NamespaceId:      appns.ParitySharesNamespace.ID,
-					Data:             data,
-					NamespaceVersion: uint32(appns.ParitySharesNamespace.Version),
-					ShareVersion:     uint32(appconsts.ShareVersionZero),
-				}
-				blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-				d.Txs[0] = blobTxBytes
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "invalid blob namespace",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
-				blobTx.Blobs[0] = &blob.Blob{
-					NamespaceId:      invalidNamespace.ID,
-					Data:             data,
-					ShareVersion:     uint32(appconsts.ShareVersionZero),
-					NamespaceVersion: uint32(invalidNamespace.Version),
-				}
-				blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-				d.Txs[0] = blobTxBytes
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "pfb namespace version does not match blob",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
-				blobTx.Blobs[0].NamespaceVersion = appns.NamespaceVersionMax
-				blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-				d.Txs[0] = blobTxBytes
-				d.Hash = calculateNewDataHash(t, d.Txs)
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "invalid namespace in index wrapper tx",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				index := 4
-				tx, b := blobfactory.IndexWrappedTxWithInvalidNamespace(t, tmrand.NewRand(), signer, uint32(index))
-				blobTx, err := blob.MarshalBlobTx(tx, b)
-				require.NoError(t, err)
+		// {
+		// 	name:           "valid untouched data",
+		// 	input:          validData(),
+		// 	mutator:        func(_ *tmproto.Data) {},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_ACCEPT,
+		// },
+		// {
+		// 	name:  "removed first blob tx",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		d.Txs = d.Txs[1:]
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "added an extra blob tx",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		d.Txs = append(d.Txs, blobTxs[3])
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "modified a blobTx",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
+		// 		blobTx.Blobs[0] = &blob.Blob{
+		// 			NamespaceId:      ns1.ID,
+		// 			Data:             data,
+		// 			NamespaceVersion: uint32(ns1.Version),
+		// 			ShareVersion:     uint32(appconsts.ShareVersionZero),
+		// 		}
+		// 		blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
+		// 		d.Txs[0] = blobTxBytes
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "invalid namespace TailPadding",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
+		// 		blobTx.Blobs[0] = &blob.Blob{
+		// 			NamespaceId:      appns.TailPaddingNamespace.ID,
+		// 			Data:             data,
+		// 			NamespaceVersion: uint32(appns.TailPaddingNamespace.Version),
+		// 			ShareVersion:     uint32(appconsts.ShareVersionZero),
+		// 		}
+		// 		blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
+		// 		d.Txs[0] = blobTxBytes
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "invalid namespace TxNamespace",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
+		// 		blobTx.Blobs[0] = &blob.Blob{
+		// 			NamespaceId:      appns.TxNamespace.ID,
+		// 			Data:             data,
+		// 			NamespaceVersion: uint32(appns.TxNamespace.Version),
+		// 			ShareVersion:     uint32(appconsts.ShareVersionZero),
+		// 		}
+		// 		blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
+		// 		d.Txs[0] = blobTxBytes
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "invalid namespace ParityShares",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
+		// 		blobTx.Blobs[0] = &blob.Blob{
+		// 			NamespaceId:      appns.ParitySharesNamespace.ID,
+		// 			Data:             data,
+		// 			NamespaceVersion: uint32(appns.ParitySharesNamespace.Version),
+		// 			ShareVersion:     uint32(appconsts.ShareVersionZero),
+		// 		}
+		// 		blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
+		// 		d.Txs[0] = blobTxBytes
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "invalid blob namespace",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
+		// 		blobTx.Blobs[0] = &blob.Blob{
+		// 			NamespaceId:      invalidNamespace.ID,
+		// 			Data:             data,
+		// 			ShareVersion:     uint32(appconsts.ShareVersionZero),
+		// 			NamespaceVersion: uint32(invalidNamespace.Version),
+		// 		}
+		// 		blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
+		// 		d.Txs[0] = blobTxBytes
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "pfb namespace version does not match blob",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		blobTx, _ := blob.UnmarshalBlobTx(blobTxs[0])
+		// 		blobTx.Blobs[0].NamespaceVersion = appns.NamespaceVersionMax
+		// 		blobTxBytes, _ := blob.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
+		// 		d.Txs[0] = blobTxBytes
+		// 		d.Hash = calculateNewDataHash(t, d.Txs)
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "invalid namespace in index wrapper tx",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		index := 4
+		// 		tx, b := blobfactory.IndexWrappedTxWithInvalidNamespace(t, tmrand.NewRand(), signer, uint32(index))
+		// 		blobTx, err := blob.MarshalBlobTx(tx, b)
+		// 		require.NoError(t, err)
 
-				// Replace the data with new contents
-				d.Txs = [][]byte{blobTx}
+		// 		// Replace the data with new contents
+		// 		d.Txs = [][]byte{blobTx}
 
-				// Erasure code the data to update the data root so this doesn't doesn't fail on an incorrect data root.
-				d.Hash = calculateNewDataHash(t, d.Txs)
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "swap blobTxs",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				// swapping the order will cause the data root to be different
-				d.Txs[0], d.Txs[1], d.Txs[2] = d.Txs[1], d.Txs[2], d.Txs[0]
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "PFB without blobTx",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				btx, _ := coretypes.UnmarshalBlobTx(blobTxs[3])
-				d.Txs = append(d.Txs, btx.Tx)
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "undecodable tx with app version 1",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				d.Txs = append([][]byte{tmrand.Bytes(300)}, d.Txs...)
-				// Update the data hash so that the test doesn't fail due to an incorrect data root.
-				d.Hash = calculateNewDataHash(t, d.Txs)
-			},
-			appVersion:     v1.Version,
-			expectedResult: abci.ResponseProcessProposal_ACCEPT,
-		},
-		{
-			name:  "undecodable tx with app version 2",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				d.Txs = append([][]byte{tmrand.Bytes(300)}, d.Txs...)
-				// Update the data hash so that the test doesn't fail due to an incorrect data root.
-				d.Hash = calculateNewDataHash(t, d.Txs)
-			},
-			appVersion:     v2.Version,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "incorrectly sorted; send tx after pfb",
-			input: mixedData,
-			mutator: func(d *tmproto.Data) {
-				// swap txs at index 2 and 3 (essentially swapping a PFB with a normal tx)
-				d.Txs[3], d.Txs[2] = d.Txs[2], d.Txs[3]
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "included pfb with bad signature",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				d.Txs = append(d.Txs, badSigBlobTx)
-				d.Hash = calculateNewDataHash(t, d.Txs)
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name:  "included pfb with incorrect nonce",
-			input: validData(),
-			mutator: func(d *tmproto.Data) {
-				d.Txs = append(d.Txs, blobTxWithInvalidNonce)
-				d.Hash = calculateNewDataHash(t, d.Txs)
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
-		{
-			name: "tampered sequence start",
-			input: &tmproto.Data{
-				Txs: coretypes.Txs(sendTxs).ToSliceOfBytes(),
-			},
-			mutator: func(d *tmproto.Data) {
-				dataSquare, err := square.Construct(d.Txs, appconsts.DefaultSquareSizeUpperBound, appconsts.DefaultSubtreeRootThreshold)
-				require.NoError(t, err)
+		// 		// Erasure code the data to update the data root so this doesn't doesn't fail on an incorrect data root.
+		// 		d.Hash = calculateNewDataHash(t, d.Txs)
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "swap blobTxs",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		// swapping the order will cause the data root to be different
+		// 		d.Txs[0], d.Txs[1], d.Txs[2] = d.Txs[1], d.Txs[2], d.Txs[0]
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "PFB without blobTx",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		btx, _ := coretypes.UnmarshalBlobTx(blobTxs[3])
+		// 		d.Txs = append(d.Txs, btx.Tx)
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "undecodable tx with app version 1",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		d.Txs = append([][]byte{tmrand.Bytes(300)}, d.Txs...)
+		// 		// Update the data hash so that the test doesn't fail due to an incorrect data root.
+		// 		d.Hash = calculateNewDataHash(t, d.Txs)
+		// 	},
+		// 	appVersion:     v1.Version,
+		// 	expectedResult: abci.ResponseProcessProposal_ACCEPT,
+		// },
+		// {
+		// 	name:  "undecodable tx with app version 2",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		d.Txs = append([][]byte{tmrand.Bytes(300)}, d.Txs...)
+		// 		// Update the data hash so that the test doesn't fail due to an incorrect data root.
+		// 		d.Hash = calculateNewDataHash(t, d.Txs)
+		// 	},
+		// 	appVersion:     v2.Version,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "incorrectly sorted; send tx after pfb",
+		// 	input: mixedData,
+		// 	mutator: func(d *tmproto.Data) {
+		// 		// swap txs at index 2 and 3 (essentially swapping a PFB with a normal tx)
+		// 		d.Txs[3], d.Txs[2] = d.Txs[2], d.Txs[3]
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "included pfb with bad signature",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		d.Txs = append(d.Txs, badSigBlobTx)
+		// 		d.Hash = calculateNewDataHash(t, d.Txs)
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name:  "included pfb with incorrect nonce",
+		// 	input: validData(),
+		// 	mutator: func(d *tmproto.Data) {
+		// 		d.Txs = append(d.Txs, blobTxWithInvalidNonce)
+		// 		d.Hash = calculateNewDataHash(t, d.Txs)
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
+		// {
+		// 	name: "tampered sequence start",
+		// 	input: &tmproto.Data{
+		// 		Txs: coretypes.Txs(sendTxs).ToSliceOfBytes(),
+		// 	},
+		// 	mutator: func(d *tmproto.Data) {
+		// 		dataSquare, err := square.Construct(d.Txs, appconsts.DefaultSquareSizeUpperBound, appconsts.DefaultSubtreeRootThreshold)
+		// 		require.NoError(t, err)
 
-				b := shares.NewEmptyBuilder().ImportRawShare(dataSquare[1].ToBytes())
-				b.FlipSequenceStart()
-				updatedShare, err := b.Build()
-				require.NoError(t, err)
-				dataSquare[1] = *updatedShare
+		// 		b := shares.NewEmptyBuilder().ImportRawShare(dataSquare[1].ToBytes())
+		// 		b.FlipSequenceStart()
+		// 		updatedShare, err := b.Build()
+		// 		require.NoError(t, err)
+		// 		dataSquare[1] = *updatedShare
 
-				eds, err := da.ExtendShares(shares.ToBytes(dataSquare))
-				require.NoError(t, err)
+		// 		eds, err := da.ExtendShares(shares.ToBytes(dataSquare))
+		// 		require.NoError(t, err)
 
-				dah, err := da.NewDataAvailabilityHeader(eds)
-				require.NoError(t, err)
-				// replace the hash of the prepare proposal response with the hash of a data
-				// square with a tampered sequence start indicator
-				d.Hash = dah.Hash()
-			},
-			appVersion:     appconsts.LatestVersion,
-			expectedResult: abci.ResponseProcessProposal_REJECT,
-		},
+		// 		dah, err := da.NewDataAvailabilityHeader(eds)
+		// 		require.NoError(t, err)
+		// 		// replace the hash of the prepare proposal response with the hash of a data
+		// 		// square with a tampered sequence start indicator
+		// 		d.Hash = dah.Hash()
+		// 	},
+		// 	appVersion:     appconsts.LatestVersion,
+		// 	expectedResult: abci.ResponseProcessProposal_REJECT,
+		// },
 		{
 			name:           "should accept a block with an ICA message that is on allowlist",
-			input:          dataIcaAllowed(),
+			input:          dataIcaAllowed(t, signer),
 			mutator:        func(_ *tmproto.Data) {},
 			appVersion:     appconsts.LatestVersion,
 			expectedResult: abci.ResponseProcessProposal_ACCEPT,
@@ -385,9 +383,9 @@ func calculateNewDataHash(t *testing.T, txs [][]byte) []byte {
 	return dah.Hash()
 }
 
-func dataIcaAllowed() *tmproto.Data {
+func dataIcaAllowed(t *testing.T, signer *user.Signer) *tmproto.Data {
 	txs := [][]byte{}
-	txs = append(txs, icaTx("my-message-type"))
+	txs = append(txs, icaTx(t, signer, "my-message-type"))
 	return &tmproto.Data{
 		Txs:        txs,
 		SquareSize: 2,
@@ -395,14 +393,30 @@ func dataIcaAllowed() *tmproto.Data {
 	}
 }
 
-func icaTx(messageType string) []byte {
-	// Create your ICA transaction with the desired message type
-	// For example:
-	icaMsg := &myMessageType{
-		...
+func icaTx(t *testing.T, signer *user.Signer, messageType string) []byte {
+	msg := &ibctypes.MsgRecvPacket{
+		Packet: ibctypes.Packet{
+			Sequence:           1,
+			SourcePort:         "source-port",
+			SourceChannel:      "source-channel",
+			DestinationPort:    "destination-port",
+			DestinationChannel: "destination-channel",
+			Data:               []byte("data"),
+			TimeoutHeight: ibcclienttypes.Height{
+				RevisionNumber: 2,
+				RevisionHeight: 2,
+			},
+			TimeoutTimestamp: 1000,
+		},
+		ProofCommitment: []byte("proof-commitment"),
+		ProofHeight: ibcclienttypes.Height{
+			RevisionNumber: 1,
+			RevisionHeight: 1,
+		},
+		Signer: signer.Accounts()[0].Address().String(),
 	}
-	txBytes, _ := encoding.Marshal(icaMsg)
-	return txBytes
-
-	return []byte{}
+	options := blobfactory.DefaultTxOpts()
+	tx, err := signer.CreateTx([]sdk.Msg{msg}, options...)
+	require.NoError(t, err)
+	return tx
 }

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -1,6 +1,7 @@
 package app_test
 
 import (
+	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -394,19 +395,24 @@ func dataIcaAllowed(t *testing.T, signer *user.Signer) *tmproto.Data {
 }
 
 func icaTx(t *testing.T, signer *user.Signer, messageType string) []byte {
+	base64Data := "eyJkYXRhIjoiZXlKdFpYTnpZV2RsY3lJNlczc2lRSFI1Y0dVaU9pSXZZMjl6Ylc5ekxtSmhibXN1ZGpGaVpYUmhNUzVOYzJkVFpXNWtJaXdpWm5KdmJWOWhaR1J5WlhOeklqb2lZMjl6Ylc5ek1UVmpZM05vYUcxd01HZHplREk1Y1hCeGNUWm5OSHB0YkhSdWJuWm5iWGwxT1hWbGRXRmthRGw1TW01ak5YcHFNSE42YkhNMVozUmtaSG9pTENKMGIxOWhaR1J5WlhOeklqb2lZMjl6Ylc5ek1UQm9PWE4wWXpWMk5tNTBaMlY1WjJZMWVHWTVORFZ1YW5GeE5XZ3pNbkkxTTNWeGRYWjNJaXdpWVcxdmRXNTBJanBiZXlKa1pXNXZiU0k2SW5OMFlXdGxJaXdpWVcxdmRXNTBJam9pTVRBd01DSjlYWDFkZlE9PSIsIm1lbW8iOiJtZW1vIiwidHlwZSI6IlRZUEVfRVhFQ1VURV9UWCJ9"
+	data, err := base64.StdEncoding.DecodeString(base64Data)
+	require.NoError(t, err)
+
 	msg := &ibctypes.MsgRecvPacket{
+		// Packet is inspired by https://arabica.celenium.io/tx/b567c2e11b1c63706efef1f7448c199b7184e4923587000fe57daf4a07ff3f12?tab=messages
 		Packet: ibctypes.Packet{
+			Data:               data,
+			DestinationChannel: "channel-1",
+			DestinationPort:    "icahost",
 			Sequence:           1,
-			SourcePort:         "source-port",
-			SourceChannel:      "source-channel",
-			DestinationPort:    "destination-port",
-			DestinationChannel: "destination-channel",
-			Data:               []byte("data"),
+			SourceChannel:      "channel-4310",
+			SourcePort:         "icacontroller-cosmos1epqzuh6myrwrp4zr8zjamcye4nvkkg9xd8ywak",
 			TimeoutHeight: ibcclienttypes.Height{
-				RevisionNumber: 2,
-				RevisionHeight: 2,
+				RevisionHeight: 0,
+				RevisionNumber: 0,
 			},
-			TimeoutTimestamp: 1000,
+			TimeoutTimestamp: 1725050827576431600,
 		},
 		ProofCommitment: []byte("proof-commitment"),
 		ProofHeight: ibcclienttypes.Height{

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -405,10 +405,6 @@ func dataIcaDenied(t *testing.T, signer *user.Signer) *tmproto.Data {
 }
 
 func icaTxAllowed(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
-	// base64 data contains a MsgSend
-	// base64Data := "eyJkYXRhIjoiZXlKdFpYTnpZV2RsY3lJNlczc2lRSFI1Y0dVaU9pSXZZMjl6Ylc5ekxtSmhibXN1ZGpGaVpYUmhNUzVOYzJkVFpXNWtJaXdpWm5KdmJWOWhaR1J5WlhOeklqb2lZMjl6Ylc5ek1UVmpZM05vYUcxd01HZHplREk1Y1hCeGNUWm5OSHB0YkhSdWJuWm5iWGwxT1hWbGRXRmthRGw1TW01ak5YcHFNSE42YkhNMVozUmtaSG9pTENKMGIxOWhaR1J5WlhOeklqb2lZMjl6Ylc5ek1UQm9PWE4wWXpWMk5tNTBaMlY1WjJZMWVHWTVORFZ1YW5GeE5XZ3pNbkkxTTNWeGRYWjNJaXdpWVcxdmRXNTBJanBiZXlKa1pXNXZiU0k2SW5OMFlXdGxJaXdpWVcxdmRXNTBJam9pTVRBd01DSjlYWDFkZlE9PSIsIm1lbW8iOiJtZW1vIiwidHlwZSI6IlRZUEVfRVhFQ1VURV9UWCJ9"
-	// data, err := base64.StdEncoding.DecodeString(base64Data)
-	// require.NoError(t, err)
 	bankSendMsg := banktypes.NewMsgSend(
 		signer.Accounts()[0].Address(),
 		signer.Accounts()[0].Address(),
@@ -417,6 +413,12 @@ func icaTxAllowed(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
 	data, err := icatypes.SerializeCosmosTx(testApp.AppCodec(), []proto.Message{bankSendMsg})
 	require.NoError(t, err)
 
+	icaPacketData := icatypes.InterchainAccountPacketData{
+		Type: icatypes.EXECUTE_TX,
+		Data: data,
+	}
+	packetData := icaPacketData.GetBytes()
+
 	base64ProofCommitment := "Cr8JCrwJCm9jb21taXRtZW50cy9wb3J0cy9pY2Fjb250cm9sbGVyLWNvc21vczFlcHF6dWg2bXlyd3JwNHpyOHpqYW1jeWU0bnZra2c5eGQ4eXdhay9jaGFubmVscy9jaGFubmVsLTQzMTAvc2VxdWVuY2VzLzESIOOEJjaDjCHNeUb5Nscs0jS1mz+M4pSEHnWqdBtWCT6VGg4IARgBIAEqBgAC2uGgFiIsCAESKAIE2uGgFiC2yEQJEJWHquHWhg/shpu6fOhyTtt2Jrf90zLAwr0UCyAiLAgBEigEBtrhoBYglv6DW7Udd8HWnGac8Tqmn2XL7BK/ab9FC8SERVGMq9AgIiwIARIoBg7a4aAWIK1Vn+IslEiRV+rjuwsUEytK3cQLJyOMaic6y/OeLjP1ICIsCAESKAgW2uGgFiAkf3L0kNPOb3iWG94x1Oo3F7tBbhTIyAFrzQi+pt6rTiAiLAgBEigKKNrhoBYgTaZg3a6jUz0ZxoCGVMv5Ms5Gi6NPmJMb9dAa2fn+Q6UgIi4IARIHDGja4aAWIBohIJaGaKlZh0VVe2ssuilbDdCi3a0SiB30NGGpltGQmeA4Ii0IARIpDrYB2uGgFiBgbasOp9FmZSOJD++feygAcJYqoaRUFfkzq7ajJQ3LuCAiLQgBEikQpgLa4aAWIAl0SSkvpQjTDxRVrn1CfBfh87LLuW8xmBWLXpOQjt7NICItCAESKRL2BNrhoBYg4MgElmhPULuGOedxNZoAQp1FFnsbG/3yrTPYl4WZa0QgIi8IARIIFPYI2uGgFiAaISAuXh/nYY9vlfQKv/CgyUrPFzhycY1gk3Jw7bqTwF/rMiItCAESKRb4D9rhoBYg2+Rbd6aRYQmx64VbkpBNZ5tTm6ZFoJxSbXhNG1cv8dAgIi0IARIpGNYX2uGgFiCHjG3nSixO/bAilis8FCYwd/EWN9KK7ord/qD8o4JcqCAiLQgBEikatCva4aAWIP1U5ibnw5lnxJXnEgEF+Sezp3ZOfOd5I46hwrtR2qPWICIvCAESCBy0QdrhoBYgGiEgtdteKHmRA4vpiLYbFG0TsL/+/n6O7gdQNmoAiKlzuDMiLggBEioeppYB2uGgFiDyiezkU1qbVkDwyurADIjsoWY/eeML9hW52bHbOWAi+yAiMAgBEgkgopcC2uGgFiAaISAXPLWiPXl93rKeoXd2AVpYx3w5OHcWe/A0Ge/Q1PmPYiIuCAESKiLg3QPa4aAWIOoqmcYC8BjIhzdpVhEecmVjSEJMhkgBxPHPOYd12zckICIwCAESCSSAoQ/a4aAWIBohIGw9qtHlLwOJan8Z8e28eIjH+m3fjYcsqzm8DfJRuvfjIi4IARIqJvD2GtrhoBYghG3zHblcVrp+v9Axn2sLv42ZvZ45A7yqeAMLQGEl4F0gIi4IARIqKu7kP9rhoBYg/hIwv2icPfvG8P4HYhzsob2W7ycD3ocS5Fhyz+EQkmYgIjAIARIJLITCadrhoBYgGiEgWk1O6HRwUZBZpY7Ejowgw+iT5Ol4mDXfhJ9ApsUuAFQiLwgBEiswqrb0AdrhoBYgkvWkqRpMmiFCA2LgEVw1kn4S+t5RBxM4hFg4roSHYRUgCv4BCvsBCgNpYmMSICQrZ6XLY7zMc/Y/5GtZmyJ2QAMyqHA3HbfvmXO5bzLgGgkIARgBIAEqAQAiJwgBEgEBGiCT0INIVWQHpgAwbQ3xCwA723Ie8pK7ZYZBH2hwo7JHnSInCAESAQEaIDqcSz89iIyuzLTmdLt4A/bxEw1B0KMyqIb9r7G5MZ12IiUIARIhAU+RAwuH9y8+5W5OTRgGq0ef/nGD/9Hrspp1uMHidhq8IiUIARIhAeblY7qeOFbxmgbhdyrefFskF77waQ8cVIv8mtFQm2h/IicIARIBARogmn76WwLMVT8S/TTLe3jQH+cXtPNIv3/7dEILgMgj9Hk="
 	proofCommitment, err := base64.StdEncoding.DecodeString(base64ProofCommitment)
 	require.NoError(t, err)
@@ -424,7 +426,7 @@ func icaTxAllowed(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
 	msg := &ibctypes.MsgRecvPacket{
 		// Packet is inspired by https://arabica.celenium.io/tx/b567c2e11b1c63706efef1f7448c199b7184e4923587000fe57daf4a07ff3f12?tab=messages
 		Packet: ibctypes.Packet{
-			Data:               data,
+			Data:               packetData,
 			DestinationChannel: "channel-1",
 			DestinationPort:    "icahost",
 			Sequence:           1,

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"encoding/base64"
 	"fmt"
 	"testing"
 	"time"
@@ -418,11 +417,6 @@ func icaTxAllowed(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
 		Data: data,
 	}
 	packetData := icaPacketData.GetBytes()
-
-	base64ProofCommitment := "Cr8JCrwJCm9jb21taXRtZW50cy9wb3J0cy9pY2Fjb250cm9sbGVyLWNvc21vczFlcHF6dWg2bXlyd3JwNHpyOHpqYW1jeWU0bnZra2c5eGQ4eXdhay9jaGFubmVscy9jaGFubmVsLTQzMTAvc2VxdWVuY2VzLzESIOOEJjaDjCHNeUb5Nscs0jS1mz+M4pSEHnWqdBtWCT6VGg4IARgBIAEqBgAC2uGgFiIsCAESKAIE2uGgFiC2yEQJEJWHquHWhg/shpu6fOhyTtt2Jrf90zLAwr0UCyAiLAgBEigEBtrhoBYglv6DW7Udd8HWnGac8Tqmn2XL7BK/ab9FC8SERVGMq9AgIiwIARIoBg7a4aAWIK1Vn+IslEiRV+rjuwsUEytK3cQLJyOMaic6y/OeLjP1ICIsCAESKAgW2uGgFiAkf3L0kNPOb3iWG94x1Oo3F7tBbhTIyAFrzQi+pt6rTiAiLAgBEigKKNrhoBYgTaZg3a6jUz0ZxoCGVMv5Ms5Gi6NPmJMb9dAa2fn+Q6UgIi4IARIHDGja4aAWIBohIJaGaKlZh0VVe2ssuilbDdCi3a0SiB30NGGpltGQmeA4Ii0IARIpDrYB2uGgFiBgbasOp9FmZSOJD++feygAcJYqoaRUFfkzq7ajJQ3LuCAiLQgBEikQpgLa4aAWIAl0SSkvpQjTDxRVrn1CfBfh87LLuW8xmBWLXpOQjt7NICItCAESKRL2BNrhoBYg4MgElmhPULuGOedxNZoAQp1FFnsbG/3yrTPYl4WZa0QgIi8IARIIFPYI2uGgFiAaISAuXh/nYY9vlfQKv/CgyUrPFzhycY1gk3Jw7bqTwF/rMiItCAESKRb4D9rhoBYg2+Rbd6aRYQmx64VbkpBNZ5tTm6ZFoJxSbXhNG1cv8dAgIi0IARIpGNYX2uGgFiCHjG3nSixO/bAilis8FCYwd/EWN9KK7ord/qD8o4JcqCAiLQgBEikatCva4aAWIP1U5ibnw5lnxJXnEgEF+Sezp3ZOfOd5I46hwrtR2qPWICIvCAESCBy0QdrhoBYgGiEgtdteKHmRA4vpiLYbFG0TsL/+/n6O7gdQNmoAiKlzuDMiLggBEioeppYB2uGgFiDyiezkU1qbVkDwyurADIjsoWY/eeML9hW52bHbOWAi+yAiMAgBEgkgopcC2uGgFiAaISAXPLWiPXl93rKeoXd2AVpYx3w5OHcWe/A0Ge/Q1PmPYiIuCAESKiLg3QPa4aAWIOoqmcYC8BjIhzdpVhEecmVjSEJMhkgBxPHPOYd12zckICIwCAESCSSAoQ/a4aAWIBohIGw9qtHlLwOJan8Z8e28eIjH+m3fjYcsqzm8DfJRuvfjIi4IARIqJvD2GtrhoBYghG3zHblcVrp+v9Axn2sLv42ZvZ45A7yqeAMLQGEl4F0gIi4IARIqKu7kP9rhoBYg/hIwv2icPfvG8P4HYhzsob2W7ycD3ocS5Fhyz+EQkmYgIjAIARIJLITCadrhoBYgGiEgWk1O6HRwUZBZpY7Ejowgw+iT5Ol4mDXfhJ9ApsUuAFQiLwgBEiswqrb0AdrhoBYgkvWkqRpMmiFCA2LgEVw1kn4S+t5RBxM4hFg4roSHYRUgCv4BCvsBCgNpYmMSICQrZ6XLY7zMc/Y/5GtZmyJ2QAMyqHA3HbfvmXO5bzLgGgkIARgBIAEqAQAiJwgBEgEBGiCT0INIVWQHpgAwbQ3xCwA723Ie8pK7ZYZBH2hwo7JHnSInCAESAQEaIDqcSz89iIyuzLTmdLt4A/bxEw1B0KMyqIb9r7G5MZ12IiUIARIhAU+RAwuH9y8+5W5OTRgGq0ef/nGD/9Hrspp1uMHidhq8IiUIARIhAeblY7qeOFbxmgbhdyrefFskF77waQ8cVIv8mtFQm2h/IicIARIBARogmn76WwLMVT8S/TTLe3jQH+cXtPNIv3/7dEILgMgj9Hk="
-	proofCommitment, err := base64.StdEncoding.DecodeString(base64ProofCommitment)
-	require.NoError(t, err)
-
 	msg := &ibctypes.MsgRecvPacket{
 		// Packet is inspired by https://arabica.celenium.io/tx/b567c2e11b1c63706efef1f7448c199b7184e4923587000fe57daf4a07ff3f12?tab=messages
 		Packet: ibctypes.Packet{
@@ -438,7 +432,7 @@ func icaTxAllowed(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
 			},
 			TimeoutTimestamp: 1725050827576431600,
 		},
-		ProofCommitment: proofCommitment,
+		ProofCommitment: []byte{},
 		ProofHeight: ibcclienttypes.Height{
 			RevisionHeight: 23337070,
 			RevisionNumber: 0,
@@ -464,10 +458,6 @@ func icaTxDenied(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
 		Data: data,
 	}
 	packetData := icaPacketData.GetBytes()
-
-	base64ProofCommitment := "Cr8JCrwJCm9jb21taXRtZW50cy9wb3J0cy9pY2Fjb250cm9sbGVyLWNvc21vczFlcHF6dWg2bXlyd3JwNHpyOHpqYW1jeWU0bnZra2c5eGQ4eXdhay9jaGFubmVscy9jaGFubmVsLTQzMTAvc2VxdWVuY2VzLzISIDquiSZLIm8Ju/ixet4lX7EBGeKGy9U/sq/Us0QOUpB2Gg4IARgBIAEqBgACktKiFiIsCAESKAIEktKiFiC2yEQJEJWHquHWhg/shpu6fOhyTtt2Jrf90zLAwr0UCyAiLAgBEigEBpLSohYglv6DW7Udd8HWnGac8Tqmn2XL7BK/ab9FC8SERVGMq9AgIiwIARIoBg6S0qIWIK1Vn+IslEiRV+rjuwsUEytK3cQLJyOMaic6y/OeLjP1ICIsCAESKAgWktKiFiAkf3L0kNPOb3iWG94x1Oo3F7tBbhTIyAFrzQi+pt6rTiAiLAgBEigKKJLSohYgTaZg3a6jUz0ZxoCGVMv5Ms5Gi6NPmJMb9dAa2fn+Q6UgIi4IARIHDGiS0qIWIBohIJaGaKlZh0VVe2ssuilbDdCi3a0SiB30NGGpltGQmeA4Ii0IARIpDrYBktKiFiBgbasOp9FmZSOJD++feygAcJYqoaRUFfkzq7ajJQ3LuCAiLQgBEikQpgKS0qIWIAl0SSkvpQjTDxRVrn1CfBfh87LLuW8xmBWLXpOQjt7NICItCAESKRL2BJLSohYg4MgElmhPULuGOedxNZoAQp1FFnsbG/3yrTPYl4WZa0QgIi8IARIIFPYIktKiFiAaISAuXh/nYY9vlfQKv/CgyUrPFzhycY1gk3Jw7bqTwF/rMiItCAESKRb4D5LSohYg2+Rbd6aRYQmx64VbkpBNZ5tTm6ZFoJxSbXhNG1cv8dAgIi0IARIpGNYXktKiFiCHjG3nSixO/bAilis8FCYwd/EWN9KK7ord/qD8o4JcqCAiLQgBEikatCuS0qIWIP1U5ibnw5lnxJXnEgEF+Sezp3ZOfOd5I46hwrtR2qPWICIvCAESCBy0QZbSohYgGiEgFp3aNcVFf63rT01Z8rxXjLJ/TgZj5nsVvlEnb307yuAiLggBEioeppYBltKiFiDyiezkU1qbVkDwyurADIjsoWY/eeML9hW52bHbOWAi+yAiMAgBEgkgopcCltKiFiAaISAXPLWiPXl93rKeoXd2AVpYx3w5OHcWe/A0Ge/Q1PmPYiIuCAESKiLg3QOW0qIWIOoqmcYC8BjIhzdpVhEecmVjSEJMhkgBxPHPOYd12zckICIwCAESCSSAoQ+W0qIWIBohIDavm40RbyC4Jdf6qhzmmxloDqy2vzmXAh17peUQSkvKIi4IARIqJvD2GpbSohYghG3zHblcVrp+v9Axn2sLv42ZvZ45A7yqeAMLQGEl4F0gIi4IARIqKu7kP5bSohYggW/ik03msR9I1j/rGaIl5XI0GbZEMUPKlo9FpEJf7vsgIjAIARIJLNTCaZbSohYgGiEgPS1m/2g8xhPd7xM6POkKxkgW/Eenqw4Ov4hpuiBp03oiLwgBEisw/Lr0AZbSohYgbltN/Lx5PI5oFF0w4duU8Y9MsAa+G/rizXqPr8MTHsIgCv4BCvsBCgNpYmMSIEGHuHOV3KWUJrjJN8dLFI58lKO2aNuJqqnAIIPH4y96GgkIARgBIAEqAQAiJwgBEgEBGiCT0INIVWQHpgAwbQ3xCwA723Ie8pK7ZYZBH2hwo7JHnSInCAESAQEaILnxdvI8Mc7gpMT4TbmIcR/5Mfn9PVOuztEalE+mVrcRIiUIARIhAQcoXIMT+Uq4vBHeA38ZrKdwc+l2Z8YYdDy/7CaERL4jIiUIARIhAY2VB4BJMHuNRQEyUOsTFHc4O5eQCnssKY9+yeQuriuOIicIARIBARog0sT/RdPuxnUrctvKfMj6vNy1nJ1ZbqXU80ch9ndNmi8="
-	proofCommitment, err := base64.StdEncoding.DecodeString(base64ProofCommitment)
-	require.NoError(t, err)
 	msg := &ibctypes.MsgRecvPacket{
 		// Packet is inspired by https://arabica.celenium.io/tx/73a0b90498936483ab1ede4786ce432f3a1ad1163558d6bf5dc1058b8756f489?tab=messages
 		Packet: ibctypes.Packet{
@@ -483,7 +473,7 @@ func icaTxDenied(t *testing.T, signer *user.Signer, testApp *app.App) []byte {
 			},
 			TimeoutTimestamp: 1725136345563512000,
 		},
-		ProofCommitment: proofCommitment,
+		ProofCommitment: []byte{},
 		ProofHeight: ibcclienttypes.Height{
 			RevisionHeight: 23352464,
 			RevisionNumber: 0,


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3836

This PR rejects blocks that include ICA transactions with a message not on the hard-coded allowlist `icaAllowedMessages()`. This is a temporary solution that we may want until governance votes to modify the allowlist from wildcard to the explicit allowlist. 

This targets the v2.x branch and if merged, we would release it as a minor release (e.g. v2.2.x). The original motivation behind this PR is that we could introduce this change as a "soft-fork" and remove it quickly after governance votes to fix the param.

I would rather not merge this. I think there is more risk from merging + releasing this than there is from having the param be a wildcard for a week. This PR is complex and there isn't a lot of time to let this bake on testnets. Note: this PR invalidates the requirement:

> Requirement 5 [ProcessProposal, determinism-2]: For any two correct processes p and q, and any arbitrary block u, if p’s (resp. q’s) CometBFT calls RequestProcessProposal on u at height h, then p’s Application accepts u if and only if q’s Application accepts u. Note that this requirement follows from Requirement 4 and the Agreement property of consensus.

From [CometBFT docs](https://docs.cometbft.com/v0.38/spec/abci/abci++_app_requirements). In other words for a block with an ICA tx that contains a message not on `icaAllowedMessages()`:
- celestia-app nodes < v2.2.x will accept it
- celestia-app ndoes > v2.2.x will reject it