### PR TITLE
chore: docs fix 

### DIFF
--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -131,7 +131,7 @@ lastUnbondingHeight := k.GetLastUnBondingBlockHeight(ctx)
 significantPowerDiff := false
 ```
 
-#### Check if there was a signification power difference between valsets
+#### Check if there was a significant power difference between valsets
 
 If the previous valset is not null, then we had a previous set of validators defining a certain power.
 We check if the current valset power is significantly different from the previous one. If so, we set the `significantPowerDiff` to true.


### PR DESCRIPTION
# Description

**docs/architecture/adr-002-qgb-valset.md**
- Fixed typo: "`signification`" →  "`significant`"