### PR TITLE
docs: fix typo

### DIFF
--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -16,7 +16,7 @@ PS: The `ValsetConfirm` has been updated in `adr-005-qgb-reduce-state-usage`. Pl
 
 ## Detailed Design
 
-Since the QGB is only a one-way bridge and does not transfer assets, it doesn't require the portions of the gravity module that recreate the state from the bridged chain. We only need to keep things relating to signing over the validator set (such as`MsgSetOrchestratorAddress` and `MsgValsetConfirm`) and relayer queries (such as `ValsetConfirm` and `GetDelegateKeyByOrchestrator`).
+Since the QGB is only a one-way bridge and does not transfer assets, it doesn't require the portions of the gravity module that recreate the state from the bridged chain. We only need to keep things relating to signing over the validator set (such as `MsgSetOrchestratorAddress` and `MsgValsetConfirm`) and relayer queries (such as `ValsetConfirm` and `GetDelegateKeyByOrchestrator`).
 
 It works by relying on a set of signers to attest to some event on Celestia: the Celestia validator set.
 


### PR DESCRIPTION
as`MsgSetOrchestratorAddress` - as `MsgSetOrchestratorAddress`

add space 