### PR TITLE
chore: fix minor typos and syntax issues in startup scripts

### DIFF
--- a/scripts/build-run-single-node.sh
+++ b/scripts/build-run-single-node.sh
@@ -16,7 +16,7 @@ CHAINID="private"
 coins="1000000000000000utia"
 ${BIN_PATH} init $CHAINID --chain-id $CHAINID --home ${HOME_DIR}
 ${BIN_PATH} keys add validator --keyring-backend="test" --home ${HOME_DIR}
-# this won't work because the some proto types are declared twice and the logs output to stdout (dependency hell involving iavl)
+# this won't work because some proto types are declared twice and the logs output to stdout (dependency hell involving iavl)
 ${BIN_PATH} genesis add-genesis-account $(${BIN_PATH} keys show validator -a --keyring-backend="test" --home ${HOME_DIR}) $coins --home ${HOME_DIR}
 ${BIN_PATH} genesis gentx validator 5000000000utia \
 	--keyring-backend="test" \

--- a/scripts/localnet-blocks-test.sh
+++ b/scripts/localnet-blocks-test.sh
@@ -49,7 +49,7 @@ while [ ${CNT} -lt $ITER ]; do
     docker restart ${rand_container} &>/dev/null &
   fi
 
-  let CNT=CNT+1
+  CNT=$((CNT + 1))
   sleep $SLEEP
 done
 

--- a/scripts/mocha-block-sync.sh
+++ b/scripts/mocha-block-sync.sh
@@ -36,7 +36,7 @@ rm -r "$CELESTIA_APP_HOME"
 echo "Initializing config files..."
 celestia-appd init ${NODE_NAME} --chain-id ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
-echo "Settings seeds in config.toml..."
+echo "Setting seeds in config.toml..."
 sed -i.bak -e "s/^seeds *=.*/seeds = \"$SEEDS\"/" $CELESTIA_APP_HOME/config/config.toml
 
 echo "Downloading genesis file..."


### PR DESCRIPTION
This PR makes small but meaningful improvements across several scripts:

- **Fixed a comment typo**  where "the some" was corrected to "some".
- **Corrected arithmetic syntax**, replacing `let CNT=CNT+1` with the more portable `CNT=$((CNT + 1))`.
- **Fixed a typo in output**,  "Settings seeds" → "Setting seeds".