### PR TITLE
chore(all): replace interface{}

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -211,6 +211,6 @@ func (nw *NoopWriter) Write(p []byte) (n int, err error) {
 // NoopAppOptions is a no-op implementation of servertypes.AppOptions.
 type NoopAppOptions struct{}
 
-func (nao NoopAppOptions) Get(string) interface{} {
+func (nao NoopAppOptions) Get(string) any {
 	return nil
 }

--- a/app/module/server_wrapper.go
+++ b/app/module/server_wrapper.go
@@ -18,11 +18,11 @@ type serverWrapper struct {
 	msgServer   pbgrpc.Server
 }
 
-func (s *serverWrapper) RegisterService(sd *grpc.ServiceDesc, v interface{}) {
+func (s *serverWrapper) RegisterService(sd *grpc.ServiceDesc, v any) {
 	msgs := make([]string, len(sd.Methods))
 	for idx, method := range sd.Methods {
 		// we execute the handler to extract the message type
-		_, _ = method.Handler(nil, context.Background(), func(i interface{}) error {
+		_, _ = method.Handler(nil, context.Background(), func(i any) error {
 			msg, ok := i.(sdk.Msg)
 			if !ok {
 				panic(fmt.Errorf("unable to register service method %s/%s: %T does not implement sdk.Msg", sd.ServiceName, method.MethodName, i))
@@ -36,6 +36,6 @@ func (s *serverWrapper) RegisterService(sd *grpc.ServiceDesc, v interface{}) {
 	s.msgServer.RegisterService(sd, v)
 }
 
-func noopInterceptor(_ context.Context, _ interface{}, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (interface{}, error) {
+func noopInterceptor(_ context.Context, _ any, _ *grpc.UnaryServerInfo, _ grpc.UnaryHandler) (any, error) {
 	return nil, nil
 }

--- a/app/module/versioned_ibc_module_test.go
+++ b/app/module/versioned_ibc_module_test.go
@@ -29,8 +29,8 @@ func TestVersionedIBCModule(t *testing.T) {
 		name          string
 		version       uint64
 		setupMocks    func(ctx sdk.Context)
-		method        func(ctx sdk.Context) (interface{}, error)
-		expectedValue interface{}
+		method        func(ctx sdk.Context) (any, error)
+		expectedValue any
 	}{
 		{
 			name:    "OnChanOpenInit with supported version",
@@ -38,7 +38,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnChanOpenInit(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1").Return("wrapped_version", nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return versionedModule.OnChanOpenInit(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1")
 			},
 			expectedValue: "wrapped_version",
@@ -49,7 +49,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnChanOpenInit(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1").Return("next_version", nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return versionedModule.OnChanOpenInit(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1")
 			},
 			expectedValue: "next_version",
@@ -60,7 +60,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnChanOpenTry(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1").Return("wrapped_version", nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return versionedModule.OnChanOpenTry(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1")
 			},
 			expectedValue: "wrapped_version",
@@ -71,7 +71,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnChanOpenTry(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1").Return("next_version", nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return versionedModule.OnChanOpenTry(ctx, types.ORDERED, []string{"connection"}, "port", "channel", nil, types.Counterparty{}, "1")
 			},
 			expectedValue: "next_version",
@@ -82,7 +82,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnChanOpenAck(ctx, "port", "channel", "counterpartyChannelID", "counterpartyVersion").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanOpenAck(ctx, "port", "channel", "counterpartyChannelID", "counterpartyVersion")
 			},
 			expectedValue: nil,
@@ -93,7 +93,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnChanOpenAck(ctx, "port", "channel", "counterpartyChannelID", "counterpartyVersion").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanOpenAck(ctx, "port", "channel", "counterpartyChannelID", "counterpartyVersion")
 			},
 			expectedValue: nil,
@@ -104,7 +104,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnChanOpenConfirm(ctx, "port", "channel").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanOpenConfirm(ctx, "port", "channel")
 			},
 			expectedValue: nil,
@@ -115,7 +115,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnChanOpenConfirm(ctx, "port", "channel").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanOpenConfirm(ctx, "port", "channel")
 			},
 			expectedValue: nil,
@@ -126,7 +126,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnChanCloseInit(ctx, "port", "channel").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanCloseInit(ctx, "port", "channel")
 			},
 			expectedValue: nil,
@@ -137,7 +137,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnChanCloseInit(ctx, "port", "channel").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanCloseInit(ctx, "port", "channel")
 			},
 			expectedValue: nil,
@@ -148,7 +148,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnChanCloseConfirm(ctx, "port", "channel").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanCloseConfirm(ctx, "port", "channel")
 			},
 			expectedValue: nil,
@@ -159,7 +159,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnChanCloseConfirm(ctx, "port", "channel").Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnChanCloseConfirm(ctx, "port", "channel")
 			},
 			expectedValue: nil,
@@ -171,7 +171,7 @@ func TestVersionedIBCModule(t *testing.T) {
 				expectedAck := types.NewResultAcknowledgement([]byte("wrapped_ack"))
 				mockWrappedModule.EXPECT().OnRecvPacket(ctx, types.Packet{}, sdk.AccAddress{}).Return(expectedAck)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return versionedModule.OnRecvPacket(ctx, types.Packet{}, sdk.AccAddress{}), nil
 			},
 			expectedValue: types.NewResultAcknowledgement([]byte("wrapped_ack")),
@@ -183,7 +183,7 @@ func TestVersionedIBCModule(t *testing.T) {
 				expectedAck := types.NewResultAcknowledgement([]byte("next_ack"))
 				mockNextModule.EXPECT().OnRecvPacket(ctx, types.Packet{}, sdk.AccAddress{}).Return(expectedAck)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return versionedModule.OnRecvPacket(ctx, types.Packet{}, sdk.AccAddress{}), nil
 			},
 			expectedValue: types.NewResultAcknowledgement([]byte("next_ack")),
@@ -194,7 +194,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnAcknowledgementPacket(ctx, types.Packet{}, []byte{}, sdk.AccAddress{}).Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnAcknowledgementPacket(ctx, types.Packet{}, []byte{}, sdk.AccAddress{})
 			},
 			expectedValue: nil,
@@ -205,7 +205,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnAcknowledgementPacket(ctx, types.Packet{}, []byte{}, sdk.AccAddress{}).Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnAcknowledgementPacket(ctx, types.Packet{}, []byte{}, sdk.AccAddress{})
 			},
 			expectedValue: nil,
@@ -216,7 +216,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockWrappedModule.EXPECT().OnTimeoutPacket(ctx, types.Packet{}, sdk.AccAddress{}).Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnTimeoutPacket(ctx, types.Packet{}, sdk.AccAddress{})
 			},
 			expectedValue: nil,
