### PR TITLE
feat: increase default mempool `TTLNumBlocks` to 12

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -264,7 +264,7 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	cfg.RPC.MaxBodyBytes = int64(8388608) // 8 MiB
 
 	cfg.Mempool.TTLNumBlocks = 12
-	cfg.Mempool.TTLDuration = time.Duration(75 * time.Second)
+	cfg.Mempool.TTLDuration = 75 * time.Second
 	cfg.Mempool.MaxTxBytes = 8 * mebibyte   // 8 MiB
 	cfg.Mempool.MaxTxsBytes = 40 * mebibyte // 40 MiB
 	cfg.Mempool.Version = "v1"              // prioritized mempool

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -36,8 +36,6 @@ import (
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
-const mebibyte = 1024 * 1024
-
 // bankModule defines a custom wrapper around the x/bank module's AppModuleBasic
 // implementation to provide custom default genesis state.
 type bankModule struct {

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -265,9 +265,9 @@ func DefaultConsensusConfig() *tmcfg.Config {
 
 	cfg.Mempool.TTLNumBlocks = 12
 	cfg.Mempool.TTLDuration = 75 * time.Second
-	cfg.Mempool.MaxTxBytes = 8 * mebibyte   // 8 MiB
-	cfg.Mempool.MaxTxsBytes = 40 * mebibyte // 40 MiB
-	cfg.Mempool.Version = "v1"              // prioritized mempool
+	cfg.Mempool.MaxTxBytes = 7_897_088
+	cfg.Mempool.MaxTxsBytes = 39_485_440
+	cfg.Mempool.Version = "v1" // prioritized mempool
 
 	cfg.Consensus.TimeoutPropose = appconsts.TimeoutPropose
 	cfg.Consensus.TimeoutCommit = appconsts.TimeoutCommit

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -80,11 +80,11 @@ func TestDefaultConsensusConfig(t *testing.T) {
 			Size:                  tmcfg.DefaultMempoolConfig().Size,
 			WalPath:               tmcfg.DefaultMempoolConfig().WalPath,
 
-			// overrides
-			MaxTxBytes:   7_897_088,
-			MaxTxsBytes:  39_485_440,
+			// Overrides
+			TTLNumBlocks: 12,
 			TTLDuration:  75 * time.Second,
-			TTLNumBlocks: 5,
+			MaxTxBytes:   8 * mebibyte,
+			MaxTxsBytes:  40 * mebibyte,
 			Version:      "v1",
 		}
 		assert.Equal(t, want, *got.Mempool)

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -81,10 +81,10 @@ func TestDefaultConsensusConfig(t *testing.T) {
 			WalPath:               tmcfg.DefaultMempoolConfig().WalPath,
 
 			// Overrides
-			TTLNumBlocks: 12,
+			MaxTxBytes:   7_897_088,
+			MaxTxsBytes:  39_485_440,
 			TTLDuration:  75 * time.Second,
-			MaxTxBytes:   8 * mebibyte,
-			MaxTxsBytes:  40 * mebibyte,
+			TTLNumBlocks: 12,
 			Version:      "v1",
 		}
 		assert.Equal(t, want, *got.Mempool)


### PR DESCRIPTION
Motivation in the **Mempool TTL duration** section of https://github.com/celestiaorg/celestia-app/issues/3959#issuecomment-2405769487

## Description

Modify the default consensus node config for mempools so that:

- TTLNumBlocks from 5 to 12 because 12 six second blocks = 72 seconds which is comparable to the existing 75 second TTLDuration.
- ~~MaxTxBytes from approx 7.5 MiB to 8 MiB because it's easier to understand and communicate~~
- ~~MaxTxsBytes from approx 37.6 MiB to 40 MiB because it's easier to understand and communicate~~

## Testing

`make install && ./scripts/single-node.sh` then cat the config

```toml
version = "v1"
ttl-duration = "1m15s"
ttl-num-blocks = 12
```

