### PR TITLE
feat(ante)!: reject MsgExec if it contains a MsgExec or MsgPayForBlobs

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -62,8 +62,8 @@ func NewAnteHandler(
 		// account sequence number of the signer.
 		// Note: does not consume gas from the gas meter.
 		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
-		// Ensure that the tx does not contain any nested MsgExec messages.
-		// Only applies to app version >= 4.
+		// Ensure that the tx does not contain a MsgExec with a nested MsgExec
+		// or MsgPayForBlobs.
 		NewMsgExecDecorator(),
 		// Ensure that the tx's gas limit is > the gas consumed based on the blob size(s).
 		// Contract: must be called after all decorators that consume gas.

--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -62,6 +62,9 @@ func NewAnteHandler(
 		// account sequence number of the signer.
 		// Note: does not consume gas from the gas meter.
 		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
+		// Ensure that the tx does not contain any nested MsgExec messages.
+		// Only applies to app version >= 4.
+		NewMsgExecDecorator(),
 		// Ensure that the tx's gas limit is > the gas consumed based on the blob size(s).
 		// Contract: must be called after all decorators that consume gas.
 		// Note: does not consume gas from the gas meter.

--- a/app/ante/msg_exec.go
+++ b/app/ante/msg_exec.go
@@ -6,10 +6,10 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/authz"
 )
 
-var (
-	_ sdk.AnteDecorator = MsgExecDecorator{}
-)
+var _ sdk.AnteDecorator = MsgExecDecorator{}
 
+// MsgExecDecorator ensures that the tx does not contain any nested MsgExec messages.
+// Only applies to app version >= 4.
 type MsgExecDecorator struct{}
 
 func NewMsgExecDecorator() *MsgExecDecorator {

--- a/app/ante/msg_exec.go
+++ b/app/ante/msg_exec.go
@@ -18,12 +18,6 @@ func NewMsgExecDecorator() *MsgExecDecorator {
 }
 
 func (mgk MsgExecDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
-	// Only apply this decorator in checkTx.
-	// TODO: in v4, consider enforcing this in ProcessProposal too.
-	if !ctx.IsCheckTx() {
-		return next(ctx, tx, simulate)
-	}
-
 	for _, msg := range tx.GetMsgs() {
 		if msgExec, ok := msg.(*authz.MsgExec); ok {
 			nestedMsgs, err := msgExec.GetMessages()
@@ -34,8 +28,6 @@ func (mgk MsgExecDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 				if _, ok := nestedMsg.(*authz.MsgExec); ok {
 					return ctx, sdkerrors.ErrNotSupported.Wrapf("MsgExec inside MsgExec is not supported")
 				}
-			}
-			for _, nestedMsg := range nestedMsgs {
 				if _, ok := nestedMsg.(*blobtypes.MsgPayForBlobs); ok {
 					return ctx, sdkerrors.ErrNotSupported.Wrapf("MsgPayForBlobs inside MsgExec is not supported")
 				}

--- a/app/ante/msg_exec.go
+++ b/app/ante/msg_exec.go
@@ -1,0 +1,39 @@
+package ante
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+)
+
+var (
+	_ sdk.AnteDecorator = MsgExecDecorator{}
+)
+
+type MsgExecDecorator struct{}
+
+func NewMsgExecDecorator() *MsgExecDecorator {
+	return &MsgExecDecorator{}
+}
+
+func (mgk MsgExecDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	// This decorator is only applicable to app version 4 and above
+	if ctx.BlockHeader().Version.App < 4 {
+		return next(ctx, tx, simulate)
+	}
+
+	for _, msg := range tx.GetMsgs() {
+		if msgExec, ok := msg.(*authz.MsgExec); ok {
+			nestedMsgs, err := msgExec.GetMessages()
+			if err != nil {
+				return ctx, err
+			}
+			for _, nestedMsg := range nestedMsgs {
+				if _, ok := nestedMsg.(*authz.MsgExec); ok {
+					return ctx, sdkerrors.ErrNotSupported.Wrapf("MsgExec inside MsgExec is not supported")
+				}
+			}
+		}
+	}
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/msg_exec_test.go
+++ b/app/ante/msg_exec_test.go
@@ -6,48 +6,39 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/ante"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
+	blobtypes "github.com/celestiaorg/celestia-app/v3/x/blob/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	version "github.com/tendermint/tendermint/proto/tendermint/version"
 )
 
 func TestMsgExecDecorator(t *testing.T) {
 	msgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&banktypes.MsgSend{}})
 	nestedMsgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&msgExec})
+	nestedMsgPayForBlobs := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&blobtypes.MsgPayForBlobs{}})
 
 	tests := []struct {
-		name       string
-		msg        sdk.Msg
-		appVersion uint64
-		wantErr    error
+		name    string
+		msg     sdk.Msg
+		wantErr error
 	}{
 		{
-			name:       "Accept msgExec on v3",
-			msg:        &msgExec,
-			appVersion: 3,
-			wantErr:    nil,
+			name:    "Accept msgExec",
+			msg:     &msgExec,
+			wantErr: nil,
 		},
 		{
-			name:       "Accept nestedMsgExec on v3",
-			msg:        &nestedMsgExec,
-			appVersion: 3,
-			wantErr:    nil,
+			name:    "Reject nestedMsgExec",
+			msg:     &nestedMsgExec,
+			wantErr: sdkerrors.ErrNotSupported,
 		},
 		{
-			name:       "Accept msgExec on v4",
-			msg:        &msgExec,
-			appVersion: 4,
-			wantErr:    nil,
-		},
-		{
-			name:       "Reject nestedMsgExec on v4",
-			msg:        &nestedMsgExec,
-			appVersion: 4,
-			wantErr:    sdkerrors.ErrNotSupported,
+			name:    "Reject nestedMsgPayForBlobs",
+			msg:     &nestedMsgPayForBlobs,
+			wantErr: sdkerrors.ErrNotSupported,
 		},
 	}
 
