### PR TITLE
test(e2e): filter out retracted version

### DIFF
--- a/test/e2e/minor_version_compatibility.go
+++ b/test/e2e/minor_version_compatibility.go
@@ -14,6 +14,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app"
 	v1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
+	v3 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v3"
 	"github.com/celestiaorg/celestia-app/v3/test/e2e/testnet"
 	"github.com/celestiaorg/knuu/pkg/knuu"
 )
@@ -22,13 +23,22 @@ func MinorVersionCompatibility(logger *log.Logger) error {
 	const (
 		testName = "MinorVersionCompatibility"
 		numNodes = 4
+		// retractedCelestiaApp is a version of celestia-app that was retracted.
+		retractedCelestiaApp = "v1.8.0"
 	)
 
 	versionStr, err := getAllVersions()
 	testnet.NoError("failed to get versions", err)
-	versions1 := testnet.ParseVersions(versionStr).FilterMajor(v1.Version).FilterOutReleaseCandidates()
-	versions2 := testnet.ParseVersions(versionStr).FilterMajor(v2.Version) // include release candidates for v2 because there isn't an official release yet.
-	versions := slices.Concat(versions1, versions2)
+
+	retracted, ok := testnet.ParseVersion(retractedCelestiaApp)
+	if !ok {
+		logger.Fatal("failed to parse retracted version")
+	}
+
+	versions1 := testnet.ParseVersions(versionStr).FilterMajor(v1.Version).FilterOutReleaseCandidates().FilterOut(retracted)
+	versions2 := testnet.ParseVersions(versionStr).FilterMajor(v2.Version).FilterOutReleaseCandidates()
+	versions3 := testnet.ParseVersions(versionStr).FilterMajor(v3.Version).FilterOutReleaseCandidates()
+	versions := slices.Concat(versions1, versions2, versions3)
 
 	if len(versions) == 0 {
 		logger.Fatal("no versions to test")

--- a/test/e2e/testnet/versions.go
+++ b/test/e2e/testnet/versions.go
@@ -124,6 +124,16 @@ func (v VersionSet) FilterOutReleaseCandidates() VersionSet {
 	return output
 }
 
+func (v VersionSet) FilterOut(retracted Version) VersionSet {
+	output := make(VersionSet, 0, len(v))
+	for _, version := range v {
+		if version != retracted {
+			output = append(output, version)
+		}
+	}
+	return output
+}
+
 func (v VersionSet) GetLatest() Version {
 	latest := Version{}
 	for _, version := range v {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4116

## Testing

```shell
test-e2e2024/12/13 10:44:02 === RUN MinorVersionCompatibility
test-e2e2024/12/13 10:44:02 Running MinorVersionCompatibility test with versions v1.0.0	v1.1.0	v1.10.0	v1.10.1	v1.11.0	v1.12.0	v1.13.0	v1.14.0	v1.2.0	v1.3.0	v1.3.0	v1.4.0	v1.5.0	v1.6.0	v1.7.0	v1.9.0	v2.0.0	v2.1.0	v2.1.1	v2.1.2	v2.2.0	v2.2.0	v2.2.0	v2.3.0	v2.3.0	v2.3.1	v2.3.1	v3.0.0	v3.0.0	v3.0.0	v3.0.1	v3.0.1	v3.0.1	v3.0.2	v3.0.2	v3.0.2
```

- Doesn't contain the retracted version: https://github.com/celestiaorg/celestia-app/releases/tag/v1.8.0
- Doesn't contain release candidates
- Does contain v3 versions