### PR TITLE
chore: update the default address for remote ABCI over grpc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -299,7 +299,7 @@ replace (
 	// celestia-core: v1.53.0-tm-v0.38.17
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.53.0-tm-v0.38.17
 	// cosmos-sdk: v1.29.0-sdk-v0.50.12
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.0-sdk-v0.50.12
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12
 	// goleveldb: canonical version
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	// celestia-core(v0.34.x): used for multiplexing abci v1 requests

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/celestiaorg/celestia-core v1.45.0-tm-v0.34.35 h1:T21AhezjcByAlWDHmiVb
 github.com/celestiaorg/celestia-core v1.45.0-tm-v0.34.35/go.mod h1:fQ46s1hYFTGFBsHsuGsbxDZ720ZPQow5Iyqw+yErZSo=
 github.com/celestiaorg/celestia-core v1.53.0-tm-v0.38.17 h1:AHjnWwPoOFH5zr+aPqdWkF1CutP1ynVEOGOuW1/8iq8=
 github.com/celestiaorg/celestia-core v1.53.0-tm-v0.38.17/go.mod h1:PiU80T/t0z8FPlz7DRZgvrBux0jJiqxFi9lNBFdGUps=
-github.com/celestiaorg/cosmos-sdk v1.29.0-sdk-v0.50.12 h1:I5Wvy9BDSzPlr7RKtDofVhRH1rp6Wk/48Ah4FElMvjY=
-github.com/celestiaorg/cosmos-sdk v1.29.0-sdk-v0.50.12/go.mod h1:clLEg7hWK0iJfiO1Vp71tcQ0vGbFzVsEcLxxnRobIZM=
+github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12 h1:EWJIBTMB9H2KFMqmNB22KvgqvAObqcToJbAdPCM+LBw=
+github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12/go.mod h1:clLEg7hWK0iJfiO1Vp71tcQ0vGbFzVsEcLxxnRobIZM=
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.1.0 h1:+i3G5mP/kPgFEn83EEXGly29QDin2Gvdt0kgpmw/vTg=
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.1.0/go.mod h1:T4K9O18zQNKNpt4YvTL3lcUt4aKOEU05ZIFWVdQi3Ak=
 github.com/celestiaorg/go-square/v2 v2.2.0 h1:zJnUxCYc65S8FgUfVpyG/osDcsnjzo/JSXw/Uwn8zp4=

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -253,7 +253,7 @@ func (m *Multiplexer) initRemoteGrpcConn() error {
 	const flagTMAddress = "address"
 	tmAddress := m.svrCtx.Viper.GetString(flagTMAddress)
 	if tmAddress == "" {
-		tmAddress = "127.0.0.1:26658"
+		tmAddress = "127.0.0.1:36658"
 	}
 
 	// remove tcp:// prefix if present


### PR DESCRIPTION
## Overview

closes: #4646

needs: 
- [x] https://github.com/celestiaorg/cosmos-sdk/pull/576
- [x] New cosmos-sdk tag to be consumed in this PR
- [ ] New multiplexer tag after this PR
- [ ] Consume new multiplexer tag in celestia-app go module