### PR TITLE
refactor(benchmarks): align metric name to `block_size(mb)`

### DIFF
--- a/app/benchmarks/benchmark_msg_send_test.go
+++ b/app/benchmarks/benchmark_msg_send_test.go
@@ -209,7 +209,7 @@ func BenchmarkProcessProposal_MsgSend_8MB(b *testing.B) {
 	require.GreaterOrEqual(b, len(prepareProposalResp.Txs), 1)
 
 	b.ReportMetric(float64(len(prepareProposalResp.Txs)), "number_of_transactions")
-	b.ReportMetric(calculateBlockSizeInMb(prepareProposalResp.Txs), "block_size_(mb)")
+	b.ReportMetric(calculateBlockSizeInMb(prepareProposalResp.Txs), "block_size(mb)")
 	b.ReportMetric(float64(calculateTotalGasUsed(testApp, prepareProposalResp.Txs)), "total_gas_used")
 
 	processProposalReq := types.RequestProcessProposal{


### PR DESCRIPTION
BenchmarkProcessProposal_MsgSend_8MB emitted `block_size_(mb)` (extra underscore), creating a duplicate metric and splitting dashboard/alert data. Renamed to `block_size(mb)` for consistent aggregation across all benchmarks.