### PR TITLE
docs: fix typos in prebuilt-binaries.md and release-guide.md

### DIFF
--- a/docs/maintainers/prebuilt-binaries.md
+++ b/docs/maintainers/prebuilt-binaries.md
@@ -13,7 +13,7 @@ Prebuilt binaries are attached to each release via [GoReleaser](https://goreleas
 
 ## Steps
 
-1. [Optional] If you need to make any code changes to fix the issue that occured when CI tried to generate and attach the prebuilt binaries, then you likely need to skip validation when running GoReleaser locally. To skip validation, modify the Makefile command like so:
+1. [Optional] If you need to make any code changes to fix the issue that occurred when CI tried to generate and attach the prebuilt binaries, then you likely need to skip validation when running GoReleaser locally. To skip validation, modify the Makefile command like so:
 
     ```diff
     ## prebuilt-binary: Create prebuilt binaries and attach them to GitHub release. Requires Docker.

--- a/docs/maintainers/release-guide.md
+++ b/docs/maintainers/release-guide.md
@@ -15,7 +15,7 @@ The target audience for this guide is maintainers of this repo. In general, the 
 1. Choose a version tag based on [Semantic Versioning](https://semver.org/). Include the `-rc` suffix followed by the next integer. RCs start at 0.
 1. Change the target branch to `v1.x` or `v2.x` based on the version you're releasing.
 1. Click **Generate release notes**.
-1. Toggle on the **Set as a pre-relase** checkbox.
+1. Toggle on the **Set as a pre-release** checkbox.
 1. **Publish release**.
 
 ### After creating the release candidate


### PR DESCRIPTION
## Overview

**Description**:
This pull request addresses two spelling errors in the documentation files:

1. **In `docs/maintainers/prebuilt-binaries.md`**:
   - The word **occured** is corrected to **occurred** (with two "r"s).
   
2. **In `docs/maintainers/release-guide.md`**:
   - The word **relase** is corrected to **release** (with an extra "e").

**Importance**:
These spelling corrections ensure that the documentation is accurate and professional. Correct spelling is important in maintaining clarity and trust in the documentation, especially for new contributors and users. It also improves searchability, as users may encounter issues when searching for these terms with the incorrect spelling.