### PR TITLE
fix: ensure remote abci conn ports are aligned

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -299,7 +299,7 @@ require (
 replace (
 	// x/upgrade: v0.1.0
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.1.0
-	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17
+	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.54.1-tm-v0.38.17
 	// cosmos-sdk: v1.29.1-sdk-v0.50.12
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12
 	// goleveldb: canonical version

--- a/go.sum
+++ b/go.sum
@@ -354,8 +354,8 @@ github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7 h1:nxplQi8w
 github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7/go.mod h1:1EF5MfOxVf0WC51Gb7pJ6bcZxnXKNAf9pqWtjgPBAYc=
 github.com/celestiaorg/celestia-core v1.52.0-tm-v0.34.35 h1:iU2igosCxYKzEUi85u3YqNslIO+rCXtx4GKAHUzxrDQ=
 github.com/celestiaorg/celestia-core v1.52.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17 h1:ysqC/+W85pjczBaF8DyraYdHIyVFnVYUHD6Ddtqgdqo=
-github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17/go.mod h1:vEUPDabqnVPUMBb9EyzI0dkUN6B3If0NI74jKvk+n0Q=
+github.com/celestiaorg/celestia-core v1.54.1-tm-v0.38.17 h1:oNKu7TSENdgBvtdGtIjEfO4jnpupZjQTa2YUxkE/VFM=
+github.com/celestiaorg/celestia-core v1.54.1-tm-v0.38.17/go.mod h1:vEUPDabqnVPUMBb9EyzI0dkUN6B3If0NI74jKvk+n0Q=
 github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12 h1:EWJIBTMB9H2KFMqmNB22KvgqvAObqcToJbAdPCM+LBw=
 github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12/go.mod h1:clLEg7hWK0iJfiO1Vp71tcQ0vGbFzVsEcLxxnRobIZM=
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.1.0 h1:+i3G5mP/kPgFEn83EEXGly29QDin2Gvdt0kgpmw/vTg=

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -263,7 +263,8 @@ func (m *Multiplexer) initRemoteGrpcConn() error {
 	abciClientAddr := m.svrCtx.Viper.GetString(flagABCIClientAddr)
 	abciServerAddr := m.svrCtx.Viper.GetString(flagABCIServerAddr)
 	if abciServerAddr != abciClientAddr {
-		return fmt.Errorf("ABCI client and server addresses must match: client=%s, server=%s", abciClientAddr, abciServerAddr)
+		return fmt.Errorf("ABCI client and server addresses must match:\n client=%s\n server=%s\n"+
+			"To resolve, please configure the ABCI client (via --proxy_app flag) to match the ABCI server (via --address flag)", abciClientAddr, abciServerAddr)
 	}
 
 	// remove tcp:// prefix if present

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -250,18 +250,27 @@ func (m *Multiplexer) startApp() error {
 
 // initRemoteGrpcConn initializes a gRPC connection to the remote application client and configures transport credentials.
 func (m *Multiplexer) initRemoteGrpcConn() error {
-	// prepare remote app client
-	const flagTMAddress = "address"
-	tmAddress := m.svrCtx.Viper.GetString(flagTMAddress)
-	if tmAddress == "" {
-		tmAddress = "127.0.0.1:36658"
+	// Prepare the remote app client.
+	//
+	// Here we assert that the merged viper configuration contains the same address for both the ABCI
+	// client and server addresses. This ensures the app state machine is running on the port which
+	// the consensus engine expects.
+	const (
+		flagABCIClientAddr = "proxy_app"
+		flagABCIServerAddr = "address"
+	)
+
+	abciClientAddr := m.svrCtx.Viper.GetString(flagABCIClientAddr)
+	abciServerAddr := m.svrCtx.Viper.GetString(flagABCIServerAddr)
+	if abciServerAddr != abciClientAddr {
+		return fmt.Errorf("ABCI client and server addresses must match: client=%s, server=%s", abciClientAddr, abciServerAddr)
 	}
 
 	// remove tcp:// prefix if present
-	tmAddress = strings.TrimPrefix(tmAddress, "tcp://")
+	abciServerAddr = strings.TrimPrefix(abciServerAddr, "tcp://")
 
 	conn, err := grpc.NewClient(
-		tmAddress,
+		abciServerAddr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallSendMsgSize(math.MaxInt32),
@@ -272,7 +281,7 @@ func (m *Multiplexer) initRemoteGrpcConn() error {
 		return fmt.Errorf("failed to prepare app connection: %w", err)
 	}
 
-	m.logger.Info("initialized remote app client", "address", tmAddress)
+	m.logger.Info("initialized remote app client", "address", abciServerAddr)
 	m.conn = conn
 	return nil
 }

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -270,7 +270,7 @@ replace (
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.1.0
 
 	github.com/celestiaorg/celestia-app/v4 => ../..
-	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17
+	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.54.1-tm-v0.38.17
 	// cosmos-sdk: v1.29.1-sdk-v0.50.12
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12
 

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -344,8 +344,8 @@ github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4
 github.com/bytedance/sonic/loader v0.2.4 h1:ZWCw4stuXUsn1/+zQDqeE7JKP+QO47tz7QCNan80NzY=
 github.com/bytedance/sonic/loader v0.2.4/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17 h1:ysqC/+W85pjczBaF8DyraYdHIyVFnVYUHD6Ddtqgdqo=
-github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17/go.mod h1:vEUPDabqnVPUMBb9EyzI0dkUN6B3If0NI74jKvk+n0Q=
+github.com/celestiaorg/celestia-core v1.54.1-tm-v0.38.17 h1:oNKu7TSENdgBvtdGtIjEfO4jnpupZjQTa2YUxkE/VFM=
+github.com/celestiaorg/celestia-core v1.54.1-tm-v0.38.17/go.mod h1:vEUPDabqnVPUMBb9EyzI0dkUN6B3If0NI74jKvk+n0Q=
 github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12 h1:EWJIBTMB9H2KFMqmNB22KvgqvAObqcToJbAdPCM+LBw=
 github.com/celestiaorg/cosmos-sdk v1.29.1-sdk-v0.50.12/go.mod h1:clLEg7hWK0iJfiO1Vp71tcQ0vGbFzVsEcLxxnRobIZM=
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.1.0 h1:+i3G5mP/kPgFEn83EEXGly29QDin2Gvdt0kgpmw/vTg=


### PR DESCRIPTION
## Overview

This PR adds an assertion in the multiplexer which ensures that the configuration of the consensus engine remote ABCI client, matches that of the app state machine ABCI server.

The intension is to fix issues where changes to the configuration file `config.toml` which belongs to consensus engine and not respected. 

If a user or node operator wants to use an alternative port to the default port (:36658), then they should override both the client and server configurations `--proxy_app` and `--address` on startup.

closes: #4936 