### PR TITLE
docs: fix grammar in logs

### DIFF
--- a/test/e2e/benchmark/main.go
+++ b/test/e2e/benchmark/main.go
@@ -22,9 +22,9 @@ func main() {
 
 	// check the test name passed as an argument and run it
 	if len(os.Args) < 2 {
-		logger.Println("No test is specified.")
+		logger.Println("No test was specified.")
 		logger.Println("Usage: go run ./test/e2e/benchmark <test_name>")
-		logger.Printf("Valid tests are: %s\n\n", getTestNames(tests))
+		logger.Printf("Valid test names are: %s\n\n", getTestNames(tests))
 		return
 
 	}
@@ -39,7 +39,7 @@ func main() {
 	}
 	if !found {
 		logger.Printf("Invalid test name: %s\n", testName)
-		logger.Printf("Valid tests are: %s\n", getTestNames(tests))
+		logger.Printf("Valid test names are: %s\n", getTestNames(tests))
 		logger.Println("Usage: go run ./test/e2e/benchmark <test_name>")
 
 	}


### PR DESCRIPTION
"No test is specified." → "No test was specified."

Reason: The second version ("No test was specified") is grammatically correct and clearer. Using past tense ("was specified") is more appropriate as it indicates that no test was provided at the time of executing the command.
"Valid tests are: %s\n\n" → "Valid test names are: %s\n\n"

Reason: The change from "tests" to "test names" clarifies that it is not the actual tests that are being referred to, but rather the names of the available tests. This makes the message more precise and understandable.
"Valid tests are: %s\n" → "Valid test names are: %s\n"

Reason: Similarly to the previous change, this modification emphasizes that the printed list is a set of test names, not the tests themselves. It adds clarity to the output message.

