### PR TITLE
feat: build on network tags and manual dispatch

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -13,14 +13,22 @@ on:
       - "v[0-9]+.[0-9]+.[0-9]+-alpha.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-beta.[0-9]+"
       - "v[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-arabica"
+      - "v[0-9]+.[0-9]+.[0-9]+-mocha"
   pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "The checkout reference (ie tag, branch, sha)"
+        required: true
+        type: string
 
 jobs:
   docker-security-build:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.3
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.4
     with:
       dockerfile: Dockerfile
     secrets: inherit
@@ -29,7 +37,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.3
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.4.4
     with:
       dockerfile: docker/Dockerfile_txsim
       packageName: txsim


### PR DESCRIPTION
This PR add two features:

1. Allow docker to trigger on network specific tags.
2. This PR shows how to use the new input for the docker ci workflow added in celestiaorg/.github#112
This would allow triggering the docker workflow on a tag that (such as the new arabica and mocha tags) that didn't trigger the workflow originally.


Ref: 
- https://github.com/celestiaorg/celestia-node/pull/3765
- https://github.com/celestiaorg/celestia-node/pull/3766