### PR TITLE
Fix Typo in simapp.go

### DIFF
--- a/test/pfm/simapp.go
+++ b/test/pfm/simapp.go
@@ -115,7 +115,7 @@ type App interface {
 	Name() string
 
 	// The application types codec.
-	// NOTE: This shoult be sealed before being returned.
+	// NOTE: This should be sealed before being returned.
 	LegacyAmino() *codec.LegacyAmino
 
 	// Application updates every begin block.


### PR DESCRIPTION
# Pull Request: Fix Typo in simapp.go

## Description of changes
This pull request fixes a typo in the comment in the `test/pfm/simapp.go` file. The word "shoult" was corrected to "should".

### Changes:
- Fixed the typo in the comment from "shoult" to "should".

## Task
No related task; just a typo fix in the comments.

## How to test
1. Review the changes in the `simapp.go` file.
2. Ensure the typo in the comment has been corrected to "should".

## Additional Information
- The typo was in the comment on line 115.

