### PR TITLE
docs(blob): add links to inclusion and fraud proofs documentation

### DIFF
--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -24,7 +24,7 @@ in a block via a blob inclusion proof. A blob inclusion proof uses the
 block's data square to prove to the user that the shares that compose their
 original data do in fact exist in a particular block.
 
-> TODO: link to blob inclusion (and fraud) proof
+For detailed information about blob inclusion proofs and fraud proofs, see the [Fraud Proofs specification](../specs/src/fraud_proofs.md) and [ADR-011: Optimistic Blob Size Independent Inclusion Proofs and PFB Fraud Proofs](../docs/architecture/adr-011-optimistic-blob-size-independent-inclusion-proofs-and-pfb-fraud-proofs.md).
 
 ## State
 

--- a/x/mint/client/testutil/suite_test.go
+++ b/x/mint/client/testutil/suite_test.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -16,6 +17,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
+	"github.com/cosmos/cosmos-sdk/x/bank/types"
 )
 
 type IntegrationTestSuite struct {
@@ -84,6 +86,13 @@ func (s *IntegrationTestSuite) TestGetCmdQueryInflationRate() {
 //
 // TODO assert that total supply is 500_000_000 utia.
 func (s *IntegrationTestSuite) TestGetCmdQueryAnnualProvisions() {
+	// Verify that the initial total supply is 500_000_000 utia
+	bankClient := banktypes.NewQueryClient(s.cctx.Context)
+	resp, err := bankClient.TotalSupply(context.Background(), &banktypes.QueryTotalSupplyRequest{})
+	s.Require().NoError(err)
+	expectedTotalSupply := sdk.NewInt(500_000_000).Mul(sdk.NewInt(1_000_000)) // 500_000_000 utia
+	s.Require().Equal(expectedTotalSupply.String(), resp.Supply.AmountOf("utia").String())
+
 	testCases := []struct {
 		name string
 		args []string


### PR DESCRIPTION
Added links to the Fraud Proofs specification and ADR-011 in the blob module README.
This provides readers with detailed information about blob inclusion proofs and
fraud proofs implementation.

Resolves TODO in x/blob/README.md

Also

Added verification of the initial total supply in TestGetCmdQueryAnnualProvisions.
This ensures that the total supply is exactly 500,000,000 utia before calculating
annual provisions, which is a critical assumption for the test.

Resolves TODO comment in x/mint/client/testutil/suite_test.go