### PR TITLE
chore: fix error message for startShare validation

### DIFF
--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -132,7 +132,7 @@ func QueryShareInclusionProof(_ sdk.Context, path []string, req abci.RequestQuer
 // The provided range, defined by startShare and endShare, is end-exclusive.
 func ParseNamespace(rawShares []share.Share, startShare int, endShare int) (share.Namespace, error) {
 	if startShare < 0 {
-		return share.Namespace{}, fmt.Errorf("start share %d should be positive", startShare)
+		return share.Namespace{}, fmt.Errorf("start share %d should not be negative", startShare)
 	}
 
 	if endShare < 0 {


### PR DESCRIPTION
## Overview

I’ve updated the error message to clarify that startShare should not be negative. The previous message was a bit misleading, as startShare can be zero, which isn’t a negative number.

Now the message reads: "start share %d should not be negative," making it clearer.