### PR TITLE
refactor: use 127.0.0.1 for RPC GRPC listen address

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -269,7 +269,7 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	// Set broadcast timeout to be 50 seconds in order to avoid timeouts for long block times
 	cfg.RPC.TimeoutBroadcastTxCommit = 50 * time.Second
 	cfg.RPC.MaxBodyBytes = int64(8388608) // 8 MiB
-	cfg.RPC.GRPCListenAddress = "tcp://0.0.0.0:9098"
+	cfg.RPC.GRPCListenAddress = "tcp://127.0.0.1:9098"
 
 	cfg.Mempool.TTLNumBlocks = 12
 	cfg.Mempool.TTLDuration = 75 * time.Second

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -64,7 +64,7 @@ func TestDefaultConsensusConfig(t *testing.T) {
 		want := tmcfg.DefaultRPCConfig()
 		want.TimeoutBroadcastTxCommit = 50 * time.Second
 		want.MaxBodyBytes = int64(8388608) // 8 MiB
-		want.GRPCListenAddress = "tcp://0.0.0.0:9098"
+		want.GRPCListenAddress = "tcp://127.0.0.1:9098"
 
 		assert.Equal(t, want, got.RPC)
 	})

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -12,14 +12,14 @@ Celestia-app v4.0.0 introduces support for a [multiplexer](https://github.com/ce
 
 #### `rpc.grpc_laddr`
 
-The `rpc.grpc_laddr` config option is now required when running the celestia-app binary with the multiplexer. This option can be set via CLI flag `--rpc.grpc_laddr tcp://0.0.0.0:9098` or in the `config.toml`:
+The `rpc.grpc_laddr` config option is now required when running the celestia-app binary with the multiplexer. This option can be set via CLI flag `--rpc.grpc_laddr tcp://127.0.0.1:9098` or in the `config.toml`:
 
 ```toml
 [rpc]
 
 # TCP or UNIX socket address for the gRPC server to listen on
 # NOTE: This server only supports /broadcast_tx_commit
-grpc_laddr = "tcp://0.0.0.0:9098"
+grpc_laddr = "tcp://127.0.0.1:9098"
 ```
 
 ## v3.0.0

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -112,7 +112,6 @@ startCelestiaApp() {
     --grpc.enable \
     --grpc-web.enable \
     --timeout-commit 1s \
-    --rpc.grpc_laddr tcp://0.0.0.0:9098 \
     --force-no-bbr # no need to require BBR usage on a local node
 }
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4729

## Testing

IIUC then the RPC GRPC listen address is used when the multiplexer binary is running celestia-app v3 prior to the v4 activation height. Since `./scripts/single-node-upgrades.sh` still works, it seems safe to use `127.0.0.1` instead of `0.0.0.0`.