### PR TITLE
issue in function

### DIFF
--- a/x/blobstream/keeper/keeper_attestation.go
+++ b/x/blobstream/keeper/keeper_attestation.go
@@ -120,7 +120,7 @@ func (k Keeper) GetAttestationByNonce(ctx sdk.Context, nonce uint64) (types.Atte
 	var at types.AttestationRequestI
 	err := k.cdc.UnmarshalInterface(bz, &at)
 	if err != nil {
-		return nil, false, types.ErrUnmarshalllAttestation
+		return nil, false, types.ErrUnmarshallAttestation
 	}
 	return at, true, nil
 }


### PR DESCRIPTION
x/blobstream/keeper/keeper_attestation.go
types.ErrUnmarshalllAttestation - types.ErrUnmarshallAttestation