### PR TITLE
Update mocha-block-sync.sh script message for better clarity

### DIFF
--- a/scripts/mocha-block-sync.sh
+++ b/scripts/mocha-block-sync.sh
@@ -36,7 +36,7 @@ rm -r "$CELESTIA_APP_HOME"
 echo "Initializing config files..."
 celestia-appd init ${NODE_NAME} --chain-id ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
-echo "Settings seeds in config.toml..."
+echo "Setting seeds in config.toml..."
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $CELESTIA_APP_HOME/config/config.toml
 
 echo "Downloading genesis file..."


### PR DESCRIPTION
A typo in the text where "Settings" was used instead of "Setting." Since it refers to a singular action, I corrected it to "Setting."