### PR TITLE
fix(e2e): proper timeout handling in initial height polling loop

### DIFF
--- a/test/docker-e2e/e2e_state_sync_test.go
+++ b/test/docker-e2e/e2e_state_sync_test.go
@@ -83,11 +83,12 @@ func (s *CelestiaTestSuite) TestStateSync() {
 	defer heightCancel()
 
 	// Check immediately first, then on ticker intervals
+	InitialHeightLoop:
 	for {
 		status, err := nodeClient.Status(heightTimeoutCtx)
 		if err == nil && status.SyncInfo.LatestBlockHeight > 0 {
 			initialHeight = status.SyncInfo.LatestBlockHeight
-			break
+			break InitialHeightLoop
 		}
 
 		select {
@@ -95,11 +96,11 @@ func (s *CelestiaTestSuite) TestStateSync() {
 			// Continue the loop
 		case <-heightTimeoutCtx.Done():
 			t.Logf("Timed out waiting for initial height")
-			break
+			break InitialHeightLoop
 		}
 	}
 
-	s.Require().Greater(initialHeight, int64(0), "failed to get initial height")
+	s.Require().Greater(initialHeight, int64(0), "failed to get initial height after timeout or error")
 	targetHeight := initialHeight + blocksToProduce
 	t.Logf("Successfully reached initial height %d", initialHeight)
 


### PR DESCRIPTION
Previously, the `break` inside the `select` block for `heightTimeoutCtx.Done()` only exited the `select`, not the surrounding `for` loop. As a result, if no block was produced within the timeout window, the test would continue looping, repeatedly logging `"Timed out waiting for initial height"`.

###  Fix
The loop is now labeled (`InitialHeightLoop:`), and `break InitialHeightLoop` is used to exit the polling loop cleanly on timeout. This ensures the test exits as expected and fails deterministically if block production is stuck.
