### PR TITLE
refactor: remove duplicate `SetMinRetainBlocks` invocation

### DIFF
--- a/cmd/celestia-appd/cmd/app_server.go
+++ b/cmd/celestia-appd/cmd/app_server.go
@@ -57,7 +57,6 @@ func NewAppServer(logger log.Logger, db dbm.DB, traceStore io.Writer, appOptions
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOptions.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOptions.Get(server.FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOptions.Get(server.FlagHaltTime))),
-		baseapp.SetMinRetainBlocks(cast.ToUint64(appOptions.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetInterBlockCache(cache),
 		baseapp.SetTrace(cast.ToBool(appOptions.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOptions.Get(server.FlagIndexEvents))),

--- a/test/util/malicious/test_app.go
+++ b/test/util/malicious/test_app.go
@@ -86,7 +86,6 @@ func NewAppServer(logger log.Logger, db dbm.DB, traceStore io.Writer, appOpts se
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOpts.Get(server.FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOpts.Get(server.FlagHaltTime))),
-		baseapp.SetMinRetainBlocks(cast.ToUint64(appOpts.Get(server.FlagMinRetainBlocks))),
 		baseapp.SetInterBlockCache(cache),
 		baseapp.SetTrace(cast.ToBool(appOpts.Get(server.FlagTrace))),
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),


### PR DESCRIPTION
## Overview

I am verifying some lint idea in my project see https://github.com/alingse/sundrylint/pull/10
it report the function call with repeat args from a sub-function call.

we think the sub-function call is heavy, so the repeat args probably a copy-and-paste mistake.

I check the top 4000 github repos, and found this repo has this case.