### PR TITLE
fix: reduce multiplexer logging noise

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -429,7 +429,7 @@ func (m *Multiplexer) getApp() (servertypes.ABCI, error) {
 		}
 
 		if m.nativeApp == nil {
-			m.logger.Info("no app found in multiplexer for app version, starting latest app", "app_version", m.appVersion)
+			m.logger.Info("using latest app", "app_version", m.appVersion)
 			app, err := m.startNativeApp()
 			if err != nil {
 				return nil, fmt.Errorf("failed to start latest app: %w", err)
@@ -441,19 +441,16 @@ func (m *Multiplexer) getApp() (servertypes.ABCI, error) {
 				return nil, fmt.Errorf("failed to enable gRPC and API servers: %w", err)
 			}
 		}
-
-		m.logger.Info("using latest app", "app_version", m.appVersion)
 		return m.nativeApp, nil
 	}
 
 	// check if we need to start the app or if we have a different app running
 	if !m.started || currentVersion.AppVersion > m.activeVersion.AppVersion {
+		m.logger.Info("Using ABCI remote connection", "maximum_app_version", m.activeVersion.AppVersion, "abci_version", m.activeVersion.ABCIVersion.String(), "chain_id", m.chainID)
 		if err := m.startEmbeddedApp(currentVersion); err != nil {
 			return nil, fmt.Errorf("failed to start embedded app: %w", err)
 		}
 	}
-
-	m.logger.Info("Using ABCI remote connection", "maximum_app_version", m.activeVersion.AppVersion, "abci_version", m.activeVersion.ABCIVersion.String(), "chain_id", m.chainID)
 
 	switch m.activeVersion.ABCIVersion {
 	case ABCIClientVersion1:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Logs would be populated like this one each block because there was a log line in `getApp` and this is called for every ABCI lifecycle method.

```
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
2025-04-29 14:21:42 1:21PM INF using latest app app_version=4 module=server
```

This PR updates the logging to only say the version when it is switching to a new embedded version, or using the native version.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
