### PR TITLE
fix: enable celestia-app to run in Vercel Go runtime

### DIFF
--- a/app/init.go
+++ b/app/init.go
@@ -26,24 +26,16 @@ var DefaultNodeHome string
 
 func init() {
 	nodeHome := os.Getenv(nodeHome)
-	if nodeHome != "" {
-		DefaultNodeHome = nodeHome
-		return
-	}
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		panic(err)
-	}
 	celestiaHome := os.Getenv(celestiaHome)
-	DefaultNodeHome = getDefaultNodeHome(userHome, celestiaHome)
+	userHome, _ := os.UserHomeDir() // ignore the error because the userHome is not set in Vercel's Go runtime.
+	DefaultNodeHome = getDefaultNodeHome(nodeHome, celestiaHome, userHome)
 }
 
-// getDefaultNodeHome computes the default node home directory based on the
-// provided userHome and celestiaHome. If celestiaHome is provided, it takes
-// precedence and constructs the path by appending the application directory.
-// Otherwise, it falls back to using the userHome with the application directory
-// appended.
-func getDefaultNodeHome(userHome string, celestiaHome string) string {
+// getDefaultNodeHome returns the location of the node home directory.
+func getDefaultNodeHome(nodeHome string, celestiaHome string, userHome string) string {
+	if nodeHome != "" {
+		return nodeHome
+	}
 	if celestiaHome != "" {
 		return filepath.Join(celestiaHome, appDirectory)
 	}

--- a/app/init.go
+++ b/app/init.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -23,7 +24,11 @@ var DefaultNodeHome string
 
 func init() {
 	celestiaHome := os.Getenv(celestiaHome)
-	userHome, _ := os.UserHomeDir() // ignore the error because the userHome is not set in Vercel's Go runtime.
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		// The userHome is not set in Vercel's Go runtime so log a warning but don't panic.
+		fmt.Printf("Warning userHome err: %s\n", err)
+	}
 	DefaultNodeHome = getDefaultNodeHome(celestiaHome, userHome)
 }
 

--- a/app/init.go
+++ b/app/init.go
@@ -12,6 +12,10 @@ const Name = "celestia-app"
 // to store configs, data, keyrings, etc.
 const appDirectory = ".celestia-app"
 
+// nodeHome is an environment variable that sets where the app directory will be placed.
+// If nodeHome isn't specified, the default user home directory will be used.
+const nodeHome = "NODE_HOME"
+
 // celestiaHome is an environment variable that sets where appDirectory will be placed.
 // If celestiaHome isn't specified, the default user home directory will be used.
 const celestiaHome = "CELESTIA_HOME"
@@ -21,6 +25,11 @@ const celestiaHome = "CELESTIA_HOME"
 var DefaultNodeHome string
 
 func init() {
+	nodeHome := os.Getenv(nodeHome)
+	if nodeHome != "" {
+		DefaultNodeHome = nodeHome
+		return
+	}
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		panic(err)

--- a/app/init.go
+++ b/app/init.go
@@ -12,30 +12,23 @@ const Name = "celestia-app"
 // to store configs, data, keyrings, etc.
 const appDirectory = ".celestia-app"
 
-// nodeHome is an environment variable that sets where the app directory will be placed.
-// If nodeHome isn't specified, the default user home directory will be used.
-const nodeHome = "NODE_HOME"
-
 // celestiaHome is an environment variable that sets where appDirectory will be placed.
 // If celestiaHome isn't specified, the default user home directory will be used.
 const celestiaHome = "CELESTIA_HOME"
 
-// DefaultNodeHome is the default home directory for the application daemon.
-// This gets set as a side-effect of the init() function.
+// DefaultNodeHome is the home directory for the app directory. In other words,
+// this is the path to the directory that will contain .celestia-app. This gets
+// set as a side-effect of the init() function.
 var DefaultNodeHome string
 
 func init() {
-	nodeHome := os.Getenv(nodeHome)
 	celestiaHome := os.Getenv(celestiaHome)
 	userHome, _ := os.UserHomeDir() // ignore the error because the userHome is not set in Vercel's Go runtime.
-	DefaultNodeHome = getDefaultNodeHome(nodeHome, celestiaHome, userHome)
+	DefaultNodeHome = getDefaultNodeHome(celestiaHome, userHome)
 }
 
-// getDefaultNodeHome returns the location of the node home directory.
-func getDefaultNodeHome(nodeHome string, celestiaHome string, userHome string) string {
-	if nodeHome != "" {
-		return nodeHome
-	}
+// getDefaultNodeHome returns the location of the default home app directory.
+func getDefaultNodeHome(celestiaHome string, userHome string) string {
 	if celestiaHome != "" {
 		return filepath.Join(celestiaHome, appDirectory)
 	}

--- a/app/init_test.go
+++ b/app/init_test.go
@@ -9,51 +9,32 @@ import (
 func Test_getDefaultNodeHome(t *testing.T) {
 	type testCase struct {
 		name         string
-		nodeHome     string
-		userHome     string
 		celestiaHome string
+		userHome     string
 		want         string
 	}
 
 	testCases := []testCase{
 		{
-			name:         "if everything is empty, use the root",
-			nodeHome:     "",
+			name:         "by default use the root directory",
 			celestiaHome: "",
 			userHome:     "",
 			want:         ".celestia-app",
 		},
 		{
-			name:         "if nodeHome is set, use it",
-			nodeHome:     "node-home",
-			userHome:     "",
-			celestiaHome: "",
-			want:         "node-home/.celestia-app",
-		},
-		{
-			name:         "if celestiaHome is set, use it",
-			nodeHome:     "",
+			name:         "use celestia-home if it is set",
 			celestiaHome: "celestia-home",
 			userHome:     "",
 			want:         "celestia-home/.celestia-app",
 		},
 		{
-			name:         "if userHome is set, use it",
-			nodeHome:     "",
+			name:         "use user-home if it is set",
 			celestiaHome: "",
 			userHome:     "user-home",
 			want:         "user-home/.celestia-app",
 		},
 		{
-			name:         "node-home takes precedence over celestia-home and user-home",
-			nodeHome:     "node-home",
-			celestiaHome: "celestia-home",
-			userHome:     "user-home",
-			want:         "node-home/.celestia-app",
-		},
-		{
 			name:         "celestia-home takes precedence over user-home",
-			nodeHome:     "",
 			celestiaHome: "celestia-home",
 			userHome:     "user-home",
 			want:         "celestia-home/.celestia-app",
@@ -62,7 +43,7 @@ func Test_getDefaultNodeHome(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getDefaultNodeHome(tc.nodeHome, tc.celestiaHome, tc.userHome)
+			got := getDefaultNodeHome(tc.celestiaHome, tc.userHome)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/app/init_test.go
+++ b/app/init_test.go
@@ -9,6 +9,7 @@ import (
 func Test_getDefaultNodeHome(t *testing.T) {
 	type testCase struct {
 		name         string
+		nodeHome     string
 		userHome     string
 		celestiaHome string
 		want         string
@@ -16,34 +17,52 @@ func Test_getDefaultNodeHome(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:         "want .celestia-app when userHome is empty and celestiaHome is empty",
-			userHome:     "",
+			name:         "if everything is empty, use the root",
+			nodeHome:     "",
 			celestiaHome: "",
+			userHome:     "",
 			want:         ".celestia-app",
 		},
 		{
-			name:         "want celestia-home/.celestia-app when userHome is empty and celestiaHome is not empty",
+			name:         "if nodeHome is set, use it",
+			nodeHome:     "node-home",
 			userHome:     "",
+			celestiaHome: "",
+			want:         "node-home/.celestia-app",
+		},
+		{
+			name:         "if celestiaHome is set, use it",
+			nodeHome:     "",
 			celestiaHome: "celestia-home",
+			userHome:     "",
 			want:         "celestia-home/.celestia-app",
 		},
 		{
-			name:         "want user-home/.celestia-app when userHome is not empty and celestiaHome is empty",
-			userHome:     "user-home",
+			name:         "if userHome is set, use it",
+			nodeHome:     "",
 			celestiaHome: "",
+			userHome:     "user-home",
 			want:         "user-home/.celestia-app",
 		},
 		{
-			name:         "want celestiaHome to take precedence if both are not empty",
-			userHome:     "user-home",
+			name:         "node-home takes precedence over celestia-home and user-home",
+			nodeHome:     "node-home",
 			celestiaHome: "celestia-home",
+			userHome:     "user-home",
+			want:         "node-home/.celestia-app",
+		},
+		{
+			name:         "celestia-home takes precedence over user-home",
+			nodeHome:     "",
+			celestiaHome: "celestia-home",
+			userHome:     "user-home",
 			want:         "celestia-home/.celestia-app",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getDefaultNodeHome(tc.userHome, tc.celestiaHome)
+			got := getDefaultNodeHome(tc.nodeHome, tc.celestiaHome, tc.userHome)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -258,7 +258,7 @@ require (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.27.0-sdk-v0.46.16
 	// Replace IBC with celestiaorg fork which includes fixes for security vulnerabilities.
-	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.2.4
+	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.2.5
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.51.0-tm-v0.34.35

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/celestiaorg/go-square v1.1.1 h1:Cy3p8WVspVcyOqHM8BWFuuYPwMitO1pYGe+Im
 github.com/celestiaorg/go-square v1.1.1/go.mod h1:1EXMErhDrWJM8B8V9hN7dqJ2kUTClfwdqMOmF9yQUa0=
 github.com/celestiaorg/go-square/v2 v2.1.0 h1:ECIvYEeHIWiIJGDCJxQNtzqm5DmnBly7XGhSpLsl+Lw=
 github.com/celestiaorg/go-square/v2 v2.1.0/go.mod h1:n3ztrh8CBjWOD6iWYMo3pPOlQIgzLK9yrnqMPcNo6g8=
-github.com/celestiaorg/ibc-go/v6 v6.2.4 h1:S9jH7e+faYWF9PgDQAQnHxgm+FeDWTKcOF99Zez40bA=
-github.com/celestiaorg/ibc-go/v6 v6.2.4/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
+github.com/celestiaorg/ibc-go/v6 v6.2.5 h1:mUmZptulQGsGgyBqmdBeSCPQtMu0aFMJstgvKhUdqy4=
+github.com/celestiaorg/ibc-go/v6 v6.2.5/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
 github.com/celestiaorg/knuu v0.16.3 h1:ORmcBoSW+67iPKF0yIGKwWMefphk5hvy08KklmCT0aw=
 github.com/celestiaorg/knuu v0.16.3/go.mod h1:nB7IGCR984YKEDW+j5xHPOidYfbO4DoZI1rDKijvF5E=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/test/interchain/go.mod
+++ b/test/interchain/go.mod
@@ -226,7 +226,7 @@ replace (
 replace (
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.27.0-sdk-v0.46.16
 	// Replace IBC with celestiaorg fork which includes fixes for security vulnerabilities.
-	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.2.4
+	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.2.5
 	github.com/docker/docker => github.com/docker/docker v24.0.1+incompatible
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7

--- a/test/interchain/go.sum
+++ b/test/interchain/go.sum
@@ -253,8 +253,8 @@ github.com/celestiaorg/celestia-core v1.51.0-tm-v0.34.35 h1:B9CRRq3VtraIe3Jktqep
 github.com/celestiaorg/celestia-core v1.51.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
 github.com/celestiaorg/cosmos-sdk v1.27.0-sdk-v0.46.16 h1:qxWiGrDEcg4FzVTpIXU/v3wjP7q1Lz4AMhSBBRABInU=
 github.com/celestiaorg/cosmos-sdk v1.27.0-sdk-v0.46.16/go.mod h1:W30mNt3+2l516HVR8Gt9+Gf4qOrWC9/x18MTEx2GljE=
-github.com/celestiaorg/ibc-go/v6 v6.2.4 h1:S9jH7e+faYWF9PgDQAQnHxgm+FeDWTKcOF99Zez40bA=
-github.com/celestiaorg/ibc-go/v6 v6.2.4/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
+github.com/celestiaorg/ibc-go/v6 v6.2.5 h1:mUmZptulQGsGgyBqmdBeSCPQtMu0aFMJstgvKhUdqy4=
+github.com/celestiaorg/ibc-go/v6 v6.2.5/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
 github.com/celestiaorg/nmt v0.23.0 h1:cfYy//hL1HeDSH0ub3CPlJuox5U5xzgg4JGZrw23I/I=
 github.com/celestiaorg/nmt v0.23.0/go.mod h1:kYfIjRq5rmA2mJnv41GLWkxn5KyLNPlma3v5Q68rHdI=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4427

The only important change is ignoring the error returned by `os.UserHomeDir()`. The rest of the diff is a refactor for legibility. I re-ordered celestiaHome in arguments and test cases first because it takes precedence over userHome.

cc: @lzrscg