### PR TITLE
fix: `CELESTIA_HOME` for app v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ make bbr-enable
 
 ### Environment variables
 
-| Variable        | Explanation                                                       | Default value                                            | Required |
-|-----------------|-------------------------------------------------------------------|----------------------------------------------------------|----------|
-| `CELESTIA_HOME` | Where the application directory (`.celestia-app`) should be saved | [User home directory](https://pkg.go.dev/os#UserHomeDir) | Optional |
+| Variable            | Explanation                                  | Default value                                               | Required |
+|---------------------|----------------------------------------------|-------------------------------------------------------------|----------|
+| `CELESTIA_APP_HOME` | Where the application files should be saved. | [`$HOME/.celestia-appd`](https://pkg.go.dev/os#UserHomeDir) | Optional |
 
 ### Using celestia-appd
 

--- a/app/init.go
+++ b/app/init.go
@@ -8,7 +8,7 @@ import (
 
 // EnvPrefix is the environment variable prefix for celestia-appd.
 // Environment variables that Cobra reads must be prefixed with this value.
-const EnvPrefix = "CELESTIA"
+const EnvPrefix = "CELESTIA_APP"
 
 // Name is the name of the application.
 const Name = "celestia-app"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ FROM ${RUNTIME_IMAGE} AS runtime
 # Ref: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000
 ARG UID=10001
 ARG USER_NAME=celestia
-ENV CELESTIA_HOME=/home/${USER_NAME}
+ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-appd
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     bash \
@@ -63,7 +63,7 @@ RUN apk update && apk add --no-cache \
     && adduser ${USER_NAME} \
     -D \
     -g ${USER_NAME} \
-    -h ${CELESTIA_HOME} \
+    -h ${CELESTIA_APP_HOME} \
     -s /sbin/nologin \
     -u ${UID}
 # Copy the celestia-appd binary from the builder into the final image.
@@ -73,7 +73,7 @@ COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /opt/entrypoint.sh
 # Set the user to celestia.
 USER ${USER_NAME}
 # Set the working directory to the home directory.
-WORKDIR ${CELESTIA_HOME}
+WORKDIR ${CELESTIA_APP_HOME}
 # Expose ports:
 # 1317 is the default API server port.
 # 9090 is the default GRPC server port.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,10 +3,10 @@
 # This script creates the necessary files before starting celestia-appd
 
 # only create the priv_validator_state.json if it doesn't exist and the command is start
-if [[ $1 == "start" && ! -f ${CELESTIA_HOME}/data/priv_validator_state.json ]]
+if [[ $1 == "start" && ! -f ${CELESTIA_APP_HOME}/data/priv_validator_state.json ]]
 then
-    mkdir -p ${CELESTIA_HOME}/data
-    cat <<EOF > ${CELESTIA_HOME}/data/priv_validator_state.json
+    mkdir -p ${CELESTIA_APP_HOME}/data
+    cat <<EOF > ${CELESTIA_APP_HOME}/data/priv_validator_state.json
 {
   "height": "0",
   "round": 0,

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -77,7 +77,7 @@ FROM ${RUNTIME_IMAGE} AS runtime
 # Ref: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000
 ARG UID=10001
 ARG USER_NAME=celestia
-ENV CELESTIA_HOME=/home/${USER_NAME}
+ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-appd
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     bash \
@@ -86,7 +86,7 @@ RUN apk update && apk add --no-cache \
     && adduser ${USER_NAME} \
     -D \
     -g ${USER_NAME} \
-    -h ${CELESTIA_HOME} \
+    -h ${CELESTIA_APP_HOME} \
     -s /sbin/nologin \
     -u ${UID}
 # Copy the celestia-appd binary from the builder into the final image.
@@ -96,7 +96,7 @@ COPY --chown=${USER_NAME}:${USER_NAME} docker/entrypoint.sh /opt/entrypoint.sh
 # Set the user to celestia.
 USER ${USER_NAME}
 # Set the working directory to the home directory.
-WORKDIR ${CELESTIA_HOME}
+WORKDIR ${CELESTIA_APP_HOME}
 # Expose ports:
 # 1317 is the default API server port.
 # 9090 is the default GRPC server port.

--- a/docker/txsim/Dockerfile
+++ b/docker/txsim/Dockerfile
@@ -29,7 +29,7 @@ FROM docker.io/alpine:3.20
 ARG UID=10001
 ARG USER_NAME=celestia
 
-ENV CELESTIA_HOME=/home/${USER_NAME}
+ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-appd
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
@@ -40,7 +40,7 @@ RUN apk update && apk add --no-cache \
     && adduser ${USER_NAME} \
     -D \
     -g ${USER_NAME} \
-    -h ${CELESTIA_HOME} \
+    -h ${CELESTIA_APP_HOME} \
     -s /sbin/nologin \
     -u ${UID}
 
@@ -52,6 +52,6 @@ COPY --chown=${USER_NAME}:${USER_NAME} docker/txsim/entrypoint.sh /opt/entrypoin
 USER ${USER_NAME}
 
 # Set the working directory to the home directory.
-WORKDIR ${CELESTIA_HOME}
+WORKDIR ${CELESTIA_APP_HOME}
 
 ENTRYPOINT [ "/bin/bash", "/opt/entrypoint.sh" ]

--- a/local_devnet/docker-compose.yml
+++ b/local_devnet/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - core0
     environment:
       - MONIKER=core1
-      - CELESTIA_HOME=/opt
+      - CELESTIA_APP_HOME=/opt
       - AMOUNT=5000000000utia
     entrypoint: [
       "/bin/bash"
@@ -68,7 +68,7 @@ services:
       - core0
     environment:
       - MONIKER=core2
-      - CELESTIA_HOME=/opt
+      - CELESTIA_APP_HOME=/opt
       - AMOUNT=5000000000utia
     entrypoint: [
       "/bin/bash"
@@ -97,7 +97,7 @@ services:
       - core0
     environment:
       - MONIKER=core3
-      - CELESTIA_HOME=/opt
+      - CELESTIA_APP_HOME=/opt
       - AMOUNT=5000000000utia
     entrypoint: [
       "/bin/bash"

--- a/local_devnet/scripts/init.sh
+++ b/local_devnet/scripts/init.sh
@@ -5,20 +5,20 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 PWD=$(pwd)
 
 if [ -z "$CELESTIA_BIN" ]; then echo "CELESTIA_BIN is not set. Make sure to run 'make install' before"; exit 1; fi
-CELESTIA_HOME=$($CELESTIA_BIN config home)
-if [ -d "$CELESTIA_HOME" ]; then rm -r $CELESTIA_HOME; fi
+CELESTIA_APP_HOME=$($CELESTIA_BIN config home)
+if [ -d "$CELESTIA_APP_HOME" ]; then rm -r $CELESTIA_APP_HOME; fi
 $CELESTIA_BIN config set client chain-id local_devnet
 $CELESTIA_BIN config set client keyring-backend test
 $CELESTIA_BIN config set app api.enable true
 $CELESTIA_BIN keys add alice
 
 if [ "$MULTIPLEXER" = "true" ]; then
-cd $SCRIPT_DIR; cp ../celestia-app/genesis_046.json $CELESTIA_HOME/config/genesis.json; cd $PWD # use local_devnet genesis
+cd $SCRIPT_DIR; cp ../celestia-app/genesis_046.json $CELESTIA_APP_HOME/config/genesis.json; cd $PWD # use local_devnet genesis
 $CELESTIA_BIN passthrough v3 add-genesis-account alice 5000000000utia --keyring-backend test
 $CELESTIA_BIN passthrough v3 gentx alice 1000000utia --fees 1utia --chain-id local_devnet
 $CELESTIA_BIN passthrough v3 collect-gentxs
 else
-cd $SCRIPT_DIR; cp ../celestia-app/genesis.json $CELESTIA_HOME/config/genesis.json; cd $PWD # use local_devnet genesis
+cd $SCRIPT_DIR; cp ../celestia-app/genesis.json $CELESTIA_APP_HOME/config/genesis.json; cd $PWD # use local_devnet genesis
 $CELESTIA_BIN genesis add-genesis-account alice 5000000000utia --keyring-backend test
 $CELESTIA_BIN genesis gentx alice 1000000utia --fees 1utia --chain-id local_devnet
 $CELESTIA_BIN genesis collect-gentxs

--- a/local_devnet/scripts/start_node_and_create_validator.sh
+++ b/local_devnet/scripts/start_node_and_create_validator.sh
@@ -4,17 +4,17 @@
 # keeps running it validating blocks.
 
 # check if environment variables are set
-if [[ -z "${CELESTIA_HOME}" || -z "${MONIKER}" || -z "${AMOUNT}" ]]
+if [[ -z "${CELESTIA_APP_HOME}" || -z "${MONIKER}" || -z "${AMOUNT}" ]]
 then
-  echo "Environment not setup correctly. Please set: CELESTIA_HOME, MONIKER, AMOUNT variables"
+  echo "Environment not setup correctly. Please set: CELESTIA_APP_HOME, MONIKER, AMOUNT variables"
   exit 1
 fi
 
 # create necessary structure if doesn't exist
-if [[ ! -f ${CELESTIA_HOME}/data/priv_validator_state.json ]]
+if [[ ! -f ${CELESTIA_APP_HOME}/data/priv_validator_state.json ]]
 then
-    mkdir "${CELESTIA_HOME}"/data
-    cat <<EOF > ${CELESTIA_HOME}/data/priv_validator_state.json
+    mkdir "${CELESTIA_APP_HOME}"/data
+    cat <<EOF > ${CELESTIA_APP_HOME}/data/priv_validator_state.json
 {
   "height": "0",
   "round": 0,
@@ -42,7 +42,7 @@ fi
     # create validator
     celestia-appd tx staking create-validator \
       --amount="${AMOUNT}" \
-      --pubkey="$(celestia-appd tendermint show-validator --home "${CELESTIA_HOME}")" \
+      --pubkey="$(celestia-appd tendermint show-validator --home "${CELESTIA_APP_HOME}")" \
       --moniker="${MONIKER}" \
       --chain-id="test" \
       --commission-rate=0.1 \
@@ -51,7 +51,7 @@ fi
       --min-self-delegation=1000000 \
       --from="${MONIKER}" \
       --keyring-backend=test \
-      --home="${CELESTIA_HOME}" \
+      --home="${CELESTIA_APP_HOME}" \
       --broadcast-mode=block \
       --fees="300000utia" \
       --yes
@@ -66,7 +66,7 @@ fi
 
 # start node
 celestia-appd start \
-  --home="${CELESTIA_HOME}" \
+  --home="${CELESTIA_APP_HOME}" \
   --moniker="${MONIKER}" \
   --p2p.persistent_peers=1c29bcd0d568df34f148b26205543566e4d1a177@core0:26656 \
   --rpc.laddr=tcp://0.0.0.0:26657 \


### PR DESCRIPTION
Ref: #4532

Per https://github.com/celestiaorg/celestia-app/issues/4532#issuecomment-2832582855, #4400 actually changed (breaking) the behavior of `CELESTIA_HOME` to be the directory directly. This PR renames the environment variable to `CELESTIA_APP_HOME` but does not further change the behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated all references of the environment variable from `CELESTIA_HOME` to `CELESTIA_APP_HOME` across documentation, Dockerfiles, scripts, and configuration files.
  - Adjusted default directory paths and working directories to use `.celestia-appd` for improved consistency.
  - Refined documentation to reflect these changes and clarified environment variable usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->