### PR TITLE
fix: use standard appDirectory where applicable

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ make bbr-enable
 
 | Variable            | Explanation                                  | Default value                                               | Required |
 |---------------------|----------------------------------------------|-------------------------------------------------------------|----------|
-| `CELESTIA_APP_HOME` | Where the application files should be saved. | [`$HOME/.celestia-appd`](https://pkg.go.dev/os#UserHomeDir) | Optional |
+| `CELESTIA_APP_HOME` | Where the application files should be saved. | [`$HOME/.celestia-app`](https://pkg.go.dev/os#UserHomeDir) | Optional |
 
 ### Using celestia-appd
 

--- a/cmd/celestia-appd/cmd/testnet.go
+++ b/cmd/celestia-appd/cmd/testnet.go
@@ -50,7 +50,7 @@ func NewInPlaceTestnetCmd() *cobra.Command {
 with the aim of facilitating testing procedures. This command replaces existing validator data with updated information,
 thereby removing the old validator set and introducing a new set suitable for local testing purposes. By altering the state extracted from the mainnet node,
 it enables developers to configure their local environments to reflect mainnet conditions more accurately.`
-	cmd.Example = `celestia-appd in-place-testnet testing-1 celestiavaloper1plclwg8j7lx42aufxmq5xsuuwddd0840f4a56d --home $HOME/.celestia-appd/validator1 --accounts-to-fund="celestia1hhtl7m03qnkk9s0ane7dr720ujegq03sd64arq,celestia1plclwg8j7lx42aufxmq5xsuuwddd0840v2ldvt"`
+	cmd.Example = `celestia-appd in-place-testnet testing-1 celestiavaloper1plclwg8j7lx42aufxmq5xsuuwddd0840f4a56d --home $HOME/.celestia-app/validator1 --accounts-to-fund="celestia1hhtl7m03qnkk9s0ane7dr720ujegq03sd64arq,celestia1plclwg8j7lx42aufxmq5xsuuwddd0840v2ldvt"`
 
 	cmd.Flags().String(flagAccountsToFund, "", "Comma-separated list of account addresses that will be funded for testing purposes")
 	return cmd

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,7 +54,7 @@ FROM ${RUNTIME_IMAGE} AS runtime
 # Ref: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000
 ARG UID=10001
 ARG USER_NAME=celestia
-ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-appd
+ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-app
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     bash \

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -77,7 +77,7 @@ FROM ${RUNTIME_IMAGE} AS runtime
 # Ref: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000
 ARG UID=10001
 ARG USER_NAME=celestia
-ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-appd
+ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-app
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \
     bash \

--- a/docker/txsim/Dockerfile
+++ b/docker/txsim/Dockerfile
@@ -29,7 +29,7 @@ FROM docker.io/alpine:3.20
 ARG UID=10001
 ARG USER_NAME=celestia
 
-ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-appd
+ENV CELESTIA_APP_HOME=/home/${USER_NAME}/.celestia-app
 
 # hadolint ignore=DL3018
 RUN apk update && apk add --no-cache \


### PR DESCRIPTION
## Overview

Fixes a regression introduced in https://github.com/celestiaorg/celestia-app/pull/4666

Should use the standard `appDirectory` const: https://github.com/celestiaorg/celestia-app/blob/main/app/init.go#L18