### PR TITLE
fix(multiplexer): arabica block sync

### DIFF
--- a/multiplexer/abci/remote_v1.go
+++ b/multiplexer/abci/remote_v1.go
@@ -536,6 +536,10 @@ func validatorUpdatesV2ToV1(validators []abciv2.ValidatorUpdate) []abciv1.Valida
 }
 
 func consensusParamsV1ToV2(params *abciv1.ConsensusParams) *typesv2.ConsensusParams {
+	if params == nil {
+		return nil
+	}
+
 	consensusParamsV2 := &typesv2.ConsensusParams{}
 	if blockParams := params.GetBlock(); blockParams != nil {
 		consensusParamsV2.Block = &typesv2.BlockParams{

--- a/multiplexer/abci/remote_v1_test.go
+++ b/multiplexer/abci/remote_v1_test.go
@@ -1,0 +1,14 @@
+package abci
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConsensusParamsV1ToV2(t *testing.T) {
+	t.Run("should return nil if params are nil", func(t *testing.T) {
+		got := consensusParamsV1ToV2(nil)
+		assert.Nil(t, got)
+	})
+}

--- a/scripts/arabica-block-sync.sh
+++ b/scripts/arabica-block-sync.sh
@@ -43,4 +43,4 @@ echo "Downloading genesis file..."
 celestia-appd download-genesis ${CHAIN_ID}
 
 echo "Starting celestia-appd..."
-celestia-appd start --v2-upgrade-height 1751707 --force-no-bbr
+celestia-appd start --force-no-bbr


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4800

The multiplexer was converting a `nil` consensus params into a zeroed out consensus params. celestia-core used the zeroed out consensus params to overwrite the app version in state 😭 

This fix modifies the multiplexer to return `nil` consensus params if InitChain returned `nil` consensus params to match the behavior on v3.x.

## Testing

```
make install
./scripts/arabica-block-sync.sh
```

starts block syncing from genesis