### PR TITLE
refactor(multiplexer): simplify `getState`

### DIFF
--- a/multiplexer/cmd/start.go
+++ b/multiplexer/cmd/start.go
@@ -70,11 +70,6 @@ func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error)
 		return "", 0, err
 	}
 
-	var (
-		appVersion uint64
-		chainID    string
-	)
-
 	switch genVer {
 	case internal.GenesisVersion1:
 		s, _, err := tmnode.LoadStateFromDBOrGenesisDocProvider(
@@ -88,7 +83,7 @@ func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error)
 		}
 
 		appVersion = s.ConsensusParams.Version.AppVersion
-		chainID = s.ChainID
+		chainId = s.ChainID
 
 	case internal.GenesisVersion2:
 		s, _, err := node.LoadStateFromDBOrGenesisDocProvider(db, internal.GetGenDocProvider(cfg))
@@ -97,10 +92,10 @@ func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error)
 		}
 
 		appVersion = s.ConsensusParams.Version.App
-		chainID = s.ChainID
+		chainId = s.ChainID
 	}
 
-	return chainID, appVersion, nil
+	return chainId, appVersion, nil
 }
 
 func getAndValidateConfig(svrCtx *server.Context) (serverconfig.Config, error) {

--- a/multiplexer/cmd/start.go
+++ b/multiplexer/cmd/start.go
@@ -64,7 +64,7 @@ func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error)
 		// fallback to latest version if the genesis version doesn't exist
 		if errors.Is(err, internal.ErrGenesisNotFound) {
 			s, _, err := node.LoadStateFromDBOrGenesisDocProvider(db, internal.GetGenDocProvider(cfg))
-			return s.ChainID, s.ConsensusParams.Version.App, err
+			return s.ChainID, s.Version.Consensus.App, err
 		}
 
 		return "", 0, err
@@ -82,7 +82,7 @@ func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error)
 			return "", 0, err
 		}
 
-		appVersion = s.ConsensusParams.Version.AppVersion
+		appVersion = s.Version.Consensus.App
 		chainId = s.ChainID
 
 	case internal.GenesisVersion2:
@@ -91,7 +91,7 @@ func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error)
 			return "", 0, err
 		}
 
-		appVersion = s.ConsensusParams.Version.App
+		appVersion = s.Version.Consensus.App
 		chainId = s.ChainID
 	}
 

--- a/multiplexer/cmd/start.go
+++ b/multiplexer/cmd/start.go
@@ -52,7 +52,7 @@ func start(versions abci.Versions, svrCtx *server.Context, clientCtx client.Cont
 }
 
 // getState opens the db and fetches the existing state.
