### PR TITLE
fix: replace bash syntax with sh in configure-v3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -305,8 +305,8 @@ CONFIG_FILE ?= ${HOME}/.celestia-app/config/config.toml
 SEND_RECV_RATE ?= 10485760  # 10 MiB
 
 configure-v3:
-	@echo "Using config file at: $(CONFIG_FILE)"; \
-	if [[ "$$(uname)" == "Darwin" ]]; then \
+	@echo "Using config file at: $(CONFIG_FILE)"
+	@if [ "$$(uname)" = "Darwin" ]; then \
 		sed -i '' "s/^recv_rate = .*/recv_rate = $(SEND_RECV_RATE)/" $(CONFIG_FILE); \
 		sed -i '' "s/^send_rate = .*/send_rate = $(SEND_RECV_RATE)/" $(CONFIG_FILE); \
 		sed -i '' "s/ttl-num-blocks = 5/ttl-num-blocks = 12/" $(CONFIG_FILE); \


### PR DESCRIPTION
## Overview

Since sh is the default shell in the Makefile, running configure-v3 resulted in the error: `/bin/sh: 2: [[: not found`. This fix modifies the syntax to be compatible with sh, allowing the script to run successfully without errors.
