### PR TITLE
fix: Fix incorrect namespace byte length Update adr-014-versioned-nam…

### DIFF
--- a/docs/architecture/adr-014-versioned-namespaces.md
+++ b/docs/architecture/adr-014-versioned-namespaces.md
@@ -145,10 +145,10 @@ Regardless of the option chosen, end-users must explicitly specify the namespace
 
 Since the NMT needs to be aware of the version byte, Option A is equivalent to increasing the namespace ID size to `9` bytes and then constraining the namespaces available for use to namespaces that have a leading `0` byte. In other words:
 
-- MinReservedNamespace: []byte{0, 0, 0, 0, 0, 0, 0, 0, 1}
-- MaxReservedNamespace: []byte{0, 0, 0, 0, 0, 0, 0, 0, 255}
-- MinBlobNamespace: []byte{0, 0, 0, 0, 0, 0, 0, 1, 0}
-- MaxBlobNamespace: []byte{0, 255, 255, 255, 255, 255, 255, 255, 255}
+- MinReservedNamespace: []byte{0, 0, 0, 0, 0, 0, 0, 1}
+- MaxReservedNamespace: []byte{0, 0, 0, 0, 0, 0, 0, 255}
+- MinBlobNamespace: []byte{0, 0, 0, 0, 0, 0, 1, 0}
+- MaxBlobNamespace: []byte{0, 255, 255, 255, 255, 255, 255, 255}
 
 When a user creates a PFB, concatenate the namespace version with the namespace ID to derive the namespace that is pushed to the NMT. Option C is similar to Option A, if we constrain the available share versions at mainnet to `0`.
 


### PR DESCRIPTION
## Overview

I noticed a mismatch in the byte length for `MinReservedNamespace` and `MaxReservedNamespace` in the **Implementation Details** section. According to Option A, the Namespace ID should be 8 bytes when Namespace Version = 0, but the current implementation uses 9 bytes.  

I’ve corrected the values to align with the specification:  
- `MinReservedNamespace` and `MaxReservedNamespace` now use 8 bytes.  
- Adjusted `MinBlobNamespace` and `MaxBlobNamespace` accordingly.  

