### PR TITLE
fix: make passthrough show help

### DIFF
--- a/multiplexer/cmd/passthrough.go
+++ b/multiplexer/cmd/passthrough.go
@@ -16,13 +16,16 @@ import (
 func NewPassthroughCmd(versions abci.Versions) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "passthrough [version] [command]",
-		Args:               cobra.MinimumNArgs(1),
 		DisableFlagParsing: true,
 		Short:              "Execute a command on a specific app version",
 		Long: `Execute a command on a specific app version.
 This allows interacting with older app versions for debugging or older queries.`,
 		Example: `passthrough v3 status`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) == 0 || (args[0] == "-h" || args[0] == "--help") {
+				return cmd.Help()
+			}
+
 			if len(args) >= 2 && strings.EqualFold("start", args[1]) {
 				return errors.New("cannot passthrough start command")
 			}

--- a/multiplexer/cmd/passthrough_test.go
+++ b/multiplexer/cmd/passthrough_test.go
@@ -20,10 +20,9 @@ func TestNewPassthroughCmd(t *testing.T) {
 		expectedOutput string
 	}{
 		{
-			name:           "required arguments not specified",
-			args:           []string{},
-			versions:       []abci.Version{},
-			expectedErrStr: "requires at least 1 arg(s), only received 0",
+			name:     "arguments not specified",
+			args:     []string{},
+			versions: []abci.Version{},
 		},
 		{
 			name: "version not found existing versions",


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

this pr makes `celestia-appd passthrough`, `celestia-appd passthrough -h` or `celestia-appd passthrough --help` show the commands help information. 


closes #4850 

the reason this change is needed is because `DisableFlagParsing` is set to true so it would always try to execute the command of the underlying binary which would fail without the top level `passthrough` command help showing
