### PR TITLE
fix: use 36658 for abci over grpc for v3.x

### DIFF
--- a/cmd/celestia-appd/cmd/start.go
+++ b/cmd/celestia-appd/cmd/start.go
@@ -160,7 +160,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 
 	cmd.Flags().String(flags.FlagHome, defaultNodeHome, "The application home directory")
 	cmd.Flags().Bool(flagWithTendermint, true, "Run abci app embedded in-process with tendermint")
-	cmd.Flags().String(flagAddress, "tcp://0.0.0.0:26658", "Listen address")
+	cmd.Flags().String(flagAddress, "tcp://0.0.0.0:36658", "Listen address")
 	cmd.Flags().String(flagTransport, "socket", "Transport protocol: socket, grpc")
 	cmd.Flags().String(flagTraceStore, "", "Enable KVStore tracing to an output file")
 	cmd.Flags().String(server.FlagMinGasPrices, "", "Minimum gas prices to accept for transactions; Any fee in a tx must meet this minimum (e.g. 0.01photino;0.0001stake)")

--- a/local_devnet/celestia-app/config.toml
+++ b/local_devnet/celestia-app/config.toml
@@ -12,7 +12,7 @@
 
 # TCP or UNIX socket address of the ABCI application,
 # or the name of an ABCI application compiled in with the CometBFT binary
-proxy_app = "tcp://127.0.0.1:26658"
+proxy_app = "tcp://127.0.0.1:36658"
 
 # A custom human readable name for this node
 moniker = "local_devnet"
@@ -96,10 +96,16 @@ laddr = "tcp://0.0.0.0:26657"
 cors_allowed_origins = []
 
 # A list of methods the client is allowed to use with cross-domain requests
-cors_allowed_methods = ["HEAD", "GET", "POST", ]
+cors_allowed_methods = ["HEAD", "GET", "POST"]
 
 # A list of non simple headers the client is allowed to use with cross-domain requests
-cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time", ]
+cors_allowed_headers = [
+    "Origin",
+    "Accept",
+    "Content-Type",
+    "X-Requested-With",
+    "X-Server-Time",
+]
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -516,4 +522,13 @@ pyroscope_trace = false
 # pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 # inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 # block_count, block_duration.
-pyroscope_profile_types = ["cpu", "alloc_objects", "inuse_objects", "goroutines", "mutex_count", "mutex_duration", "block_count", "block_duration", ]
+pyroscope_profile_types = [
+    "cpu",
+    "alloc_objects",
+    "inuse_objects",
+    "goroutines",
+    "mutex_count",
+    "mutex_duration",
+    "block_count",
+    "block_duration",
+]

--- a/local_devnet/celestia-app/config.toml
+++ b/local_devnet/celestia-app/config.toml
@@ -96,16 +96,10 @@ laddr = "tcp://0.0.0.0:26657"
 cors_allowed_origins = []
 
 # A list of methods the client is allowed to use with cross-domain requests
-cors_allowed_methods = ["HEAD", "GET", "POST"]
+cors_allowed_methods = ["HEAD", "GET", "POST", ]
 
 # A list of non simple headers the client is allowed to use with cross-domain requests
-cors_allowed_headers = [
-    "Origin",
-    "Accept",
-    "Content-Type",
-    "X-Requested-With",
-    "X-Server-Time",
-]
+cors_allowed_headers = ["Origin", "Accept", "Content-Type", "X-Requested-With", "X-Server-Time", ]
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
@@ -522,13 +516,4 @@ pyroscope_trace = false
 # pyroscope. Available profile types are: cpu, alloc_objects, alloc_space,
 # inuse_objects, inuse_space, goroutines, mutex_count, mutex_duration,
 # block_count, block_duration.
-pyroscope_profile_types = [
-    "cpu",
-    "alloc_objects",
-    "inuse_objects",
-    "goroutines",
-    "mutex_count",
-    "mutex_duration",
-    "block_count",
-    "block_duration",
-]
+pyroscope_profile_types = ["cpu", "alloc_objects", "inuse_objects", "goroutines", "mutex_count", "mutex_duration", "block_count", "block_duration", ]


### PR DESCRIPTION
## Overview

I hope this is the correct target branch?

This PR replicates the changes in https://github.com/celestiaorg/cosmos-sdk/pull/576 but for celestia-app/v3.

ref: #4646