### PR TITLE
docs: fix typos in multiple files

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -58,7 +58,7 @@ import (
 
 var (
 	// ModuleBasics defines the module BasicManager is in charge of setting up basic,
-	// non-dependant module elements, such as codec registration
+	// non-dependent module elements, such as codec registration
 	// and genesis verification.
 	ModuleBasics = sdkmodule.NewBasicManager(
 		auth.AppModuleBasic{},

--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -54,7 +54,7 @@ message BridgeValidator {
 
 #### ValSet
 
-`Valset` is the Ethereum Bridge Multsig Set, each qgb validator also maintains an ETH key to sign messages, these are used to check signatures on ETH because of the significant gas savings.
+`Valset` is the Ethereum Bridge Multisig Set, each qgb validator also maintains an ETH key to sign messages, these are used to check signatures on ETH because of the significant gas savings.
 
 ```protobuf
 message Valset {

--- a/local_devnet/celestia-app/app.toml
+++ b/local_devnet/celestia-app/app.toml
@@ -166,7 +166,7 @@ retries = 3
 offline = false
 
 # EnableDefaultSuggestedFee defines if the server should suggest fee by default.
-# If 'construction/medata' is called without gas limit and gas price,
+# If 'construction/metadata' is called without gas limit and gas price,
 # suggested fee based on gas-to-suggest and denom-to-suggest will be given.
 enable-fee-suggestion = false
 

--- a/local_devnet/celestia-app/app.toml
+++ b/local_devnet/celestia-app/app.toml
@@ -43,7 +43,7 @@ halt-time = 0
 # It has no bearing on application state pruning which is determined by the
 # "pruning-*" configurations.
 #
-# Note: Tendermint block pruning is dependant on this parameter in conjunction
+# Note: Tendermint block pruning is dependent on this parameter in conjunction
 # with the unbonding (safety threshold) period, state pruning and state sync
 # snapshot parameters to determine the correct minimum value of
 # ResponseCommit.RetainHeight.

--- a/pkg/proof/proof.pb.go
+++ b/pkg/proof/proof.pb.go
@@ -192,7 +192,7 @@ type NMTProof struct {
 	// and min namespaces along with the actual hash, resulting in each being 48
 	// bytes each
 	Nodes [][]byte `protobuf:"bytes,3,rep,name=nodes,proto3" json:"nodes,omitempty"`
-	// leafHash are nil if the namespace is present in the NMT. In case the
+	// leafHash is nil if the namespace is present in the NMT. In case the
 	// namespace to be proved is in the min/max range of the tree but absent, this
 	// will contain the leaf hash necessary to verify the proof of absence. Leaf
 	// hashes should consist of the namespace along with the actual hash,

--- a/pkg/proof/proof.pb.go
+++ b/pkg/proof/proof.pb.go
@@ -192,7 +192,7 @@ type NMTProof struct {
 	// and min namespaces along with the actual hash, resulting in each being 48
 	// bytes each
 	Nodes [][]byte `protobuf:"bytes,3,rep,name=nodes,proto3" json:"nodes,omitempty"`
-	// leafHash is nil if the namespace is present in the NMT. In case the
+	// leafHash are nil if the namespace is present in the NMT. In case the
 	// namespace to be proved is in the min/max range of the tree but absent, this
 	// will contain the leaf hash necessary to verify the proof of absence. Leaf
 	// hashes should consist of the namespace along with the actual hash,

--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -54,7 +54,7 @@ type Tree interface {
 // this tree is committing to. squareSize must be greater than zero.
 func NewErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint, options ...nmt.Option) ErasuredNamespacedMerkleTree {
 	if squareSize == 0 {
-		panic("cannot create a ErasuredNamespacedMerkleTree of squareSize == 0")
+		panic("cannot create an ErasuredNamespacedMerkleTree of squareSize == 0")
 	}
 	options = append(options, nmt.NamespaceIDSize(share.NamespaceSize))
 	options = append(options, nmt.IgnoreMaxNamespace(true))

--- a/specs/src/parameters_v1.md
+++ b/specs/src/parameters_v1.md
@@ -3,7 +3,7 @@
 The parameters below represent the parameters for app version 1.
 
 Note that not all of these parameters are changeable via governance. This list
-also includes parameter that require a hardfork to change due to being manually
+also includes parameters that require a hardfork to change due to being manually
 hardcoded in the application or they are blocked by the `x/paramfilter` module.
 
 ## Global parameters

--- a/test/pfm/simapp.go
+++ b/test/pfm/simapp.go
@@ -149,7 +149,7 @@ var (
 	DefaultNodeHome string
 
 	// ModuleBasics defines the module BasicManager is in charge of setting up basic,
-	// non-dependant module elements, such as codec registration
+	// non-dependent module elements, such as codec registration
 	// and genesis verification.
 	ModuleBasics = module.NewBasicManager(
 		auth.AppModuleBasic{},

--- a/x/blobstream/README.md
+++ b/x/blobstream/README.md
@@ -24,7 +24,7 @@ When an orchestrator sees a newly generated valset published by the Celestia sta
 A valset is comprised of the following fields:
 
 ```protobuf
-// Valset is the EVM Bridge Multsig Set, each blobstream validator also
+// Valset is the EVM Bridge Multisig Set, each blobstream validator also
 // maintains an ETH key to sign messages, these are used to check signatures on
 // ETH because of the significant gas savings
 message Valset {


### PR DESCRIPTION
Fixed typos in documentation:
- "dependant" → "dependent"
- "Multsig" → "Multisig"
- "parameter" → "parameters"
- "medata" → "metadata"
- "a ErasuredNamespacedMerkleTree" → "an ErasuredNamespacedMerkleTree"
