### PR TITLE
Typ+cod/fix

### DIFF
--- a/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
+++ b/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
@@ -173,7 +173,7 @@ Proof size increases from 2928 bytes to 10352 bytes in 2 GB blocks. In the curre
 
 ### Proof Size for Light-Nodes
 
-Light Nodes have additional access to row and collum roots from the Data Availability header. Therefore we can discard any blue nodes to the `DataRoot` from the analysis.
+Light Nodes have additional access to row and column roots from the Data Availability header. Therefore we can discard any blue nodes to the `DataRoot` from the analysis.
 
 ![Proof Size Result 2](./assets/adr009/proof-size-result2.png)
 

--- a/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
+++ b/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
@@ -177,7 +177,7 @@ Light Nodes have additional access to row and column roots from the Data Availab
 
 ![Proof Size Result 2](./assets/adr009/proof-size-result2.png)
 
-### Total Proof Size for Parital Nodes
+### Total Proof Size for Partial Nodes
 
 Partial nodes in this context are light clients that may download all of the data in the reserved namespace. They check that the data behind the PFB was included in the `DataRoot`, via blob inclusion proofs.
 


### PR DESCRIPTION
# Fix: Corrected typos in documentation files

## Changes
- `docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md:180`: "Parital" corrected to "Partial".
- `docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md:176`: "collum" corrected to "column".

## Purpose
- Improved documentation accuracy and professionalism.

