### PR TITLE
Fix typos in genesis.json and mocha-block-sync.sh

### DIFF
--- a/local_devnet/celestia-app/genesis.json
+++ b/local_devnet/celestia-app/genesis.json
@@ -347,7 +347,7 @@
     "mint": {
       "bond_denom": "utia"
     },
-    "packetfowardmiddleware": {
+    "packetforwardmiddleware": {
       "params": {
         "fee_percentage": "0.000000000000000000"
       },

--- a/scripts/mocha-block-sync.sh
+++ b/scripts/mocha-block-sync.sh
@@ -36,7 +36,7 @@ rm -r "$CELESTIA_APP_HOME"
 echo "Initializing config files..."
 celestia-appd init ${NODE_NAME} --chain-id ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
-echo "Settings seeds in config.toml..."
+echo "Setting seeds in config.toml..."
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $CELESTIA_APP_HOME/config/config.toml
 
 echo "Downloading genesis file..."

--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -27,7 +27,7 @@ var bigBlockManifest = Manifest{
 		Volume:        resource.MustParse("1Gi"),
 	},
 	SelfDelegation: 10000000,
-	// @TODO Update the CelestiaAppVersion and  TxClientVersion to the latest
+	// @TODO Update the CelestiaAppVersion and TxClientVersion to the latest
 	// version of the main branch once the PR#3261 is merged by addressing this
 	// issue https://github.com/celestiaorg/celestia-app/issues/3603.
 	CelestiaAppVersion: "pr-3261",


### PR DESCRIPTION
This PR includes two fixes:

1. Fix typo in genesis.json:
   - Correct "packetfowardmiddleware" to "packetforwardmiddleware"

2. Fix grammar in mocha-block-sync.sh:
   - Update message from "Settings seeds" to "Setting seeds"

These changes improve code readability and fix spelling inconsistencies in configuration files.