@@ -227,7 +227,7 @@ func TestVersionedIBCModule(t *testing.T) {
 			setupMocks: func(ctx sdk.Context) {
 				mockNextModule.EXPECT().OnTimeoutPacket(ctx, types.Packet{}, sdk.AccAddress{}).Return(nil)
 			},
-			method: func(ctx sdk.Context) (interface{}, error) {
+			method: func(ctx sdk.Context) (any, error) {
 				return nil, versionedModule.OnTimeoutPacket(ctx, types.Packet{}, sdk.AccAddress{})
 			},
 			expectedValue: nil,

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -15,8 +15,8 @@ func TestVersionedConsts(t *testing.T) {
 	testCases := []struct {
 		name             string
 		version          uint64
-		expectedConstant interface{}
-		got              interface{}
+		expectedConstant any
+		got              any
 	}{
 		{
 			name:             "SubtreeRootThreshold v1",

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -57,7 +57,7 @@ func init() {
 type EmptyAppOptions struct{}
 
 // Get implements AppOptions
-func (ao EmptyAppOptions) Get(_ string) interface{} {
+func (ao EmptyAppOptions) Get(_ string) any {
 	return nil
 }
 

--- a/test/util/testnode/app_options.go
+++ b/test/util/testnode/app_options.go
@@ -5,23 +5,30 @@ import (
 	"github.com/cosmos/cosmos-sdk/server"
 )
 
+// KVAppOptions implements the AppOptions interface backed by a simple key-value map
 type KVAppOptions struct {
-	options map[string]interface{}
+	options map[string]any
 }
 
 // Get returns the option value for the given option key.
-func (ao *KVAppOptions) Get(option string) interface{} {
+func (ao *KVAppOptions) Get(option string) any {
 	return ao.options[option]
 }
 
 // Set sets a key-value app option.
-func (ao *KVAppOptions) Set(option string, value interface{}) {
+func (ao *KVAppOptions) Set(option string, value any) {
 	ao.options[option] = value
 }
 
 // DefaultAppOptions returns the default application options.
 func DefaultAppOptions() *KVAppOptions {
-	opts := &KVAppOptions{options: make(map[string]interface{})}
+	opts := &KVAppOptions{options: make(map[string]any)}
 	opts.Set(server.FlagPruning, pruningtypes.PruningOptionNothing)
+	return opts
+}
+
+// NewKVAppOptions creates a new instance of KVAppOptions
+func NewKVAppOptions() *KVAppOptions {
+	opts := &KVAppOptions{options: make(map[string]any)}
 	return opts
 }

--- a/test/util/testnode/read_test.go
+++ b/test/util/testnode/read_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestReverseSlice(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{[]int{1, 2, 3, 4, 5}, []int{5, 4, 3, 2, 1}},
 		{[]string{"a", "b", "c", "d"}, []string{"d", "c", "b", "a"}},

--- a/x/blob/types/params.go
+++ b/x/blob/types/params.go
@@ -60,7 +60,7 @@ func (p Params) String() string {
 }
 
 // validateGasPerBlobByte validates the GasPerBlobByte param
-func validateGasPerBlobByte(v interface{}) error {
+func validateGasPerBlobByte(v any) error {
 	gasPerBlobByte, ok := v.(uint32)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", v)
@@ -74,7 +74,7 @@ func validateGasPerBlobByte(v interface{}) error {
 }
 
 // validateGovMaxSquareSize validates the GovMaxSquareSize param
-func validateGovMaxSquareSize(v interface{}) error {
+func validateGovMaxSquareSize(v any) error {
 	govMaxSquareSize, ok := v.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", v)

--- a/x/blob/types/params_test.go
+++ b/x/blob/types/params_test.go
@@ -10,7 +10,7 @@ import (
 func Test_validateGovMaxSquareSize(t *testing.T) {
 	type test struct {
 		name      string
-		input     interface{}
+		input     any
 		expectErr bool
 	}
 	tests := []test{

--- a/x/blobstream/types/genesis.go
+++ b/x/blobstream/types/genesis.go
@@ -54,7 +54,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	}
 }
 
-func validateDataCommitmentWindow(i interface{}) error {
+func validateDataCommitmentWindow(i any) error {
 	val, ok := i.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)

--- a/x/minfee/params.go
+++ b/x/minfee/params.go
@@ -50,7 +50,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 }
 
 // Validate validates the param type
-func ValidateMinGasPrice(i interface{}) error {
+func ValidateMinGasPrice(i any) error {
 	_, ok := i.(sdk.Dec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

replacing interface{} by the 'any' type added in go1.18;

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
