### PR TITLE
chore(ci): run `make lint-fix` for multiplexer in lint workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,12 @@ jobs:
           version: v2.0.1
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.0.1
+        if: env.GIT_DIFF
+      - name: Run golangci-lint in multiplexer module
+        working-directory: multiplexer
+        run: golangci-lint run --timeout 10m
         if: env.GIT_DIFF
 
   # hadolint lints the Dockerfile

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -614,7 +614,9 @@ func (m *Multiplexer) setupRemoteAppCleanup(cleanupFn func() error) {
 
 		// Re-send the signal to allow the normal process termination
 		signal.Reset(os.Interrupt, syscall.SIGTERM)
-		syscall.Kill(os.Getpid(), sig.(syscall.Signal))
+		if err := syscall.Kill(os.Getpid(), sig.(syscall.Signal)); err != nil {
+			m.logger.Error("Failed to re-send termination signal", "err", err)
+		}
 	}()
 }
 

--- a/multiplexer/abci/remote_v1.go
+++ b/multiplexer/abci/remote_v1.go
@@ -174,7 +174,7 @@ func (a *RemoteABCIClientV1) FinalizeBlock(req *abciv2.RequestFinalizeBlock) (*a
 	events = append(events, abciEventV1ToV2(endBlockResp.Events...)...)
 
 	// convert tx results
-	var txResults []*abciv2.ExecTxResult
+	txResults := make([]*abciv2.ExecTxResult, 0, len(commitBlockResps))
 	for _, commitBlockResp := range commitBlockResps {
 		txResults = append(txResults, &abciv2.ExecTxResult{
 			Code:      commitBlockResp.Code,


### PR DESCRIPTION
## Overview
Closes #4676 
This PR updates the `.github/workflows/lint.yml` workflow to include a step that runs `make lint-fix -C multiplexer`.

The purpose of this change is to automatically apply formatting fixes (via `golangci-lint --fix` and `markdownlint --fix`) inside the `multiplexer` directory as part of the CI linting process.

This addresses the request mentioned in [#4676](https://github.com/celestiaorg/celestia-app/issues/4676#issuecomment-2058851480).

## Changes

- Add `make lint-fix -C multiplexer` step under the `golangci-lint` job in `lint.yml`
- Fixed two lint warnings inside `multiplexer`:
  - Handled the error return value of `syscall.Kill` (`errcheck` warning).
  - Pre-allocated the `txResults` slice (`prealloc` warning).

After applying the fixes:

```bash
himess@Semih-MacBook-Air multiplexer % make lint-fix
golangci-lint run --fix
multiplexer/abci/multiplexer.go:620:15: Error return value of `syscall.Kill` is not checked (errcheck)
                syscall.Kill(os.Getpid(), sig.(syscall.Signal))
                            ^
multiplexer/abci/remote_v1.go:177:2: Consider pre-allocating `txResults` (prealloc)
        var txResults []*abciv2.ExecTxResult
        ^
2 issues:
* errcheck: 1
* prealloc: 1
make: *** [lint-fix] Error 1
himess@Semih-MacBook-Air multiplexer % make lint-fix
golangci-lint run --fix
0 issues.
himess@Semih-MacBook-Air multiplexer %
