### PR TITLE
chore: fix goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -95,7 +95,7 @@ builds:
       - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
 dist: ./build/goreleaser
 archives:
-  - format: tar.gz
+  - formats: [ 'tar.gz' ]
     # this name template makes the OS and Arch compatible with the results of
     # uname.
     name_template: >-


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4671

`format` was deprecated in favor of `formats`. Ref: https://goreleaser.com/deprecations/#archivesformat