### PR TITLE
docs: improve proto comments

### DIFF
--- a/app/grpc/tx/tx.pb.go
+++ b/app/grpc/tx/tx.pb.go
@@ -30,7 +30,7 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 // TxStatusRequest is the request type for the TxStatus gRPC method.
 type TxStatusRequest struct {
-	// this is the hex encoded transaction hash (should be 64 bytes long)
+	// this is the hex encoded transaction hash (should be 64 characters long representing 32 bytes)
 	TxId string `protobuf:"bytes,1,opt,name=tx_id,json=txId,proto3" json:"tx_id,omitempty"`
 }
 

--- a/proto/celestia/core/v1/tx/tx.proto
+++ b/proto/celestia/core/v1/tx/tx.proto
@@ -21,7 +21,7 @@ service Tx {
 
 // TxStatusRequest is the request type for the TxStatus gRPC method.
 message TxStatusRequest {
-    // this is the hex encoded transaction hash (should be 64 bytes long)
+    // this is the hex encoded transaction hash (should be 64 characters long representing 32 bytes)
     string tx_id = 1;
 }
 

--- a/proto/celestia/qgb/v1/query.proto
+++ b/proto/celestia/qgb/v1/query.proto
@@ -14,7 +14,7 @@ option go_package = "github.com/celestiaorg/celestia-app/x/blobstream/types";
 service Query {
   // Params queries the current parameters for the blobstream module
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http) = { get: "/qgb/v1/params" };
+    option (google.api.http).get = "/qgb/v1/params";
   }
 
   // Queries for attestation requests waiting to be signed by an orchestrator

--- a/proto/celestia/qgb/v1/query.proto
+++ b/proto/celestia/qgb/v1/query.proto
@@ -14,10 +14,10 @@ option go_package = "github.com/celestiaorg/celestia-app/x/blobstream/types";
 service Query {
   // Params queries the current parameters for the blobstream module
   rpc Params(QueryParamsRequest) returns (QueryParamsResponse) {
-    option (google.api.http).get = "/qgb/v1/params";
+    option (google.api.http) = { get: "/qgb/v1/params" };
   }
 
-  // queries for attestations requests waiting to be signed by an orchestrator
+  // Queries for attestation requests waiting to be signed by an orchestrator
 
   // AttestationRequestByNonce queries attestation request by nonce.
   // Returns nil if not found.
@@ -66,8 +66,7 @@ service Query {
     option (google.api.http).get = "/qgb/v1/data_commitment/latest";
   }
 
-  // EVMAddress returns the evm address associated with a supplied
-  // validator address
+  // EVMAddress returns the EVM address associated with the provided validator address
   rpc EVMAddress(QueryEVMAddressRequest) returns (QueryEVMAddressResponse) {
     option (google.api.http).get = "/qgb/v1/evm_address";
   }
@@ -85,7 +84,7 @@ message QueryAttestationRequestByNonceRequest { uint64 nonce = 1; }
 
 // QueryAttestationRequestByNonceResponse
 message QueryAttestationRequestByNonceResponse {
-  // AttestationRequestI is either a Data Commitment or a Valset.
+  // AttestationRequestI can be either a DataCommitment or a Valset.
   // This was decided as part of the universal nonce approach under:
   // https://github.com/celestiaorg/celestia-app/issues/468#issuecomment-1156887715
   google.protobuf.Any attestation = 1

--- a/x/blobstream/types/query.pb.go
+++ b/x/blobstream/types/query.pb.go
@@ -160,7 +160,7 @@ func (m *QueryAttestationRequestByNonceRequest) GetNonce() uint64 {
 
 // QueryAttestationRequestByNonceResponse
 type QueryAttestationRequestByNonceResponse struct {
-	// AttestationRequestI is either a Data Commitment or a Valset.
+	// AttestationRequestI can be either a DataCommitment or a Valset.
 	// This was decided as part of the universal nonce approach under:
 	// https://github.com/celestiaorg/celestia-app/issues/468#issuecomment-1156887715
 	Attestation *types.Any `protobuf:"bytes,1,opt,name=attestation,proto3" json:"attestation,omitempty"`
@@ -940,8 +940,7 @@ type QueryClient interface {
 	DataCommitmentRangeForHeight(ctx context.Context, in *QueryDataCommitmentRangeForHeightRequest, opts ...grpc.CallOption) (*QueryDataCommitmentRangeForHeightResponse, error)
 	// LatestDataCommitment returns the latest data commitment in store
 	LatestDataCommitment(ctx context.Context, in *QueryLatestDataCommitmentRequest, opts ...grpc.CallOption) (*QueryLatestDataCommitmentResponse, error)
-	// EVMAddress returns the evm address associated with a supplied
-	// validator address
+	// EVMAddress returns the EVM address associated with the provided validator address
 	EVMAddress(ctx context.Context, in *QueryEVMAddressRequest, opts ...grpc.CallOption) (*QueryEVMAddressResponse, error)
 }
 
@@ -1058,8 +1057,7 @@ type QueryServer interface {
 	DataCommitmentRangeForHeight(context.Context, *QueryDataCommitmentRangeForHeightRequest) (*QueryDataCommitmentRangeForHeightResponse, error)
 	// LatestDataCommitment returns the latest data commitment in store
 	LatestDataCommitment(context.Context, *QueryLatestDataCommitmentRequest) (*QueryLatestDataCommitmentResponse, error)
-	// EVMAddress returns the evm address associated with a supplied
-	// validator address
+	// EVMAddress returns the EVM address associated with the provided validator address
 	EVMAddress(context.Context, *QueryEVMAddressRequest) (*QueryEVMAddressResponse, error)
 }
 


### PR DESCRIPTION
✅ **tx.proto**
- Updated the description of `tx_id` in `TxStatusRequest` to clarify it is a **64-character hex string representing 32 bytes** instead of misleading "64 bytes".

✅ **query.proto**
- Refactored HTTP option formatting for consistency (`option (google.api.http) = { get: ... }`).
- Improved comment clarity.
