### PR TITLE
refactor: make mebibyte a constant

### DIFF
--- a/app/benchmarks/benchmark_msg_send_test.go
+++ b/app/benchmarks/benchmark_msg_send_test.go
@@ -307,9 +307,6 @@ func generateMsgSendTransactions(b *testing.B, count int) (*app.App, [][]byte) {
 	return testApp, rawTxs
 }
 
-// mebibyte the number of bytes in a mebibyte
-const mebibyte = 1048576
-
 // calculateBlockSizeInMb returns the block size in mb given a set
 // of raw transactions.
 func calculateBlockSizeInMb(txs [][]byte) float64 {
@@ -317,7 +314,7 @@ func calculateBlockSizeInMb(txs [][]byte) float64 {
 	for _, tx := range txs {
 		numberOfBytes += len(tx)
 	}
-	mb := float64(numberOfBytes) / mebibyte
+	mb := float64(numberOfBytes) / app.Mebibyte
 	return mb
 }
 

--- a/app/benchmarks/benchmark_msg_send_test.go
+++ b/app/benchmarks/benchmark_msg_send_test.go
@@ -314,7 +314,7 @@ func calculateBlockSizeInMb(txs [][]byte) float64 {
 	for _, tx := range txs {
 		numberOfBytes += len(tx)
 	}
-	mb := float64(numberOfBytes) / app.Mebibyte
+	mb := float64(numberOfBytes) / Mebibyte
 	return mb
 }
 

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -36,6 +36,8 @@ import (
 	coretypes "github.com/tendermint/tendermint/types"
 )
 
+const Mebibyte = 1048576
+
 // bankModule defines a custom wrapper around the x/bank module's AppModuleBasic
 // implementation to provide custom default genesis state.
 type bankModule struct {
@@ -274,9 +276,8 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	cfg.TxIndex.Indexer = "null"
 	cfg.Storage.DiscardABCIResponses = true
 
-	const mebibyte = 1048576
-	cfg.P2P.SendRate = 10 * mebibyte
-	cfg.P2P.RecvRate = 10 * mebibyte
+	cfg.P2P.SendRate = 10 * Mebibyte
+	cfg.P2P.RecvRate = 10 * Mebibyte
 
 	return cfg
 }
@@ -295,7 +296,6 @@ func DefaultAppConfig() *serverconfig.Config {
 	cfg.StateSync.SnapshotKeepRecent = 2
 	cfg.MinGasPrices = fmt.Sprintf("%v%s", appconsts.DefaultMinGasPrice, BondDenom)
 
-	const mebibyte = 1048576
-	cfg.GRPC.MaxRecvMsgSize = 20 * mebibyte
+	cfg.GRPC.MaxRecvMsgSize = 20 * Mebibyte
 	return cfg
 }

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -90,7 +90,7 @@ func (stakingModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	})
 }
 
-// stakingModule wraps the x/staking module in order to overwrite specific
+// slashingModule wraps the x/slashing module in order to overwrite specific
 // ModuleManager APIs.
 type slashingModule struct {
 	slashing.AppModuleBasic

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -294,5 +294,8 @@ func DefaultAppConfig() *serverconfig.Config {
 	cfg.StateSync.SnapshotInterval = 1500
 	cfg.StateSync.SnapshotKeepRecent = 2
 	cfg.MinGasPrices = fmt.Sprintf("%v%s", appconsts.DefaultMinGasPrice, BondDenom)
+
+	const mebibyte = 1048576
+	cfg.GRPC.MaxRecvMsgSize = 20 * mebibyte
 	return cfg
 }

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -64,6 +64,9 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, uint64(1500), cfg.StateSync.SnapshotInterval)
 	assert.Equal(t, uint32(2), cfg.StateSync.SnapshotKeepRecent)
 	assert.Equal(t, "0.002utia", cfg.MinGasPrices)
+
+	mebibyte := 1048576
+	assert.Equal(t, 20*mebibyte, cfg.GRPC.MaxRecvMsgSize)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -65,8 +66,7 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, uint32(2), cfg.StateSync.SnapshotKeepRecent)
 	assert.Equal(t, "0.002utia", cfg.MinGasPrices)
 
-	mebibyte := 1048576
-	assert.Equal(t, 20*mebibyte, cfg.GRPC.MaxRecvMsgSize)
+	assert.Equal(t, 20*app.Mebibyte, cfg.GRPC.MaxRecvMsgSize)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {
@@ -93,9 +93,8 @@ func TestDefaultConsensusConfig(t *testing.T) {
 		assert.Equal(t, want, *got.Mempool)
 	})
 	t.Run("p2p overrides", func(t *testing.T) {
-		const mebibyte = 1048576
-		assert.Equal(t, int64(10*mebibyte), got.P2P.SendRate)
-		assert.Equal(t, int64(10*mebibyte), got.P2P.RecvRate)
+		assert.Equal(t, int64(10*app.Mebibyte), got.P2P.SendRate)
+		assert.Equal(t, int64(10*app.Mebibyte), got.P2P.RecvRate)
 	})
 }
 

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/cosmos/cosmos-sdk/types"
 	distributiontypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
