### PR TITLE
chore: option to provide home

### DIFF
--- a/scripts/single-node-upgrades.sh
+++ b/scripts/single-node-upgrades.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # This script starts a single node testnet on app version 1. Then it upgrades
-# from v1 -> v2 -> v3.
+# from v1 -> v2 -> v3.gs
 
 # Stop script execution if an error is encountered
 set -o errexit
@@ -21,8 +21,14 @@ KEYRING_BACKEND="test"
 FEES="500utia"
 BROADCAST_MODE="block"
 
+# Use argument as home directory if provided, else default to ~/.celestia-app
+if [ $# -ge 1 ]; then
+  APP_HOME="$1"
+else
+  APP_HOME="${HOME}/.celestia-app"
+fi
+
 VERSION=$(celestia-appd version 2>&1)
-APP_HOME="${HOME}/.celestia-app"
 GENESIS_FILE="${APP_HOME}/config/genesis.json"
 
 echo "celestia-app version: ${VERSION}"

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -13,6 +13,13 @@ then
     exit 1
 fi
 
+# Use argument as home directory if provided, else default to ~/.celestia-app
+if [ $# -ge 1 ]; then
+  APP_HOME="$1"
+else
+  APP_HOME="${HOME}/.celestia-app"
+fi
+
 # Constants
 CHAIN_ID="test"
 KEY_NAME="validator"
@@ -20,7 +27,6 @@ KEYRING_BACKEND="test"
 FEES="500utia"
 
 VERSION=$(celestia-appd version 2>&1)
-APP_HOME="${HOME}/.celestia-app"
 GENESIS_FILE="${APP_HOME}/config/genesis.json"
 
 echo "celestia-app version: ${VERSION}"
@@ -71,9 +77,6 @@ createGenesis() {
 
     # Persist ABCI responses
     sed -i'.bak' 's#discard_abci_responses = true#discard_abci_responses = false#g' "${APP_HOME}"/config/config.toml
-
-    # Override the log level to debug
-    # sed -i'.bak' 's#log_level = "info"#log_level = "debug"#g' "${APP_HOME}"/config/config.toml
 
     # Override the VotingPeriod from 1 week to 1 minute
     sed -i'.bak' 's#"604800s"#"60s"#g' "${APP_HOME}"/config/genesis.json

--- a/scripts/state-sync.sh
+++ b/scripts/state-sync.sh
@@ -14,12 +14,18 @@ then
     exit 1
 fi
 
+# Use argument as home directory if provided, else default to ~/.celestia-app
+if [ $# -ge 1 ]; then
+  SINGLE_NODE_HOME="$1"
+else
+  SINGLE_NODE_HOME="${HOME}/.celestia-app"
+fi
+
 CHAIN_ID="test"
 KEY_NAME="validator"
 KEYRING_BACKEND="test"
 COINS="1000000000000000utia"
 DELEGATION_AMOUNT="5000000000utia"
-SINGLE_NODE_HOME="${HOME}/.celestia-app"
 CELESTIA_APP_HOME="${HOME}/.celestia-app-state-sync"
 CELESTIA_APP_VERSION=$(celestia-appd version 2>&1)
 GENESIS_FILE="${CELESTIA_APP_HOME}/config/genesis.json"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This pr adds an option to provide a home directory to the three scripts (single-node, single-node-upgrades and state-sync)

To use it run the script as normal and provide a home directory of your choice. 
