### PR TITLE
fix: MinGasPFB decorator check for nested authz messages 

### DIFF
--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -30,6 +30,11 @@ func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 		return next(ctx, tx, simulate)
 	}
 
+	// Skip gas checks during genesis initialization
+	if ctx.BlockHeight() == 0 {
+		return next(ctx, tx, simulate)
+	}
+
 	gasPerByte := d.getGasPerByte(ctx)
 	txGas := ctx.GasMeter().GasRemaining()
 	err := d.validatePFBHasEnoughGas(tx.GetMsgs(), gasPerByte, txGas)

--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -32,37 +32,34 @@ func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 
 	gasPerByte := d.getGasPerByte(ctx)
 	txGas := ctx.GasMeter().GasRemaining()
-	for _, m := range tx.GetMsgs() {
-		// NOTE: here we assume only one PFB per transaction
-		if pfb, ok := m.(*types.MsgPayForBlobs); ok {
-			if err := validateEnoughGas(pfb, gasPerByte, txGas); err != nil {
-				return ctx, err
-			}
-		}
-		if execMsg, ok := m.(*authz.MsgExec); ok {
-			nestedMsgs, err := execMsg.GetMessages()
-			if err != nil {
-				return ctx, err
-			}
-			for _, nestedMsg := range nestedMsgs {
-				// NOTE: here we assume only one PFB per transaction
-				if pfb, ok := nestedMsg.(*types.MsgPayForBlobs); ok {
-					if err := validateEnoughGas(pfb, gasPerByte, txGas); err != nil {
-						return ctx, err
-					}
-				}
-			}
-		}
+	err := d.validatePFBHasEnoughGas(tx.GetMsgs(), gasPerByte, txGas)
+	if err != nil {
+		return ctx, err
 	}
 
 	return next(ctx, tx, simulate)
 }
 
-// validateEnoughGas checks if the transaction has enough gas to pay for the PFB.
-func validateEnoughGas(pfb *types.MsgPayForBlobs, gasPerByte uint32, txGas uint64) error {
-	gasToConsume := pfb.Gas(gasPerByte)
-	if gasToConsume > txGas {
-		return errors.Wrapf(sdkerrors.ErrInsufficientFee, "not enough gas to pay for blobs (minimum: %d, got: %d)", gasToConsume, txGas)
+func (d MinGasPFBDecorator) validatePFBHasEnoughGas(msgs []sdk.Msg, gasPerByte uint32, txGas uint64) error {
+	for _, m := range msgs {
+		if execMsg, ok := m.(*authz.MsgExec); ok {
+			// Recursively look for PFBs in nested authz messages.
+			nestedMsgs, err := execMsg.GetMessages()
+			if err != nil {
+				return err
+			}
+			err = d.validatePFBHasEnoughGas(nestedMsgs, gasPerByte, txGas)
+			if err != nil {
+				return err
+			}
+		}
+		// NOTE: here we assume only one PFB per transaction
+		if pfb, ok := m.(*types.MsgPayForBlobs); ok {
+			err := validateEnoughGas(pfb, gasPerByte, txGas)
+			if err != nil {
+				return err
+			}
+		}
 	}
 	return nil
 }
@@ -72,6 +69,15 @@ func (d MinGasPFBDecorator) getGasPerByte(ctx sdk.Context) uint32 {
 		return d.k.GasPerBlobByte(ctx)
 	}
 	return appconsts.GasPerBlobByte(ctx.BlockHeader().Version.App)
+}
+
+// validateEnoughGas checks if the pfb has enough gas to pay for the PFB.
+func validateEnoughGas(pfb *types.MsgPayForBlobs, gasPerByte uint32, txGas uint64) error {
+	gasToConsume := pfb.Gas(gasPerByte)
+	if gasToConsume > txGas {
+		return errors.Wrapf(sdkerrors.ErrInsufficientFee, "not enough gas to pay for blobs (minimum: %d, got: %d)", gasToConsume, txGas)
+	}
+	return nil
 }
 
 type BlobKeeper interface {

--- a/x/blob/ante/ante_test.go
+++ b/x/blob/ante/ante_test.go
@@ -127,6 +127,7 @@ func TestPFBAnteHandler(t *testing.T) {
 					Version: version.Consensus{
 						App: currentVersion,
 					},
+					Height: 1,
 				}, true, nil).WithGasMeter(sdk.NewGasMeter(uint64(tc.txGas(gasPerBlobByte)))).WithIsCheckTx(true)
 
 				ctx.GasMeter().ConsumeGas(tc.gasConsumed, "test")
@@ -157,6 +158,7 @@ func TestMinGasPFBDecoratorWithMsgExec(t *testing.T) {
 		Version: version.Consensus{
 			App: appconsts.LatestVersion,
 		},
+		Height: 1,
 	}, true, nil).WithGasMeter(sdk.NewGasMeter(gasLimit)).WithIsCheckTx(true)
 
 	// Build a tx with a MsgExec containing a MsgPayForBlobs with a huge gas cost

--- a/x/blob/ante/ante_test.go
+++ b/x/blob/ante/ante_test.go
@@ -173,7 +173,7 @@ func TestMinGasPFBDecoratorWithMsgExec(t *testing.T) {
 	tx := txBuilder.GetTx()
 
 	// Run the ante handler
-	_, err := anteHandler.AnteHandle(ctx, tx, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil })
+	_, err := anteHandler.AnteHandle(ctx, tx, false, mockNext)
 	require.Error(t, err)
 	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
 
@@ -183,7 +183,7 @@ func TestMinGasPFBDecoratorWithMsgExec(t *testing.T) {
 	tx = txBuilder.GetTx()
 
 	// Run the ante handler
-	_, err = anteHandler.AnteHandle(ctx, tx, false, func(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) { return ctx, nil })
+	_, err = anteHandler.AnteHandle(ctx, tx, false, mockNext)
 	require.Error(t, err)
 }
 

--- a/x/blob/ante/ante_test.go
+++ b/x/blob/ante/ante_test.go
@@ -153,7 +153,7 @@ func TestMinGasPFBDecoratorWithMsgExec(t *testing.T) {
 	txConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...).TxConfig
 
 	// Create a context with a gas meter with a high gas limit
-	gasLimit := uint64(10000)
+	gasLimit := uint64(100_000_000)
 	ctx := sdk.NewContext(nil, tmproto.Header{
 		Version: version.Consensus{
 			App: appconsts.LatestVersion,
@@ -185,6 +185,7 @@ func TestMinGasPFBDecoratorWithMsgExec(t *testing.T) {
 	// Run the ante handler
 	_, err = anteHandler.AnteHandle(ctx, tx, false, mockNext)
 	require.Error(t, err)
+	require.ErrorIs(t, err, sdkerrors.ErrInsufficientFee)
 }
 
 type mockBlobKeeper struct{}


### PR DESCRIPTION
Previously the MinGasPFB decorator was not looking inside authz `MsgExec`s.