### PR TITLE
chore: fix `find` issue with `-prune` in proto search

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -12,7 +12,7 @@ protoc_gen_gocosmos() {
 protoc_gen_gocosmos
 
 cd proto
-proto_dirs=$(find . -path ./cosmos -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+proto_dirs=$(find . ! -path "./cosmos/*" -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
     if grep "option go_package" $file &> /dev/null ; then


### PR DESCRIPTION
## Overview

I encountered an issue where the `-prune` option in the `find` command wasn't working as expected. It prevented the search in the `./cosmos` directory, but the `-name '*.proto'` still applied to all files, causing unexpected results.  

To fix this, I replaced `-prune` with `! -path`, which now correctly excludes the `./cosmos` directory from the search. This should prevent unnecessary files from being included in the search for `.proto` files.
