### PR TITLE
Fix typos and clarify phrasing in ADRs 001–004

### DIFF
--- a/docs/architecture/adr-001-abci++-adoption.md
+++ b/docs/architecture/adr-001-abci++-adoption.md
@@ -26,6 +26,7 @@ We also need this functionality for validators to verify that:
 - For every `MsgPayForBlob` (previously `MsgPayForData`) included in the block, there is also a corresponding blob and vice versa.
 - The data hash represents the properly-erasure-coded block data for the selected block size.
 - The included messages are arranged in the expected locations in the square according to the non-interactive default rules (this validation is not implemented here)
+
 Technically, we don’t have to use ABCI++ yet, we could still test some needed features in the upcoming testnet without it. However, these implementations would not be representative of the implementations that would actually make it to mainnet, as they would have to be significantly different from their ABCI++ counterparts. The decision to adopt ABCI++ earlier becomes easier considering that the Tendermint team has already done most of the heavy lifting, and it is possible to start working on the needed features without waiting for the cosmos-sdk team to use them. We explain our plans below to do just this, by using a subset of ABCI++ (ABCI+?) using only the new methods that are necessary, finished, and easy to incorporate into the cosmos-sdk.
 
 ## Alternative Approaches

--- a/docs/architecture/adr-001-abci++-adoption.md
+++ b/docs/architecture/adr-001-abci++-adoption.md
@@ -25,9 +25,8 @@ We also need this functionality for validators to verify that:
 
 - For every `MsgPayForBlob` (previously `MsgPayForData`) included in the block, there is also a corresponding blob and vice versa.
 - The data hash represents the properly-erasure-coded block data for the selected block size.
-- The included messages are arranged in the expected locations in the square according to the non-interactive default rules (not done here)
-
-Technically, we don’t have to use ABCI++ yet, we could still test some needed features in the upcoming testnet without it. However, these implementations would not be representative of the implementations that would actually make it to mainnet, as they would have to be significantly different from their ABCI++ counterparts. The decision to adopt ABCI++ earlier becomes easier considering that the tendermint team has already done most of the heavy lifting, and it is possible to start working on the needed features without waiting for the cosmos-sdk team to use them. We explain our plans below to do just this, by using a subset of ABCI++ (ABCI+?) using only the new methods that are necessary, finished, and easy to incorporate into the cosmos-sdk.
+- The included messages are arranged in the expected locations in the square according to the non-interactive default rules (this validation is not implemented here)
+Technically, we don’t have to use ABCI++ yet, we could still test some needed features in the upcoming testnet without it. However, these implementations would not be representative of the implementations that would actually make it to mainnet, as they would have to be significantly different from their ABCI++ counterparts. The decision to adopt ABCI++ earlier becomes easier considering that the Tendermint team has already done most of the heavy lifting, and it is possible to start working on the needed features without waiting for the cosmos-sdk team to use them. We explain our plans below to do just this, by using a subset of ABCI++ (ABCI+?) using only the new methods that are necessary, finished, and easy to incorporate into the cosmos-sdk.
 
 ## Alternative Approaches
 
@@ -53,15 +52,15 @@ type Application interface {
 }
 ```
 
-It's also important to note the changes made to the request types for both methods. In upstream, they are only passing the transactions to the applications. This has been modified to pass the entire block data. This is because Celestia separates some block data that cannot modify state (messages), and the application has to have access to both normal transaction data and messages to perform the necessary processing and checks.
+It's also important to note the changes made to the request types for both methods. In upstream, they are only passing the transactions to the applications. This has been modified to pass the entire block data. This is because Celestia separates some block data that cannot modify state (messages) and the application has to have access to both normal transaction data and messages to perform the necessary processing and checks.
 
 ```protobuf
 message RequestPrepareProposal {
  // block_data is an array of transactions that will be included in a block,
  // sent to the app for possible modifications.
- // applications can not exceed the size of the data passed to it.
+ // applications cannot exceed the size of the data passed to it.
  tendermint.types.Data block_data = 1;
- // If an application decides to populate block_data with extra information, they can not exceed this value.
+ // If an application decides to populate block_data with extra information, they cannot exceed this value.
  int64 block_data_size = 2;
 }
 

