### PR TITLE
chore(appconsts)!: remove default prefix from versioned consts

### DIFF
--- a/app/ante/max_tx_size.go
+++ b/app/ante/max_tx_size.go
@@ -19,7 +19,7 @@ func NewMaxTxSizeDecorator() MaxTxSizeDecorator {
 // AnteHandle implements the AnteHandler interface. It ensures that tx size is under application's configured threshold.
 func (d MaxTxSizeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	currentTxSize := len(ctx.TxBytes())
-	maxTxSize := appconsts.DefaultMaxTxSize
+	maxTxSize := appconsts.MaxTxSize
 	if currentTxSize > maxTxSize {
 		bytesOverLimit := currentTxSize - maxTxSize
 		return ctx, fmt.Errorf("tx size %d bytes is larger than the application's configured threshold of %d bytes. Please reduce the size by %d bytes", currentTxSize, maxTxSize, bytesOverLimit)

--- a/app/ante/max_tx_size_test.go
+++ b/app/ante/max_tx_size_test.go
@@ -23,19 +23,19 @@ func TestMaxTxSizeDecorator(t *testing.T) {
 	}{
 		{
 			name:        "good tx; under max tx size threshold",
-			txSize:      appconsts.DefaultMaxTxSize - 1,
+			txSize:      appconsts.MaxTxSize - 1,
 			expectError: false,
 			isCheckTx:   []bool{true, false},
 		},
 		{
 			name:        "bad tx; over max tx size threshold",
-			txSize:      appconsts.DefaultMaxTxSize + 1,
+			txSize:      appconsts.MaxTxSize + 1,
 			expectError: true,
 			isCheckTx:   []bool{true, false},
 		},
 		{
 			name:        "good tx; equal to max tx size threshold",
-			txSize:      appconsts.DefaultMaxTxSize,
+			txSize:      appconsts.MaxTxSize,
 			expectError: false,
 			isCheckTx:   []bool{true, false},
 		},

--- a/app/ante/tx_size_gas.go
+++ b/app/ante/tx_size_gas.go
@@ -65,7 +65,7 @@ func (cgts ConsumeTxSizeGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 		return ctx, errors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
 	}
 
-	ctx.GasMeter().ConsumeGas(appconsts.DefaultTxSizeCostPerByte*storetypes.Gas(len(ctx.TxBytes())), "txSize")
+	ctx.GasMeter().ConsumeGas(appconsts.TxSizeCostPerByte*storetypes.Gas(len(ctx.TxBytes())), "txSize")
 
 	// simulate gas cost for signatures in simulate mode
 	if simulate {
@@ -107,7 +107,7 @@ func (cgts ConsumeTxSizeGasDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 				txBytes *= params.TxSigLimit
 			}
 
-			ctx.GasMeter().ConsumeGas(appconsts.DefaultTxSizeCostPerByte*txBytes, "txSize")
+			ctx.GasMeter().ConsumeGas(appconsts.TxSizeCostPerByte*txBytes, "txSize")
 		}
 	}
 

--- a/app/ante/tx_size_gas_test.go
+++ b/app/ante/tx_size_gas_test.go
@@ -91,7 +91,7 @@ func TestConsumeGasForTxSize(t *testing.T) {
 			txBytes, err := clientCtx.TxConfig.TxJSONEncoder()(tx)
 			require.Nil(t, err, "Cannot marshal tx: %v", err)
 
-			txSizeCostPerByte := appconsts.DefaultTxSizeCostPerByte
+			txSizeCostPerByte := appconsts.TxSizeCostPerByte
 			expectedGas := storetypes.Gas(len(txBytes)) * txSizeCostPerByte
 
 			// set suite.ctx with TxBytes manually

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -20,7 +20,7 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 	tx := req.Tx
 
 	// all txs must be less than or equal to the max tx size limit
-	maxTxSize := appconsts.DefaultMaxTxSize
+	maxTxSize := appconsts.MaxTxSize
 	currentTxSize := len(tx)
 	if currentTxSize > maxTxSize {
 		return responseCheckTxWithEvents(errors.Wrapf(apperr.ErrTxExceedsMaxSize, "tx size %d bytes is larger than the application's configured MaxTxSize of %d bytes for version %d", currentTxSize, maxTxSize, appconsts.LatestVersion), 0, 0, []abci.Event{}, false), nil

--- a/app/square_size.go
+++ b/app/square_size.go
@@ -20,6 +20,6 @@ func (app *App) MaxEffectiveSquareSize(ctx sdk.Context) int {
 
 	govMax := int(app.BlobKeeper.GetParams(ctx).GovMaxSquareSize)
 
-	hardMax := appconsts.DefaultSquareSizeUpperBound
+	hardMax := appconsts.SquareSizeUpperBound
 	return min(govMax, hardMax)
 }

--- a/app/test/fuzz_abci_test.go
+++ b/app/test/fuzz_abci_test.go
@@ -33,7 +33,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 	for i := range accounts {
 		accounts[i] = random.Str(20)
 	}
-	maxShareCount := int64(appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound)
+	maxShareCount := int64(appconsts.SquareSizeUpperBound * appconsts.SquareSizeUpperBound)
 
 	type test struct {
 		name                   string
@@ -64,7 +64,7 @@ func TestPrepareProposalConsistency(t *testing.T) {
 		{
 			"max",
 			maxShareCount * share.ContinuationSparseShareContentSize,
-			appconsts.DefaultSquareSizeUpperBound,
+			appconsts.SquareSizeUpperBound,
 		},
 		{
 			"larger MaxBytes than SquareSize",

--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -237,7 +237,7 @@ func (s *IntegrationTestSuite) TestShareInclusionProof() {
 
 		// get the blob shares
 		shareRange, err := square.BlobShareRange(blockRes.Block.Txs.ToSliceOfBytes(), int(txResp.Index), 0,
-			appconsts.DefaultSquareSizeUpperBound,
+			appconsts.SquareSizeUpperBound,
 			appconsts.SubtreeRootThreshold,
 		)
 		require.NoError(t, err)

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -203,7 +203,7 @@ func TestProcessProposal(t *testing.T) {
 				Txs: coretypes.Txs(sendTxs).ToSliceOfBytes(),
 			},
 			mutator: func(d *tmproto.Data) {
-				dataSquare, err := square.Construct(d.Txs, appconsts.DefaultSquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+				dataSquare, err := square.Construct(d.Txs, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 				require.NoError(t, err)
 
 				b := dataSquare[1].ToBytes()
@@ -296,7 +296,7 @@ func TestProcessProposal(t *testing.T) {
 }
 
 func calculateNewDataHash(t *testing.T, txs [][]byte) []byte {
-	dataSquare, err := square.Construct(txs, appconsts.DefaultSquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	dataSquare, err := square.Construct(txs, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	require.NoError(t, err)
 	eds, err := da.ExtendShares(share.ToBytes(dataSquare))
 	require.NoError(t, err)

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -88,9 +88,9 @@ func (s *SquareSizeIntegrationTest) TestSquareSizeUpperBound() {
 		},
 		{
 			name:             "gov square size == hardcoded max",
-			govMaxSquareSize: appconsts.DefaultSquareSizeUpperBound,
+			govMaxSquareSize: appconsts.SquareSizeUpperBound,
 			maxBytes:         appconsts.DefaultUpperBoundMaxBytes,
-			expMaxSquareSize: appconsts.DefaultSquareSizeUpperBound,
+			expMaxSquareSize: appconsts.SquareSizeUpperBound,
 		},
 	}
 

--- a/pkg/appconsts/initial_consts.go
+++ b/pkg/appconsts/initial_consts.go
@@ -33,4 +33,4 @@ const (
 	DefaultNetworkMinGasPrice = 0.000001 // utia
 )
 
-var DefaultUpperBoundMaxBytes = DefaultSquareSizeUpperBound * DefaultSquareSizeUpperBound * share.ContinuationSparseShareContentSize
+var DefaultUpperBoundMaxBytes = SquareSizeUpperBound * SquareSizeUpperBound * share.ContinuationSparseShareContentSize

--- a/pkg/appconsts/versioned_consts.go
+++ b/pkg/appconsts/versioned_consts.go
@@ -11,23 +11,24 @@ const (
 )
 
 var (
-	DefaultSquareSizeUpperBound = v4.SquareSizeUpperBound
-	DefaultTxSizeCostPerByte    = v4.TxSizeCostPerByte
-	DefaultGasPerBlobByte       = v4.GasPerBlobByte
-	DefaultVersion              = v4.Version
-	DefaultUpgradeHeightDelay   = v4.UpgradeHeightDelay
-	DefaultMaxTxSize            = v4.MaxTxSize
-	SubtreeRootThreshold        = v4.SubtreeRootThreshold
-	TimeoutCommit               = v4.TimeoutCommit
-	TimeoutPropose              = v4.TimeoutPropose
+	SquareSizeUpperBound = v4.SquareSizeUpperBound
+	TxSizeCostPerByte    = v4.TxSizeCostPerByte
+	GasPerBlobByte       = v4.GasPerBlobByte
+	Version              = v4.Version
+	UpgradeHeightDelay   = v4.UpgradeHeightDelay
+	MaxTxSize            = v4.MaxTxSize
+	SubtreeRootThreshold = v4.SubtreeRootThreshold
+	TimeoutCommit        = v4.TimeoutCommit
+	TimeoutPropose       = v4.TimeoutPropose
 )
 
 func GetTimeoutCommit(_ uint64) time.Duration {
 	return v4.TimeoutCommit
 }
 
-// UpgradeHeightDelay returns the delay in blocks after a quorum has been reached that the chain should upgrade to the new version.
-func UpgradeHeightDelay(chainID string) int64 {
+// GetUpgradeHeightDelay returns the delay in blocks after a quorum has been
+// reached that the chain should upgrade to the new version.
+func GetUpgradeHeightDelay(chainID string) int64 {
 	if chainID == TestChainID {
 		return 3
 	}

--- a/pkg/appconsts/versioned_consts_test.go
+++ b/pkg/appconsts/versioned_consts_test.go
@@ -22,13 +22,13 @@ func TestUpgradeHeightDelay(t *testing.T) {
 		{
 			name:                       "the upgrade delay should be latest value",
 			chainID:                    "arabica-11",
-			expectedUpgradeHeightDelay: appconsts.DefaultUpgradeHeightDelay,
+			expectedUpgradeHeightDelay: appconsts.UpgradeHeightDelay,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			actual := appconsts.UpgradeHeightDelay(tc.chainID)
+			actual := appconsts.GetUpgradeHeightDelay(tc.chainID)
 			require.Equal(t, tc.expectedUpgradeHeightDelay, actual)
 		})
 	}

--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	maxExtendedSquareWidth = appconsts.DefaultSquareSizeUpperBound * 2
+	maxExtendedSquareWidth = appconsts.SquareSizeUpperBound * 2
 	minExtendedSquareWidth = appconsts.MinSquareSize * 2
 )
 

--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -51,8 +51,8 @@ func TestNewDataAvailabilityHeader(t *testing.T) {
 		{
 			name:         "max square size",
 			expectedHash: []byte{0xb, 0xd3, 0xab, 0xee, 0xac, 0xfb, 0xb0, 0xb9, 0x2d, 0xfb, 0xda, 0xc4, 0xa1, 0x54, 0x86, 0x8e, 0x3c, 0x4e, 0x79, 0x66, 0x6f, 0x7f, 0xcf, 0x6c, 0x62, 0xb, 0xb9, 0xd, 0xd3, 0xa0, 0xdc, 0xf0},
-			squareSize:   uint64(appconsts.DefaultSquareSizeUpperBound),
-			shares:       generateShares(appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound),
+			squareSize:   uint64(appconsts.SquareSizeUpperBound),
+			shares:       generateShares(appconsts.SquareSizeUpperBound * appconsts.SquareSizeUpperBound),
 		},
 	}
 
@@ -80,7 +80,7 @@ func TestExtendShares(t *testing.T) {
 		{
 			name:        "too large square size",
 			expectedErr: true,
-			shares:      generateShares((appconsts.DefaultSquareSizeUpperBound + 1) * (appconsts.DefaultSquareSizeUpperBound + 1)),
+			shares:      generateShares((appconsts.SquareSizeUpperBound + 1) * (appconsts.SquareSizeUpperBound + 1)),
 		},
 		{
 			name:        "invalid number of shares",
@@ -105,7 +105,7 @@ func TestDataAvailabilityHeaderProtoConversion(t *testing.T) {
 		dah  DataAvailabilityHeader
 	}
 
-	shares := generateShares(appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound)
+	shares := generateShares(appconsts.SquareSizeUpperBound * appconsts.SquareSizeUpperBound)
 	eds, err := ExtendShares(shares)
 	require.NoError(t, err)
 	bigdah, err := NewDataAvailabilityHeader(eds)
@@ -140,7 +140,7 @@ func Test_DAHValidateBasic(t *testing.T) {
 		errStr    string
 	}
 
-	maxSize := appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound
+	maxSize := appconsts.SquareSizeUpperBound * appconsts.SquareSizeUpperBound
 
 	shares := generateShares(maxSize)
 	eds, err := ExtendShares(shares)
@@ -229,7 +229,7 @@ func TestSquareSize(t *testing.T) {
 		{
 			name: "max data availability header has an original square size of default square size upper bound",
 			dah:  maxDataAvailabilityHeader(t),
-			want: appconsts.DefaultSquareSizeUpperBound,
+			want: appconsts.SquareSizeUpperBound,
 		},
 	}
 
@@ -270,7 +270,7 @@ func sortByteArrays(arr [][]byte) {
 // maxDataAvailabilityHeader returns a DataAvailabilityHeader the maximum square
 // size. This should only be used for testing.
 func maxDataAvailabilityHeader(t *testing.T) (dah DataAvailabilityHeader) {
-	shares := generateShares(appconsts.DefaultSquareSizeUpperBound * appconsts.DefaultSquareSizeUpperBound)
+	shares := generateShares(appconsts.SquareSizeUpperBound * appconsts.SquareSizeUpperBound)
 
 	eds, err := ExtendShares(shares)
 	require.NoError(t, err)

--- a/pkg/proof/proof.go
+++ b/pkg/proof/proof.go
@@ -25,7 +25,7 @@ func NewTxInclusionProof(txs [][]byte, txIndex, _ uint64) (ShareProof, error) {
 		return ShareProof{}, fmt.Errorf("txIndex %d out of bounds", txIndex)
 	}
 
-	builder, err := square.NewBuilder(appconsts.DefaultSquareSizeUpperBound, appconsts.SubtreeRootThreshold, txs...)
+	builder, err := square.NewBuilder(appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold, txs...)
 	if err != nil {
 		return ShareProof{}, err
 	}

--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -104,7 +104,7 @@ func TestNewShareInclusionProof(t *testing.T) {
 	txs := testfactory.GenerateRandomTxs(50, 500)
 	txs = append(txs, blobTxs...)
 
-	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.DefaultSquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	if err != nil {
 		panic(err)
 	}
@@ -239,7 +239,7 @@ func TestNewShareInclusionProof(t *testing.T) {
 func TestAllSharesInclusionProof(t *testing.T) {
 	txs := testfactory.GenerateRandomTxs(243, 500)
 
-	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.DefaultSquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	dataSquare, err := square.Construct(txs.ToSliceOfBytes(), appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	require.NoError(t, err)
 	assert.Equal(t, 256, len(dataSquare))
 

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -94,7 +94,7 @@ func QueryShareInclusionProof(_ sdk.Context, path []string, req *abci.RequestQue
 	// construct the data square from the block data. As we don't have
 	// access to the application's state machine we use the upper bound
 	// square size instead of the square size dictated from governance
-	dataSquare, err := square.Construct(pbb.Data.Txs, appconsts.DefaultSquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	dataSquare, err := square.Construct(pbb.Data.Txs, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	if err != nil {
 		return nil, err
 	}

--- a/test/util/blobfactory/payforblob_factory.go
+++ b/test/util/blobfactory/payforblob_factory.go
@@ -26,7 +26,7 @@ import (
 
 var (
 	// TestMaxBlobSize is the maximum size of each blob in a blob transaction, for testing purposes
-	TestMaxBlobSize = share.ShareSize * 2 * appconsts.DefaultSquareSizeUpperBound
+	TestMaxBlobSize = share.ShareSize * 2 * appconsts.SquareSizeUpperBound
 	// TestMaxBlobCount is the maximum number of blobs in a blob transaction, for testing purposes
 	TestMaxBlobCount = 5
 )

--- a/test/util/malicious/app_test.go
+++ b/test/util/malicious/app_test.go
@@ -97,7 +97,7 @@ func TestMaliciousTestNode(t *testing.T) {
 
 	// check that we can recalculate the data root using the malicious code but
 	// not the correct code
-	s, err := Construct(block.Block.Txs.ToSliceOfBytes(), appconsts.LatestVersion, appconsts.DefaultSquareSizeUpperBound, OutOfOrderExport)
+	s, err := Construct(block.Block.Txs.ToSliceOfBytes(), appconsts.LatestVersion, appconsts.SquareSizeUpperBound, OutOfOrderExport)
 	require.NoError(t, err)
 
 	rawSquare := share.ToBytes(s)
@@ -109,7 +109,7 @@ func TestMaliciousTestNode(t *testing.T) {
 	require.Equal(t, block.Block.DataHash.Bytes(), dah.Hash())
 
 	correctSquare, err := square.Construct(block.Block.Txs.ToSliceOfBytes(),
-		appconsts.DefaultSquareSizeUpperBound,
+		appconsts.SquareSizeUpperBound,
 		appconsts.SubtreeRootThreshold,
 	)
 	require.NoError(t, err)

--- a/test/util/testnode/comet_node_test.go
+++ b/test/util/testnode/comet_node_test.go
@@ -59,7 +59,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 
 	enc := encoding.MakeTestConfig(app.ModuleEncodingRegisters...)
 	blobGenState := blobtypes.DefaultGenesis()
-	blobGenState.Params.GovMaxSquareSize = uint64(appconsts.DefaultSquareSizeUpperBound)
+	blobGenState.Params.GovMaxSquareSize = uint64(appconsts.SquareSizeUpperBound)
 
 	cfg := DefaultConfig().
 		WithFundedAccounts(s.accounts...).

--- a/x/blob/ante/ante.go
+++ b/x/blob/ante/ante.go
@@ -34,7 +34,7 @@ func (d MinGasPFBDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 		return next(ctx, tx, simulate)
 	}
 
-	gasPerByte := appconsts.DefaultGasPerBlobByte
+	gasPerByte := appconsts.GasPerBlobByte
 	txGas := ctx.GasMeter().GasRemaining()
 	err := d.validatePFBHasEnoughGas(tx.GetMsgs(), gasPerByte, txGas)
 	if err != nil {

--- a/x/blob/ante/ante_test.go
+++ b/x/blob/ante/ante_test.go
@@ -118,7 +118,7 @@ func TestPFBAnteHandler(t *testing.T) {
 				},
 			}
 			ctx := sdk.NewContext(nil, header, true, log.NewNopLogger()).
-				WithGasMeter(storetypes.NewGasMeter(uint64(tc.txGas(appconsts.DefaultGasPerBlobByte)))).
+				WithGasMeter(storetypes.NewGasMeter(uint64(tc.txGas(appconsts.GasPerBlobByte)))).
 				WithIsCheckTx(true)
 
 			ctx.GasMeter().ConsumeGas(tc.gasConsumed, "test")

--- a/x/blob/ante/blob_share_decorator.go
+++ b/x/blob/ante/blob_share_decorator.go
@@ -91,7 +91,7 @@ func (d BlobShareDecorator) getMaxSquareSize(ctx sdk.Context) int {
 		return int(appconsts.DefaultGovMaxSquareSize)
 	}
 
-	upperBound := appconsts.DefaultSquareSizeUpperBound
+	upperBound := appconsts.SquareSizeUpperBound
 	govParam := d.k.GetParams(ctx).GovMaxSquareSize
 	return min(upperBound, int(govParam))
 }

--- a/x/blob/ante/max_total_blob_size_ante.go
+++ b/x/blob/ante/max_total_blob_size_ante.go
@@ -66,7 +66,7 @@ func (d MaxTotalBlobSizeDecorator) getMaxSquareSize(ctx sdk.Context) int {
 		return int(appconsts.DefaultGovMaxSquareSize)
 	}
 
-	upperBound := appconsts.DefaultSquareSizeUpperBound
+	upperBound := appconsts.SquareSizeUpperBound
 	govParam := d.k.GetParams(ctx).GovMaxSquareSize
 	return min(upperBound, int(govParam))
 }

--- a/x/blob/keeper/gas_test.go
+++ b/x/blob/keeper/gas_test.go
@@ -25,27 +25,27 @@ func TestPayForBlobGas(t *testing.T) {
 		{
 			name:            "1 byte blob", // occupies 1 share
 			msg:             types.MsgPayForBlobs{BlobSizes: []uint32{1}},
-			wantGasConsumed: uint64(1 * share.ShareSize * appconsts.DefaultGasPerBlobByte), // 1 share * 512 bytes per share * 8 gas per byte= 4096 gas
+			wantGasConsumed: uint64(1 * share.ShareSize * appconsts.GasPerBlobByte), // 1 share * 512 bytes per share * 8 gas per byte= 4096 gas
 		},
 		{
 			name:            "100 byte blob", // occupies 1 share
 			msg:             types.MsgPayForBlobs{BlobSizes: []uint32{100}},
-			wantGasConsumed: uint64(1 * share.ShareSize * appconsts.DefaultGasPerBlobByte),
+			wantGasConsumed: uint64(1 * share.ShareSize * appconsts.GasPerBlobByte),
 		},
 		{
 			name:            "1024 byte blob", // occupies 3 shares because share prefix (e.g. namespace, info byte)
 			msg:             types.MsgPayForBlobs{BlobSizes: []uint32{1024}},
-			wantGasConsumed: uint64(3 * share.ShareSize * appconsts.DefaultGasPerBlobByte), // 3 shares * 512 bytes per share * 8 gas per byte = 12288 gas
+			wantGasConsumed: uint64(3 * share.ShareSize * appconsts.GasPerBlobByte), // 3 shares * 512 bytes per share * 8 gas per byte = 12288 gas
 		},
 		{
 			name:            "3 blobs, 1 share each",
 			msg:             types.MsgPayForBlobs{BlobSizes: []uint32{1, 1, 1}},
-			wantGasConsumed: uint64(3 * share.ShareSize * appconsts.DefaultGasPerBlobByte), // 3 shares * 512 bytes per share * 8 gas per byte = 12288 gas
+			wantGasConsumed: uint64(3 * share.ShareSize * appconsts.GasPerBlobByte), // 3 shares * 512 bytes per share * 8 gas per byte = 12288 gas
 		},
 		{
 			name:            "3 blobs, 6 shares total",
 			msg:             types.MsgPayForBlobs{BlobSizes: []uint32{1024, 800, 100}},
-			wantGasConsumed: uint64(6 * share.ShareSize * appconsts.DefaultGasPerBlobByte), // 6 shares * 512 bytes per share * 8 gas per byte = 24576 gas
+			wantGasConsumed: uint64(6 * share.ShareSize * appconsts.GasPerBlobByte), // 6 shares * 512 bytes per share * 8 gas per byte = 24576 gas
 		},
 	}
 

--- a/x/blob/keeper/keeper.go
+++ b/x/blob/keeper/keeper.go
@@ -52,7 +52,7 @@ func (k Keeper) GetAuthority() string {
 // PayForBlobs consumes gas based on the blob sizes in the MsgPayForBlobs.
 func (k Keeper) PayForBlobs(goCtx context.Context, msg *types.MsgPayForBlobs) (*types.MsgPayForBlobsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	gasToConsume := types.GasToConsume(msg.BlobSizes, appconsts.DefaultGasPerBlobByte)
+	gasToConsume := types.GasToConsume(msg.BlobSizes, appconsts.GasPerBlobByte)
 
 	ctx.GasMeter().ConsumeGas(gasToConsume, payForBlobGasDescriptor)
 

--- a/x/blob/types/genesis_test.go
+++ b/x/blob/types/genesis_test.go
@@ -25,7 +25,7 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				Params: types.Params{
 					GasPerBlobByte:   20,
-					GovMaxSquareSize: uint64(appconsts.DefaultSquareSizeUpperBound),
+					GovMaxSquareSize: uint64(appconsts.SquareSizeUpperBound),
 				},
 			},
 			valid: true,
@@ -35,7 +35,7 @@ func TestGenesisState_Validate(t *testing.T) {
 			genState: &types.GenesisState{
 				Params: types.Params{
 					GasPerBlobByte:   20,
-					GovMaxSquareSize: uint64(appconsts.DefaultSquareSizeUpperBound + 1),
+					GovMaxSquareSize: uint64(appconsts.SquareSizeUpperBound + 1),
 				},
 			},
 			valid: false,

--- a/x/blob/types/params.go
+++ b/x/blob/types/params.go
@@ -14,9 +14,11 @@ import (
 var _ paramtypes.ParamSet = (*Params)(nil)
 
 var (
-	KeyGasPerBlobByte              = []byte("GasPerBlobByte")
-	DefaultGasPerBlobByte   uint32 = appconsts.GasPerBlobByte
-	KeyGovMaxSquareSize            = []byte("GovMaxSquareSize")
+	KeyGasPerBlobByte = []byte("GasPerBlobByte")
+	// DefaultGasPerBlobByte is the initial value of the gas per blob byte parameter.
+	DefaultGasPerBlobByte uint32 = appconsts.GasPerBlobByte
+	KeyGovMaxSquareSize          = []byte("GovMaxSquareSize")
+	// DefaultGovMaxSquareSize is the initial value of the gov max square size parameter.
 	DefaultGovMaxSquareSize uint64 = appconsts.DefaultGovMaxSquareSize
 )
 

--- a/x/blob/types/params.go
+++ b/x/blob/types/params.go
@@ -15,7 +15,7 @@ var _ paramtypes.ParamSet = (*Params)(nil)
 
 var (
 	KeyGasPerBlobByte              = []byte("GasPerBlobByte")
-	DefaultGasPerBlobByte   uint32 = appconsts.DefaultGasPerBlobByte
+	DefaultGasPerBlobByte   uint32 = appconsts.GasPerBlobByte
 	KeyGovMaxSquareSize            = []byte("GovMaxSquareSize")
 	DefaultGovMaxSquareSize uint64 = appconsts.DefaultGovMaxSquareSize
 )

--- a/x/blob/types/params_test.go
+++ b/x/blob/types/params_test.go
@@ -22,7 +22,7 @@ func Test_validateGovMaxSquareSize(t *testing.T) {
 		},
 		{
 			name:      "not a power of 2",
-			input:     uint64(appconsts.DefaultSquareSizeUpperBound - 1),
+			input:     uint64(appconsts.SquareSizeUpperBound - 1),
 			expectErr: true,
 		},
 		{

--- a/x/blob/types/payforblob.go
+++ b/x/blob/types/payforblob.go
@@ -163,7 +163,7 @@ func EstimateGas(blobSizes []uint32, gasPerByte uint32, txSizeCost uint64) uint6
 
 // DefaultEstimateGas runs EstimateGas with the system defaults.
 func DefaultEstimateGas(blobSizes []uint32) uint64 {
-	return EstimateGas(blobSizes, appconsts.DefaultGasPerBlobByte, appconsts.DefaultTxSizeCostPerByte)
+	return EstimateGas(blobSizes, appconsts.GasPerBlobByte, appconsts.TxSizeCostPerByte)
 }
 
 // ValidateBlobNamespace returns an error if the provided namespace is an

--- a/x/signal/integration_test.go
+++ b/x/signal/integration_test.go
@@ -88,7 +88,7 @@ func TestUpgradeIntegration(t *testing.T) {
 	require.False(t, shouldUpgrade)
 	require.EqualValues(t, 0, upgrade.AppVersion)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + appconsts.UpgradeHeightDelay(appconsts.TestChainID))
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + appconsts.GetUpgradeHeightDelay(appconsts.TestChainID))
 
 	shouldUpgrade, upgrade = app.SignalKeeper.ShouldUpgrade(ctx)
 	require.True(t, shouldUpgrade)

--- a/x/signal/keeper.go
+++ b/x/signal/keeper.go
@@ -116,7 +116,7 @@ func (k *Keeper) TryUpgrade(ctx context.Context, _ *types.MsgTryUpgrade) (*types
 		header := sdkCtx.HeaderInfo()
 		upgrade := types.Upgrade{
 			AppVersion:    version,
-			UpgradeHeight: header.Height + appconsts.UpgradeHeightDelay(header.ChainID),
+			UpgradeHeight: header.Height + appconsts.GetUpgradeHeightDelay(header.ChainID),
 		}
 		k.setUpgrade(sdkCtx, upgrade)
 	}

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -184,7 +184,7 @@ func TestTallyingLogic(t *testing.T) {
 	require.False(t, shouldUpgrade) // should be false because upgrade height hasn't been reached.
 	require.Equal(t, uint64(0), upgrade.AppVersion)
 
-	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + appconsts.UpgradeHeightDelay(appconsts.TestChainID))
+	ctx = ctx.WithBlockHeight(ctx.BlockHeight() + appconsts.GetUpgradeHeightDelay(appconsts.TestChainID))
 
 	shouldUpgrade, upgrade = upgradeKeeper.ShouldUpgrade(ctx)
 	require.True(t, shouldUpgrade) // should be true because upgrade height has been reached.
@@ -421,7 +421,7 @@ func TestGetUpgrade(t *testing.T) {
 		got, err := upgradeKeeper.GetUpgrade(ctx, &types.QueryGetUpgradeRequest{})
 		require.NoError(t, err)
 		assert.Equal(t, v2.Version, got.Upgrade.AppVersion)
-		assert.Equal(t, appconsts.UpgradeHeightDelay(appconsts.TestChainID), got.Upgrade.UpgradeHeight)
+		assert.Equal(t, appconsts.GetUpgradeHeightDelay(appconsts.TestChainID), got.Upgrade.UpgradeHeight)
 	})
 }
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4508

Marked as breaking because renames exported consts and renames the function `UpgradeHeightDelay` to `GetUpgradeHeightDelay` to avoid a name conflict with the exported const.