### PR TITLE
Update Makefile: Fix typo max_txs_bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,7 +350,7 @@ configure-v3:
 		sed -i "s/^send_rate = .*/send_rate = $(SEND_RECV_RATE)/" $(CONFIG_FILE); \
 		sed -i "s/^ttl-num-blocks = .*/ttl-num-blocks = 12/" $(CONFIG_FILE); \
 		sed -i "s/^ttl-duration = .*/ttl-duration = \"1m15s\"/" $(CONFIG_FILE); \
-		sed -i "s/^max_txs_bytes = .*/max_tx_bytes = 7897088/" $(CONFIG_FILE); \
+		sed -i "s/^max_tx_bytes = .*/max_tx_bytes = 7897088/" $(CONFIG_FILE); \
 		sed -i '' "s/^max_txs_bytes = .*/max_txs_bytes = 39485440/" $(CONFIG_FILE); \
 	fi
 .PHONY: configure-v3


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
There was a typo on the sed command
sed -i "s/^max_txs_bytes = .*/max_tx_bytes = 7897088/" $(CONFIG_FILE);
Instead of
sed -i "s/^max_tx_bytes = .*/max_tx_bytes = 7897088/" $(CONFIG_FILE);
-->
