### PR TITLE
chore: fix typos

### DIFF
--- a/test/e2e/minor_version_compatibility.go
+++ b/test/e2e/minor_version_compatibility.go
@@ -127,11 +127,11 @@ func MinorVersionCompatibility(logger *log.Logger) error {
 	}
 
 	logger.Println("checking that all nodes are at the same height")
-	const maxPermissableDiff = 2
+	const maxPermissibleDiff = 2
 	for i := 0; i < len(heights); i++ {
 		for j := i + 1; j < len(heights); j++ {
 			diff := heights[i] - heights[j]
-			if diff > maxPermissableDiff {
+			if diff > maxPermissibleDiff {
 				logger.Fatalf("node %d is behind node %d by %d blocks", j, i, diff)
 			}
 		}

--- a/test/txsim/stake.go
+++ b/test/txsim/stake.go
@@ -18,7 +18,7 @@ var _ Sequence = &StakeSequence{}
 // to a single validator at a time. TODO: Allow for multiple delegations
 type StakeSequence struct {
 	initialStake          int
-	redelegatePropability int
+	redelegateProbability int
 	delegatedTo           string
 	account               types.AccAddress
 }
@@ -26,7 +26,7 @@ type StakeSequence struct {
 func NewStakeSequence(initialStake int) *StakeSequence {
 	return &StakeSequence{
 		initialStake:          initialStake,
-		redelegatePropability: 10, // 1 in every 10
+		redelegateProbability: 10, // 1 in every 10
 	}
 }
 
@@ -68,7 +68,7 @@ func (s *StakeSequence) Next(ctx context.Context, querier grpc.ClientConn, rand 
 	}
 
 	// occasionally redelegate the initial stake to another validator at random
-	if rand.Intn(s.redelegatePropability) == 0 {
+	if rand.Intn(s.redelegateProbability) == 0 {
 		val, err := getRandomValidator(ctx, querier, rand)
 		if err != nil {
 			return Operation{}, err


### PR DESCRIPTION
# Explanation of Changes

1. Renamed `maxPermissableDiff` to `maxPermissibleDiff` to fix a spelling error.
   - Correct spelling improves clarity and reduces confusion in both code reviews and search queries.

2. Renamed `redelegatePropability` to `redelegateProbability` to fix a spelling error.
   - Accurate names are essential for readability and maintaining consistent terminology throughout the codebase.
