### PR TITLE
fix: correct version command in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell echo $(shell git describe --tags 2>/dev/null || git log -1 --format='%h') | sed 's/^v//')
+VERSION := $(shell echo $(shell git describe --tags --always --match "v*") | sed 's/^v//')
 COMMIT := $(shell git rev-parse --short HEAD)
 DOCKER := $(shell which docker)
 PROJECTNAME=$(shell basename "$(PWD)")

--- a/docker/txsim/Dockerfile
+++ b/docker/txsim/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: generate txsim binary
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.23.6-alpine3.20 as builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.23.6-alpine3.20 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION


<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
closes #4712

The existing command just looked at tags with no constraints, this became a problem with a second go.mod being introduced. 

The new command filters by tags beginning with `v` (i.e no workflow or multiplexer tags ), and strips the v. This is in line with how it is in other binaries.

running locally I get

```sh
celestia-appd version
4.0.0-rc1-32-g229e6ab4

# embedded version
celestia-appd passthrough v3 version
3.9.0-rc0
```

If this is run on a tag itself, it should return just the tag. E.g. `4.0.0-rc1`

This is in line with how it is done in [the sdk](https://github.com/celestiaorg/cosmos-sdk/blob/9901e41a28bad6e39de0e464038a2718ed4e8ac3/Makefile#L5)

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
