### PR TITLE
feat!: reduce upgrade height delay for Arabica and Mocha

### DIFF
--- a/docs/release-notes/pending-release.md
+++ b/docs/release-notes/pending-release.md
@@ -4,6 +4,6 @@
 
 ### Node Operators (v4.0.0)
 
-- Arabica node operators must upgrade to release of celestia-app that contains <https://github.com/celestiaorg/celestia-app/pull/4414> prior to signalling for the v3 to v4 upgrade.
+- Node operators must upgrade to the latest release of celestia-app (e.g. v4.x.x) prior to signalling for the v4 upgrade. This release will run the latest v3.x.x celestia-app via the multiplexer prior to the v4 activation height. The latest v3.x.x release contains a reduction to the upgrade delay height. See <https://github.com/celestiaorg/celestia-app/pull/4414>.
 
 ### Library Consumers (v4.0.0)

--- a/docs/release-notes/pending-release.md
+++ b/docs/release-notes/pending-release.md
@@ -4,6 +4,6 @@
 
 ### Node Operators (v4.0.0)
 
-- Node operators must upgrade to the latest release of celestia-app (e.g. v4.x.x) prior to signalling for the v4 upgrade. This release will run the latest v3.x.x celestia-app via the multiplexer prior to the v4 activation height. The latest v3.x.x release contains a reduction to the upgrade delay height. See <https://github.com/celestiaorg/celestia-app/pull/4414>.
+- Node operators must upgrade to the latest release of celestia-app (e.g. v4.x.x) prior to signalling for the v4 upgrade. This release will run the latest v3.x.x celestia-app via the multiplexer prior to the v4 activation height. The latest v3.x.x release contains a reduction to the upgrade delay height on testnets. See <https://github.com/celestiaorg/celestia-app/pull/4414>.
 
 ### Library Consumers (v4.0.0)

--- a/docs/release-notes/pending-release.md
+++ b/docs/release-notes/pending-release.md
@@ -4,4 +4,6 @@
 
 ### Node Operators (v4.0.0)
 
+- Arabica node operators must upgrade to release of celestia-app that contains <https://github.com/celestiaorg/celestia-app/pull/4414> prior to signalling for the v3 to v4 upgrade.
+
 ### Library Consumers (v4.0.0)

--- a/pkg/appconsts/versioned_consts.go
+++ b/pkg/appconsts/versioned_consts.go
@@ -11,6 +11,9 @@ import (
 
 const (
 	LatestVersion = v3.Version
+	// numBlocksPerDay is the number of blocks in a day assuming a block
+	// interval of 6 seconds. Equivalent to 14,400 blocks.
+	numBlocksPerDay = int64(24 * 60 * 60 / 6)
 )
 
 // SubtreeRootThreshold works as a target upper bound for the number of subtree
@@ -95,6 +98,10 @@ func UpgradeHeightDelay(chainID string, v uint64) int64 {
 		}
 		return v2.UpgradeHeightDelay
 	default:
+		// ONLY ON ARABICA: decrease the delay to 1 day.
+		if chainID == ArabicaChainID {
+			return numBlocksPerDay
+		}
 		return v3.UpgradeHeightDelay
 	}
 }

--- a/pkg/appconsts/versioned_consts.go
+++ b/pkg/appconsts/versioned_consts.go
@@ -107,7 +107,7 @@ func UpgradeHeightDelay(chainID string, version uint64) int64 {
 		case MochaChainID:
 			return numBlocksPerDay * 2
 		case MainnetChainID:
-			return numBlocksPerDay * 3
+			return v3.UpgradeHeightDelay
 		}
 	}
 	// TODO: this should panic because this should never be invoked for v4+

--- a/pkg/appconsts/versioned_consts.go
+++ b/pkg/appconsts/versioned_consts.go
@@ -81,12 +81,15 @@ func GetTimeoutCommit(v uint64) time.Duration {
 	}
 }
 
