### PR TITLE
docs: update release guide

### DIFF
--- a/docs/maintainers/release-guide.md
+++ b/docs/maintainers/release-guide.md
@@ -13,7 +13,8 @@ The target audience for this guide is maintainers of this repo. In general, the 
 
 1. Navigate to <https://github.com/celestiaorg/celestia-app/releases/new>.
 1. Choose a version tag based on [Semantic Versioning](https://semver.org/). Include the `-rc` suffix followed by the next integer. RCs start at 0.
-1. Change the target branch to `v1.x` or `v2.x` based on the version you're releasing.
+1. If a minor version branch doex not exist for the release you are about to create, create one. Example: `v3.4.x`.
+1. Change the target branch to a minor version based. Example: `v3.4.x`.
 1. Click **Generate release notes**.
 1. Toggle on the **Set as a pre-release** checkbox.
 1. **Publish release**.
@@ -25,16 +26,25 @@ The target audience for this guide is maintainers of this repo. In general, the 
 1. [Optional] Start a testnet via auto-devops that uses the release candidate. Confirm it works.
 1. [Optional] Use the release candidate to sync from genesis. Confirm it works.
 
-## Official Release
+## Testnet Release
+
+### Creating a pre-release
 
 Follow the [creating a release candidate](#creating-a-release-candidate) section with the following considerations:
 
-- The version tag should not include the `-rc` suffix.
-- If the release targets a testnet, suffix the release with `-arabica` or `-mocha`.
+- The version tag should not include the `-rc` suffix. Instead append the release with `-arabica` or `-mocha` depending on the target network.
 - The release notes should contain an **Upgrade Notice** section with notable changes for node operators or library consumers.
 - The release notes section should contain a link to <https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md> where we capture breaking changes
 
-After creating the release:
+### After creating the release:
 
 1. Wait until CI passes on the release and verify that prebuilt binaries were attached to the release.
 1. Create a PR to bump the celestia-app dependency in [celestia-node](https://github.com/celestiaorg/celestia-node).
+
+## Mainnet Release
+
+Follow the [creating a release candidate](#creating-a-release-candidate) section with the following considerations:
+- The version tag should not include the `-rc`, `-arabica`, or `-mocha` suffix.
+- Toggle off the **Set as a pre-release** checkbox.
+- Toggle on the **Set as the latest release** checkbox.
+


### PR DESCRIPTION
To instruct maintainers to use a minor version branch.

Note: this still doesn't enforce that releases are created via minor branches but it's a first step.