### PR TITLE
fix: only apply MinGasPFB decorator if checkTx is true

### DIFF
--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -26,7 +26,7 @@ func NewMinGasPFBDecorator(k BlobKeeper) MinGasPFBDecorator {
 // if the transaction contains a MsgPayForBlobs and if so, checks that
 // the transaction has allocated enough gas.
 func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
-	if ctx.IsReCheckTx() {
+	if !ctx.IsCheckTx() {
 		return next(ctx, tx, simulate)
 	}
 


### PR DESCRIPTION
Modify the MinGasPFB decorator to only run when `CheckTx=true` so that it doesn't run in process proposal.