### PR TITLE
docs: fix typo in Docker documentation (#4183)

### DIFF
--- a/docs/maintainers/docker.md
+++ b/docs/maintainers/docker.md
@@ -10,7 +10,7 @@ Github Actions should automatically build and publish a Docker image for each re
 
 ## Steps
 
-1. Verify that a Docker image with the correct tag doesn't already exist for the release you're trying to create publish on [GHCR](https://github.com/celestiaorg/celestia-app/pkgs/container/celestia-app/versions)
+1. Verify that a Docker image with the correct tag doesn't already exist for the release you're trying to publish on [GHCR](https://github.com/celestiaorg/celestia-app/pkgs/container/celestia-app/versions)
 
 1. In a new terminal
 


### PR DESCRIPTION
Corrected a minor typo in the Docker image publishing instructions to improve clarity. The word "create publish" was changed to "publish" for grammatical accuracy. This change enhances the readability of the documentation without affecting functionality.

