### PR TITLE
fix: download only current platform's embedded v3 binary in `make install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,18 +65,20 @@ install: check-bbr download-v3-binaries
 	@go install $(BUILD_FLAGS_MULTIPLEXER) ./cmd/celestia-appd
 .PHONY: install
 
-## download-v3-binaries: Download the binaries for the latest v3.x.x release.
+## download-v3-binaries: Download the binary for the current platform for v3.
 download-v3-binaries:
-	@echo "--> Downloading embedded binaries for v3"
-	@for pair in \
-		"celestia-app_Darwin_arm64.tar.gz:celestia-app_darwin_v3_arm64.tar.gz" \
-		"celestia-app_Linux_arm64.tar.gz:celestia-app_linux_v3_arm64.tar.gz" \
-		"celestia-app_Darwin_x86_64.tar.gz:celestia-app_darwin_v3_amd64.tar.gz" \
-		"celestia-app_Linux_x86_64.tar.gz:celestia-app_linux_v3_amd64.tar.gz"; do \
-		url=$${pair%%:*}; out=$${pair##*:}; \
-		$(EMBED_BIN); \
-	done
-	@echo "--> Downloaded embedded binaries for v3"
+	@echo "--> Downloading embedded binary for v3"
+	@mkdir -p internal/embedding
+	@os=$$(go env GOOS); arch=$$(go env GOARCH); \
+	case "$$os-$$arch" in \
+		darwin-arm64) url=celestia-app_Darwin_arm64.tar.gz; out=celestia-app_darwin_v3_arm64.tar.gz ;; \
+		linux-arm64) url=celestia-app_Linux_arm64.tar.gz; out=celestia-app_linux_v3_arm64.tar.gz ;; \
+		darwin-amd64) url=celestia-app_Darwin_x86_64.tar.gz; out=celestia-app_darwin_v3_amd64.tar.gz ;; \
+		linux-amd64) url=celestia-app_Linux_x86_64.tar.gz; out=celestia-app_linux_v3_amd64.tar.gz ;; \
+		*) echo "Unsupported platform: $$os-$$arch"; exit 1 ;; \
+	esac; \
+	bash scripts/download_v3_binary.sh "$$url" "$$out" "$(CELESTIA_V3_VERSION)"
+	@echo "--> Done"
 .PHONY: download-v3-binaries
 
 ## mod: Update all go.mod files.

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ install: check-bbr download-v3-binaries
 
 ## download-v3-binaries: Download the celestia-app v3 binary for the current platform.
 download-v3-binaries:
-	@echo "--> Downloading embedded binary for v3"
+	@echo "--> Downloading celestia-app $(CELESTIA_V3_VERSION) binary"
 	@mkdir -p internal/embedding
 	@os=$$(go env GOOS); arch=$$(go env GOARCH); \
 	case "$$os-$$arch" in \

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install: check-bbr download-v3-binaries
 	@go install $(BUILD_FLAGS_MULTIPLEXER) ./cmd/celestia-appd
 .PHONY: install
 
-## download-v3-binaries: Download the binary for the current platform for v3.
+## download-v3-binaries: Download the celestia-app v3 binary for the current platform.
 download-v3-binaries:
 	@echo "--> Downloading embedded binary for v3"
 	@mkdir -p internal/embedding

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,6 @@ download-v3-binaries:
 		*) echo "Unsupported platform: $$os-$$arch"; exit 1 ;; \
 	esac; \
 	bash scripts/download_v3_binary.sh "$$url" "$$out" "$(CELESTIA_V3_VERSION)"
-	@echo "--> Done"
 .PHONY: download-v3-binaries
 
 ## mod: Update all go.mod files.


### PR DESCRIPTION
## Overview
Closes #4664

This PR refactors the `make install` process to download only the embedded v3 binary required for the current platform (`GOOS`/`GOARCH`), instead of downloading all 4 binaries (linux/macOS, amd64/arm64). This improves efficiency and reduces redundant downloads.

## Changes

- Added platform detection logic (`go env GOOS` / `GOARCH`) in the `download-v3-binaries` Makefile target.
- Replaced the loop over all 4 platforms with a `case` statement that selects the appropriate binary for the current host.
- Updated `download_v3_binary.sh` script is used to handle version checking and downloading.

## Result

On an M2 MacBook (`darwin/arm64`), the following result is observed:

```bash
make install
Checking if BBR is enabled...
sysctl: unknown oid 'net.ipv4.tcp_congestion_control'
WARNING: BBR is not enabled. Please enable BBR for optimal performance. Call make enable-bbr or see Usage section in the README.
--> Downloading embedded binary for v3
Binary celestia-app_darwin_v3_arm64.tar.gz not found, downloading
--> Done
--> Installing celestia-appd with multiplexer support