### PR TITLE
refactor: fix initialization of minTime and maxTime variables

### DIFF
--- a/tools/blocktime/main.go
+++ b/tools/blocktime/main.go
@@ -77,20 +77,31 @@ Block Time (from %d to %d):
 // analyzeBlockTimes returns the average, min, max, and standard deviation of the block times.
 // Units are in milliseconds.
 func analyzeBlockTimes(times []time.Time) (float64, float64, float64, float64) {
-	numberOfObservations := len(times) - 1
-	totalTime := times[numberOfObservations].Sub(times[0])
-	averageTime := float64(totalTime.Milliseconds()) / float64(numberOfObservations)
-	variance, minTime, maxTime := float64(0), float64(0), float64(0)
-	for i := 0; i < numberOfObservations; i++ {
-		diff := float64(times[i+1].Sub(times[i]).Milliseconds())
-		if minTime == 0 || diff < minTime {
-			minTime = diff
-		}
-		if maxTime == 0 || diff > maxTime {
-			maxTime = diff
-		}
-		variance += math.Pow(averageTime-diff, 2)
-	}
-	stddev := math.Sqrt(variance / float64(numberOfObservations))
-	return averageTime, minTime, maxTime, stddev
+    numberOfObservations := len(times) - 1
+    totalTime := times[numberOfObservations].Sub(times[0])
+    averageTime := float64(totalTime.Milliseconds()) / float64(numberOfObservations)
+    
+    // Initialize minTime and maxTime correctly
+    minTime := math.MaxFloat64
+    maxTime := -math.MaxFloat64
+    
+    variance := float64(0)
+    
+    for i := 0; i < numberOfObservations; i++ {
+        diff := float64(times[i+1].Sub(times[i]).Milliseconds())
+        
+        // Calculate the minimum and maximum block times
+        if diff < minTime {
+            minTime = diff
+        }
+        if diff > maxTime {
+            maxTime = diff
+        }
+        
+        variance += math.Pow(averageTime-diff, 2)
+    }
+    
+    stddev := math.Sqrt(variance / float64(numberOfObservations))
+    return averageTime, minTime, maxTime, stddev
 }
+


### PR DESCRIPTION
## Overview

I’ve updated the initialization of the `minTime` and `maxTime` variables.
Now, they are set to values that ensure the correct calculation of the minimum and maximum times during the process.
This change eliminates the issue with incorrect time boundaries in earlier computations.
