### PR TITLE
fix: nonce_mismatch log parsing

### DIFF
--- a/app/errors/nonce_mismatch.go
+++ b/app/errors/nonce_mismatch.go
@@ -32,7 +32,7 @@ func ParseNonceMismatch(err error) (uint64, error) {
 // ParseExpectedSequence extracts the expected sequence number from the
 // ErrWrongSequence error.
 func ParseExpectedSequence(str string) (uint64, error) {
-	if !strings.HasPrefix(str, "account sequence mismatch") {
+	if !strings.Contains(str, "incorrect account sequence") {
 		return 0, fmt.Errorf("unexpected wrong sequence error: %s", str)
 	}
 


### PR DESCRIPTION
The actual error log that would bubble up is actually (using this in celestia-node)
```
broadcast tx error: account sequence mismatch, expected 357545, got 357544: incorrect account sequence
```
So seeking a prefix for `account sequence mismatch` would not work.