--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -85,7 +85,7 @@ message MsgSetOrchestratorAddress {
 }
 ```
 
-#### ValSetConfirmfix last e2e tests
+#### ValSetConfirm fix last e2e tests
 
 `MsgValsetConfirm` is the message sent by the validators when they wish to submit their signatures over the validator set at a given block height. A validator must first call `SetOrchestratorAddress` to set their Ethereum's address to be used for signing. Then, using `EndBlocker()`, the protocol makes a `ValsetRequest`, the request is essentially a messaging mechanism to determine which block all validators should submit signatures over. Finally, validators sign the `validator set`, `powers`, and `Ethereum addresses` of the entire validator set at the height of a `Valset` and submit that signature with this message.
 

--- a/docs/architecture/adr-003-qgb-data-commitments.md
+++ b/docs/architecture/adr-003-qgb-data-commitments.md
@@ -90,7 +90,7 @@ Next, we verify the Ethereum address and check if it was used to create the sign
 ```go
 ethAddress, err := types.NewEthAddress(msg.EthAddress)
 if err != nil {
-    return nil, sdkerrors.Wrap(types.ErrInvalid, "invalid eth address")
+    return nil, sdkerrors.Wrap(types.ErrInvalid, "invalid Ethereum address")
 }
 err = types.ValidateEthereumSignature([]byte(msg.Commitment), sigBytes, *ethAddress)
 if err != nil {
@@ -107,10 +107,10 @@ if err != nil {
 }
 ethAddressFromStore, found := k.GetEthAddressByValidator(ctx, validator.GetOperator())
 if !found {
-    return nil, sdkerrors.Wrap(types.ErrEmpty, "no eth address set for validator")
+    return nil, sdkerrors.Wrap(types.ErrEmpty, "no Ethereum address set for validator")
 }
 if *ethAddressFromStore != *ethAddress {
-    return nil, sdkerrors.Wrap(types.ErrInvalid, "submitted eth address does not match delegate eth address")
+    return nil, sdkerrors.Wrap(types.ErrInvalid, "submitted Ethereum address does not match delegate Ethereum address")
 }
 ```
 

--- a/docs/architecture/adr-004-qgb-relayer-security.md
+++ b/docs/architecture/adr-004-qgb-relayer-security.md
@@ -30,7 +30,7 @@ Now, if the relayer is missing some data commitments or valset updates, then it 
 
 The problem with this approach is that there is a constant risk for any relayer to mess up the ordering of the attestations submission, i.e. relaying the next valset before relaying all the data commitments that were signed using the previous valset, and ending up with signatures holes.
 
-Also, a malicious relayer, can target any honest QGB relayer in normal mode, or while catching up, and mess its attestations submission order, as follows:
+Also, a malicious relayer can target any honest QGB relayer in normal mode, or while catching up, and mess its attestations submission order, as follows:
 
 - Get the latest relayed valset
 - Listen for new signed valsets
@@ -62,7 +62,7 @@ This approach consists of switching to a synchronous QGB design utilizing univer
 - Pros:
   - Simpler QGB smart contract
 
-### Add more state to the contract: Store valsets and their nonce
+### Add more state to the contract: Store valsets and their nonces
 
 Update the QGB contract to store the valset hashes + their nonces:
 


### PR DESCRIPTION
- ADR 001: Fixed phrasing related to `cannot` usage, improved formality and removed ambiguous parenthetical comments. Minor grammatical cleanups.

- ADR 002: Fixed heading typo (`ValSetConfirmfix` → `ValSetConfirm fix`).

- ADR 003: Replaced informal "eth address" with "Ethereum address" in user-facing error messages for consistency and clarity.

-*ADR 004: Removed an unnecessary comma in a sentence and corrected plural usage ("nonce" → "nonces").