### PR TITLE
docs: remove redundant double spaces

### DIFF
--- a/test/e2e/benchmark/throughput.go
+++ b/test/e2e/benchmark/throughput.go
@@ -28,7 +28,7 @@ var bigBlockManifest = Manifest{
 		Volume:        resource.MustParse("1Gi"),
 	},
 	SelfDelegation: 10000000,
-	// @TODO Update the CelestiaAppVersion and  TxClientVersion to the latest
+	// @TODO Update the CelestiaAppVersion and TxClientVersion to the latest
 	// version of the main branch once the PR#3261 is merged by addressing this
 	// issue https://github.com/celestiaorg/celestia-app/issues/3603.
 	CelestiaAppVersion: "pr-3261",
@@ -70,7 +70,7 @@ func TwoNodeSimple(logger *log.Logger) error {
 		CelestiaAppVersion: latestVersion,
 		TxClientVersion:    testnet.TxsimVersion,
 		EnableLatency:      false,
-		LatencyParams:      LatencyParams{70, 0}, // in  milliseconds
+		LatencyParams:      LatencyParams{70, 0}, // in milliseconds
 		BlobsPerSeq:        6,
 		BlobSequences:      60,
 		BlobSizes:          "200000",

--- a/test/e2e/testnet/node.go
+++ b/test/e2e/testnet/node.go
@@ -59,7 +59,7 @@ type Node struct {
 
 	rpcProxyHost string
 	// FIXME: This does not work currently with the reverse proxy
-	// grpcProxyHost  string
+	// grpcProxyHost string
 	traceProxyHost string
 
 	logger *log.Logger


### PR DESCRIPTION

* Trimmed extra spaces/invisible chars in:
  - test/e2e/benchmark/throughput.go
  - test/e2e/testnet/node.go

No functional changes.
