### PR TITLE
chore(scripts): mainnet v2 upgrade height

### DIFF
--- a/scripts/mainnet.sh
+++ b/scripts/mainnet.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# This script starts a consensus node on Mainnet Beta and state syncs to the tip
+# of the chain.
+
 # Stop script execution if an error is encountered
 set -o errexit
 # Stop script execution if an undefined variable is used
@@ -10,6 +13,7 @@ NODE_NAME="node-name"
 SEEDS="e6116822e1a5e283d8a85d3ec38f4d232274eaf3@consensus-full-seed-1.celestia-bootstrap.net:26656,cf7ac8b19ff56a9d47c75551bd4864883d1e24b5@consensus-full-seed-2.celestia-bootstrap.net:26656"
 CELESTIA_APP_HOME="${HOME}/.celestia-app"
 CELESTIA_APP_VERSION=$(celestia-appd version 2>&1)
+RPC="https://celestia-rpc.polkachu.com:443"
 
 echo "celestia-app home: ${CELESTIA_APP_HOME}"
 echo "celestia-app version: ${CELESTIA_APP_VERSION}"
@@ -35,10 +39,20 @@ celestia-appd init ${NODE_NAME} --chain-id ${CHAIN_ID} > /dev/null 2>&1 # Hide o
 echo "Settings seeds in config.toml..."
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $CELESTIA_APP_HOME/config/config.toml
 
+LATEST_HEIGHT=$(curl -s $RPC/block | jq -r .result.block.header.height);
+BLOCK_HEIGHT=$((LATEST_HEIGHT - 2000)); \
+TRUST_HASH=$(curl -s "$RPC/block?height=$BLOCK_HEIGHT" | jq -r .result.block_id.hash)
+
+echo "Block height: $BLOCK_HEIGHT"
+echo "Trust hash: $TRUST_HASH"
+echo "Enabling state sync in config.toml..."
+sed -i.bak -E "s|^(enable[[:space:]]+=[[:space:]]+).*$|\1true| ; \
+s|^(rpc_servers[[:space:]]+=[[:space:]]+).*$|\1\"$RPC,$RPC\"| ; \
+s|^(trust_height[[:space:]]+=[[:space:]]+).*$|\1$BLOCK_HEIGHT| ; \
+s|^(trust_hash[[:space:]]+=[[:space:]]+).*$|\1\"$TRUST_HASH\"|" $HOME/.celestia-app/config/config.toml
+
 echo "Downloading genesis file..."
 celestia-appd download-genesis ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
-echo "Starting celestia-appd in the background and piping logs to mainnet.log"
-nohup celestia-appd start > "${HOME}/mainnet.log" 2>&1 &
-
-echo "You can check the node's status via: celestia-appd status"
+echo "Starting celestia-appd..."
+celestia-appd start --v2-upgrade-height 2371495


### PR DESCRIPTION
Modify the mainnet.sh script to provide the `--v2-upgrade-height` and use state sync.
