### PR TITLE
Improve documentation in `x/mint/module.go`

### DIFF
--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -151,7 +151,7 @@ func (AppModule) GenerateGenesisState(_ *module.SimulationState) {
 	// no-op
 }
 
-// ProposalContents doesn't return any content functions for governance proposals.
+// ProposalContents returns nil because the mint module does not support governance proposals.
 func (AppModule) ProposalContents(_ module.SimulationState) []simtypes.WeightedProposalContent {
 	return nil
 }

--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -31,8 +31,6 @@ type AppModuleBasic struct {
 	cdc codec.Codec
 }
 
-var _ module.AppModuleBasic = AppModuleBasic{}
-
 // Name returns the mint module's name.
 func (AppModuleBasic) Name() string {
 	return types.ModuleName


### PR DESCRIPTION
This PR improves documentation in the `x/mint/module.go` file by making the following changes:

## Changes
- Removed unnecessary `var _ module.AppModuleBasic = AppModuleBasic{}`.
- Improved comment for `ProposalContents` to explicitly state that governance proposals are not supported.

## Checklist
- [x] Code compiles successfully  
- [x] Documentation is clear and concise  
- [x] No functionality has been changed  
