### PR TITLE
chore: fix array indexing error in bash script

### DIFF
--- a/scripts/localnet-blocks-test.sh
+++ b/scripts/localnet-blocks-test.sh
@@ -44,7 +44,7 @@ while [ ${CNT} -lt $ITER ]; do
   #
   # Every 10 blocks, pick a random container and restart it.
   if ! ((${CNT} % 10)); then
-    rand_container=${docker_containers["$[RANDOM % ${#docker_containers[@]}]"]};
+    rand_container=${docker_containers[$((RANDOM % ${#docker_containers[@]}))]};
     echo "Restarting random docker container ${rand_container}"
     docker restart ${rand_container} &>/dev/null &
   fi


### PR DESCRIPTION
## Overview

Fixed an issue with array indexing. The old syntax:

```sh
rand_container=${docker_containers["$[RANDOM % ${#docker_containers[@]}]"]};
```

was incorrect. Updated it to the correct version:

```sh
rand_container=${docker_containers[$((RANDOM % ${#docker_containers[@]}))]};
```

This ensures proper syntax for both arithmetic and array indexing in bash.
