### PR TITLE
feat(pkg/user): Add non-existent accounts to Signer's account map for lazy loading

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -158,8 +158,6 @@ func (s *Signer) AccountByAddress(address sdktypes.AccAddress) *Account {
 			return nil
 		}
 
-		// We found a keyring record for this address
-		// Add it to our accounts map with zeroed account/sequence for lazy loading later
 		acc := &Account{
 			name:          record.Name,
 			address:       address,

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -167,7 +167,6 @@ func (s *Signer) AccountByAddress(address sdktypes.AccAddress) *Account {
 			sequence:      0,
 		}
 
-		// Get the pubkey if possible
 		if pk, err := record.GetPubKey(); err == nil {
 			acc.pubKey = pk
 		}

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -165,11 +165,12 @@ func (s *Signer) AccountByAddress(address sdktypes.AccAddress) *Account {
 			sequence:      0,
 		}
 
-		if pk, err := record.GetPubKey(); err == nil {
-			acc.pubKey = pk
+		pk, err := record.GetPubKey()
+		if err != nil {
+			return nil
 		}
+		acc.pubKey = pk
 
-		// Add to our maps
 		s.accounts[record.Name] = acc
 		s.addressToAccountMap[addrStr] = record.Name
 

--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -153,7 +153,6 @@ func (s *Signer) AccountByAddress(address sdktypes.AccAddress) *Account {
 
 	accountName, exists := s.addressToAccountMap[addrStr]
 	if !exists {
-		// Try to find this address in the keyring
 		record, err := s.keys.KeyByAddress(address)
 		if err != nil {
 			return nil

--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -686,7 +686,11 @@ func (client *TxClient) Account(name string) *Account {
 func (client *TxClient) AccountByAddress(address sdktypes.AccAddress) *Account {
 	client.mtx.Lock()
 	defer client.mtx.Unlock()
-	return client.signer.AccountByAddress(address)
+	acc, err := client.signer.AccountByAddress(address)
+	if err != nil {
+		return nil
+	}
+	return acc
 }
 
 func (client *TxClient) DefaultAddress() sdktypes.AccAddress {


### PR DESCRIPTION
Fixes #4803 by:
- Modified SetupTxClient to add accounts with zero values if not in state
- Updated checkAccountLoaded to retry querying for zero-value accounts
- Enhanced AccountByAddress to lookup addresses in keyring when not found

Allows proper lazy-loading of accounts that don't exist during node startup.