### PR TITLE
chore: remove default gas price in tx client

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -84,13 +84,7 @@ func (e *ExecutionError) Error() string {
 	return fmt.Sprintf("tx execution failed with code %d: %s", e.Code, e.ErrorLog)
 }
 
-// WithDefaultGasPrice sets the gas price.
-func WithDefaultGasPrice(price float64) Option {
-	return func(c *TxClient) {
-		c.defaultGasPrice = price
-	}
-}
-
+// WithPollTime sets a custom polling interval with which to check if a transaction has been submitted
 func WithPollTime(time time.Duration) Option {
 	return func(c *TxClient) {
 		c.pollTime = time
@@ -154,8 +148,7 @@ type TxClient struct {
 	conns []*grpc.ClientConn
 	// how often to poll the network for confirmation of a transaction
 	pollTime time.Duration
-	// defaultGasPrice is the price used if no price is provided
-	defaultGasPrice float64
+	// sets the default account with which to submit transactions
 	defaultAccount  string
 	defaultAddress  sdktypes.AccAddress
 	// txTracker maps the tx hash to the Sequence and signer of the transaction
@@ -190,7 +183,6 @@ func NewTxClient(
 		registry:            registry,
 		conns:               []*grpc.ClientConn{conn},
 		pollTime:            DefaultPollTime,
-		defaultGasPrice:     appconsts.DefaultMinGasPrice,
 		defaultAccount:      records[0].Name,
 		defaultAddress:      addr,
 		txTracker:           make(map[string]txInfo),
@@ -248,13 +240,6 @@ func SetupTxClient(
 
 		accounts = append(accounts, NewAccount(record.Name, accNum, seqNum))
 	}
-
-	// query the min gas price from the chain
-	minPrice, err := QueryMinimumGasPrice(ctx, conn)
-	if err != nil {
-		return nil, fmt.Errorf("querying minimum gas price: %w", err)
-	}
-	options = append([]Option{WithDefaultGasPrice(minPrice)}, options...)
 
 	signer, err := NewSigner(keys, encCfg.TxConfig, chainID, accounts...)
 	if err != nil {
@@ -634,9 +619,6 @@ func (client *TxClient) EstimateGasPriceAndUsage(
 
 // EstimateGasPrice calls the gas estimation endpoint to return the estimated gas price based on priority.
 func (client *TxClient) EstimateGasPrice(ctx context.Context, priority gasestimation.TxPriority) (float64, error) {
-	client.mtx.Lock()
-	defer client.mtx.Unlock()
-
 	resp, err := client.gasEstimationClient.EstimateGasPrice(ctx, &gasestimation.EstimateGasPriceRequest{
 		TxPriority: priority,
 	})
@@ -747,12 +729,6 @@ func (client *TxClient) GetTxFromTxTracker(hash string) (sequence uint64, signer
 // Signer exposes the tx clients underlying signer
 func (client *TxClient) Signer() *Signer {
 	return client.signer
-}
-
-func (client *TxClient) SetDefaultGasPrice(price float64) {
-	client.mtx.Lock()
-	defer client.mtx.Unlock()
-	client.defaultGasPrice = price
 }
 
 // QueryMinimumGasPrice queries both the nodes local and network wide

--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -146,14 +146,6 @@ func (suite *TxClientTestSuite) TestSubmitTx() {
 		require.NoError(t, err)
 		require.Equal(t, abci.CodeTypeOK, resp.Code)
 	})
-
-	t.Run("submit tx with an updated default gas price", func(t *testing.T) {
-		suite.txClient.SetDefaultGasPrice(appconsts.DefaultMinGasPrice / 2)
-		resp, err := suite.txClient.SubmitTx(suite.ctx.GoContext(), []sdk.Msg{msg})
-		require.NoError(t, err)
-		require.Equal(t, abci.CodeTypeOK, resp.Code)
-		suite.txClient.SetDefaultGasPrice(appconsts.DefaultMinGasPrice)
-	})
 }
 
 func (suite *TxClientTestSuite) TestConfirmTx() {


### PR DESCRIPTION
I believe this should have been removed as part of the switch to using the gas estimation services
