### PR TITLE
ci: request reviews from all celestia-core members

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -12,7 +12,3 @@ options:
   ignored_keywords:
     - DO NOT REVIEW
   enable_group_assignment: false
-
-  # Randomly pick reviewers up to this number.
-  # Do not set this option if you'd like to assign all matching reviewers.
-  number_of_reviewers: 2


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3850

I'm not sure if this explicitly assigns all celestia-core members as reviewers or just the entire group. 