### PR TITLE
refactor: use slices.Equal

### DIFF
--- a/x/blob/types/blob_tx.go
+++ b/x/blob/types/blob_tx.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"slices"
 
 	v3 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v3"
 	"github.com/celestiaorg/go-square/v2/inclusion"
@@ -90,7 +91,7 @@ func ValidateBlobTx(txcfg client.TxEncodingConfig, bTx *tx.BlobTx, subtreeRootTh
 	}
 
 	// check that the sizes in the blobTx match the sizes in the msgPFB
-	if !equalSlices(sizes, msgPFB.BlobSizes) {
+	if !slices.Equal(sizes, msgPFB.BlobSizes) {
 		return ErrBlobSizeMismatch.Wrapf("actual %v declared %v", sizes, msgPFB.BlobSizes)
 	}
 
@@ -125,16 +126,4 @@ func BlobTxSharesUsed(btx tmproto.BlobTx) int {
 		sharesUsed += share.SparseSharesNeeded(uint32(len(blob.Data)))
 	}
 	return sharesUsed
-}
-
-func equalSlices[T comparable](a, b []T) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

In the Go 1.21 standard library, a new function has been introduced that enhances code conciseness and readability. It can be find  [here](https://pkg.go.dev/slices@go1.21.1#Equal).

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
