### PR TITLE
docs: fix typo

### DIFF
--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -36,7 +36,7 @@ func (app *App) ProcessProposal(req abci.RequestProcessProposal) (resp abci.Resp
 		}
 	}()
 
-	// Create the anteHander that is used to check the validity of
+	// Create the anteHandler that is used to check the validity of
 	// transactions. All transactions need to be equally validated here
 	// so that the nonce number is always correctly incremented (which
 	// may affect the validity of future transactions).

--- a/x/mint/test/mint_test.go
+++ b/x/mint/test/mint_test.go
@@ -57,13 +57,13 @@ func (s *IntegrationTestSuite) TestTotalSupplyIncreasesOverTime() {
 	err := s.cctx.WaitForNextBlock()
 	require.NoError(err)
 
-	initalSupply := s.getTotalSupply(initialHeight)
+	initialSupply := s.getTotalSupply(initialHeight)
 
 	_, err = s.cctx.WaitForHeight(laterHeight + 1)
 	require.NoError(err)
 	laterSupply := s.getTotalSupply(laterHeight)
 
-	require.True(initalSupply.AmountOf(app.BondDenom).LT(laterSupply.AmountOf(app.BondDenom)))
+	require.True(initialSupply.AmountOf(app.BondDenom).LT(laterSupply.AmountOf(app.BondDenom)))
 }
 
 // TestInflationRate verifies that the inflation rate each year matches the


### PR DESCRIPTION
Hi! Just a quick cleanup PR to fix a couple of typos:

- **`process_proposal.go`** – Fixed a comment typo (`anteHander` → `anteHandler`).
- **`mint_test.go`** – Corrected a variable name (`initalSupply` → `initialSupply`).