### PR TITLE
Fix import path

### DIFF
--- a/cmd/celestia-appd/cmd/app_exporter.go
+++ b/cmd/celestia-appd/cmd/app_exporter.go
@@ -7,7 +7,7 @@ import (
 	dbm "github.com/cosmos/cosmos-db"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 
-	"github.com/celestiaorg/celestia-app/v4/app"
+	"github.com/celestiaorg/celestia-app/tree/main/app"
 )
 
 func appExporter(


### PR DESCRIPTION
Updated import from v4/app to tree/main/app to align with the current module structure in the Celestia repo. Prevents import errors with outdated paths.