### PR TITLE
docs: fix typos

### DIFF
--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -52,7 +52,7 @@ func (a *App) OutOfOrderPrepareProposal(req abci.RequestPrepareProposal) abci.Re
 	}
 
 	// erasure the data square which we use to create the data root. Note: this
-	// is using a modified version of nmt where the order of the namepspaces is
+	// is using a modified version of nmt where the order of the namespaces is
 	// not enforced.
 	eds, err := ExtendShares(share.ToBytes(dataSquare))
 	if err != nil {

--- a/test/util/malicious/tree.go
+++ b/test/util/malicious/tree.go
@@ -14,7 +14,7 @@ import (
 
 // BlindTree is a wrapper around the erasured NMT that skips verification of
 // namespace ordering when hashing and adding leaves to the tree. It does this
-// by using a custom malicious hahser and wraps using the ForceAddLeaf method
+// by using a custom malicious hasher and wraps using the ForceAddLeaf method
 // instead of the normal Push.
 type BlindTree struct {
 	*nmt.NamespacedMerkleTree


### PR DESCRIPTION
"namepspaces - namespaces"
"hahser - hasher"