### PR TITLE
docs: fix markdown links

### DIFF
--- a/specs/src/state_machine_modules_v1.md
+++ b/specs/src/state_machine_modules_v1.md
@@ -5,9 +5,9 @@ The modules used in app version 1 are:
 ## `celestia-app` modules
 
 - [blob](https://github.com/celestiaorg/celestia-app/blob/main/x/blob/README.md)
-- [blobstream](https://github.com/celestiaorg/celestia-app/blob/main/x/blobstream/README.md)
+- [blobstream](https://github.com/celestiaorg/celestia-app/tree/06f24f5dbe48c29964e1d8cfb030cffd90797ded/x/blobstream)
 - [mint](https://github.com/celestiaorg/celestia-app/blob/main/x/mint/README.md)
-- [paramfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/paramfilter/README.md)
+- [paramfilter](https://github.com/celestiaorg/celestia-app/blob/e293a5ed5ed8e7d35d609bf12a9754fc45463a39/x/paramfilter/README.md)
 - [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/tokenfilter/README.md)
 
 ## `cosmos-sdk` modules

--- a/specs/src/state_machine_modules_v2.md
+++ b/specs/src/state_machine_modules_v2.md
@@ -7,7 +7,7 @@ The modules used in app version 2 are:
 - [blob](https://github.com/celestiaorg/celestia-app/blob/main/x/blob/README.md)
 - [minfee](https://github.com/celestiaorg/celestia-app/blob/main/x/minfee/README.md)
 - [mint](https://github.com/celestiaorg/celestia-app/blob/main/x/mint/README.md)
-- [paramfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/paramfilter/README.md)
+- [paramfilter](https://github.com/celestiaorg/celestia-app/blob/e293a5ed5ed8e7d35d609bf12a9754fc45463a39/x/paramfilter/README.md)
 - [signal](https://github.com/celestiaorg/celestia-app/blob/main/x/signal/README.md)
 - [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/tokenfilter/README.md)
 


### PR DESCRIPTION
Trying to get green CI checks on `main`.

## Testing

`make markdown-link-check` passes locally