### PR TITLE
test: default override rates

### DIFF
--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -89,6 +89,11 @@ func TestDefaultConsensusConfig(t *testing.T) {
 		}
 		assert.Equal(t, want, *got.Mempool)
 	})
+	t.Run("p2p overrides", func(t *testing.T) {
+		const mebibyte = 1048576
+		assert.Equal(t, int64(10*mebibyte), *&got.P2P.SendRate)
+		assert.Equal(t, int64(10*mebibyte), *&got.P2P.RecvRate)
+	})
 }
 
 func Test_icaDefaultGenesis(t *testing.T) {

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -91,8 +91,8 @@ func TestDefaultConsensusConfig(t *testing.T) {
 	})
 	t.Run("p2p overrides", func(t *testing.T) {
 		const mebibyte = 1048576
-		assert.Equal(t, int64(10*mebibyte), *&got.P2P.SendRate)
-		assert.Equal(t, int64(10*mebibyte), *&got.P2P.RecvRate)
+		assert.Equal(t, int64(10*mebibyte), got.P2P.SendRate)
+		assert.Equal(t, int64(10*mebibyte), got.P2P.RecvRate)
 	})
 }
 


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/4213

The real fix is in https://github.com/celestiaorg/cosmos-sdk/pull/425 but this is a nice to have.