### PR TITLE
chore: fix typos

### DIFF
--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -37,7 +37,7 @@ Finally, if there are no validator set updates for the unbonding window, the bri
 
 ### Message types
 
-We added the following messages types:
+We added the following message types:
 
 #### Bridge Validator
 

--- a/pkg/appconsts/global_consts.go
+++ b/pkg/appconsts/global_consts.go
@@ -11,7 +11,7 @@ import (
 //
 // They cannot change throughout the lifetime of a network.
 const (
-	// DefaultShareVersion is the defacto share version. Use this if you are
+	// DefaultShareVersion is the de facto share version. Use this if you are
 	// unsure of which version to use.
 	DefaultShareVersion = share.ShareVersionZero
 

--- a/pkg/appconsts/initial_consts.go
+++ b/pkg/appconsts/initial_consts.go
@@ -7,7 +7,7 @@ import (
 )
 
 // The following defaults correspond to initial parameters of the network that can be changed, not via app versions
-// but other means such as on-chain governance, or the nodes local config
+// but other means such as on-chain governance, or the node's local config
 const (
 	// DefaultGovMaxSquareSize is the default value for the governance modifiable
 	// max square size.
@@ -19,7 +19,7 @@ const (
 
 	// DefaultMinGasPrice is the default min gas price that gets set in the app.toml file.
 	// The min gas price acts as a filter. Transactions below that limit will not pass
-	// a nodes `CheckTx` and thus not be proposed by that node.
+	// a node's `CheckTx` and thus not be proposed by that node.
 	DefaultMinGasPrice = 0.002 // utia
 
 	// DefaultUnbondingTime is the default time a validator must wait

--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -187,7 +187,7 @@ func Test_DAHValidateBasic(t *testing.T) {
 			errStr:    "minimum valid DataAvailabilityHeader has at least",
 		},
 		{
-			name:      "bash hash",
+			name:      "bad hash",
 			dah:       badHashDah,
 			expectErr: true,
 			errStr:    "wrong hash",


### PR DESCRIPTION
This pull request addresses the following errors in the documentation:

"messages" -> "message"
"defacto" -> "de facto"
"nodes" -> "node's"
"bash hash" -> "bad hash"

I hope my corrections will help you. Thank you for your work.