### PR TITLE
fix(txsim): Correct BlobSequence share version assignment and PollTime env var priority

### DIFF
--- a/test/cmd/txsim/cli.go
+++ b/test/cmd/txsim/cli.go
@@ -134,7 +134,7 @@ account that can act as the master account. The command runs until all sequences
 
 				sequence := txsim.NewBlobSequence(sizes, blobsPerPFB)
 				if blobShareVersion >= 0 {
-					sequence.WithShareVersion(uint8(blobShareVersion))
+					sequence = sequence.WithShareVersion(uint8(blobShareVersion))
 				}
 
 				sequences = append(sequences, sequence.Clone(blob)...)
@@ -161,11 +161,12 @@ account that can act as the master account. The command runs until all sequences
 				}
 			}
 
-			if os.Getenv(TxsimPoll) != "" && pollTime != user.DefaultPollTime {
-				pollTime, err = time.ParseDuration(os.Getenv(TxsimPoll))
+			if pTimeEnv := os.Getenv(TxsimPoll); pTimeEnv != "" {
+				parsedPollTime, err := time.ParseDuration(pTimeEnv)
 				if err != nil {
-					return fmt.Errorf("parsing poll time: %w", err)
+					return fmt.Errorf("parsing poll time from env %s: %w", TxsimPoll, err)
 				}
+				pollTime = parsedPollTime
 			}
 
 			opts := txsim.DefaultOptions().


### PR DESCRIPTION
1.  **Incorrect `WithShareVersion` usage:** The `WithShareVersion` method on `BlobSequence` returns a new sequence instance, but its result was not being assigned back. This meant the share version was not actually being applied to the sequence. This has been corrected by assigning the result of `sequence.WithShareVersion(...)` back to the `sequence` variable.

2.  **Flawed `TXSIM_POLL` environment variable logic:** The logic for overriding the `pollTime` via the `TXSIM_POLL` environment variable was incorrect. It would ignore the environment variable if the `--poll-time` flag was set to a non-default value. This has been fixed to ensure that if `TXSIM_POLL` is set, its value correctly parses and overrides any `pollTime` value set by the flag or its default. The error message for a failed parse of the environment variable has also been made more specific.
