### PR TITLE
test(scripts): add missing genesis

### DIFF
--- a/local_devnet/celestia-app/genesis.json
+++ b/local_devnet/celestia-app/genesis.json
@@ -264,8 +264,16 @@
       "constitution": ""
     },
     "hyperlane": {
-      "ism_genesis": null,
-      "post_dispatch_genesis": null,
+      "ism_genesis": {
+        "isms": [],
+        "validator_storage_locations": []
+      },
+      "post_dispatch_genesis": {
+        "igps": [],
+        "igp_gas_configs": [],
+        "merkle_tree_hooks": [],
+        "noop_hooks": []
+      },
       "mailboxes": [],
       "messages": [],
       "ism_sequence": "0",

--- a/multiplexer/cmd/start.go
+++ b/multiplexer/cmd/start.go
@@ -87,6 +87,9 @@ func getState(cfg *cmtcfg.Config) (state.State, error) {
 				return tmtypes.GenesisDocFromFile(cfg.GenesisFile())
 			},
 		)
+		if err != nil {
+			return state.State{}, err
+		}
 
 		// we only fill the app version and the chain id
 		// the rest of the state is not needed by the multiplexer
@@ -100,9 +103,9 @@ func getState(cfg *cmtcfg.Config) (state.State, error) {
 		}
 	case internal.GenesisVersion2:
 		s, _, err = node.LoadStateFromDBOrGenesisDocProvider(db, internal.GetGenDocProvider(cfg))
-	}
-	if err != nil {
-		return state.State{}, err
+		if err != nil {
+			return state.State{}, err
+		}
 	}
 
 	return s, nil


### PR DESCRIPTION
found when trying to replicate https://github.com/celestiaorg/celestia-app/issues/4763#issuecomment-2855796623.
running ` ./local_devnet/scripts/init.sh` would fail on hyperlane genesis unmarshal.

the script doesn't work nice because of the renaming of local_devnet chain id.
`MULTIPLEXER=true  ./local_devnet/scripts/init.sh` works fine tho.