### PR TITLE
docs(specs): Fix Decimal type spec link to current location

### DIFF
--- a/specs/src/proto/types.proto
+++ b/specs/src/proto/types.proto
@@ -53,7 +53,7 @@ message PeriodEntry {
   uint64 rewardRate = 1;
 }
 
-// https://github.com/celestiaorg/celestia-specs/blob/master/specs/networking.md#decimal
+// https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#decimal
 message Decimal {
   // Rational numerator
   uint64 numerator = 1;


### PR DESCRIPTION
## Overview


Replaced the outdated reference to the Decimal type specification in types.proto with the correct, up-to-date link:
https://github.com/celestiaorg/celestia-specs/blob/master/src/specs/data_structures.md#decimal
This ensures the documentation comment points to an existing and relevant section in the Celestia specs.