### PR TITLE
docs: fix broken links in docs

### DIFF
--- a/docs/architecture/adr-023-gas-used-and-gas-price-estimation.md
+++ b/docs/architecture/adr-023-gas-used-and-gas-price-estimation.md
@@ -11,7 +11,7 @@ Implemented
 
 ## Context
 
-As per [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-18.md), celestia-app will provide a base implementation for the gas and fee estimation so it can be used when building transactions.
+As per [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-018.md), celestia-app will provide a base implementation for the gas and fee estimation so it can be used when building transactions.
 
 ## Decision
 
@@ -21,7 +21,7 @@ The fee estimation mechanism is described below.
 
 ## Detailed Design
 
-The API will be provided through gRPC following the interface provided in [CIP-18](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-18.md).
+The API will be provided through gRPC following the interface provided in [CIP-18](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-018.md).
 
 ### Gas used estimation
 
@@ -92,4 +92,4 @@ None.
 
 ## References
 
-- [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-18.md).
+- [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-018.md).

--- a/x/minfee/README.md
+++ b/x/minfee/README.md
@@ -6,4 +6,4 @@ The `x/minfee` module is responsible for managing the gov-modifiable parameter `
 
 ## Resources
 
-1. <https://github.com/celestiaorg/CIPs/blob/main/cips/cip-6.md>
+1. <https://github.com/celestiaorg/CIPs/blob/main/cips/cip-006.md>

--- a/x/signal/README.md
+++ b/x/signal/README.md
@@ -44,6 +44,6 @@ grpcurl -plaintext localhost:9090 celestia.signal.v1.Query/VersionTally
 ## Appendix
 
 1. <https://github.com/celestiaorg/celestia-app/blob/main/docs/architecture/adr-018-network-upgrades.md>
-1. <https://github.com/celestiaorg/CIPs/blob/main/cips/cip-10.md>
+1. <https://github.com/celestiaorg/CIPs/blob/main/cips/cip-010.md>
 1. <https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/x/upgrade/README.md>
 1. <https://github.com/cosmos/cosmos-sdk/blob/v0.46.15/x/gov/README.md>


### PR DESCRIPTION
Hi! I fixed broken links in the documentation across multiple files. The links to Celestia Improvement Proposals (CIPs) were incorrect due to inconsistent formatting of the CIP numbers (e.g., `cip-18.md` instead of `cip-018.md`). This PR standardizes the links to ensure they point to the correct resources.