### PR TITLE
ci: update go releaser to support multiplexer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,6 @@ builds:
       - CGO_ENABLED=1
       - CC=o64-clang
       - CXX=o64-clang++
-      - STANDALONE=true
     goarch:
       - amd64
     goos:
@@ -38,7 +37,6 @@ builds:
       - CGO_ENABLED=1
       - CC=oa64-clang
       - CXX=oa64-clang++
-      - STANDALONE=true
     goarch:
       - arm64
     goos:
@@ -60,7 +58,6 @@ builds:
       - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
-      - STANDALONE=true
     goarch:
       - amd64
     goos:
@@ -82,7 +79,6 @@ builds:
       - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-      - STANDALONE=true
     goarch:
       - arm64
     goos:
@@ -99,12 +95,17 @@ builds:
       - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
 dist: ./build/goreleaser
 archives:
-  - formats: ['tar.gz']
+  - id: standalone
+    builds:
+      - darwin-amd64
+      - darwin-arm64
+      - linux-amd64
+      - linux-arm64
+    formats: ['tar.gz']
     # this name template makes the OS and Arch compatible with the results of
     # uname.
     name_template: >-
-      {{ .ProjectName }}
-      {{- if eq .Env.STANDALONE "true" }}-standalone{{ end }}_
+      {{ .ProjectName }}-standalone_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,11 +2,110 @@
 # Since GoReleaser doesn't support CGO natively, our GoReleaser process builds
 # binaries in a Docker image maintained by goreleaser-cross that has CGO support
 # for multiple platforms. See https://github.com/goreleaser/goreleaser-cross
+
 version: 2
 before:
   hooks:
     - go mod tidy
+    # these hooks get run once. We want to explicitly download every embedded binary so we can build the multiplexer
+    # for every arch.
+    - ./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.0-arabica
+    - ./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.0-arabica
+    - ./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.0-arabica
+    - ./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.0-arabica
 builds:
+  - id: darwin-amd64-multiplexer
+    main: ./cmd/celestia-appd
+    binary: celestia-appd
+    env:
+      - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goarch:
+      - amd64
+    goos:
+      - darwin
+    tags:
+      - ledger
+      - multiplexer
+    ldflags:
+      # Ref: https://goreleaser.com/customization/templates/#common-fields
+      # .Version is the version being released
+      # .FullCommit is git commit hash goreleaser is using for the release
+      - -X "{{ .Env.SDKPath }}.Name=celestia-app"
+      - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
+      - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
+      - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
+  - id: darwin-arm64-multiplexer
+    main: ./cmd/celestia-appd
+    binary: celestia-appd
+    env:
+      - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goarch:
+      - arm64
+    goos:
+      - darwin
+    tags:
+      - ledger
+      - multiplexer
+    ldflags:
+      # Ref: https://goreleaser.com/customization/templates/#common-fields
+      # .Version is the version being released
+      # .FullCommit is git commit hash goreleaser is using for the release
+      - -X "{{ .Env.SDKPath }}.Name=celestia-app"
+      - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
+      - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
+      - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
+  - id: linux-amd64-multiplexer
+    main: ./cmd/celestia-appd
+    binary: celestia-appd
+    env:
+      - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    goarch:
+      - amd64
+    goos:
+      - linux
+    tags:
+      - ledger
+      - multiplexer
+    ldflags:
+      # Ref: https://goreleaser.com/customization/templates/#common-fields
+      # .Version is the version being released
+      # .FullCommit is git commit hash goreleaser is using for the release
+      - -X "{{ .Env.SDKPath }}.Name=celestia-app"
+      - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
+      - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
+      - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
+  - id: linux-arm64-multiplexer
+    main: ./cmd/celestia-appd
+    binary: celestia-appd
+    env:
+      - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goarch:
+      - arm64
+    goos:
+      - linux
+    tags:
+      - ledger
+      - multiplexer
+    ldflags:
+      # Ref: https://goreleaser.com/customization/templates/#common-fields
+      # .Version is the version being released
+      # .FullCommit is git commit hash goreleaser is using for the release
+      - -X "{{ .Env.SDKPath }}.Name=celestia-app"
+      - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
+      - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
+      - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
   - id: darwin-amd64
     main: ./cmd/celestia-appd
     binary: celestia-appd
