### PR TITLE
docs: replace TODO with links to blob inclusion and fraud proof documentation

### DIFF
--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -24,7 +24,11 @@ in a block via a blob inclusion proof. A blob inclusion proof uses the
 block's data square to prove to the user that the shares that compose their
 original data do in fact exist in a particular block.
 
-> TODO: link to blob inclusion (and fraud) proof
+See [`CreateCommitment` implementation](https://github.com/celestiaorg/celestia-app/blob/main/x/blob/types/payforblob.go#L169-L236)
+for the implementation that generates the share commitment used in inclusion proofs.
+
+For details on fraud proofs, refer to the [fraud_proofs.md](https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fraud_proofs.md)
+specification.
 
 ## State
 

--- a/x/blob/README.md
+++ b/x/blob/README.md
@@ -24,10 +24,10 @@ in a block via a blob inclusion proof. A blob inclusion proof uses the
 block's data square to prove to the user that the shares that compose their
 original data do in fact exist in a particular block.
 
-See [`CreateCommitment` implementation](https://github.com/celestiaorg/celestia-app/blob/main/x/blob/types/payforblob.go#L169-L236)
+See [CreateCommitment implementation](./types/payforblob.go#L169-L236)
 for the implementation that generates the share commitment used in inclusion proofs.
 
-For details on fraud proofs, refer to the [fraud_proofs.md](https://github.com/celestiaorg/celestia-app/blob/main/specs/src/fraud_proofs.md)
+For details on fraud proofs, refer to the [fraud_proofs.md](../../specs/src/fraud_proofs.md)
 specification.
 
 ## State


### PR DESCRIPTION
- Added a reference to the implementation responsible for generating the share commitment used in blob inclusion proofs.
- Included a mention of the specification that explains how fraud proofs work in the context of data availability.