@@ -57,9 +48,12 @@ func TestMsgExecDecorator(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := sdk.NewContext(nil, tmproto.Header{Version: version.Consensus{App: tc.appVersion}}, true, nil)
+			// Setup
+			ctx := sdk.NewContext(nil, tmproto.Header{}, true, nil)
 			txBuilder := cdc.TxConfig.NewTxBuilder()
 			require.NoError(t, txBuilder.SetMsgs(tc.msg))
+
+			// Run the ante handler
 			_, err := anteHandler(ctx, txBuilder.GetTx(), false)
 			if tc.wantErr != nil {
 				require.Error(t, err)

--- a/app/ante/msg_exec_test.go
+++ b/app/ante/msg_exec_test.go
@@ -21,24 +21,34 @@ func TestMsgExecDecorator(t *testing.T) {
 	nestedMsgPayForBlobs := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&blobtypes.MsgPayForBlobs{}})
 
 	tests := []struct {
-		name    string
-		msg     sdk.Msg
-		wantErr error
+		name      string
+		msg       sdk.Msg
+		isCheckTx bool
+		wantErr   error
 	}{
 		{
-			name:    "Accept msgExec",
-			msg:     &msgExec,
-			wantErr: nil,
+			name:      "Accept msgExec",
+			msg:       &msgExec,
+			isCheckTx: true,
+			wantErr:   nil,
 		},
 		{
-			name:    "Reject nestedMsgExec",
-			msg:     &nestedMsgExec,
-			wantErr: sdkerrors.ErrNotSupported,
+			name:      "Reject nestedMsgExec",
+			msg:       &nestedMsgExec,
+			isCheckTx: true,
+			wantErr:   sdkerrors.ErrNotSupported,
 		},
 		{
-			name:    "Reject nestedMsgPayForBlobs",
-			msg:     &nestedMsgPayForBlobs,
-			wantErr: sdkerrors.ErrNotSupported,
+			name:      "Reject nestedMsgPayForBlobs",
+			msg:       &nestedMsgPayForBlobs,
+			isCheckTx: true,
+			wantErr:   sdkerrors.ErrNotSupported,
+		},
+		{
+			name:      "Accept nestedMsgExec if isCheckTx is false",
+			msg:       &nestedMsgPayForBlobs,
+			isCheckTx: false,
+			wantErr:   nil,
 		},
 	}
 
@@ -49,7 +59,7 @@ func TestMsgExecDecorator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
-			ctx := sdk.NewContext(nil, tmproto.Header{}, true, nil)
+			ctx := sdk.NewContext(nil, tmproto.Header{}, tc.isCheckTx, nil)
 			txBuilder := cdc.TxConfig.NewTxBuilder()
 			require.NoError(t, txBuilder.SetMsgs(tc.msg))
 

--- a/app/ante/msg_exec_test.go
+++ b/app/ante/msg_exec_test.go
@@ -21,34 +21,24 @@ func TestMsgExecDecorator(t *testing.T) {
 	nestedMsgPayForBlobs := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&blobtypes.MsgPayForBlobs{}})
 
 	tests := []struct {
-		name      string
-		msg       sdk.Msg
-		isCheckTx bool
-		wantErr   error
+		name    string
+		msg     sdk.Msg
+		wantErr error
 	}{
 		{
-			name:      "Accept msgExec",
-			msg:       &msgExec,
-			isCheckTx: true,
-			wantErr:   nil,
+			name:    "Accept msgExec",
+			msg:     &msgExec,
+			wantErr: nil,
 		},
 		{
-			name:      "Reject nestedMsgExec",
-			msg:       &nestedMsgExec,
-			isCheckTx: true,
-			wantErr:   sdkerrors.ErrNotSupported,
+			name:    "Reject nestedMsgExec",
+			msg:     &nestedMsgExec,
+			wantErr: sdkerrors.ErrNotSupported,
 		},
 		{
-			name:      "Reject nestedMsgPayForBlobs",
-			msg:       &nestedMsgPayForBlobs,
-			isCheckTx: true,
-			wantErr:   sdkerrors.ErrNotSupported,
-		},
-		{
-			name:      "Accept nestedMsgExec if isCheckTx is false",
-			msg:       &nestedMsgPayForBlobs,
-			isCheckTx: false,
-			wantErr:   nil,
+			name:    "Reject nestedMsgPayForBlobs",
+			msg:     &nestedMsgPayForBlobs,
+			wantErr: sdkerrors.ErrNotSupported,
 		},
 	}
 