@@ -95,6 +194,20 @@ builds:
       - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
 dist: ./build/goreleaser
 archives:
+  - id: multiplexer
+    builds:
+      - darwin-amd64-multiplexer
+      - darwin-arm64-multiplexer
+      - linux-amd64-multiplexer
+      - linux-arm64-multiplexer
+    formats: ['tar.gz']
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
   - id: standalone
     builds:
       - darwin-amd64

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,6 +15,7 @@ builds:
       - CGO_ENABLED=1
       - CC=o64-clang
       - CXX=o64-clang++
+      - STANDALONE=true
     goarch:
       - amd64
     goos:
@@ -37,6 +38,7 @@ builds:
       - CGO_ENABLED=1
       - CC=oa64-clang
       - CXX=oa64-clang++
+      - STANDALONE=true
     goarch:
       - arm64
     goos:
@@ -58,6 +60,7 @@ builds:
       - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
+      - STANDALONE=true
     goarch:
       - amd64
     goos:
@@ -79,6 +82,7 @@ builds:
       - SDKPath={{ "github.com/cosmos/cosmos-sdk/version" }}
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
+      - STANDALONE=true
     goarch:
       - arm64
     goos:
@@ -99,7 +103,8 @@ archives:
     # this name template makes the OS and Arch compatible with the results of
     # uname.
     name_template: >-
-      {{ .ProjectName }}_
+      {{ .ProjectName }}
+      {{- if eq .Env.STANDALONE "true" }}-standalone{{ end }}_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/Makefile
+++ b/Makefile
@@ -338,6 +338,20 @@ prebuilt-binary:
 		release --clean --parallelism 1
 .PHONY: prebuilt-binary
 
+prebuilt-binary-dry-run:
+	@echo "Running GoReleaser in dry-run mode..."
+	docker run \
+		--rm \
+		--env CGO_ENABLED=1 \
+		--env GORELEASER_CURRENT_TAG=${GORELEASER_CURRENT_TAG} \
+		--env-file .release-env \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/$(PACKAGE_NAME) \
+		-w /go/src/$(PACKAGE_NAME) \
+		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
+		release --snapshot --clean --parallelism 1
+.PHONY: prebuilt-binary-dry-run
+
 ## goreleaser: Create prebuilt binaries and attach them to GitHub release. Requires Docker.
 goreleaser: prebuilt-binary
 .PHONY: goreleaser

--- a/Makefile
+++ b/Makefile
@@ -335,10 +335,12 @@ prebuilt-binary:
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --clean --parallelism 1
+		release --clean --parallelism 2
 .PHONY: prebuilt-binary
 
-prebuilt-binary-dry-run:
+## go-releaser-dry-run ensures that the go releaser tool and build all the artefacts correctly.
+## specifies parallelism as 4 so should be run locally. On the regular github runners 2 should be the max.
+go-releaser-dry-run:
 	@echo "Running GoReleaser in dry-run mode..."
 	docker run \
 		--rm \
@@ -349,8 +351,8 @@ prebuilt-binary-dry-run:
 		-v `pwd`:/go/src/$(PACKAGE_NAME) \
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
-		release --snapshot --clean --parallelism 1
-.PHONY: prebuilt-binary-dry-run
+		release --snapshot --clean --parallelism 4
+.PHONY: go-releaser-dry-run
 
 ## goreleaser: Create prebuilt binaries and attach them to GitHub release. Requires Docker.
 goreleaser: prebuilt-binary

