### PR TITLE
docs: fix typo

### DIFF
--- a/test/txsim/stake.go
+++ b/test/txsim/stake.go
@@ -80,7 +80,7 @@ func (s *StakeSequence) Next(ctx context.Context, querier grpc.ClientConn, rand 
 						DelegatorAddress:    s.account.String(),
 						ValidatorSrcAddress: s.delegatedTo,
 						ValidatorDstAddress: val.OperatorAddress,
-						// NOTE: only the initial stake is redelgated (not the entire balance)
+						// NOTE: only the initial stake is redelegated (not the entire balance)
 						Amount: types.NewInt64Coin(appconsts.BondDenom, int64(s.initialStake)),
 					},
 				},

--- a/test/util/genesis/accounts.go
+++ b/test/util/genesis/accounts.go
@@ -71,7 +71,7 @@ func NewDefaultValidator(name string) Validator {
 	}
 }
 
-// ValidateBasic performs stateless validation on the validitor
+// ValidateBasic performs stateless validation on the validator
 func (v *Validator) ValidateBasic() error {
 	if err := v.KeyringAccount.ValidateBasic(); err != nil {
 		return err


### PR DESCRIPTION

Changes Made:
1. test/util/genesis/accounts.go:
- Old: "validitor" -> New: "validator"
- Location: Comment before ValidateBasic function

2. test/txs/stake.go:
- Old: "redelgated" -> New: "redelegated" 
- Location: Comment in stake sequence function

Reason:
Fixed misspellings in code comments to improve readability and maintain consistent terminology. These are documentation-only changes with no functional impact.
