### PR TITLE
chore: bump txsim version

### DIFF
--- a/test/e2e/testnet/defaults.go
+++ b/test/e2e/testnet/defaults.go
@@ -10,7 +10,7 @@ var DefaultResources = Resources{
 }
 
 const (
-	TxsimVersion = "pr-3541"
+	TxsimVersion = "8e573bb"
 	MB           = 1000 * 1000
 	GB           = 1000 * MB
 	MiB          = 1024 * 1024


### PR DESCRIPTION
There was an issue with the txsim that did not allow the E2ESimple test to run; consequently, ongoing celestia-node e2e tests fail.

```sh
/opt/entrypoint.sh: illegal option -- -
Invalid option:
```

Thanks to @smuu for his investigation to discover the root cause of the issue and to propose a solution that bumps the txsim version to make it work.

This PR proposes a version bump for txsim docker image in the e2e test.