### PR TITLE
fix: add registration of tendermint and node services in standalone mode

### DIFF
--- a/cmd/celestia-appd/cmd/start.go
+++ b/cmd/celestia-appd/cmd/start.go
@@ -235,6 +235,11 @@ func startStandAlone(ctx *server.Context, clientCtx client.Context, appCreator s
 	// service if API or gRPC is enabled.
 	if config.API.Enable || config.GRPC.Enable {
 		app.RegisterTxService(clientCtx)
+		app.RegisterTendermintService(clientCtx)
+
+		if a, ok := app.(srvrtypes.ApplicationQueryService); ok {
+			a.RegisterNodeService(clientCtx)
+		}
 	}
 
 	metrics, err := startTelemetry(config)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Currently, when running in standalone mode (i.e. as an embedded binary in the multiplexer), the tm services are not registered correctly. 


When running the E2E upgrade test, txsim got the following error

```
Error: rpc error: code = Unimplemented desc = unknown service cosmos.base.tendermint.v1beta1.Service
Usage:
  txsim [flags]
```

When working with local binaries we didn't hit the same api.

This will need to make its way into a v3 tag.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
