### PR TITLE
docs: fix typo

### DIFF
--- a/proto/celestia/core/v1/proof/proof.proto
+++ b/proto/celestia/core/v1/proof/proof.proto
@@ -37,7 +37,7 @@ message NMTProof {
   // and min namespaces along with the actual hash, resulting in each being 48
   // bytes each
   repeated bytes nodes = 3;
-  // leafHash are nil if the namespace is present in the NMT. In case the
+  // leafHash is nil if the namespace is present in the NMT. In case the
   // namespace to be proved is in the min/max range of the tree but absent, this
   // will contain the leaf hash necessary to verify the proof of absence. Leaf
   // hashes should consist of the namespace along with the actual hash,


### PR DESCRIPTION
proto/celestia/core/v1/proof/proof.proto:

leafHash are nil → leafHash is nil
