### PR TITLE
Typos fix

### DIFF
--- a/docs/architecture/adr-014-versioned-namespaces.md
+++ b/docs/architecture/adr-014-versioned-namespaces.md
@@ -57,7 +57,7 @@ For example, consider the scenario where at mainnet launch blobs are laid out ac
 - When a namespace starts with `1`, all blobs in the namespace conform to the new set of non-interactive default rules.
 
 ```go
-optionA := []byte{
+optional := []byte{
   0,                      // namespace version
   1, 2, 3, 4, 5, 6, 7, 8, // namespace ID
   1,          // info byte (sequence start indicator = true)

--- a/docs/architecture/adr-023-gas-used-and-gas-price-estimation.md
+++ b/docs/architecture/adr-023-gas-used-and-gas-price-estimation.md
@@ -11,7 +11,7 @@ Implemented
 
 ## Context
 
-As per [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-018.md), celestia-app will provide a base implementation for the gas and fee estimation so it can be used when building transactions.
+As per [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/chips/blob/main/chips/cip-018.md), celestia-app will provide a base implementation for the gas and fee estimation so it can be used when building transactions.
 
 ## Decision
 
@@ -21,7 +21,7 @@ The fee estimation mechanism is described below.
 
 ## Detailed Design
 
-The API will be provided through gRPC following the interface provided in [CIP-18](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-018.md).
+The API will be provided through gRPC following the interface provided in [CIP-18](https://github.com/celestiaorg/chips/blob/main/chips/cip-018.md).
 
 ### Gas used estimation
 
@@ -94,4 +94,4 @@ None.
 
 ## References
 
-- [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/CIPs/blob/main/cips/cip-018.md).
+- [CIP-18: Standardised Gas and Pricing Estimation Interface](https://github.com/celestiaorg/chips/blob/main/chips/cip-018.md).

--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -150,7 +150,7 @@ type TxClient struct {
 	cdc      codec.Codec
 	signer   *Signer
 	registry codectypes.InterfaceRegistry
-	// list of core endpoints for tx submission (primary + additionals)
+	// list of core endpoints for tx submission (primary + additional)
 	conns []*grpc.ClientConn
 	// how often to poll the network for confirmation of a transaction
 	pollTime time.Duration


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /docs/architecture/adr-023-gas-used-and-gas-price-estimation.md (Line 14)

"CIPs" → "chips"

Corrected typo in /docs/architecture/adr-023-gas-used-and-gas-price-estimation.md (Line 14)

"cips" → "chips"

Corrected typo in /docs/architecture/adr-023-gas-used-and-gas-price-estimation.md (Line 24)

"CIPs" → "chips"

Corrected typo in /docs/architecture/adr-014-versioned-namespaces.md (Line 60)

"optionA" → "optional"

Corrected typo in /pkg/user/tx_client.go (Line 153)

"additionals" → "additional"

**Purpose**

Improved code accuracy and professionalism by fixing typos.