### PR TITLE
chore: add a knuu getter

### DIFF
--- a/test/e2e/testnet/testnet.go
+++ b/test/e2e/testnet/testnet.go
@@ -57,6 +57,10 @@ func New(ctx context.Context, name string, seed int64, grafana *GrafanaInfo, cha
 	}, nil
 }
 
+func (t *Testnet) Knuu() *knuu.Knuu {
+	return t.knuu
+}
+
 func (t *Testnet) NewPreloader() (*preloader.Preloader, error) {
 	if t.knuu == nil {
 		return nil, errors.New("knuu is not initialized")


### PR DESCRIPTION
While attempting to use testnet pkg in the node repo. There is a need to use `knuu` object that is initialized by the `testnet.New()` to create new instances and interact with `knuu`. Since it is not exported, this PR proposed to have a getter func for it, so users can interact with knuu easily.