### PR TITLE
fix: download v3 binaries on make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ build-standalone: mod
 .PHONY: build-standalone
 
 ## build: Build the celestia-appd binary into the ./build directory.
-build: mod
+build: mod download-v3-binaries
 	@cd ./cmd/celestia-appd
 	@mkdir -p build/
 	@echo "--> Building build/celestia-appd with multiplexer enabled"
@@ -56,15 +56,21 @@ install-standalone: check-bbr
 
 ## install: Build and install the multiplexer version of celestia-appd into the $GOPATH/bin directory.
 # TODO: Improve logic here and in goreleaser to make it future proof and less expensive.
-install: check-bbr
+install: check-bbr download-v3-binaries
+	@echo "--> Installing celestia-appd with multiplexer support"
+	@go install $(BUILD_FLAGS_MULTIPLEXER) ./cmd/celestia-appd
+.PHONY: install
+
+## download-v3-binaries: Download the binaries for the latest v3.x.x release.
+# TODO: Do not re-download if the files already exist.
+download-v3-binaries:
 	@echo "--> Download embedded binaries for v3"
 	wget https://github.com/celestiaorg/celestia-app/releases/download/$(CELESTIA_V3_VERSION)/celestia-app_Darwin_arm64.tar.gz -O internal/embedding/celestia-app_darwin_v3_arm64.tar.gz
 	wget https://github.com/celestiaorg/celestia-app/releases/download/$(CELESTIA_V3_VERSION)/celestia-app_Linux_arm64.tar.gz -O internal/embedding/celestia-app_linux_v3_arm64.tar.gz
 	wget https://github.com/celestiaorg/celestia-app/releases/download/$(CELESTIA_V3_VERSION)/celestia-app_Darwin_x86_64.tar.gz -O internal/embedding/celestia-app_darwin_v3_amd64.tar.gz
 	wget https://github.com/celestiaorg/celestia-app/releases/download/$(CELESTIA_V3_VERSION)/celestia-app_Linux_x86_64.tar.gz -O internal/embedding/celestia-app_linux_v3_amd64.tar.gz
-	@echo "--> Installing celestia-appd with multiplexer support"
-	@go install $(BUILD_FLAGS_MULTIPLEXER) ./cmd/celestia-appd
-.PHONY: install
+	@echo "--> Downloaded embedded binaries for v3"
+.PHONY: download-v3-binaries
 
 ## mod: Update all go.mod files.
 mod:

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,6 @@ install: check-bbr download-v3-binaries
 .PHONY: install
 
 ## download-v3-binaries: Download the binaries for the latest v3.x.x release.
-# TODO: Do not re-download if the files already exist.
 download-v3-binaries:
 	@echo "--> Downloading embedded binaries for v3"
 	@for pair in \

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ node            |  |                               |  |
 
 1. [Install Go](https://go.dev/doc/install) 1.23.6
 1. Clone this repo
-1. Install the celestia-appd binary
+1. Install the celestia-appd binary. This installs a "multiplexer" binary that will also download embedded binaries for the latest celestia-app v3.x.x release.
 
     ```shell
     make install


### PR DESCRIPTION
Motivated by https://celestia-team.slack.com/archives/C02PFFCGMNW/p1745700834072559

## Testing

```
$ rm internal/embedding/*.tar.gz
$ make build
--> Updating go.mod
--> Updating go.mod in ./test/interchain
--> Downloading embedded binaries for v3
Binary celestia-app_darwin_v3_arm64.tar.gz not found, downloading
Binary celestia-app_linux_v3_arm64.tar.gz not found, downloading
Binary celestia-app_darwin_v3_amd64.tar.gz not found, downloading
Binary celestia-app_linux_v3_amd64.tar.gz not found, downloading
--> Downloaded embedded binaries for v3
--> Building build/celestia-appd with multiplexer enabled
```