### PR TITLE
docs: link to org wide CONTRIBUTING guideline

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ celestia-appd start --timeout-commit 1s
 
 ## Contributing
 
+If you are a new contributor, please read [contributing to Celestia](https://github.com/celestiaorg/.github/blob/main/CONTRIBUTING.md).
+
 This repo attempts to conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) so PR titles should ideally start with `fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, or `test:` because this helps with semantic versioning and changelog generation. It is especially important to include an `!` (e.g. `feat!:`) if the PR includes a breaking change.
 
 This repo contains multiple go modules. When using it, rename `go.work.example` to `go.work` and run `go work sync`.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4229

Low likelihood that this stops air-drop hunters but worth a shot. 

Ref: https://github.com/celestiaorg/.github/blob/main/CONTRIBUTING.md#pull-requests