### PR TITLE
fix: make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ install-standalone: check-bbr
 .PHONY: install-standalone
 
 define EMBED_BIN
-  ./scripts/embed_bin.sh $$url $$out $(CELESTIA_V3_VERSION)
+  ./scripts/download_v3_binary.sh $$url $$out $(CELESTIA_V3_VERSION)
 endef
 
 ## install: Build and install the multiplexer version of celestia-appd into the $GOPATH/bin directory.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4705

## Testing

- `make build` passes locally
- [CI build](https://github.com/celestiaorg/celestia-app/actions/runs/14758805123/job/41433985530?pr=4707) passes 

## Follow ups
- [x] Make build a required CI check on `main`