### PR TITLE
revert: default mempool to prioritized (v1)

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -269,7 +269,7 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	cfg.Mempool.TTLDuration = 75 * time.Second
 	cfg.Mempool.MaxTxBytes = 2 * mebibyte
 	cfg.Mempool.MaxTxsBytes = 80 * mebibyte
-	cfg.Mempool.Version = "v2" // Content Addressable Transaction (CAT) mempool
+	cfg.Mempool.Version = "v1" // Content Addressable Transaction (CAT) mempool
 
 	cfg.Consensus.TimeoutPropose = appconsts.GetTimeoutPropose(appconsts.LatestVersion)
 	cfg.Consensus.TimeoutCommit = appconsts.GetTimeoutCommit(appconsts.LatestVersion)

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -87,7 +87,7 @@ func TestDefaultConsensusConfig(t *testing.T) {
 			MaxTxsBytes:  80 * mebibyte,
 			TTLDuration:  75 * time.Second,
 			TTLNumBlocks: 12,
-			Version:      "v2",
+			Version:      "v1",
 		}
 		assert.Equal(t, want, *got.Mempool)
 	})


### PR DESCRIPTION
We got reports from @mindstyle85 that the v2 mempool caused issues for users so we're reverting the default back to the prioritized mempool v1.