### PR TITLE
fix: multiple typos

### DIFF
--- a/app/ante/tx_size_gas.go
+++ b/app/ante/tx_size_gas.go
@@ -35,7 +35,7 @@ func init() {
 
 // ConsumeTxSizeGasDecorator will take in parameters and consume gas proportional
 // to the size of tx before calling next AnteHandler. Note, the gas costs will be
-// slightly over estimated due to the fact that any given signing account may need
+// slightly overestimated due to the fact that any given signing account may need
 // to be retrieved from state.
 //
 // CONTRACT: If simulate=true, then signatures must either be completely filled

--- a/app/app.go
+++ b/app/app.go
@@ -180,7 +180,7 @@ type App struct {
 //
 // NOTE: upgradeHeightV2 refers specifically to the height that a node will
 // upgrade from v1 to v2. It will be deprecated in v3 in place for a dynamically
-//signaling scheme
+// signaling scheme
 func New(
 	logger log.Logger,
 	db dbm.DB,

--- a/app/app.go
+++ b/app/app.go
@@ -180,7 +180,7 @@ type App struct {
 //
 // NOTE: upgradeHeightV2 refers specifically to the height that a node will
 // upgrade from v1 to v2. It will be deprecated in v3 in place for a dynamically
-// signalling scheme
+//signaling scheme
 func New(
 	logger log.Logger,
 	db dbm.DB,
@@ -258,7 +258,7 @@ func New(
 	)
 
 	app.FeeGrantKeeper = feegrantkeeper.NewKeeper(appCodec, keys[feegrant.StoreKey], app.AccountKeeper)
-	// The upgrade keeper is intialised solely for the ibc keeper which depends on it to know what the next validator hash is for after the
+	// The upgrade keeper is initialised solely for the ibc keeper which depends on it to know what the next validator hash is for after the
 	// upgrade. This keeper is not used for the actual upgrades but merely for compatibility reasons. Ideally IBC has their own upgrade module
 	// for performing IBC based upgrades. Note, as we use rolling upgrades, IBC technically never needs this functionality.
 	app.UpgradeKeeper = upgradekeeper.NewKeeper(nil, keys[upgradetypes.StoreKey], appCodec, "", app.BaseApp, authtypes.NewModuleAddress(govtypes.ModuleName).String())
@@ -472,7 +472,7 @@ func (app *App) EndBlocker(ctx sdk.Context, req abci.RequestEndBlock) abci.Respo
 				panic(err)
 			}
 		}
-		// from v2 to v3 and onwards we use a signalling mechanism
+		// from v2 to v3 and onwards we use a signaling mechanism
 	} else if shouldUpgrade, newVersion := app.SignalKeeper.ShouldUpgrade(ctx); shouldUpgrade {
 		// Version changes must be increasing. Downgrades are not permitted
 		if newVersion > currentVersion {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -44,7 +44,7 @@ func TestNew(t *testing.T) {
 	})
 	t.Run("should have set StakingKeeper hooks", func(t *testing.T) {
 		// StakingKeeper doesn't expose a GetHooks method so this checks if
-		// hooks have been set by verifying the a subsequent call to SetHooks
+		// hooks have been set by verifying the subsequent call to SetHooks
 		// will panic.
 		assert.Panics(t, func() { got.StakingKeeper.SetHooks(nil) })
 	})

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG BUILDER_IMAGE=docker.io/golang:1.23.1-alpine3.20
 ARG RUNTIME_IMAGE=docker.io/alpine:3.19
 ARG TARGETOS
 ARG TARGETARCH
-# Use build args to override the maxuimum square size of the docker image i.e.
+# Use build args to override the maximum square size of the docker image i.e.
 # docker build --build-arg MAX_SQUARE_SIZE=64 -t celestia-app:latest .
 ARG MAX_SQUARE_SIZE
 # Use build args to override the upgrade height delay of the docker image i.e.


### PR DESCRIPTION
## Overview

This pull request addresses several minor grammatical and typographical fixes across comments and documentation in the codebase. These adjustments enhance readability and correctness without altering any code functionality.

### Summary of Changes
1. Corrected "over estimated" to "overestimated" in `tx_size_gas.go`.
2. Changed "signalling" to "signaling" to align with American English standards in `app.go`.
3. Fixed "intialised" to "initialised" in `app.go`.
4. Clarified a redundant phrase in `app_test.go` comments.
5. Fixed "maxuimum" to "maximum" in `Dockerfile`.

### Rationale

These fixes contribute to maintaining a clean and professional codebase, ensuring that comments and documentation are accurate and easy to understand.

## Tests

No new tests were added, as these changes are non-functional. Existing tests and workflows remain unaffected.

---

Allow edits by maintainers: ✅
