### PR TITLE
spelling errors

### DIFF
--- a/local_devnet/README.md
+++ b/local_devnet/README.md
@@ -6,7 +6,7 @@ The docker image used is built locally using the code in the root directory. So,
 
 Note: It is necessary to [build the images](#build-the-images) after every change you make so that it is reflected in the network.
 
-Note 2: If you edit the `go.mod` to contain a local package, for example, using a local version of celestia-core:
+Note 2: If you edit `go.mod` to contain a local package, for example, using a local version of celestia-core:
 
 ```go
 replace github.com/celestiaorg/celestia-core => ../celestia-core

--- a/pkg/appconsts/initial_consts.go
+++ b/pkg/appconsts/initial_consts.go
@@ -6,7 +6,7 @@ import (
 	"github.com/celestiaorg/go-square/v2/share"
 )
 
-// The following defaults correspond to initial parameters of the network that can be changed, not via app versions
+// The following defaults correspond to the initial parameters of the network that can be changed, not via app versions
 // but other means such as on-chain governance, or the node's local config
 const (
 	// DefaultGovMaxSquareSize is the default value for the governance modifiable


### PR DESCRIPTION
changed:

![image](https://github.com/user-attachments/assets/5b6c3954-babc-4ceb-a861-091f4d2e1208)

![image](https://github.com/user-attachments/assets/e608ac73-972e-47fa-8c90-0bb9644a3891)