@@ -59,7 +49,7 @@ func TestMsgExecDecorator(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Setup
-			ctx := sdk.NewContext(nil, tmproto.Header{}, tc.isCheckTx, nil)
+			ctx := sdk.NewContext(nil, tmproto.Header{}, true, nil)
 			txBuilder := cdc.TxConfig.NewTxBuilder()
 			require.NoError(t, txBuilder.SetMsgs(tc.msg))
 

--- a/app/ante/msg_exec_test.go
+++ b/app/ante/msg_exec_test.go
@@ -1,0 +1,72 @@
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v3/app"
+	"github.com/celestiaorg/celestia-app/v3/app/ante"
+	"github.com/celestiaorg/celestia-app/v3/app/encoding"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+	version "github.com/tendermint/tendermint/proto/tendermint/version"
+)
+
+func TestMsgExecDecorator(t *testing.T) {
+	msgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&banktypes.MsgSend{}})
+	nestedMsgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&msgExec})
+
+	tests := []struct {
+		name       string
+		msg        sdk.Msg
+		appVersion uint64
+		wantErr    error
+	}{
+		{
+			name:       "Accept msgExec on v3",
+			msg:        &msgExec,
+			appVersion: 3,
+			wantErr:    nil,
+		},
+		{
+			name:       "Accept nestedMsgExec on v3",
+			msg:        &nestedMsgExec,
+			appVersion: 3,
+			wantErr:    nil,
+		},
+		{
+			name:       "Accept msgExec on v4",
+			msg:        &msgExec,
+			appVersion: 4,
+			wantErr:    nil,
+		},
+		{
+			name:       "Reject nestedMsgExec on v4",
+			msg:        &nestedMsgExec,
+			appVersion: 4,
+			wantErr:    sdkerrors.ErrNotSupported,
+		},
+	}
+
+	decorator := ante.NewMsgExecDecorator()
+	cdc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	anteHandler := sdk.ChainAnteDecorators(decorator)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := sdk.NewContext(nil, tmproto.Header{Version: version.Consensus{App: tc.appVersion}}, true, nil)
+			txBuilder := cdc.TxConfig.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.msg))
+			_, err := anteHandler(ctx, txBuilder.GetTx(), false)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3609 by adding a new ante handler that rejects a tx if it contains a MsgExec which contains a MsgExec or MsgPayForBlobs.