### PR TITLE
fix(multiplexer): clean up tmp directories

### DIFF
--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -48,9 +48,7 @@ func New(name string, bin []byte, cfg ...CfgOption) (*Appd, error) {
 	}
 
 	defer func() {
-		if err != nil {
-			cleanup()
-		}
+		cleanup()
 	}()
 
 	// extract all files from the tar archive to the temp directory


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4838

Previously every `celestia-appd` invocation created a tmp directory and didn't clean it up. With this PR, the tmp directory gets cleaned up.

## Testing

```shell
$ ls  /var/folders/y0/dd92_x8x4tlf397xstgwfz_c0000gn/T/ | grep appd-v3-* | wc -l
    2289

$ rm -rf /var/folders/y0/dd92_x8x4tlf397xstgwfz_c0000gn/T/appd-v3-*

$ ls  /var/folders/y0/dd92_x8x4tlf397xstgwfz_c0000gn/T/ | grep appd-v3-* | wc -l
       0
       
$ make install

$ celestia-appd foo
Error: unknown command "foo" for "celestia-appd"
Run 'celestia-appd --help' for usage.

$ ls  /var/folders/y0/dd92_x8x4tlf397xstgwfz_c0000gn/T/ | grep appd-v3-* | wc -l
       0
```