### PR TITLE
ci: build v3 docker images with multiple platforms

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.5.0
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.6.1
     with:
       dockerfile: docker/Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.5.0
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@v0.6.1
     with:
       dockerfile: docker/txsim/Dockerfile
       packageName: txsim


### PR DESCRIPTION
## Overview

In order to build and test images in the v3 line on non amd64 architectures, we can update the workflows to build multi arch images.

The current 0.5.0 workflow builds [just for amd64](https://github.com/celestiaorg/.github/blob/45533fc35847a8568deb0d4cae1851a2872f3651/.github/workflows/reusable_dockerfile_pipeline.yml#L311) while the newer workflow builds for both [`amd64` and `arm64`](https://github.com/celestiaorg/.github/blob/v0.6.1/.github/workflows/reusable_dockerfile_pipeline.yml#L305)

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
