### PR TITLE
Fix Typos in ADR-004 and ADR-012 Documentation Files

### DIFF
--- a/docs/architecture/adr-004-qgb-relayer-security.md
+++ b/docs/architecture/adr-004-qgb-relayer-security.md
@@ -18,7 +18,7 @@ In fact, the QGB smart contract is designed to update the data commitments as fo
 - Check if the data commitment is signed using the current valset _(this is the problematic check)_
 - Then, other checks + commit
 
-So, if a relayer is up to date, it will submit data commitment and will pass the above checks.
+So, if a relayer is up-to-date, it will submit data commitment and will pass the above checks.
 
 Now, if the relayer is missing some data commitments or valset updates, then it will start catching up the following way:
 

--- a/docs/architecture/adr-012-sequence-length-encoding.md
+++ b/docs/architecture/adr-012-sequence-length-encoding.md
@@ -42,7 +42,7 @@ Inefficient space usage. Unlike compact share sequences which are bounded (i.e. 
 ## Option C: Encode the sequence length with a fixed length (e.g. big endian uint32)
 
 - If we choose this option, we should decide the number of bytes we want to allocated based on the maximum sequence length we expect to support.
-  - 4 bytes is capable of storing a uint32. A uint32 can contain a max sequence length of 4,294,967,296 bytes. In other words, a uint32 works up until 4GiB blocks. To put this into context, this max sequence length is hit with 1024 byte share size and max square size of 2048.
+  - 4 bytes is capable of storing an uint32. An uint32 can contain a max sequence length of 4,294,967,296 bytes. In other words, an uint32 works up until 4GiB blocks. To put this into context, this max sequence length is hit with 1024 byte share size and max square size of 2048.
   - 8 bytes is capable of storing a uint64. A uint64 can contain a max sequence length of 18,446,744,073,709,551,615 bytes so pebibyte scale.
 - If we choose this option, we should decide on big endian vs. little endian? Proposal: big endian because it seems more user friendly and more common on the network
   - Integers in Fuel are big endian. See <https://fuellabs.github.io/fuel-specs/master/vm/index.html?highlight=endian#semantics>.

--- a/docs/architecture/adr-012-sequence-length-encoding.md
+++ b/docs/architecture/adr-012-sequence-length-encoding.md
@@ -43,8 +43,8 @@ Inefficient space usage. Unlike compact share sequences which are bounded (i.e. 
 
 - If we choose this option, we should decide the number of bytes we want to allocated based on the maximum sequence length we expect to support.
   - 4 bytes is capable of storing an uint32. An uint32 can contain a max sequence length of 4,294,967,296 bytes. In other words, an uint32 works up until 4GiB blocks. To put this into context, this max sequence length is hit with 1024 byte share size and max square size of 2048.
-  - 8 bytes is capable of storing a uint64. A uint64 can contain a max sequence length of 18,446,744,073,709,551,615 bytes so pebibyte scale.
-- If we choose this option, we should decide on big endian vs. little endian? Proposal: big endian because it seems more user friendly and more common on the network
+  - 8 bytes is capable of storing an uint64. An uint64 can contain a max sequence length of 18,446,744,073,709,551,615 bytes so pebibyte scale.
+- If we choose this option, we should decide on big endian vs. little endian? Proposal: big endian because it seems more user-friendly and more common on the network
   - Integers in Fuel are big endian. See <https://fuellabs.github.io/fuel-specs/master/vm/index.html?highlight=endian#semantics>.
   <!-- markdown-link-check-disable -->
   - Bitcoin is little endian. Ref: <https://learnmeabitcoin.com/technical/little-endian>.


### PR DESCRIPTION
This pull request addresses several typos and minor corrections in the documentation files:

- In `adr-004-qgb-relayer-security.md`, changed "up to date" to "up-to-date".
- In `adr-012-sequence-length-encoding.md`, corrected "a uint32" and "a uint64" to "an uint32" and "an uint64", respectively.
- Added a hyphen to "user friendly" to make it "user-friendly".

These updates improve clarity and grammatical accuracy in the documentation.
