### PR TITLE
feat(ante): reject MsgExec if it contains a MsgExec or MsgPayForBlobs

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -62,6 +62,9 @@ func NewAnteHandler(
 		// account sequence number of the signer.
 		// Note: does not consume gas from the gas meter.
 		ante.NewSigVerificationDecorator(accountKeeper, signModeHandler),
+		// Ensure that the tx does not contain a MsgExec with a nested MsgExec
+		// or MsgPayForBlobs.
+		NewMsgExecDecorator(),
 		// Ensure that the tx's gas limit is > the gas consumed based on the blob size(s).
 		// Contract: must be called after all decorators that consume gas.
 		// Note: does not consume gas from the gas meter.

--- a/app/ante/msg_exec.go
+++ b/app/ante/msg_exec.go
@@ -1,0 +1,43 @@
+package ante
+
+import (
+	blobtypes "github.com/celestiaorg/celestia-app/v3/x/blob/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+)
+
+var _ sdk.AnteDecorator = MsgExecDecorator{}
+
+// MsgExecDecorator ensures that the tx does not contain a MsgExec with a
+// nested MsgExec or MsgPayForBlobs.
+type MsgExecDecorator struct{}
+
+func NewMsgExecDecorator() *MsgExecDecorator {
+	return &MsgExecDecorator{}
+}
+
+func (mgk MsgExecDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (newCtx sdk.Context, err error) {
+	// Only apply this decorator in checkTx.
+	if !ctx.IsCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	for _, msg := range tx.GetMsgs() {
+		if msgExec, ok := msg.(*authz.MsgExec); ok {
+			nestedMsgs, err := msgExec.GetMessages()
+			if err != nil {
+				return ctx, err
+			}
+			for _, nestedMsg := range nestedMsgs {
+				if _, ok := nestedMsg.(*authz.MsgExec); ok {
+					return ctx, sdkerrors.ErrNotSupported.Wrapf("MsgExec inside MsgExec is not supported")
+				}
+				if _, ok := nestedMsg.(*blobtypes.MsgPayForBlobs); ok {
+					return ctx, sdkerrors.ErrNotSupported.Wrapf("MsgPayForBlobs inside MsgExec is not supported")
+				}
+			}
+		}
+	}
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/msg_exec_test.go
+++ b/app/ante/msg_exec_test.go
@@ -1,0 +1,76 @@
+package ante_test
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v3/app"
+	"github.com/celestiaorg/celestia-app/v3/app/ante"
+	"github.com/celestiaorg/celestia-app/v3/app/encoding"
+	blobtypes "github.com/celestiaorg/celestia-app/v3/x/blob/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+)
+
+func TestMsgExecDecorator(t *testing.T) {
+	msgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&banktypes.MsgSend{}})
+	nestedMsgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&msgExec})
+	nestedMsgPayForBlobs := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&blobtypes.MsgPayForBlobs{}})
+
+	tests := []struct {
+		name      string
+		msg       sdk.Msg
+		isCheckTx bool
+		wantErr   error
+	}{
+		{
+			name:      "Accept msgExec",
+			msg:       &msgExec,
+			isCheckTx: true,
+			wantErr:   nil,
+		},
+		{
+			name:      "Reject nestedMsgExec",
+			msg:       &nestedMsgExec,
+			isCheckTx: true,
+			wantErr:   sdkerrors.ErrNotSupported,
+		},
+		{
+			name:      "Reject nestedMsgPayForBlobs",
+			msg:       &nestedMsgPayForBlobs,
+			isCheckTx: true,
+			wantErr:   sdkerrors.ErrNotSupported,
+		},
+		{
+			name:      "Accept nestedMsgExec if isCheckTx is false",
+			msg:       &nestedMsgPayForBlobs,
+			isCheckTx: false,
+			wantErr:   nil,
+		},
+	}
+
+	decorator := ante.NewMsgExecDecorator()
+	cdc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	anteHandler := sdk.ChainAnteDecorators(decorator)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup
+			ctx := sdk.NewContext(nil, tmproto.Header{}, tc.isCheckTx, nil)
+			txBuilder := cdc.TxConfig.NewTxBuilder()
+			require.NoError(t, txBuilder.SetMsgs(tc.msg))
+
+			// Run the ante handler
+			_, err := anteHandler(ctx, txBuilder.GetTx(), false)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tc.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/3609 by adding a new ante handler that rejects a tx if it contains a MsgExec which contains a MsgExec or MsgPayForBlobs.

Note: this targets v3.x so the antehandler only runs on checkTx.