### PR TITLE
Align proto field types and fix formatting in mint and query modules

### DIFF
--- a/proto/celestia/mint/v1/mint.proto
+++ b/proto/celestia/mint/v1/mint.proto
@@ -26,8 +26,7 @@ message Minter {
   ];
 
   // PreviousBlockTime is the timestamp of the previous block.
-  google.protobuf.Timestamp previous_block_time = 4
-      [ (gogoproto.stdtime) = true ];
+  google.protobuf.Timestamp previous_block_time = 4 [ (gogoproto.stdtime) = true ];
 
   // BondDenom is the denomination of the token that should be minted.
   string bond_denom = 5;

--- a/proto/celestia/mint/v1/query.proto
+++ b/proto/celestia/mint/v1/query.proto
@@ -36,7 +36,7 @@ message QueryInflationRateRequest {}
 // RPC method.
 message QueryInflationRateResponse {
   // InflationRate is the current inflation rate.
-  bytes inflation_rate = 1 [
+  string inflation_rate = 1 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable) = false
   ];
@@ -50,7 +50,7 @@ message QueryAnnualProvisionsRequest {}
 // Query/AnnualProvisions RPC method.
 message QueryAnnualProvisionsResponse {
   // AnnualProvisions is the current annual provisions.
-  bytes annual_provisions = 1 [
+  string annual_provisions = 1 [
     (gogoproto.customtype) = "github.com/cosmos/cosmos-sdk/types.Dec",
     (gogoproto.nullable) = false
   ];


### PR DESCRIPTION
1. Fixed formatting of the `previous_block_time` field in `Minter`:
  - Moved `[(gogoproto.stdtime) = true]` inline with the field declaration for proper syntax and readability.

2. Updated data types in `query.proto`:
  - Changed `bytes` → `string` for `inflation_rate` and `annual_provisions` fields in response messages to match the definition in the `Minter` struct.
  - This ensures consistency in field types across `Minter` and `Query*Response` messages using `cosmos.Dec`.
