### PR TITLE
refactor: remove x/exp dependency for slices package

### DIFF
--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	fmt "fmt"
 
+	"slices"
+
 	"cosmossdk.io/errors"
 
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
@@ -12,7 +14,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/migrations/legacytx"
 	"github.com/tendermint/tendermint/crypto/merkle"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -3,7 +3,6 @@ package types
 import (
 	"bytes"
 	fmt "fmt"
-
 	"slices"
 
 	"cosmossdk.io/errors"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.



Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

standard library package:`slices` already include slices.Contains since Go 1.21, remove experimental package `x/exp `


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
