### PR TITLE
fix: spelling errors

### DIFF
--- a/docs/architecture/adr-001-abci++-adoption.md
+++ b/docs/architecture/adr-001-abci++-adoption.md
@@ -237,7 +237,7 @@ func SplitShares(txConf client.TxConfig, squareSize uint64, data *core.Data) ([]
    for _, rawTx := range data.Txs {
        ... // decode the transaction
 
-       // write the tx to the square if it normal
+       // write the tx to the square if it is normal
        if !hasWirePayForBlob(authTx) {
            success, err := sqwr.writeTx(rawTx)
            if err != nil {

--- a/docs/architecture/adr-004-qgb-relayer-security.md
+++ b/docs/architecture/adr-004-qgb-relayer-security.md
@@ -18,7 +18,7 @@ In fact, the QGB smart contract is designed to update the data commitments as fo
 - Check if the data commitment is signed using the current valset _(this is the problematic check)_
 - Then, other checks + commit
 
-So, if a relayer is up to date, it will submit data commitment and will pass the above checks.
+So, if a relayer is up-to-date, it will submit data commitment and will pass the above checks.
 
 Now, if the relayer is missing some data commitments or valset updates, then it will start catching up the following way:
 

--- a/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
+++ b/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
@@ -179,7 +179,7 @@ Light Nodes have additional access to row and column roots from the Data Availab
 
 ### Total Proof Size for Partial Nodes
 
-Partial nodes in this context are light clients that may download all of the data in the reserved namespace. They check that the data behind the PFB was included in the `DataRoot`, via blob inclusion proofs.
+Partial nodes in this context are light clients that may download all the data in the reserved namespace. They check that the data behind the PFB was included in the `DataRoot`, via blob inclusion proofs.
 
 For this analysis, we take the result from the light nodes and scale them up to fill the whole square. We ignore for now the reserved namespace and what space it might occupy.
 For the proposed non-interactive default rules we are also creating 1 more message that could practically fit into a square. This is because the current non-interactive default rules fit one more message if we construct it this way and don't adjust the first and last messages.


### PR DESCRIPTION
- Fixed "it normal" to "it is normal" in `adr-001-abci++-adoption.md`.
- Corrected "up to date" to "up-to-date" in `adr-004-qgb-relayer-security.md`.
- Removed unnecessary "of" in "all of the" in `adr-009-non-interactive-default-rules-for-reduced-padding.md`.
