### PR TITLE
docs: document all Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ proto-format:
 	@$(DOCKER_PROTO_BUILDER) find . -name '*.proto' -path "./proto/*" -exec clang-format -i {} \;
 .PHONY: proto-format
 
+## build-docker: Build the celestia-appd Docker image using the local Dockerfile.
 build-docker:
 	@echo "--> Building Docker image"
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/Dockerfile .
@@ -89,6 +90,7 @@ build-docker:
 docker-build: build-docker
 .PHONY: docker-build
 
+## build-ghcr-docker: Build the celestia-appd Docker image tagged with the current commit hash for GitHub Container Registry.
 build-ghcr-docker:
 	@echo "--> Building Docker image"
 	$(DOCKER) build -t ghcr.io/celestiaorg/celestia-app:$(COMMIT) -f docker/Dockerfile .
@@ -98,6 +100,7 @@ build-ghcr-docker:
 docker-build-ghcr: build-ghcr-docker
 .PHONY: docker-build-ghcr
 
+## publish-ghcr-docker: Push the celestia-appd Docker image to GitHub Container Registry with the current commit tag.
 publish-ghcr-docker:
 # Make sure you are logged in and authenticated to the ghcr.io registry.
 	@echo "--> Publishing Docker image"
@@ -121,6 +124,7 @@ lint:
 	@yamllint --no-warnings . -c .yamllint.yml
 .PHONY: lint
 
+## markdown-link-check: Check all links in markdown files for validity.
 markdown-link-check:
 	@echo "--> Running markdown-link-check"
 	@find . -name \*.md -print0 | xargs -0 -n1 markdown-link-check
@@ -130,7 +134,7 @@ markdown-link-check:
 lint-links: markdown-link-check
 .PHONY: lint-links
 
-
+## fmt: Format Go code with golangci-lint and markdown files with markdownlint.
 fmt:
 	@echo "--> Running golangci-lint --fix"
 	@golangci-lint run --fix
@@ -229,6 +233,7 @@ goreleaser-check:
 		check
 .PHONY: goreleaser-check
 
+## prebuilt-binary: Create prebuilt binaries for all supported platforms using goreleaser. Used by the goreleaser target.
 prebuilt-binary:
 	@if [ ! -f ".release-env" ]; then \
 		echo "A .release-env file was not found but is required to create prebuilt binaries. This command is expected to be run in CI where a .release-env file exists. If you need to run this command locally to attach binaries to a release, you need to create a .release-env file with a Github token (classic) that has repo:public_repo scope."; \
@@ -250,6 +255,7 @@ prebuilt-binary:
 goreleaser: prebuilt-binary
 .PHONY: goreleaser
 
+## check-bbr: Internal command to check if BBR congestion control is enabled on the system.
 check-bbr:
 	@echo "Checking if BBR is enabled..."
 	@if [ "$$(sysctl net.ipv4.tcp_congestion_control | awk '{print $$3}')" != "bbr" ]; then \
@@ -263,6 +269,7 @@ check-bbr:
 bbr-check: check-bbr
 .PHONY: bbr-check
 
+## enable-bbr: Enable BBR congestion control algorithm on your system. This improves network performance. Only works on Linux.
 enable-bbr:
 	@echo "Configuring system to use BBR..."
 	@if [ "$(sysctl net.ipv4.tcp_congestion_control | awk '{print $3}')" != "bbr" ]; then \
@@ -282,6 +289,7 @@ enable-bbr:
 bbr-enable: enable-bbr
 .PHONY: bbr-enable
 
+## disable-bbr: Disable BBR congestion control algorithm and revert to default (Cubic). Only works on Linux.
 disable-bbr:
 	@echo "Disabling BBR and reverting to default congestion control algorithm..."
 	@if [ "$$(sysctl net.ipv4.tcp_congestion_control | awk '{print $$3}')" = "bbr" ]; then \
@@ -301,6 +309,7 @@ disable-bbr:
 bbr-disable: disable-bbr
 .PHONY: bbr-disable
 
+## enable-mptcp: Enable Multi-Path TCP over multiple ports (not interfaces). Improves connection reliability and throughput. Only works on Linux Kernel 5.6+.
 enable-mptcp:
 	@echo "Configuring system to use mptcp..."
 	@sudo sysctl -w net.mptcp.enabled=1
@@ -317,6 +326,7 @@ enable-mptcp:
 mptcp-enable: enable-mptcp
 .PHONY: mptcp-enable
 
+## disable-mptcp: Disable Multi-Path TCP and revert to standard TCP. Removes all MPTCP settings from system. Only works on Linux Kernel 5.6+.
 disable-mptcp:
 	@echo "Disabling MPTCP..."
 	@sudo sysctl -w net.mptcp.enabled=0


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview


The changes include:
- Adding documentation for the 'disable-mptcp' target as requested in issue #4216
- Adding documentation for internal implementation targets like 'check-bbr'
- Adding documentation for Docker-related targets (build-docker, build-ghcr-docker, publish-ghcr-docker)
- Adding documentation for the prebuilt-binary target


Fixes #4216 