### PR TITLE
chore(deps): sdk v1.26.1-sdk-v0.46.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -254,7 +254,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.26.0-sdk-v0.46.16
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.26.1-sdk-v0.46.16
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.44.2-tm-v0.34.35

--- a/go.sum
+++ b/go.sum
@@ -319,8 +319,8 @@ github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZI
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
 github.com/celestiaorg/celestia-core v1.44.2-tm-v0.34.35 h1:nzBzGv079TYgFrylV3Uh2ooLMyyrXZfg18sxQ3f9Bpw=
 github.com/celestiaorg/celestia-core v1.44.2-tm-v0.34.35/go.mod h1:bFr0lAGwaJ0mOHSBmib5/ca5pbBf1yKWGPs93Td0HPw=
-github.com/celestiaorg/cosmos-sdk v1.26.0-sdk-v0.46.16 h1:ur7UTTjFQpz0bAiZ8ttpRpLe0riFNDnpgYag9LhUgBM=
-github.com/celestiaorg/cosmos-sdk v1.26.0-sdk-v0.46.16/go.mod h1:ptAq795sDlo1DyTUK+kWng3wwcEJWj+3fzaNPs/fpCk=
+github.com/celestiaorg/cosmos-sdk v1.26.1-sdk-v0.46.16 h1:u36AbattAiIQbzUH4xA+ilXfc+siThJRDA7bcKF854s=
+github.com/celestiaorg/cosmos-sdk v1.26.1-sdk-v0.46.16/go.mod h1:ptAq795sDlo1DyTUK+kWng3wwcEJWj+3fzaNPs/fpCk=
 github.com/celestiaorg/go-square v1.1.1 h1:Cy3p8WVspVcyOqHM8BWFuuYPwMitO1pYGe+ImILFZRA=
 github.com/celestiaorg/go-square v1.1.1/go.mod h1:1EXMErhDrWJM8B8V9hN7dqJ2kUTClfwdqMOmF9yQUa0=
 github.com/celestiaorg/go-square/v2 v2.1.0 h1:ECIvYEeHIWiIJGDCJxQNtzqm5DmnBly7XGhSpLsl+Lw=

--- a/test/interchain/go.mod
+++ b/test/interchain/go.mod
@@ -224,7 +224,7 @@ replace (
 
 // These replace statements were inspired by celestia-app.
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.26.0-sdk-v0.46.16
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.26.1-sdk-v0.46.16
 	github.com/docker/docker => github.com/docker/docker v24.0.1+incompatible
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/test/interchain/go.sum
+++ b/test/interchain/go.sum
@@ -249,8 +249,8 @@ github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pY
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/celestiaorg/celestia-core v1.44.2-tm-v0.34.35 h1:nzBzGv079TYgFrylV3Uh2ooLMyyrXZfg18sxQ3f9Bpw=
 github.com/celestiaorg/celestia-core v1.44.2-tm-v0.34.35/go.mod h1:bFr0lAGwaJ0mOHSBmib5/ca5pbBf1yKWGPs93Td0HPw=
-github.com/celestiaorg/cosmos-sdk v1.26.0-sdk-v0.46.16 h1:ur7UTTjFQpz0bAiZ8ttpRpLe0riFNDnpgYag9LhUgBM=
-github.com/celestiaorg/cosmos-sdk v1.26.0-sdk-v0.46.16/go.mod h1:ptAq795sDlo1DyTUK+kWng3wwcEJWj+3fzaNPs/fpCk=
+github.com/celestiaorg/cosmos-sdk v1.26.1-sdk-v0.46.16 h1:u36AbattAiIQbzUH4xA+ilXfc+siThJRDA7bcKF854s=
+github.com/celestiaorg/cosmos-sdk v1.26.1-sdk-v0.46.16/go.mod h1:ptAq795sDlo1DyTUK+kWng3wwcEJWj+3fzaNPs/fpCk=
 github.com/celestiaorg/nmt v0.22.2 h1:JmOMtZL9zWAed1hiwb9DDs+ELcKp/ZQZ3rPverge/V8=
 github.com/celestiaorg/nmt v0.22.2/go.mod h1:/7huDiSRL/d2EGhoiKctgSzmLOJoWG8yEfbFtY1+Mow=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4213 by upgrading to https://github.com/celestiaorg/cosmos-sdk/releases/tag/v1.26.1-sdk-v0.46.16 which contains the fix.