### PR TITLE
fix: update the default bond denom in default_overrides

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -203,6 +203,9 @@ func (govModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	genState.Params.MaxDepositPeriod = &oneWeek
 	genState.Params.VotingPeriod = &oneWeek
 
+	// the ExpeditedMinDeposit list will always be of size one as set in NewGenesisState in the gov module.
+	genState.Params.ExpeditedMinDeposit[0].Denom = params.BondDenom
+
 	return cdc.MustMarshalJSON(genState)
 }
 

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -36,6 +36,7 @@ func Test_newGovModule(t *testing.T) {
 	assert.Equal(t, want, govGenesisState.Params.MinDeposit)
 	assert.Equal(t, oneWeek, *govGenesisState.Params.MaxDepositPeriod)
 	assert.Equal(t, oneWeek, *govGenesisState.Params.VotingPeriod)
+	assert.Equal(t, params.BondDenom, govGenesisState.Params.ExpeditedMinDeposit[0].Denom)
 }
 
 func TestDefaultAppConfig(t *testing.T) {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

When running `celestia-appd init` the following is present in the gov params

```json
"expedited_min_deposit": [
      {
        "denom": "stake",
        "amount": "50000000"
      }
    ],
```

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
