### PR TITLE
fix: grammatical typos

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -78,7 +78,7 @@ func NewAnteHandler(
 		NewGovProposalDecorator(),
 		// Side effect: increment the nonce for all tx signers.
 		ante.NewIncrementSequenceDecorator(accountKeeper),
-		// Ensure that the tx is not a IBC packet or update message that has already been processed.
+		// Ensure that the tx is not an IBC packet or update message that has already been processed.
 		ibcante.NewRedundantRelayDecorator(channelKeeper),
 	)
 }

--- a/app/export.go
+++ b/app/export.go
@@ -69,7 +69,7 @@ func (app *App) getExportHeight(forZeroHeight bool) int64 {
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 
-	// check if there is a allowed address list
+	// check if there is an allowed address list
 	if len(jailAllowedAddrs) > 0 {
 		applyAllowedAddrs = true
 	}

--- a/test/util/testfactory/namespace.go
+++ b/test/util/testfactory/namespace.go
@@ -34,7 +34,7 @@ func RandomBlobNamespaces(rand *tmrand.Rand, count int) (namespaces []share.Name
 	return namespaces
 }
 
-// isBlobNamespace returns an true if this namespace is a valid user-specifiable
+// isBlobNamespace returns a true if this namespace is a valid user-specifiable
 // blob namespace.
 func isBlobNamespace(namespace share.Namespace) bool {
 	if namespace.IsReserved() {

--- a/x/signal/types/keys.go
+++ b/x/signal/types/keys.go
@@ -1,7 +1,7 @@
 package types
 
 var (
-	// UpgradeKey is the key in the signal store used to persist a upgrade if one is
+	// UpgradeKey is the key in the signal store used to persist an upgrade if one is
 	// pending.
 	UpgradeKey = []byte{0x00}
 


### PR DESCRIPTION
This PR addresses and corrects grammatical errors in comments across multiple files. 
Specifically, it replaces the incorrect usage of "a" with "an" before words starting with vowel sounds. 
The affected files include:
- `ante.go`
- `export.go`
- `namespace.go`
- `keys.go`
