### PR TITLE
fix: build docker image for multiple platforms

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -37,7 +37,6 @@ jobs:
       dockerfile: docker/multiplexer.Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}
       packageName: celestia-app
-      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   docker-txsim-build:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -37,7 +37,7 @@ jobs:
       dockerfile: docker/multiplexer.Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}
       packageName: celestia-app
-      buildArgs: "TARGETOS=linux TARGETARCH=amd64"
+      platforms: linux/amd64,linux/arm64
     secrets: inherit
 
   docker-txsim-build:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR removes the usage of buildArgs since it is already set in the reusable pipeline workflow https://github.com/celestiaorg/.github/blob/main/.github/workflows/reusable_dockerfile_pipeline.yml#L269C11-L269C45

closes #4855 

CI could be skipping the build due to me being marked as external. 
