### PR TITLE
fix(linter): replace loopvar linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@ run:
 
 linters:
   enable:
-    - exportloopref
+    - copyloopvar
     - gofumpt
     - misspell
     - nakedret


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->
Closes https://github.com/celestiaorg/celestia-app/issues/3918
## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
Replase loopvar linter in the .golangci.yml.

## TODO
Fix the lint error.
This [issue](https://github.com/celestiaorg/celestia-app/issues/3919) needs to address the lint errors. 

## Test

```shell
--> Running golangci-lint
x/mint/client/testutil/suite_test.go:71:3: The copy of the 'for' variable "tc" can be deleted (Go 1.22+) (copyloopvar)
                tc := tc
                ^
x/mint/client/testutil/suite_test.go:106:3: The copy of the 'for' variable "tc" can be deleted (Go 1.22+) (copyloopvar)
                tc := tc
                ^
x/mint/client/testutil/suite_test.go:137:3: The copy of the 'for' variable "tc" can be deleted (Go 1.22+) (copyloopvar)
                tc := tc
                ^
x/blobstream/keeper/keeper_data_commitment.go:112:78: printf: non-constant format string in call to cosmossdk.io/errors.Wrapf (govet)
                        return types.DataCommitment{}, errors.Wrapf(types.ErrAttestationNotFound, fmt.Sprintf("nonce %d", i))
                                                                                                  ^
x/blobstream/keeper/keeper_data_commitment.go:139:61: printf: non-constant format string in call to cosmossdk.io/errors.Wrapf (govet)
                        return false, errors.Wrapf(types.ErrAttestationNotFound, fmt.Sprintf("nonce %d", i))
                                                                                 ^
x/blobstream/keeper/keeper_valset_test.go:60:3: The copy of the 'for' variable "spec" can be deleted (Go 1.22+) (copyloopvar)
                spec := spec
                ^
app/test/priority_test.go:83:3: The copy of the 'for' variable "accName" can be deleted (Go 1.22+) (copyloopvar)
                accName := accName // new variable per iteration
                ^
pkg/da/data_availability_header_test.go:91:3: The copy of the 'for' variable "tt" can be deleted (Go 1.22+) (copyloopvar)
                tt := tt
                ^
pkg/da/data_availability_header_test.go:125:3: The copy of the 'for' variable "tt" can be deleted (Go 1.22+) (copyloopvar)
                tt := tt
                ^
pkg/da/data_availability_header_test.go:206:3: The copy of the 'for' variable "tt" can be deleted (Go 1.22+) (copyloopvar)
                tt := tt
                ^
x/mint/simulation/decoder_test.go:54:3: The copy of the 'for' variable "i" can be deleted (Go 1.22+) (copyloopvar)
                i, tt := i, tt
                ^
make: *** [Makefile:105: lint] Error 1
```