### PR TITLE
feat: embed a gas multipler on the server's gas estimate

### DIFF
--- a/app/grpc/gasestimation/gas_estimator.go
+++ b/app/grpc/gasestimation/gas_estimator.go
@@ -17,6 +17,10 @@ import (
 	gogogrpc "github.com/gogo/protobuf/grpc"
 )
 
+// gasMultiplier is the multiplier for the gas limit. It's used to account for the fact that
+// when the gas is simulated it will occasionally underestimate the real gas used by the transaction.
+const gasMultiplier = 1.1
+
 // baseAppSimulateFn is the signature of the Baseapp#Simulate function.
 type baseAppSimulateFn func(txBytes []byte) (sdk.GasInfo, *sdk.Result, error)
 
@@ -89,9 +93,11 @@ func (s *gasEstimatorServer) EstimateGasPriceAndUsage(ctx context.Context, reque
 	if err != nil {
 		return nil, err
 	}
+	estimatedGasUsed := uint64(math.Round(float64(gasUsedInfo.GasUsed) * gasMultiplier))
+
 	return &EstimateGasPriceAndUsageResponse{
 		EstimatedGasPrice: gasPrice,
-		EstimatedGasUsed:  gasUsedInfo.GasUsed,
+		EstimatedGasUsed:  estimatedGasUsed,
 	}, nil
 }
 


### PR DESCRIPTION
When using `Simulate`, the node can occasionally return a value that would be less than the gas required to submit the transaction at a slightly different time. To lean on the conservative side, this PR adds a 1.1 multiplier to whatever gas is returned by `Simulate`