### PR TITLE
docs: Fix incorrect proof size calculation in Proposed Non-Interactiv…

### DIFF
--- a/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
+++ b/docs/architecture/adr-009-non-interactive-default-rules-for-reduced-padding.md
@@ -149,7 +149,7 @@ Proof size = 48 \* (sqrt(n) + log(k) + log(n)) + 64 \*log(k)
 ### Proposed Non-Interactive Default Rules for k/4
 
 Proof size = subtree roots (rows) + subtree roots (last row) + blue nodes (parity shares) + 2 \* blue nodes (`DataRoot`)
-Proof size = (**k/2** + log(k) + k/4) \* NMT-Node size  + 2\*log(k) \* MT-Node size
+Proof size = (3k/4 + log(k)) * NMT-Node size + 2*log(k) * MT-Node size
 Proof size = 48 \* (3k/4 + log(k)) + 64 \*log(k)
 
 ## 5. What is the worst constructible block with the most amount of padding with old and new non-interactive default rules?


### PR DESCRIPTION
## Overview

An error in the proof size formula where `k/2` and `k/4` were not combined, leading to a misleading representation. The correct simplification should be `3k/4` since `k/2 + k/4 = 3k/4`. This updates the formula to reflect this correction.  

Before:  
```  
Proof size = (k/2 + log(k) + k/4) * NMT-Node size + 2*log(k) * MT-Node size  
```  

After:  
```  
Proof size = (3k/4 + log(k)) * NMT-Node size + 2*log(k) * MT-Node size  
```  

This change ensures the formula is accurate and avoids potential confusion.
