### PR TITLE
feat: increase max-recv-msg-size default to 20 MiB

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -294,5 +294,8 @@ func DefaultAppConfig() *serverconfig.Config {
 	cfg.StateSync.SnapshotInterval = 1500
 	cfg.StateSync.SnapshotKeepRecent = 2
 	cfg.MinGasPrices = fmt.Sprintf("%v%s", appconsts.DefaultMinGasPrice, BondDenom)
+
+	const mebibyte = 1048576
+	cfg.GRPC.MaxRecvMsgSize = 20 * mebibyte
 	return cfg
 }

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -64,6 +64,9 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, uint64(1500), cfg.StateSync.SnapshotInterval)
 	assert.Equal(t, uint32(2), cfg.StateSync.SnapshotKeepRecent)
 	assert.Equal(t, "0.002utia", cfg.MinGasPrices)
+
+	mebibyte := 1048576
+	assert.Equal(t, 20*mebibyte, cfg.GRPC.MaxRecvMsgSize)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4204

Note this won't modify already existing `app.toml` files so node operators need to modify their local `app.toml`. Example command:

```shell
sed -i.bak 's/^max-recv-msg-size = "10485760"/max-recv-msg-size = "20971520"/' ~/.celestia-app/config/app.toml
```

## Testing

```shell
# Before
$ cat ~/.celestia-app/config/app.toml | grep max-recv
max-recv-msg-size = "10485760"

# After
$ ./scripts/single-node.sh
$ cat ~/.celestia-app/config/app.toml | grep max-recv
max-recv-msg-size = "20971520"
```