### PR TITLE
Fix redundant word in code comment

### DIFF
--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -308,7 +308,7 @@ func (am *AccountManager) Submit(ctx context.Context, op Operation) error {
 		return err
 	}
 
-	// update the latest latestHeight
+	// update the latest height
 	am.setLatestHeight(res.Height)
 
 	if len(op.Blobs) > 0 {


### PR DESCRIPTION
Fix a small error in the txsim package where the comment incorrectly used "latest latestHeight" instead of "latest height".
