### PR TITLE
chore: fix typo

### DIFF
--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -187,7 +187,7 @@ func Test_DAHValidateBasic(t *testing.T) {
 			errStr:    "minimum valid DataAvailabilityHeader has at least",
 		},
 		{
-			name:      "bash hash",
+			name:      "bad hash",
 			dah:       badHashDah,
 			expectErr: true,
 			errStr:    "wrong hash",


### PR DESCRIPTION
After reviewing the code’s context and function, there was a typo, so I fixed it. Thanks.






