### PR TITLE
fix: `CELESTIA_HOME` for app v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,10 @@ celestia-appd --help
 
 ### Environment variables
 
-| Variable        | Explanation                                                       | Default value                                            | Required |
-|-----------------|-------------------------------------------------------------------|----------------------------------------------------------|----------|
-| `CELESTIA_HOME` | Where the application directory (`.celestia-app`) should be saved | [User home directory](https://pkg.go.dev/os#UserHomeDir) | Optional |
+| Variable            | Explanation                                                                     | Default value                                               | Required |
+|---------------------|---------------------------------------------------------------------------------|-------------------------------------------------------------|----------|
+| `CELESTIA_APP_HOME` | Where the application files should be saved.                                    | [`$HOME/.celestia-appd`](https://pkg.go.dev/os#UserHomeDir) | Optional |
+| `CELESTIA_HOME`     | Where the application directory (`.celestia-app`) should be saved (DEPRECATED). | [User home directory](https://pkg.go.dev/os#UserHomeDir)    | Optional |
 
 ### Create your own single node devnet
 

--- a/app/init.go
+++ b/app/init.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -12,9 +13,14 @@ const Name = "celestia-app"
 // to store configs, data, keyrings, etc.
 const appDirectory = ".celestia-app"
 
-// celestiaHome is an environment variable that sets where appDirectory will be placed.
+// celestiaHome is an environment variable that sets where data will be placed.
 // If celestiaHome isn't specified, the default user home directory will be used.
-const celestiaHome = "CELESTIA_HOME"
+const celestiaHome = "CELESTIA_APP_HOME"
+
+// celestiaHomeOld is an environment variable that sets where appDirectory will be placed.
+// If celestiaHomeOld isn't specified, the default user home directory will be used.
+// Deprecated.
+const celestiaHomeOld = "CELESTIA_HOME"
 
 // DefaultNodeHome is the default home directory for the application daemon.
 // This gets set as a side-effect of the init() function.
@@ -26,17 +32,22 @@ func init() {
 		panic(err)
 	}
 	celestiaHome := os.Getenv(celestiaHome)
-	DefaultNodeHome = getDefaultNodeHome(userHome, celestiaHome)
+	celestiaHomeOld := os.Getenv(celestiaHomeOld)
+	DefaultNodeHome = getDefaultNodeHome(userHome, celestiaHome, celestiaHomeOld)
 }
 
 // getDefaultNodeHome computes the default node home directory based on the
 // provided userHome and celestiaHome. If celestiaHome is provided, it takes
-// precedence and constructs the path by appending the application directory.
+// precedence and constructs the path.
 // Otherwise, it falls back to using the userHome with the application directory
 // appended.
-func getDefaultNodeHome(userHome string, celestiaHome string) string {
+func getDefaultNodeHome(userHome string, celestiaHome string, celestiaHomeOld string) string {
 	if celestiaHome != "" {
-		return filepath.Join(celestiaHome, appDirectory)
+		return celestiaHome
+	}
+	if celestiaHomeOld != "" {
+		fmt.Print("warning CELESTIA_HOME is deprecated and will be removed in the next major release. Use CELESTIA_APP_HOME instead.\n")
+		return filepath.Join(celestiaHomeOld, appDirectory)
 	}
 	return filepath.Join(userHome, appDirectory)
 }

--- a/app/init_test.go
+++ b/app/init_test.go
@@ -17,7 +17,7 @@ func Test_getDefaultNodeHome(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name:            "want .celestia-app when userHome is empty and celestiaHomeOld is empty",
+			name:            "want .celestia-app when userHome is empty and celestiaHome/Old are empty",
 			userHome:        "",
 			celestiaHome:    "",
 			celestiaHomeOld: "",
@@ -31,18 +31,46 @@ func Test_getDefaultNodeHome(t *testing.T) {
 			want:            "celestia-home/.celestia-app",
 		},
 		{
-			name:            "want user-home/.celestia-app when userHome is not empty and celestiaHomeOld is empty",
+			name:            "want user-home/.celestia-app when userHome is not empty and celestiaHome/Old are empty",
 			userHome:        "user-home",
 			celestiaHome:    "",
 			celestiaHomeOld: "",
 			want:            "user-home/.celestia-app",
 		},
 		{
-			name:            "want celestiaHomeOld to take precedence if both are not empty",
+			name:            "want celestiaHomeOld to take precedence if both it and userHome are not empty",
 			userHome:        "user-home",
 			celestiaHome:    "",
 			celestiaHomeOld: "celestia-home",
 			want:            "celestia-home/.celestia-app",
+		},
+		{
+			name:            "want celestia-home when userHome is empty and celestiaHome is not empty",
+			userHome:        "",
+			celestiaHome:    "celestia-home",
+			celestiaHomeOld: "",
+			want:            "celestia-home",
+		},
+		{
+			name:            "want celestiaHome to take precedence if both it and userHome are not empty",
+			userHome:        "user-home",
+			celestiaHome:    "celestia-home",
+			celestiaHomeOld: "",
+			want:            "celestia-home",
+		},
+		{
+			name:            "want celestiaHome to take precedence if both it and celestiaHomeOld are not empty",
+			userHome:        "",
+			celestiaHome:    "celestia-home",
+			celestiaHomeOld: "celestia-home/.celestia-appd",
+			want:            "celestia-home",
+		},
+		{
+			name:            "want celestiaHome to take precedence if all are not empty",
+			userHome:        "user-home",
+			celestiaHome:    "celestia-home",
+			celestiaHomeOld: "celestia-home/.celestia-appd",
+			want:            "celestia-home",
 		},
 	}
 

--- a/app/init_test.go
+++ b/app/init_test.go
@@ -8,42 +8,47 @@ import (
 
 func Test_getDefaultNodeHome(t *testing.T) {
 	type testCase struct {
-		name         string
-		userHome     string
-		celestiaHome string
-		want         string
+		name            string
+		userHome        string
+		celestiaHome    string
+		celestiaHomeOld string
+		want            string
 	}
 
 	testCases := []testCase{
 		{
-			name:         "want .celestia-app when userHome is empty and celestiaHome is empty",
-			userHome:     "",
-			celestiaHome: "",
-			want:         ".celestia-app",
+			name:            "want .celestia-app when userHome is empty and celestiaHomeOld is empty",
+			userHome:        "",
+			celestiaHome:    "",
+			celestiaHomeOld: "",
+			want:            ".celestia-app",
 		},
 		{
-			name:         "want celestia-home/.celestia-app when userHome is empty and celestiaHome is not empty",
-			userHome:     "",
-			celestiaHome: "celestia-home",
-			want:         "celestia-home/.celestia-app",
+			name:            "want celestia-home/.celestia-app when userHome is empty and celestiaHomeOld is not empty",
+			userHome:        "",
+			celestiaHome:    "",
+			celestiaHomeOld: "celestia-home",
+			want:            "celestia-home/.celestia-app",
 		},
 		{
-			name:         "want user-home/.celestia-app when userHome is not empty and celestiaHome is empty",
-			userHome:     "user-home",
-			celestiaHome: "",
-			want:         "user-home/.celestia-app",
+			name:            "want user-home/.celestia-app when userHome is not empty and celestiaHomeOld is empty",
+			userHome:        "user-home",
+			celestiaHome:    "",
+			celestiaHomeOld: "",
+			want:            "user-home/.celestia-app",
 		},
 		{
-			name:         "want celestiaHome to take precedence if both are not empty",
-			userHome:     "user-home",
-			celestiaHome: "celestia-home",
-			want:         "celestia-home/.celestia-app",
+			name:            "want celestiaHomeOld to take precedence if both are not empty",
+			userHome:        "user-home",
+			celestiaHome:    "",
+			celestiaHomeOld: "celestia-home",
+			want:            "celestia-home/.celestia-app",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getDefaultNodeHome(tc.userHome, tc.celestiaHome, tc.celestiaHome)
+			got := getDefaultNodeHome(tc.userHome, tc.celestiaHome, tc.celestiaHomeOld)
 			assert.Equal(t, tc.want, got)
 		})
 	}

--- a/app/init_test.go
+++ b/app/init_test.go
@@ -43,7 +43,7 @@ func Test_getDefaultNodeHome(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := getDefaultNodeHome(tc.userHome, tc.celestiaHome)
+			got := getDefaultNodeHome(tc.userHome, tc.celestiaHome, tc.celestiaHome)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
Ref: #4532

This PR adds the environment variable `CELESTIA_APP_HOME`, behaving as #4532 prescribes. It does not change the behavior of `CELESTIA_HOME` if used without `CELESTIA_APP_HOME`. When used together, `CELESTIA_APP_HOME` takes precedence (since `CELESTIA_HOME` can still be set for `celestia-node`).