### PR TITLE
chore: Fix precision loss in time conversion

### DIFF
--- a/tools/blocketa/main.go
+++ b/tools/blocketa/main.go
@@ -72,7 +72,7 @@ func Run() error {
 	}
 	diffInBlockHeight := targetBlockHeight - currentHeight
 	diffInSeconds := blockTime * float64(diffInBlockHeight)
-	diffInTime, err := time.ParseDuration(fmt.Sprintf("%.0fs", diffInSeconds))
+	diffInTime := time.Duration(diffInSeconds * float64(time.Second))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Overview

Noticed a potential precision loss when converting `diffInSeconds` to `time.Duration`. The previous approach used `fmt.Sprintf("%.0fs", diffInSeconds)`, which could introduce rounding issues. Replaced it with a direct multiplication by `time.Second` to ensure accuracy.
