### PR TITLE
refactor: fix typos

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -355,8 +355,8 @@ func New(
 	// PacketForwardMiddleware is used only for version >= 2.
 	transferStack = module.NewVersionedIBCModule(packetForwardMiddleware, transferStack, v2, v3)
 	// Token filter wraps packet forward middleware and is thus the first module in the transfer stack.
-	tokenFilterMiddelware := tokenfilter.NewIBCMiddleware(transferStack)
-	transferStack = module.NewVersionedIBCModule(tokenFilterMiddelware, transferStack, v1, v3)
+	tokenFilterMiddleware := tokenfilter.NewIBCMiddleware(transferStack)
+	transferStack = module.NewVersionedIBCModule(tokenFilterMiddleware, transferStack, v1, v3)
 
 	app.EvidenceKeeper = *evidencekeeper.NewKeeper(
 		appCodec,

--- a/app/test/consistent_apphash_test.go
+++ b/app/test/consistent_apphash_test.go
@@ -318,8 +318,8 @@ func encodedSdkMessagesV1(t *testing.T, accountAddresses []sdk.AccAddress, genVa
 
 	// NewMsgCreatePermanentLockedAccount - creates a permanent locked account
 	newAddress = sdk.AccAddress(ed25519.GenPrivKeyFromSecret([]byte("anotherAddress2")).PubKey().Address())
-	msgCreatePermamentLockedAccount := vestingtypes.NewMsgCreatePermanentLockedAccount(accountAddresses[3], newAddress, amount)
-	secondBlockSdkMsgs = append(secondBlockSdkMsgs, msgCreatePermamentLockedAccount)
+	msgCreatePermanentLockedAccount := vestingtypes.NewMsgCreatePermanentLockedAccount(accountAddresses[3], newAddress, amount)
+	secondBlockSdkMsgs = append(secondBlockSdkMsgs, msgCreatePermanentLockedAccount)
 
 	// NewMsgCreateVestingAccount - creates a vesting account
 	newAddress = sdk.AccAddress(ed25519.GenPrivKeyFromSecret([]byte("anotherAddress3")).PubKey().Address())

--- a/x/paramfilter/test/gov_params_test.go
+++ b/x/paramfilter/test/gov_params_test.go
@@ -291,9 +291,9 @@ func (suite *GovParamsTestSuite) TestModifiableParams() {
 				Value:    `{"quorum": "0.1", "threshold": "0.2", "veto_threshold": "0.3"}`,
 			}),
 			func() {
-				gotQuroum := suite.app.GovKeeper.GetTallyParams(suite.ctx).Quorum
+				gotQuorum := suite.app.GovKeeper.GetTallyParams(suite.ctx).Quorum
 				wantQuorum := "0.1"
-				assert.Equal(wantQuorum, gotQuroum)
+				assert.Equal(wantQuorum, gotQuorum)
 
 				gotThreshold := suite.app.GovKeeper.GetTallyParams(suite.ctx).Threshold
 				wantThreshold := "0.2"


### PR DESCRIPTION
- **Fixed incorrect variable name in `app.go`**:
  - `tokenFilterMiddelware` → `tokenFilterMiddleware` to maintain proper naming consistency.
  
- **Corrected function name in `consistent_apphash_test.go`**:
  - `msgCreatePermamentLockedAccount` → `msgCreatePermanentLockedAccount` to match the intended function definition.

- **Updated incorrect variable name in `gov_params_test.go`**:
  - `gotQuroum` → `gotQuorum` to align with correct terminology in governance tally parameters.
