### PR TITLE
chore: fix typos

### DIFF
--- a/test/e2e/minor_version_compatibility.go
+++ b/test/e2e/minor_version_compatibility.go
@@ -127,11 +127,11 @@ func MinorVersionCompatibility(logger *log.Logger) error {
 	}
 
 	logger.Println("checking that all nodes are at the same height")
-	const maxPermissableDiff = 2
+	const maxPermissibleDiff = 2
 	for i := 0; i < len(heights); i++ {
 		for j := i + 1; j < len(heights); j++ {
 			diff := heights[i] - heights[j]
-			if diff > maxPermissableDiff {
+			if diff > maxPermissibleDiff {
 				logger.Fatalf("node %d is behind node %d by %d blocks", j, i, diff)
 			}
 		}

--- a/test/pfm/pfm_test.go
+++ b/test/pfm/pfm_test.go
@@ -76,10 +76,10 @@ func TestPacketForwardMiddlewareTransfer(t *testing.T) {
 	coordinator.Setup(path2)
 
 	celestiaApp := celestia.App.(*app.App)
-	originalCelestiaBalalance := celestiaApp.BankKeeper.GetBalance(celestia.GetContext(), celestia.SenderAccount.GetAddress(), sdk.DefaultBondDenom)
+	originalCelestiaBalance := celestiaApp.BankKeeper.GetBalance(celestia.GetContext(), celestia.SenderAccount.GetAddress(), sdk.DefaultBondDenom)
 
 	// Take half of the original balance
-	transferAmount := originalCelestiaBalalance.Amount.QuoRaw(2)
+	transferAmount := originalCelestiaBalance.Amount.QuoRaw(2)
 	timeoutHeight := clienttypes.NewHeight(1, 300)
 	coinToSendToB := sdk.NewCoin(sdk.DefaultBondDenom, transferAmount)
 
@@ -120,7 +120,7 @@ func TestPacketForwardMiddlewareTransfer(t *testing.T) {
 	require.NoError(t, err)
 
 	sourceBalanceAfter := celestiaApp.BankKeeper.GetBalance(celestia.GetContext(), celestia.SenderAccount.GetAddress(), sdk.DefaultBondDenom)
-	require.Equal(t, originalCelestiaBalalance.Amount.Sub(transferAmount), sourceBalanceAfter.Amount)
+	require.Equal(t, originalCelestiaBalance.Amount.Sub(transferAmount), sourceBalanceAfter.Amount)
 
 	ibcDenomTrace := types.ParseDenomTrace(types.GetPrefixedDenom(packet.GetDestPort(), packet.GetDestChannel(), sdk.DefaultBondDenom))
 	destinationBalanceAfter := chainB.App.(*SimApp).BankKeeper.GetBalance(chainB.GetContext(), chainB.SenderAccount.GetAddress(), ibcDenomTrace.IBCDenom())


### PR DESCRIPTION
This PR fixes two spelling mistakes:

Corrects "Balalance" to "Balance" in variable name
Fixes "Permissable" to "Permissible" in constant name

These changes improve code readability and maintain consistent terminology without affecting functionality. All tests should continue to pass.
