### PR TITLE
fix: ensure core block api runs through multilplexer native app

### DIFF
--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -16,7 +16,7 @@ ARG MAX_SQUARE_SIZE
 ARG UPGRADE_HEIGHT_DELAY
 # the docker registry used for the embedded v3 binary.
 ARG CELESTIA_APP_REPOSITORY=ghcr.io/celestiaorg/celestia-app-standalone
-ARG CELESTIA_VERSION="v3.10.0-rc0"
+ARG CELESTIA_VERSION="v3.10.0-rc2"
 
 # Stage 1: this base image contains already released binaries which can be embedded in the multiplexer.
 FROM ${CELESTIA_APP_REPOSITORY}:${CELESTIA_VERSION} AS base


### PR DESCRIPTION
## Overview

Due to the multiplexer copying start command functionality from the sdk, I discovered that running native apps (for example, v4) will not expose the core BlockAPI when through the multiplexer, i.e. the changes in https://github.com/celestiaorg/cosmos-sdk/pull/455 do not take effect which spin up the core BlockAPI in-process.

The BlockAPI is however available right now when:
- Running embedded apps (for example, v3) through the multiplexer. 
- Running a v4 standalone app without the multiplexer.

The replication of start command code being distributed and copied amongst different places is extremely error prone to manage, and quite frankly, its spaghetti. 