### PR TITLE
refactor(x/blob): use t.TempDir() instead of os.MkdirTemp 

### DIFF
--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -38,18 +38,16 @@ type IntegrationTestSuite struct {
 func createTestFile(t testing.TB, s string, isValid bool) *os.File {
 	t.Helper()
 
-	tempdir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = os.RemoveAll(tempdir) })
+	tempdir := t.TempDir()
 
-	var fp *os.File
-
+	filePattern := ""
 	if isValid {
-		fp, err = os.CreateTemp(tempdir, "*.json")
-	} else {
-		fp, err = os.CreateTemp(tempdir, "")
+		filePattern = "*.json"
 	}
+
+	fp, err := os.CreateTemp(tempdir, filePattern)
 	require.NoError(t, err)
+
 	_, err = fp.WriteString(s)
 
 	require.Nil(t, err)


### PR DESCRIPTION
no need remove TempDir manually, after changed to t.TempDir(), tested below

test log:
```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestIntegrationTestSuite$ -testify.m ^(TestSubmitPayForBlob)$ github.com/celestiaorg/celestia-app/v3/x/blob/client/testutil

=== RUN   TestIntegrationTestSuite
    /Users/dengdiliang/ddl/github_sources/celestia-app/x/blob/client/testutil/integration_test.go:63: setting up integration test suite
=== RUN   TestIntegrationTestSuite/TestSubmitPayForBlob
=== RUN   TestIntegrationTestSuite/TestSubmitPayForBlob/single_blob_valid_transaction
--- PASS: TestIntegrationTestSuite/TestSubmitPayForBlob/single_blob_valid_transaction (1.05s)
=== RUN   TestIntegrationTestSuite/TestSubmitPayForBlob/multiple_blobs_valid_transaction
--- PASS: TestIntegrationTestSuite/TestSubmitPayForBlob/multiple_blobs_valid_transaction (1.08s)
=== RUN   TestIntegrationTestSuite/TestSubmitPayForBlob/multiple_blobs_with_invalid_file_path_extension
--- PASS: TestIntegrationTestSuite/TestSubmitPayForBlob/multiple_blobs_with_invalid_file_path_extension (0.00s)
--- PASS: TestIntegrationTestSuite/TestSubmitPayForBlob (5.13s)
    /Users/dengdiliang/ddl/github_sources/celestia-app/x/blob/client/testutil/network.go:48: tearing down testnode
--- PASS: TestIntegrationTestSuite (16.33s)
PASS
ok      github.com/celestiaorg/celestia-app/v3/x/blob/client/testutil   16.377s
```