### PR TITLE
build: bump embedded binary to v3.9.0-rc0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app \
 BUILD_FLAGS := -tags "ledger" -ldflags '$(ldflags)'
 BUILD_FLAGS_MULTIPLEXER := -tags "ledger multiplexer" -ldflags '$(ldflags)'
 
-CELESTIA_V3_VERSION := v3.7.0
+CELESTIA_V3_VERSION := v3.9.0-rc0
 
 ## help: Get more info on make commands.
 help: Makefile


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Bump downloaded binary on `make build` and `make install` to v3.9.0-rc0

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
