### PR TITLE
chore: check if a block is empty by taking its reference

### DIFF
--- a/app/extend_block.go
+++ b/app/extend_block.go
@@ -25,8 +25,17 @@ func ExtendBlock(data coretypes.Data, appVersion uint64) (*rsmt2d.ExtendedDataSq
 	return da.ExtendShares(share.ToBytes(dataSquare))
 }
 
-// EmptyBlock returns true if the given block data is considered empty by the
+// IsEmptyBlock returns true if the given block data is considered empty by the
 // application at a given version.
+//
+// Deprecated: Use IsEmptyBlockRef for better performance with large data structures.
 func IsEmptyBlock(data coretypes.Data, _ uint64) bool {
+	return len(data.Txs) == 0
+}
+
+// IsEmptyBlockRef returns true if the application considers the given block data
+// empty at a given version.
+// This method passes the block data by reference for improved performance.
+func IsEmptyBlockRef(data *coretypes.Data, _ uint64) bool {
 	return len(data.Txs) == 0
 }

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -281,7 +281,7 @@ func (s *IntegrationTestSuite) TestIsEmptyBlock() {
 	for _, h := range emptyHeights {
 		blockRes, err := s.cctx.Client.Block(s.cctx.GoContext(), &h)
 		require.NoError(t, err)
-		require.True(t, app.IsEmptyBlock(blockRes.Block.Data, blockRes.Block.Header.Version.App))
+		require.True(t, app.IsEmptyBlock(blockRes.Block.Data, blockRes.Block.Header.Version.App)) //nolint:staticcheck
 		ExtendBlockTest(t, blockRes.Block)
 	}
 }

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -275,13 +275,24 @@ func ExtendBlockTest(t *testing.T, block *coretypes.Block) {
 	}
 }
 
-func (s *IntegrationTestSuite) TestEmptyBlock() {
+func (s *IntegrationTestSuite) TestIsEmptyBlock() {
 	t := s.T()
 	emptyHeights := []int64{1, 2, 3}
 	for _, h := range emptyHeights {
 		blockRes, err := s.cctx.Client.Block(s.cctx.GoContext(), &h)
 		require.NoError(t, err)
 		require.True(t, app.IsEmptyBlock(blockRes.Block.Data, blockRes.Block.Header.Version.App))
+		ExtendBlockTest(t, blockRes.Block)
+	}
+}
+
+func (s *IntegrationTestSuite) TestIsEmptyBlockRef() {
+	t := s.T()
+	emptyHeights := []int64{1, 2, 3}
+	for _, h := range emptyHeights {
+		blockRes, err := s.cctx.Client.Block(s.cctx.GoContext(), &h)
+		require.NoError(t, err)
+		require.True(t, app.IsEmptyBlockRef(&blockRes.Block.Data, blockRes.Block.Header.Version.App))
 		ExtendBlockTest(t, blockRes.Block)
 	}
 }


### PR DESCRIPTION
This will be helpful in Celestia-node to avoid copying the block when checking if it's empty