### PR TITLE
docs: fix typos

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -35,7 +35,7 @@ import (
 )
 
 // UpgradeName defines the on-chain upgrade name from v3 to v4.
-// IMPORTANT: UpgradeName must be formated as `v`+ app version.
+// IMPORTANT: UpgradeName must be formatted as `v`+ app version.
 const UpgradeName = "v4"
 
 func (app App) RegisterUpgradeHandlers() {

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -33,7 +33,7 @@ FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE} AS builder
 ARG TARGETOS
 ARG TARGETARCH
 
-# The multiplexer must be built with both TARGETOS and TARGETARCH build argumets
+# The multiplexer must be built with both TARGETOS and TARGETARCH build arguments
 # as the location of the embedded binary is derived from these values.
 RUN test -n "$TARGETOS" || (echo "TARGETOS is required but not set" && exit 1)
 RUN test -n "$TARGETARCH" || (echo "TARGETARCH is required but not set" && exit 1)

--- a/go.mod
+++ b/go.mod
@@ -300,7 +300,7 @@ replace (
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.53.0-tm-v0.38.17
 	// cosmos-sdk: v1.29.0-sdk-v0.50.12
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.0-sdk-v0.50.12
-	// goleveldb: cannonical version
+	// goleveldb: canonical version
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	// celestia-core(v0.34.x): used for multiplexing abci v1 requests
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.45.0-tm-v0.34.35


### PR DESCRIPTION


**Description:**
This PR fixes several typos in comments across the codebase:
- Corrected formatting in `app/upgrades.go` comment
- Fixed spelling in `docker/multiplexer.Dockerfile` comment
- Corrected spelling in `go.mod` comment for goleveldb

These changes are purely cosmetic and do not affect functionality.

