### PR TITLE
chore: upgrade to v3.10.1-mocha

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,10 +9,10 @@ before:
     - go mod tidy
     # these hooks get run once. We want to explicitly download every embedded binary so we can build the multiplexer
     # for every arch.
-    - ./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.1-arabica
-    - ./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.1-arabica
-    - ./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.1-arabica
-    - ./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.1-arabica
+    - ./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.1-mocha
+    - ./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.1-mocha
+    - ./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.1-mocha
+    - ./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.1-mocha
 builds:
   - id: darwin-amd64-multiplexer
     main: ./cmd/celestia-appd

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ BUILD_FLAGS := -tags "ledger" -ldflags '$(ldflags)'
 BUILD_FLAGS_MULTIPLEXER := -tags "ledger multiplexer" -ldflags '$(ldflags)'
 
 # NOTE: This version must be updated at the same time as the version in internal/embedding/data.go and .goreleaser.yaml
-CELESTIA_V3_VERSION := v3.10.1-arabica
+CELESTIA_V3_VERSION := v3.10.1-mocha
 
 ## help: Get more info on make commands.
 help: Makefile

--- a/internal/embedding/data.go
+++ b/internal/embedding/data.go
@@ -9,7 +9,7 @@ import (
 
 // NOTE: This version must be updated at the same time as the version in the
 // Makefile.
-const v3Version = "v3.10.1-arabica"
+const v3Version = "v3.10.1-mocha"
 
 // CelestiaAppV3 returns the compressed platform specific Celestia binary and
 // the version.


### PR DESCRIPTION
Backport of https://github.com/celestiaorg/celestia-app/pull/4918

Targets the v4.0.2-release branch