-func getState(cfg *cmtcfg.Config) (string, uint64, error) {
+func getState(cfg *cmtcfg.Config) (chainId string, appVersion uint64, err error) {
 	db, err := openDBM(cfg)
 	if err != nil {
 		return "", 0, err

--- a/multiplexer/cmd/start.go
+++ b/multiplexer/cmd/start.go
@@ -8,15 +8,11 @@ import (
 	dbm "github.com/cometbft/cometbft-db"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/node"
-	cmtstate "github.com/cometbft/cometbft/proto/tendermint/state"
-	cmtversion "github.com/cometbft/cometbft/proto/tendermint/version"
-	"github.com/cometbft/cometbft/state"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/server"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/cosmos/cosmos-sdk/server/types"
 	tmnode "github.com/tendermint/tendermint/node"
-	tmstate "github.com/tendermint/tendermint/state"
 	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/celestiaorg/celestia-app/v4/multiplexer/abci"
@@ -29,16 +25,14 @@ func start(versions abci.Versions, svrCtx *server.Context, clientCtx client.Cont
 		return err
 	}
 
-	state, err := getState(svrCtx.Config)
+	chainID, appVersion, err := getState(svrCtx.Config)
 	if err != nil {
 		return fmt.Errorf("failed to get current app state: %w", err)
 	}
 
-	appVersion := state.Version.Consensus.App
+	svrCtx.Logger.Info("initializing multiplexer", "app_version", appVersion, "chain_id", chainID)
 
-	svrCtx.Logger.Info("initializing multiplexer", "app_version", appVersion, "chain_id", state.ChainID)
-
-	mp, err := abci.NewMultiplexer(svrCtx, svrCfg, clientCtx, appCreator, versions, state.ChainID, appVersion)
+	mp, err := abci.NewMultiplexer(svrCtx, svrCfg, clientCtx, appCreator, versions, chainID, appVersion)
 	if err != nil {
 		return err
 	}
@@ -58,10 +52,10 @@ func start(versions abci.Versions, svrCtx *server.Context, clientCtx client.Cont
 }
 
 // getState opens the db and fetches the existing state.
-func getState(cfg *cmtcfg.Config) (state.State, error) {
+func getState(cfg *cmtcfg.Config) (string, uint64, error) {
 	db, err := openDBM(cfg)
 	if err != nil {
-		return state.State{}, err
+		return "", 0, err
 	}
 	defer db.Close()
 
@@ -70,45 +64,43 @@ func getState(cfg *cmtcfg.Config) (state.State, error) {
 		// fallback to latest version if the genesis version doesn't exist
 		if errors.Is(err, internal.ErrGenesisNotFound) {
 			s, _, err := node.LoadStateFromDBOrGenesisDocProvider(db, internal.GetGenDocProvider(cfg))
-			return s, err
+			return s.ChainID, s.ConsensusParams.Version.App, err
 		}
 
-		return state.State{}, err
+		return "", 0, err
 	}
 
-	var s state.State
+	var (
+		appVersion uint64
+		chainID    string
+	)
 
 	switch genVer {
 	case internal.GenesisVersion1:
-		var s1 tmstate.State
-		s1, _, err = tmnode.LoadStateFromDBOrGenesisDocProvider(
+		s, _, err := tmnode.LoadStateFromDBOrGenesisDocProvider(
 			db,
 			func() (*tmtypes.GenesisDoc, error) {
 				return tmtypes.GenesisDocFromFile(cfg.GenesisFile())
 			},
 		)
 		if err != nil {
-			return state.State{}, err
+			return "", 0, err
 		}
 
-		// we only fill the app version and the chain id
-		// the rest of the state is not needed by the multiplexer
-		s = state.State{
-			ChainID: s1.ChainID,
-			Version: cmtstate.Version{
-				Consensus: cmtversion.Consensus{
-					App: s1.Version.Consensus.App,
-				},
-			},
-		}
+		appVersion = s.ConsensusParams.Version.AppVersion
+		chainID = s.ChainID
+
 	case internal.GenesisVersion2:
-		s, _, err = node.LoadStateFromDBOrGenesisDocProvider(db, internal.GetGenDocProvider(cfg))
+		s, _, err := node.LoadStateFromDBOrGenesisDocProvider(db, internal.GetGenDocProvider(cfg))
 		if err != nil {
-			return state.State{}, err
+			return "", 0, err
 		}
+
+		appVersion = s.ConsensusParams.Version.App
+		chainID = s.ChainID
 	}
 
-	return s, nil
+	return chainID, appVersion, nil
 }
 
 func getAndValidateConfig(svrCtx *server.Context) (serverconfig.Config, error) {


### PR DESCRIPTION
Simplified `getState` while debugging https://github.com/celestiaorg/celestia-app/issues/4800.

Something was weird in core about `state.Version.Consensus.App` (https://github.com/celestiaorg/celestia-core/blob/v1.51.0-tm-v0.34.35/state/state.go#L326-L377), but eventually reverted that change https://github.com/celestiaorg/celestia-app/pull/4801/commits/b0ecce51788a29d7f33ed1c15691a561c0de9ebe as it was a core specific change.