### PR TITLE
fix: nil signer panic in `findAccount` and correct error message in `AddAccount`

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -161,8 +161,8 @@ func (s *Signer) Accounts() []*Account {
 
 func (s *Signer) findAccount(txbuilder client.TxBuilder) (*Account, error) {
 	signers := txbuilder.GetTx().GetSigners()
-	if len(signers) == 0 {
-		return nil, fmt.Errorf("message has no signer")
+	if len(signers) == 0 || signers[0] == nil {
+		return nil, fmt.Errorf("message has no valid signer")
 	}
 	accountName, exists := s.addressToAccountMap[signers[0].String()]
 	if !exists {

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -202,7 +202,7 @@ func (s *Signer) AddAccount(acc *Account) error {
 
 	addr, err := record.GetAddress()
 	if err != nil {
-		return fmt.Errorf("getting address for key %s: %w", acc.pubKey, err)
+		return fmt.Errorf("getting address for key %s: %w", acc.name, err)
 	}
 
 	pk, err := record.GetPubKey()


### PR DESCRIPTION
1. Nil Signer Safety Check:
   - Enhanced `findAccount` method with an additional check for `nil` signers to prevent potential `panic`.
   - New condition: `if len(signers) == 0 || signers[0] == nil` ensures that signer access is safe.

2. Correct Error Message Context:
   - In `AddAccount`, the error message incorrectly referenced `acc.pubKey`. 
   - Replaced it with `acc.name` for proper context when reporting failure to get the address.
