### PR TITLE
Fix: typo in public_key_cryptography.md

### DIFF
--- a/specs/src/public_key_cryptography.md
+++ b/specs/src/public_key_cryptography.md
@@ -14,7 +14,7 @@ A highly-optimized library is available in C (<https://github.com/bitcoin-core/s
 
 ### Public-keys
 
-Secp256k1 public keys can be compressed to 257-bits (or 33 bytes) per the format described [here](https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/docs/basics/accounts.md#public-keys).
+Secp256k1 public keys can be compressed to 256-bits (or 33 bytes) per the format described [here](https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/docs/basics/accounts.md#public-keys).
 
 ### Addresses
 


### PR DESCRIPTION
This PR fixes a typo in the `public_key_cryptography.md` file. Specifically, the incorrect value "257-bits" has been corrected to "256-bits" for Secp256k1 public key compression size.