### PR TITLE
fix: typos

### DIFF
--- a/docs/architecture/adr-004-qgb-relayer-security.md
+++ b/docs/architecture/adr-004-qgb-relayer-security.md
@@ -199,7 +199,7 @@ func (k Keeper) SetLatestAttestationNonce(ctx sdk.Context, nonce uint64) {
     }
 
     store := ctx.KVStore(k.storeKey)
-    store.Set([]byte(types.LatestAttestationtNonce), types.UInt64Bytes(nonce))
+    store.Set([]byte(types.LatestAttestationNonce), types.UInt64Bytes(nonce))
 }
 ```
 
@@ -210,7 +210,7 @@ This will **panic** in the following cases:
 ```go
 func (k Keeper) CheckLatestAttestationNonce(ctx sdk.Context) bool {
     store := ctx.KVStore(k.storeKey)
-    has := store.Has([]byte(types.LatestAttestationtNonce))
+    has := store.Has([]byte(types.LatestAttestationNonce))
     return has
 }
 ```


### PR DESCRIPTION
Correcting the typo from `LatestAttestationtNonce` to `LatestAttestationNonce` ensures code consistency, improves readability, and prevents confusion among developers. Accurate naming makes the code easier to maintain and reduces the risk of future errors.  

Check the code and ensure that all variables use `LatestAttestationNonce` consistently.
Thanks