### PR TITLE
fix: docker build for multiplexer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,12 @@ build-docker:
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/Dockerfile .
 .PHONY: build-docker
 
+## build-docker-multiplexer: Build the celestia-appd Multiplexer Docker image using the multiplexer Dockerfile.
+build-docker-multiplexer:
+	@echo "--> Building Multiplexer Docker image"
+	$(DOCKER) build -t celestiaorg/celestia-app-multiplexer -f docker/multiplexer.Dockerfile .
+.PHONY: build-docker-multiplexer
+
 ## docker-build: Build the celestia-appd docker image from the current branch. Requires docker.
 docker-build: build-docker
 .PHONY: docker-build

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,14 @@ build: mod download-v3-binaries
 	@go build $(BUILD_FLAGS_MULTIPLEXER) -o build/celestia-appd ./cmd/celestia-appd
 .PHONY: build
 
+## build-skip-download: Build the celestia-appd binary into the ./build directory and skip downloading the v3 binaries.
+build-skip-download: mod
+	@cd ./cmd/celestia-appd
+	@mkdir -p build/
+	@echo "--> Building build/celestia-appd with multiplexer enabled"
+	@go build $(BUILD_FLAGS_MULTIPLEXER) -o build/celestia-appd ./cmd/celestia-appd
+.PHONY: build-skip-download
+
 ## install-standalone: Build and install the celestia-appd binary into the $GOPATH/bin directory. This target does not install the multiplexer.
 install-standalone: check-bbr
 	@echo "--> Installing celestia-appd"

--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,10 @@ build-standalone: mod
 	@go build $(BUILD_FLAGS) -o build/ ./cmd/celestia-appd
 .PHONY: build-standalone
 
-download ?= true
+DOWNLOAD ?= true
 ## build: Build the celestia-appd binary into the ./build directory.
 build: mod
-	@if [ "$(download)" = "true" ]; then \
+	@if [ "$(DOWNLOAD)" = "true" ]; then \
 		$(MAKE) download-v3-binaries; \
 	fi
 	@cd ./cmd/celestia-appd

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,9 @@ build-standalone: mod
 DOWNLOAD ?= true
 ## build: Build the celestia-appd binary into the ./build directory.
 build: mod
-	@if [ "$(DOWNLOAD)" = "true" ]; then \
-		$(MAKE) download-v3-binaries; \
-	fi
-	@cd ./cmd/celestia-appd
+ifeq ($(DOWNLOAD),true)
+	@$(MAKE) download-v3-binaries
+endif
 	@mkdir -p build/
 	@echo "--> Building build/celestia-appd with multiplexer enabled"
 	@go build $(BUILD_FLAGS_MULTIPLEXER) -o build/celestia-appd ./cmd/celestia-appd

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -66,7 +66,7 @@ RUN uname -a &&\
     CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     OVERRIDE_MAX_SQUARE_SIZE=${MAX_SQUARE_SIZE} \
     OVERRIDE_UPGRADE_HEIGHT_DELAY=${UPGRADE_HEIGHT_DELAY} \
-    make build download=false
+    make build DOWNLOAD=false
 
 # Stage 3: Create a minimal image to run the celestia-appd binary
 # Ignore hadolint rule because hadolint can't parse the variable.

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -66,7 +66,7 @@ RUN uname -a &&\
     CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     OVERRIDE_MAX_SQUARE_SIZE=${MAX_SQUARE_SIZE} \
     OVERRIDE_UPGRADE_HEIGHT_DELAY=${UPGRADE_HEIGHT_DELAY} \
-    make build
+    make build-skip-download
 
 # Stage 3: Create a minimal image to run the celestia-appd binary
 # Ignore hadolint rule because hadolint can't parse the variable.

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -66,7 +66,7 @@ RUN uname -a &&\
     CGO_ENABLED=${CGO_ENABLED} GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
     OVERRIDE_MAX_SQUARE_SIZE=${MAX_SQUARE_SIZE} \
     OVERRIDE_UPGRADE_HEIGHT_DELAY=${UPGRADE_HEIGHT_DELAY} \
-    make build-skip-download
+    make build download=false
 
 # Stage 3: Create a minimal image to run the celestia-appd binary
 # Ignore hadolint rule because hadolint can't parse the variable.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4709

## Testing

```
make build-docker-multiplexer
```

```
$ make build
--> Updating go.mod
--> Updating go.mod in ./test/interchain
--> Downloading celestia-app v3.9.0-rc0 binary
Skipping download because expected version already downloaded: celestia-app_darwin_v3_arm64.tar.gz
--> Building build/celestia-appd with multiplexer enabled

$ make build DOWNLOAD=false
--> Updating go.mod
--> Updating go.mod in ./test/interchain
--> Building build/celestia-appd with multiplexer enabled

$ make build DOWNLOAD=true
--> Updating go.mod
--> Updating go.mod in ./test/interchain
--> Downloading celestia-app v3.9.0-rc0 binary
Skipping download because expected version already downloaded: celestia-app_darwin_v3_arm64.tar.gz
--> Building build/celestia-appd with multiplexer enabled
```