### PR TITLE
docs: fix typos

### DIFF
--- a/app/validate_txs.go
+++ b/app/validate_txs.go
@@ -66,7 +66,7 @@ func filterStdTxs(logger log.Logger, dec sdk.TxDecoder, ctx sdk.Context, handler
 		ctx, err = handler(ctx, sdkTx, false)
 		// either the transaction is invalid (ie incorrect nonce) and we
 		// simply want to remove this tx, or we're catching a panic from one
-		// of the anteHanders which is logged.
+		// of the anteHandlers which is logged.
 		if err != nil {
 			logger.Error(
 				"filtering already checked transaction",
@@ -110,7 +110,7 @@ func filterBlobTxs(logger log.Logger, dec sdk.TxDecoder, ctx sdk.Context, handle
 		ctx, err = handler(ctx, sdkTx, false)
 		// either the transaction is invalid (ie incorrect nonce) and we
 		// simply want to remove this tx, or we're catching a panic from one
-		// of the anteHanders which is logged.
+		// of the anteHandlers which is logged.
 		if err != nil {
 			logger.Error(
 				"filtering already checked blob transaction", "tx", tmbytes.HexBytes(coretypes.Tx(tx.Tx).Hash()), "error", err,

--- a/pkg/proof/share_proof.go
+++ b/pkg/proof/share_proof.go
@@ -65,7 +65,7 @@ func (sp ShareProof) VerifyProof() bool {
 			return false
 		}
 		// Consider extracting celestia-app's namespace package. We can't use it
-		// here because that would introduce a circulcar import.
+		// here because that would introduce a circular import.
 		namespace := append([]byte{uint8(sp.NamespaceVersion)}, sp.NamespaceId...)
 		valid := nmtProof.VerifyInclusion(
 			appconsts.NewBaseHashFunc(),


### PR DESCRIPTION
changed:

anteHanders - anteHandlers 

circulcar - circular 