### PR TITLE
fix(multiplexer): preserve home args before `start` command

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -226,7 +226,7 @@ func (m *Multiplexer) startApp() error {
 	}
 
 	if currentVersion.Appd.Pid() == appd.AppdStopped {
-		programArgs := getProgramArgs(os.Args)
+		programArgs := removeStart(os.Args)
 
 		// start an embedded app.
 		m.logger.Debug("starting embedded app", "app_version", currentVersion.AppVersion, "args", currentVersion.GetStartArgs(programArgs))
@@ -245,15 +245,17 @@ func (m *Multiplexer) startApp() error {
 	return m.initRemoteGrpcConn()
 }
 
-// getProgramArgs returns the program args that should be passed to the embedded
-// app.
-func getProgramArgs(args []string) []string {
+// removeStart removes the first argument (the binary name) and the start argument from args.
+func removeStart(args []string) []string {
+	if len(args) == 0 {
+		return args
+	}
 	result := []string{}
+	args = args[1:] // remove the first argument (the binary name)
 	for _, arg := range args {
-		if strings.HasSuffix(arg, "celestia-appd") || arg == "start" {
-			continue
+		if arg != "start" {
+			result = append(result, arg)
 		}
-		result = append(result, arg)
 	}
 	return result
 }

--- a/multiplexer/abci/multiplexer_test.go
+++ b/multiplexer/abci/multiplexer_test.go
@@ -26,7 +26,12 @@ func Test_getProgramArgs(t *testing.T) {
 			want:  []string{},
 		},
 		{
-			name:  "should remove 'celestia-appd' and 'start' from input",
+			name:  "should return empty slice if just celestia-appd is provided",
+			input: []string{"celestia-appd"},
+			want:  []string{},
+		},
+		{
+			name:  "should remove celestia-appd and start from input",
 			input: []string{"celestia-appd", "start", "--home", "foo"},
 			want:  []string{"--home", "foo"},
 		},
@@ -43,7 +48,7 @@ func Test_getProgramArgs(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		got := getProgramArgs(test.input)
+		got := removeStart(test.input)
 		require.Equal(t, test.want, got)
 	}
 }


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4926

Previously the multiplexer removed the first two arguments passed to celestia-appd. This is problematic for Everstake who start celestia-appd like this

```
celestia-appd --home /foo start
```

This PR fixes the issue by filtering the os.Args to remove `celestia-appd` and `start` but still preserve the additional flags regardless of the order they're provided.