--- a/scripts/download_v3_binary.sh
+++ b/scripts/download_v3_binary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Usage: ./scripts/embed_bin.sh <url> <out> <version>
+# Usage: ./scripts/download_v3_binary.sh <url> <out> <version>
 
 set -euo pipefail
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

closes: #4798

This PR updates the goreleaser file to add builds for the multiplexer.


Output of local dry run

```
 make go-releaser-dry-run
Running GoReleaser in dry-run mode...
docker run \
                --rm \
                --env CGO_ENABLED=1 \
                --env GORELEASER_CURRENT_TAG= \
                --env-file .release-env \
                -v /var/run/docker.sock:/var/run/docker.sock \
                -v `pwd`:/go/src/github.com/celestiaorg/celestia-app/v4 \
                -w /go/src/github.com/celestiaorg/celestia-app/v4 \
                ghcr.io/goreleaser/goreleaser-cross:v1.23.6 \
                release --snapshot --clean --parallelism 4
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credential-stores

Login Succeeded
WARNING! Your password will be stored unencrypted in /root/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credential-stores

Login Succeeded
  • skipping announce, publish and validate...
  • cleaning distribution directory
  • loading environment variables
    • using token from  $GITHUB_TOKEN
  • getting and validating git state
    • git state                                      commit=d4147fdafc578e982006f2d903275752b0e7a071 branch=cian/update-go-releaser-to-support-multiplexer current_tag=v4.0.1-arabica previous_tag=v4.0.0-mocha dirty=false
    • pipe skipped                                   reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=4.0.1-next
  • running before hooks
    • running                                        hook=go mod tidy
    • running                                        hook=./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.0-arabica
    • running                                        hook=./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.0-arabica
    • running                                        hook=./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.0-arabica
    • running                                        hook=./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.0-arabica
    • took: 15s
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • building                                       binary=build/goreleaser/linux-arm64-multiplexer_linux_arm64_v8.0/celestia-appd
    • building                                       binary=build/goreleaser/darwin-arm64-multiplexer_darwin_arm64_v8.0/celestia-appd
    • building                                       binary=build/goreleaser/linux-amd64-multiplexer_linux_amd64_v1/celestia-appd
    • building                                       binary=build/goreleaser/darwin-amd64-multiplexer_darwin_amd64_v1/celestia-appd
    • building                                       binary=build/goreleaser/darwin-amd64_darwin_amd64_v1/celestia-appd
    • building                                       binary=build/goreleaser/darwin-arm64_darwin_arm64_v8.0/celestia-appd
    • building                                       binary=build/goreleaser/linux-amd64_linux_amd64_v1/celestia-appd
    • building                                       binary=build/goreleaser/linux-arm64_linux_arm64_v8.0/celestia-appd
    • took: 4m26s
  • archives
    • archiving                                      name=build/goreleaser/celestia-app_Darwin_x86_64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app_Linux_x86_64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app_Linux_arm64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app_Darwin_arm64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app-standalone_Darwin_x86_64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app-standalone_Linux_x86_64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app-standalone_Darwin_arm64.tar.gz
    • archiving                                      name=build/goreleaser/celestia-app-standalone_Linux_arm64.tar.gz
    • took: 1m56s
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 6m38s
  • thanks for using GoReleaser!
```


Running the binaries locally

```
 ./build/goreleaser/darwin-amd64-multiplexer_darwin_amd64_v1/celestia-appd version
4.0.1-next
```

```
./build/goreleaser/darwin-amd64-multiplexer_darwin_amd64_v1/celestia-appd passthrough v3 version
3.10.0-arabica
```
And checking the standalone one

```
./build/goreleaser/darwin-amd64_darwin_amd64_v1/celestia-appd version
4.0.1-next
```


Has no passthrough, i.e. built without the multiplexer.

```
./build/goreleaser/darwin-amd64_darwin_amd64_v1/celestia-appd passthrough v3 version
Error: unknown command "passthrough" for "celestia-appd"
Run 'celestia-appd --help' for usage.
```

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