-// UpgradeHeightDelay returns the delay in blocks after a quorum has been reached that the chain should upgrade to the new version.
-func UpgradeHeightDelay(chainID string, v uint64) int64 {
+// UpgradeHeightDelay returns the delay in blocks after a quorum has been
+// reached that the chain should upgrade to the new version. The version
+// argument should be the current application version, not the version after the
+// upgrade.
+func UpgradeHeightDelay(chainID string, version uint64) int64 {
 	if chainID == TestChainID {
 		return 3
 	}
-	switch v {
+	switch version {
 	case v1.Version:
 		return v1.UpgradeHeightDelay
 	case v2.Version:
@@ -97,11 +100,16 @@ func UpgradeHeightDelay(chainID string, v uint64) int64 {
 			return v3.UpgradeHeightDelay
 		}
 		return v2.UpgradeHeightDelay
-	default:
-		// ONLY ON ARABICA: decrease the delay to 1 day.
-		if chainID == ArabicaChainID {
+	case v3.Version:
+		switch chainID {
+		case ArabicaChainID:
 			return numBlocksPerDay
+		case MochaChainID:
+			return numBlocksPerDay * 2
+		case MainnetChainID:
+			return numBlocksPerDay * 3
 		}
-		return v3.UpgradeHeightDelay
 	}
+	// TODO: this should panic because this should never be invoked for v4+
+	return v3.UpgradeHeightDelay
 }

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -125,25 +125,25 @@ func TestUpgradeHeightDelay(t *testing.T) {
 			expectedUpgradeHeightDelay: 3,
 		},
 		{
-			name:                       "v3 upgrade delay on arabica",
+			name:                       "v3 upgrade delay on arabica is 1 day",
 			chainID:                    appconsts.ArabicaChainID,
 			version:                    v3.Version,
-			expectedUpgradeHeightDelay: 14_400, // one day of 6 second blocks
+			expectedUpgradeHeightDelay: 14_400, // 1 day of 6 second blocks
 		},
 		{
-			name:                       "v3 upgrade delay on mocha",
+			name:                       "v3 upgrade delay on mocha is 2 days",
 			chainID:                    appconsts.MochaChainID,
 			version:                    v3.Version,
-			expectedUpgradeHeightDelay: 28_800, // two days of 6 second blocks
+			expectedUpgradeHeightDelay: 28_800, // 2 days of 6 second blocks
 		},
 		{
-			name:                       "v3 upgrade delay on mainnet",
+			name:                       "v3 upgrade delay on mainnet is 7 days",
 			chainID:                    appconsts.MainnetChainID,
 			version:                    v3.Version,
-			expectedUpgradeHeightDelay: 43200, // three days of 6 second blocks
+			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay, // 7 days of 6 second blocks
 		},
 		{
-			name:                       "v4 upgrade delay on arabica",
+			name:                       "v4 upgrade delay on arabica is 7 days",
 			chainID:                    appconsts.ArabicaChainID,
 			version:                    4,
 			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay, // TODO: this should panic

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -113,15 +113,9 @@ func TestUpgradeHeightDelay(t *testing.T) {
 			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay, // falls back to v3 because of arabica bug
 		},
 		{
-			name:                       "v3 upgrade delay on mocha",
-			chainID:                    "mocha-4",
-			version:                    3,
-			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay,
-		},
-		{
 			name:                       "the upgrade delay for chainID 'test' should be 3 regardless of the version",
 			chainID:                    appconsts.TestChainID,
-			version:                    3,
+			version:                    v3.Version,
 			expectedUpgradeHeightDelay: 3,
 		},
 		{
@@ -133,14 +127,26 @@ func TestUpgradeHeightDelay(t *testing.T) {
 		{
 			name:                       "v3 upgrade delay on arabica",
 			chainID:                    appconsts.ArabicaChainID,
-			version:                    3,
-			expectedUpgradeHeightDelay: 14_400,
+			version:                    v3.Version,
+			expectedUpgradeHeightDelay: 14_400, // one day of 6 secondb locks
+		},
+		{
+			name:                       "v3 upgrade delay on mocha",
+			chainID:                    appconsts.MochaChainID,
+			version:                    v3.Version,
+			expectedUpgradeHeightDelay: 28_800, // two days of 6 second locks
+		},
+		{
+			name:                       "v3 upgrade delay on mainnet",
+			chainID:                    appconsts.MainnetChainID,
+			version:                    v3.Version,
+			expectedUpgradeHeightDelay: 43200,
 		},
 		{
 			name:                       "v4 upgrade delay on arabica",
 			chainID:                    appconsts.ArabicaChainID,
 			version:                    4,
-			expectedUpgradeHeightDelay: 14_400,
+			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay, // TODO: this should panic
 		},
 	}
 

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -113,7 +113,7 @@ func TestUpgradeHeightDelay(t *testing.T) {
 			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay, // falls back to v3 because of arabica bug
 		},
 		{
-			name:                       "v3 upgrade delay",
+			name:                       "v3 upgrade delay on mocha",
 			chainID:                    "mocha-4",
 			version:                    3,
 			expectedUpgradeHeightDelay: v3.UpgradeHeightDelay,
@@ -129,6 +129,18 @@ func TestUpgradeHeightDelay(t *testing.T) {
 			chainID:                    appconsts.TestChainID,
 			version:                    4,
 			expectedUpgradeHeightDelay: 3,
+		},
+		{
+			name:                       "v3 upgrade delay on arabica",
+			chainID:                    appconsts.ArabicaChainID,
+			version:                    3,
+			expectedUpgradeHeightDelay: 14_400,
+		},
+		{
+			name:                       "v4 upgrade delay on arabica",
+			chainID:                    appconsts.ArabicaChainID,
+			version:                    4,
+			expectedUpgradeHeightDelay: 14_400,
 		},
 	}
 

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -128,19 +128,19 @@ func TestUpgradeHeightDelay(t *testing.T) {
 			name:                       "v3 upgrade delay on arabica",
 			chainID:                    appconsts.ArabicaChainID,
 			version:                    v3.Version,
-			expectedUpgradeHeightDelay: 14_400, // one day of 6 secondb locks
+			expectedUpgradeHeightDelay: 14_400, // one day of 6 second blocks
 		},
 		{
 			name:                       "v3 upgrade delay on mocha",
 			chainID:                    appconsts.MochaChainID,
 			version:                    v3.Version,
-			expectedUpgradeHeightDelay: 28_800, // two days of 6 second locks
+			expectedUpgradeHeightDelay: 28_800, // two days of 6 second blocks
 		},
 		{
 			name:                       "v3 upgrade delay on mainnet",
 			chainID:                    appconsts.MainnetChainID,
 			version:                    v3.Version,
-			expectedUpgradeHeightDelay: 43200,
+			expectedUpgradeHeightDelay: 43200, // three days of 6 second blocks
 		},
 		{
 			name:                       "v4 upgrade delay on arabica",

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -426,7 +426,7 @@ func TestGetUpgrade(t *testing.T) {
 		got, err := upgradeKeeper.GetUpgrade(ctx, &types.QueryGetUpgradeRequest{})
 		require.NoError(t, err)
 		assert.Equal(t, v2.Version, got.Upgrade.AppVersion)
-		assert.Equal(t, appconsts.UpgradeHeightDelay(appconsts.TestChainID, v2.Version), got.Upgrade.UpgradeHeight)
+		assert.Equal(t, appconsts.UpgradeHeightDelay(appconsts.TestChainID, v1.Version), got.Upgrade.UpgradeHeight)
 	})
 }
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4413

Note: This targets main but it won't ever be used on main because https://github.com/celestiaorg/celestia-app/pull/4400 simplifies the versioned constants. Main (and v4+) won't have versioned constants because they just need to support constants for the latest release. This change will be backported to v3.x where it will be used.