### PR TITLE
feat: check for correct signer in PFB construction

### DIFF
--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -321,8 +321,9 @@ func TestProcessProposal(t *testing.T) {
 				falseAddr := testnode.RandomAddress().(sdk.AccAddress)
 				blob, err := share.NewV1Blob(ns1, data, falseAddr)
 				require.NoError(t, err)
-				msg, err := blobtypes.NewMsgPayForBlobs(addr.String(), appconsts.LatestVersion, blob)
+				msg, err := blobtypes.NewMsgPayForBlobs(falseAddr.String(), appconsts.LatestVersion, blob)
 				require.NoError(t, err)
+				msg.Signer = addr.String()
 
 				rawTx, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimit(100000), user.SetFee(100000))
 				require.NoError(t, err)

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -92,10 +92,6 @@ func (s *Signer) CreatePayForBlobs(accountName string, blobs []*share.Blob, opts
 		return nil, 0, fmt.Errorf("account %s not found", accountName)
 	}
 
-	if err := blobtypes.ValidateBlobs(blobs...); err != nil {
-		return nil, 0, err
-	}
-
 	msg, err := blobtypes.NewMsgPayForBlobs(acc.address.String(), s.appVersion, blobs...)
 	if err != nil {
 		return nil, 0, err

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -232,7 +232,7 @@ func ValidateBlobs(blobs ...*share.Blob) error {
 // ValidateBlobShareVersion validates any share version specific rules
 func ValidateBlobShareVersion(signer sdk.AccAddress, blobs ...*share.Blob) error {
 	for _, blob := range blobs {
-		if blob.ShareVersion() != share.ShareVersionOne && !bytes.Equal(blob.Signer(), []byte(signer)) {
+		if blob.ShareVersion() == share.ShareVersionOne && !bytes.Equal(blob.Signer(), []byte(signer)) {
 			return ErrInvalidBlobSigner.Wrapf("blob signer %X does not match msgPFB signer %X", blob.Signer(), signer)
 		}
 	}

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	fmt "fmt"
 
 	"cosmossdk.io/errors"
@@ -42,12 +43,23 @@ const (
 // See: https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/docs/building-modules/messages-and-queries.md#legacy-amino-legacymsgs
 var _ legacytx.LegacyMsg = &MsgPayForBlobs{}
 
-func NewMsgPayForBlobs(signer string, version uint64, blobs ...*share.Blob) (*MsgPayForBlobs, error) {
+func NewMsgPayForBlobs(signer string, appVersion uint64, blobs ...*share.Blob) (*MsgPayForBlobs, error) {
 	err := ValidateBlobs(blobs...)
 	if err != nil {
 		return nil, err
 	}
-	commitments, err := inclusion.CreateCommitments(blobs, merkle.HashFromByteSlices, appconsts.SubtreeRootThreshold(version))
+
+	signerBytes, err := sdk.AccAddressFromBech32(signer)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ValidateBlobShareVersion(signerBytes, blobs...)
+	if err != nil {
+		return nil, err
+	}
+
+	commitments, err := inclusion.CreateCommitments(blobs, merkle.HashFromByteSlices, appconsts.SubtreeRootThreshold(appVersion))
 	if err != nil {
 		return nil, fmt.Errorf("creating commitments: %w", err)
 	}
@@ -214,6 +226,16 @@ func ValidateBlobs(blobs ...*share.Blob) error {
 		}
 	}
 
+	return nil
+}
+
+// ValidateBlobShareVersion validates any share version specific rules
+func ValidateBlobShareVersion(signer sdk.AccAddress, blobs ...*share.Blob) error {
+	for _, blob := range blobs {
+		if blob.ShareVersion() != share.ShareVersionOne && !bytes.Equal(blob.Signer(), []byte(signer)) {
+			return ErrInvalidBlobSigner.Wrapf("blob signer %X does not match msgPFB signer %X", blob.Signer(), signer)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
We already check this in `CheckTx` and `ProcessProposal`. This adds the same check to the client side construction so it errors before being submitted to the network. (the check being that the signer in the blob and the actual signer of the PFB are the same)