### PR TITLE
ci(goreleaser): use latest tag from GitHub action

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -9,6 +9,8 @@ on:
       - "v*"
     tags:
       - "v*"
+  release:
+    types: [published]
   pull_request:
 
 jobs:

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -22,6 +22,7 @@ jobs:
     uses: ./.github/workflows/test.yml
 
   goreleaser:
+    if: github.event_name == 'release'
     uses: ./.github/workflows/goreleaser.yml
     permissions: write-all
     secrets:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   goreleaser-check:
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,7 +15,6 @@ jobs:
           fetch-depth: 0
       - run: git fetch --force --tags
       - name: Set GORELEASER_CURRENT_TAG in GitHub env
-        if: github.event_name == 'release'
         run: echo "GORELEASER_CURRENT_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       - uses: actions/setup-go@v5
         with:
@@ -28,10 +28,9 @@ jobs:
           GORELEASER_CURRENT_TAG: ${{ env.GORELEASER_CURRENT_TAG }}
 
   goreleaser:
+    if: github.event_name == 'release'
     needs: goreleaser-check
     runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'push' && contains(github.ref, 'refs/tags/'))
     permissions: write-all
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +38,6 @@ jobs:
           fetch-depth: 0
       - run: git fetch --force --tags
       - name: Set GORELEASER_CURRENT_TAG in GitHub env
-        if: github.event_name == 'release'
         run: echo "GORELEASER_CURRENT_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
+      - name: Set GORELEASER_CURRENT_TAG in GitHub env
+        if: github.event_name == 'release'
+        run: echo "GORELEASER_CURRENT_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
@@ -21,6 +24,8 @@ jobs:
           echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' >> .release-env
       - name: Check the .goreleaser.yaml config file
         run: make goreleaser-check
+        env:
+          GORELEASER_CURRENT_TAG: ${{ env.GORELEASER_CURRENT_TAG }}
 
   goreleaser:
     needs: goreleaser-check
@@ -33,6 +38,9 @@ jobs:
         with:
           fetch-depth: 0
       - run: git fetch --force --tags
+      - name: Set GORELEASER_CURRENT_TAG in GitHub env
+        if: github.event_name == 'release'
+        run: echo "GORELEASER_CURRENT_TAG=${{ github.event.release.tag_name }}" >> $GITHUB_ENV
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
@@ -41,3 +49,5 @@ jobs:
           echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' >> .release-env
       - name: Create prebuilt binaries and attach them to the GitHub release
         run: make prebuilt-binary
+        env:
+          GORELEASER_CURRENT_TAG: ${{ env.GORELEASER_CURRENT_TAG }}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4081

## Testing

On my fork all of [these releases](https://github.com/rootulp/celestia-app/actions/workflows/ci-release.yml?query=event%3Arelease) used the correct tag and uploaded prebuilt binaries.