### PR TITLE
chore: fix typo

### DIFF
--- a/test/pfm/simapp.go
+++ b/test/pfm/simapp.go
@@ -130,7 +130,7 @@ type App interface {
 	// Loads the app at a given height.
 	LoadHeight(height int64) error
 
-	// All the registered module account addreses.
+	// All the registered module account addresses.
 	ModuleAccountAddrs() map[string]bool
 
 	// Helper for the simulation framework.


### PR DESCRIPTION
# Fix Typo in `simapp.go`

## Description
This pull request fixes a typo in the `simapp.go` file. Specifically, the word "addreses" was corrected to "addresses" in a comment.

### Changes Made
- Fixed a typo in the comment within the `ModuleAccountAddrs` method documentation:
  - Changed:
    ```
// All the registered module account addreses.
    ```
    to:
    ```
// All the registered module account addresses.
    ```

## Rationale
Ensuring comments are clear and free from typographical errors enhances the readability and professionalism of the codebase.

## Checklist
- [x] Followed the contributing guidelines.
- [x] Made only the necessary changes.
- [x] Comments remain clear and concise.

## Notes
Please let me know if any additional changes or improvements are required.
