### PR TITLE
revert: "fix(multiplexer): clean up tmp directories (#4842)"

### DIFF
--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -48,7 +48,9 @@ func New(name string, bin []byte, cfg ...CfgOption) (*Appd, error) {
 	}
 
 	defer func() {
-		cleanup()
+		if err != nil {
+			cleanup()
+		}
 	}()
 
 	// extract all files from the tar archive to the temp directory


### PR DESCRIPTION
Reverts https://github.com/celestiaorg/celestia-app/pull/4842 because it caused this regression https://github.com/celestiaorg/celestia-app/issues/4849.

This should unblock @damiannolan from testing https://github.com/celestiaorg/celestia-app/pull/4852#issuecomment-2897276927