### PR TITLE
docs: Fix spelling errors in `app.toml`

### DIFF
--- a/local_devnet/celestia-app/app.toml
+++ b/local_devnet/celestia-app/app.toml
@@ -43,7 +43,7 @@ halt-time = 0
 # It has no bearing on application state pruning which is determined by the
 # "pruning-*" configurations.
 #
-# Note: Tendermint block pruning is dependant on this parameter in conjunction
+# Note: Tendermint block pruning is dependent on this parameter in conjunction
 # with the unbonding (safety threshold) period, state pruning and state sync
 # snapshot parameters to determine the correct minimum value of
 # ResponseCommit.RetainHeight.
@@ -87,7 +87,7 @@ app-db-backend = ""
 service-name = ""
 
 # Enabled enables the application telemetry functionality. When enabled,
-# an in-memory sink is also enabled by default. Operators may also enabled
+# an in-memory sink is also enabled by default. Operators may also enable
 # other sinks such as Prometheus.
 enabled = false
 
@@ -153,7 +153,7 @@ enable = false
 # Address defines the Rosetta API server to listen on.
 address = ":8080"
 
-# Network defines the name of the blockchain that will be returned by Rosetta.
+# Blockchain defines the name of the blockchain that will be returned by Rosetta.
 blockchain = "app"
 
 # Network defines the name of the network that will be returned by Rosetta.
@@ -166,7 +166,7 @@ retries = 3
 offline = false
 
 # EnableDefaultSuggestedFee defines if the server should suggest fee by default.
-# If 'construction/medata' is called without gas limit and gas price,
+# If 'construction/metadata' is called without gas limit and gas price,
 # suggested fee based on gas-to-suggest and denom-to-suggest will be given.
 enable-fee-suggestion = false
 


### PR DESCRIPTION
- `dependant` → `dependent`
- `enabled` → `enable`
- `Blockchain` → `Network`
- `medata` → `metadata`