### PR TITLE
docs: fix typos

### DIFF
--- a/app/errors/insufficient_gas_price.go
+++ b/app/errors/insufficient_gas_price.go
@@ -21,7 +21,7 @@ var (
 // the node should accept.
 // If the error is not due to the gas price being too low, it returns 0, nil
 func ParseInsufficientMinGasPrice(err error, gasPrice float64, gasLimit uint64) (float64, error) {
-	// first work out if the error is ErrInsufficientFunds
+	// first check if the error is ErrInsufficientFee
 	if err == nil || !sdkerrors.ErrInsufficientFee.Is(err) {
 		return 0, nil
 	}
@@ -69,7 +69,7 @@ func ParseInsufficientMinGasPrice(err error, gasPrice float64, gasLimit uint64) 
 
 // IsInsufficientMinGasPrice checks if the error is due to the gas price being too low.
 func IsInsufficientMinGasPrice(err error) bool {
-	// first work out if the error is ErrInsufficientFunds
+	// first check if the error is ErrInsufficientFee
 	if err == nil || !sdkerrors.ErrInsufficientFee.Is(err) {
 		return false
 	}

--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -81,7 +81,7 @@ func (e *ExecutionError) Error() string {
 	return fmt.Sprintf("tx execution failed with code %d: %s", e.Code, e.ErrorLog)
 }
 
-// WithGasMultiplier is a functional option allows to configure the gas multiplier.
+// WithGasMultiplier is a functional option that allows configuring the gas multiplier.
 func WithGasMultiplier(multiplier float64) Option {
 	return func(c *TxClient) {
 		c.gasMultiplier = multiplier

--- a/scripts/mainnet.sh
+++ b/scripts/mainnet.sh
@@ -36,7 +36,7 @@ rm -r "$CELESTIA_APP_HOME"
 echo "Initializing config files..."
 celestia-appd init ${NODE_NAME} --chain-id ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
-echo "Settings seeds in config.toml..."
+echo "Setting seeds in config.toml..."
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $CELESTIA_APP_HOME/config/config.toml
 
 LATEST_HEIGHT=$(curl -s $RPC/block | jq -r .result.block.header.height);


### PR DESCRIPTION
Fixed misleading comments in insufficient_gas_price.go:
  - Replaced `"first work out if the error is ErrInsufficientFunds"` with `"first check if the error is ErrInsufficientFee"`.
 
Fixed grammar in function description in tx_client.go:
  - Corrected `"WithGasMultiplier is a functional option allows to configure"` to `"WithGasMultiplier is a functional option that allows configuring"`.

Fixed typo in script output message in mainnet.sh:
  - Changed `"Settings seeds in config.toml..."` to `"Setting seeds in config.toml..."`.