@@ -66,7 +65,7 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, uint32(2), cfg.StateSync.SnapshotKeepRecent)
 	assert.Equal(t, "0.002utia", cfg.MinGasPrices)
 
-	assert.Equal(t, 20*app.Mebibyte, cfg.GRPC.MaxRecvMsgSize)
+	assert.Equal(t, 20*Mebibyte, cfg.GRPC.MaxRecvMsgSize)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {
@@ -93,8 +92,8 @@ func TestDefaultConsensusConfig(t *testing.T) {
 		assert.Equal(t, want, *got.Mempool)
 	})
 	t.Run("p2p overrides", func(t *testing.T) {
-		assert.Equal(t, int64(10*app.Mebibyte), got.P2P.SendRate)
-		assert.Equal(t, int64(10*app.Mebibyte), got.P2P.RecvRate)
+		assert.Equal(t, int64(10*Mebibyte), got.P2P.SendRate)
+		assert.Equal(t, int64(10*Mebibyte), got.P2P.RecvRate)
 	})
 }
 

--- a/app/test/big_blob_test.go
+++ b/app/test/big_blob_test.go
@@ -39,10 +39,10 @@ func (s *BigBlobSuite) SetupSuite() {
 	s.accounts = testfactory.GenerateAccounts(1)
 
 	tmConfig := testnode.DefaultTendermintConfig()
-	tmConfig.Mempool.MaxTxBytes = 10 * mebibyte
+	tmConfig.Mempool.MaxTxBytes = 10 * app.Mebibyte
 
 	cParams := testnode.DefaultConsensusParams()
-	cParams.Block.MaxBytes = 10 * mebibyte
+	cParams.Block.MaxBytes = 10 * app.Mebibyte
 
 	cfg := testnode.DefaultConfig().
 		WithFundedAccounts(s.accounts...).

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -128,7 +128,7 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 			for i, tx := range txs {
 				// The default CometBFT mempool MaxTxBytes is 1 MiB so the generators in
 				// this test must create transactions that are smaller than that.
-				require.LessOrEqual(t, len(tx), 1*mebibyte)
+				require.LessOrEqual(t, len(tx), 1*app.Mebibyte)
 
 				res, err := s.cctx.Context.BroadcastTxSync(tx)
 				require.NoError(t, err)

--- a/app/test/unit_test.go
+++ b/app/test/unit_test.go
@@ -2,5 +2,4 @@ package app_test
 
 const (
 	kibibyte = 1024
-	mebibyte = 1024 * kibibyte
 )

--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -203,8 +203,8 @@ func EmptySquareShares() []share.Share {
 
 // SquareSize is a copy of the function defined in the square package to avoid
 // a circular dependency. TODO deduplicate
-func SquareSize(len int) int {
-	return RoundUpPowerOfTwo(int(math.Ceil(math.Sqrt(float64(len)))))
+func SquareSize(length int) int {
+	return RoundUpPowerOfTwo(int(math.Ceil(math.Sqrt(float64(length)))))
 }
 
 // RoundUpPowerOfTwo returns the next power of two greater than or equal to input.

--- a/test/txsim/blob.go
+++ b/test/txsim/blob.go
@@ -123,8 +123,8 @@ type Range struct {
 	Max int
 }
 
-func NewRange(min, max int) Range {
-	return Range{Min: min, Max: max}
+func NewRange(minimum, maximum int) Range {
+	return Range{Min: minimum, Max: maximum}
 }
 
 // Rand returns a random number between min (inclusive) and max (exclusive).

--- a/test/util/testnode/comet_node_test.go
+++ b/test/util/testnode/comet_node_test.go
@@ -46,7 +46,7 @@ func customTendermintConfig() *tmconfig.Config {
 	// Override the MaxBodyBytes to allow the testnode to accept very large
 	// transactions and respond to queries with large responses (200 MiB was
 	// chosen only as an arbitrary large number).
-	tmCfg.RPC.MaxBodyBytes = 200 * mebibyte
+	tmCfg.RPC.MaxBodyBytes = 200 * Mebibyte
 
 	tmCfg.RPC.TimeoutBroadcastTxCommit = time.Minute
 	return tmCfg

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	kibibyte                    = 1024      // bytes
-	mebibyte                    = 1_048_576 // bytes
+	Mebibyte                    = 1_048_576 // bytes
 	DefaultValidatorAccountName = "validator"
 	DefaultInitialBalance       = genesis.DefaultInitialBalance
 )

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	squareSize = 64
-	mebibyte   = 1_048_576 // bytes
+	Mebibyte   = 1_048_576 // bytes
 )
 
 func TestBlobShareDecorator(t *testing.T) {
@@ -42,7 +42,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "want no error if appVersion v1 and 8 MiB blob",
 			blobsPerPFB: 1,
-			blobSize:    8 * mebibyte,
+			blobSize:    8 * Mebibyte,
 			appVersion:  v1.Version,
 		},
 		{
@@ -54,13 +54,13 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "PFB with 1 blob that is 1 MiB",
 			blobsPerPFB: 1,
-			blobSize:    1 * mebibyte,
+			blobSize:    1 * Mebibyte,
 			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that is 2 MiB",
 			blobsPerPFB: 1,
-			blobSize:    2 * mebibyte,
+			blobSize:    2 * Mebibyte,
 			appVersion:  v2.Version,
 			// This test case should return an error because a square size of 64
 			// has exactly 2 MiB of total capacity so the total blob capacity
@@ -76,7 +76,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "PFB with 2 blobs that are 1 MiB each",
 			blobsPerPFB: 2,
-			blobSize:    1 * mebibyte,
+			blobSize:    1 * Mebibyte,
 			appVersion:  v2.Version,
 			// This test case should return an error for the same reason a
 			// single blob that is 2 MiB returns an error.

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	mebibyte   = 1_048_576 // 1 MiB
 	squareSize = 64
 )
 
@@ -42,7 +41,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "want no error if appVersion v1 and 8 MiB blob",
 			blobsPerPFB: 1,
-			blobSize:    8 * mebibyte,
+			blobSize:    8 * testnode.Mebibyte,
 			appVersion:  v1.Version,
 		},
 		{
@@ -54,13 +53,13 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "PFB with 1 blob that is 1 MiB",
 			blobsPerPFB: 1,
-			blobSize:    1 * mebibyte,
+			blobSize:    1 * testnode.Mebibyte,
 			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that is 2 MiB",
 			blobsPerPFB: 1,
-			blobSize:    2 * mebibyte,
+			blobSize:    2 * testnode.Mebibyte,
 			appVersion:  v2.Version,
 			// This test case should return an error because a square size of 64
 			// has exactly 2 MiB of total capacity so the total blob capacity
@@ -76,7 +75,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "PFB with 2 blobs that are 1 MiB each",
 			blobsPerPFB: 2,
-			blobSize:    1 * mebibyte,
+			blobSize:    1 * testnode.Mebibyte,
 			appVersion:  v2.Version,
 			// This test case should return an error for the same reason a
 			// single blob that is 2 MiB returns an error.

--- a/x/blob/ante/blob_share_decorator_test.go
+++ b/x/blob/ante/blob_share_decorator_test.go
@@ -25,6 +25,7 @@ import (
 
 const (
 	squareSize = 64
+	mebibyte   = 1_048_576 // bytes
 )
 
 func TestBlobShareDecorator(t *testing.T) {
@@ -41,7 +42,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "want no error if appVersion v1 and 8 MiB blob",
 			blobsPerPFB: 1,
-			blobSize:    8 * testnode.Mebibyte,
+			blobSize:    8 * mebibyte,
 			appVersion:  v1.Version,
 		},
 		{
@@ -53,13 +54,13 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "PFB with 1 blob that is 1 MiB",
 			blobsPerPFB: 1,
-			blobSize:    1 * testnode.Mebibyte,
+			blobSize:    1 * mebibyte,
 			appVersion:  v2.Version,
 		},
 		{
 			name:        "PFB with 1 blob that is 2 MiB",
 			blobsPerPFB: 1,
-			blobSize:    2 * testnode.Mebibyte,
+			blobSize:    2 * mebibyte,
 			appVersion:  v2.Version,
 			// This test case should return an error because a square size of 64
 			// has exactly 2 MiB of total capacity so the total blob capacity
@@ -75,7 +76,7 @@ func TestBlobShareDecorator(t *testing.T) {
 		{
 			name:        "PFB with 2 blobs that are 1 MiB each",
 			blobsPerPFB: 2,
-			blobSize:    1 * testnode.Mebibyte,
+			blobSize:    1 * mebibyte,
 			appVersion:  v2.Version,
 			// This test case should return an error for the same reason a
 			// single blob that is 2 MiB returns an error.

--- a/x/blob/ante/max_total_blob_size_ante.go
+++ b/x/blob/ante/max_total_blob_size_ante.go
@@ -31,11 +31,11 @@ func (d MaxTotalBlobSizeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 		return next(ctx, tx, simulate)
 	}
 
-	max := d.maxTotalBlobSize(ctx)
+	maximum := d.maxTotalBlobSize(ctx)
 	for _, m := range tx.GetMsgs() {
 		if pfb, ok := m.(*blobtypes.MsgPayForBlobs); ok {
-			if total := getTotal(pfb.BlobSizes); total > max {
-				return ctx, errors.Wrapf(blobtypes.ErrTotalBlobSizeTooLarge, "total blob size %d exceeds max %d", total, max)
+			if total := getTotal(pfb.BlobSizes); total > maximum {
+				return ctx, errors.Wrapf(blobtypes.ErrTotalBlobSizeTooLarge, "total blob size %d exceeds max %d", total, maximum)
 			}
 		}
 	}

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	v1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
-	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
 	ante "github.com/celestiaorg/celestia-app/v3/x/blob/ante"
 	blob "github.com/celestiaorg/celestia-app/v3/x/blob/types"
 	"github.com/celestiaorg/go-square/v2/share"
@@ -44,14 +43,14 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 		{
 			name: "PFB with 1 blob that is 1 MiB",
 			pfb: &blob.MsgPayForBlobs{
-				BlobSizes: []uint32{testnode.Mebibyte},
+				BlobSizes: []uint32{Mebibyte},
 			},
 			appVersion: v1.Version,
 		},
 		{
 			name: "PFB with 1 blob that is 2 MiB",
 			pfb: &blob.MsgPayForBlobs{
-				BlobSizes: []uint32{2 * testnode.Mebibyte},
+				BlobSizes: []uint32{2 * Mebibyte},
 			},
 			appVersion: v1.Version,
 			// This test case should return an error because a square size of 64
@@ -69,7 +68,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 		{
 			name: "PFB with 2 blobs that are 1 MiB each",
 			pfb: &blob.MsgPayForBlobs{
-				BlobSizes: []uint32{testnode.Mebibyte, testnode.Mebibyte},
+				BlobSizes: []uint32{Mebibyte, Mebibyte},
 			},
 			appVersion: v1.Version,
 			// This test case should return an error for the same reason a

--- a/x/blob/ante/max_total_blob_size_ante_test.go
+++ b/x/blob/ante/max_total_blob_size_ante_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	v1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
+	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
 	ante "github.com/celestiaorg/celestia-app/v3/x/blob/ante"
 	blob "github.com/celestiaorg/celestia-app/v3/x/blob/types"
 	"github.com/celestiaorg/go-square/v2/share"
@@ -43,14 +44,14 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 		{
 			name: "PFB with 1 blob that is 1 MiB",
 			pfb: &blob.MsgPayForBlobs{
-				BlobSizes: []uint32{mebibyte},
+				BlobSizes: []uint32{testnode.Mebibyte},
 			},
 			appVersion: v1.Version,
 		},
 		{
 			name: "PFB with 1 blob that is 2 MiB",
 			pfb: &blob.MsgPayForBlobs{
-				BlobSizes: []uint32{2 * mebibyte},
+				BlobSizes: []uint32{2 * testnode.Mebibyte},
 			},
 			appVersion: v1.Version,
 			// This test case should return an error because a square size of 64
@@ -68,7 +69,7 @@ func TestMaxTotalBlobSizeDecorator(t *testing.T) {
 		{
 			name: "PFB with 2 blobs that are 1 MiB each",
 			pfb: &blob.MsgPayForBlobs{
-				BlobSizes: []uint32{mebibyte, mebibyte},
+				BlobSizes: []uint32{testnode.Mebibyte, testnode.Mebibyte},
 			},
 			appVersion: v1.Version,
 			// This test case should return an error for the same reason a

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -156,14 +156,14 @@ func TestCalculateBlockProvisionError(t *testing.T) {
 }
 
 func randomBlockInterval() time.Duration {
-	min := (14 * time.Second).Nanoseconds()
-	max := (16 * time.Second).Nanoseconds()
-	return time.Duration(randInRange(min, max))
+	minimum := (14 * time.Second).Nanoseconds()
+	maximum := (16 * time.Second).Nanoseconds()
+	return time.Duration(randInRange(minimum, maximum))
 }
 
 // randInRange returns a random number in the range (min, max) inclusive.
-func randInRange(min int64, max int64) int64 {
-	return rand.Int63n(max-min) + min
+func randInRange(minimum int64, maximum int64) int64 {
+	return rand.Int63n(maximum-minimum) + minimum
 }
 
 func BenchmarkCalculateBlockProvision(b *testing.B) {


### PR DESCRIPTION
## Overview


This PR refactors the use of mebibyte by centralizing it as a constant to avoid redundant declarations and improve code maintainability. This aligns with DRY principles, ensuring consistency and simplifying future updates.

Issue: [#4211](https://github.com/celestiaorg/celestia-app/issues/4211)

