### PR TITLE
fix: fixed arithmetic syntax in bash script

### DIFF
--- a/scripts/localnet-blocks-test.sh
+++ b/scripts/localnet-blocks-test.sh
@@ -44,7 +44,7 @@ while [ ${CNT} -lt $ITER ]; do
   #
   # Every 10 blocks, pick a random container and restart it.
   if ! ((${CNT} % 10)); then
-    rand_container=${docker_containers["$[RANDOM % ${#docker_containers[@]}]"]};
+    rand_container=${docker_containers[$((RANDOM % ${#docker_containers[@]}))]};
     echo "Restarting random docker container ${rand_container}"
     docker restart ${rand_container} &>/dev/null &
   fi


### PR DESCRIPTION
## Overview

I replaced `$[...]` with the correct `$((...))` syntax for arithmetic operations in the script.
This ensures proper functionality when selecting a random container.
