### PR TITLE
fix: can not open trace writer for empty file

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -401,9 +401,11 @@ func openDB(rootDir string, backendType db.BackendType) (db.DB, error) {
 	return db.NewDB("application", backendType, dataDir)
 }
 
+// openTraceWriter opens a trace writer for the given file.
+// If the file is empty, it returns no writer and no error.
 func openTraceWriter(traceWriterFile string) (w io.WriteCloser, err error) {
 	if traceWriterFile == "" {
-		return w, fmt.Errorf("can not open trace writer for empty file")
+		return w, err
 	}
 	return os.OpenFile(
 		traceWriterFile,


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4713

## Testing

```shell
./scripts/single-node.sh
```

works now.

## Follow ups
- [ ] Create another multiplexer release
- [ ] Bump multiplexer release in go.mod