### PR TITLE
chore: fixed bash array syntax issue

### DIFF
--- a/scripts/test_cover.sh
+++ b/scripts/test_cover.sh
@@ -13,7 +13,7 @@ for DIR in "${EXCLUDE_DIRS[@]}"; do
 done
 
 echo "mode: atomic" > coverage.txt
-for pkg in ${PKGS[@]}; do
+for pkg in "${PKGS[@]}"; do
     go test -v -timeout 30m -test.short -coverprofile=profile.out -covermode=atomic "$pkg"
     if [ -f profile.out ]; then
         tail -n +2 profile.out >> coverage.txt;


### PR DESCRIPTION
## Overview

I noticed an issue in the loop where the array elements were not properly quoted, which could lead to problems if any of the package paths contained spaces. The correct syntax is to use `"${PKGS[@]}"` instead of `${PKGS[@]}`.
