### PR TITLE
fix: pass env and sigkill to embedded app

### DIFF
--- a/multiplexer/appd/run_test.go
+++ b/multiplexer/appd/run_test.go
@@ -3,10 +3,15 @@
 package appd
 
 import (
+	"bufio"
 	"bytes"
+	"fmt"
 	"os"
+	"os/exec"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/celestiaorg/celestia-app/v4/internal/embedding"
 
@@ -103,4 +108,53 @@ func createMockExecutable(t *testing.T, bashCommand string) string {
 	require.NoError(t, os.Chmod(tmpFile.Name(), 0o755))
 
 	return tmpFile.Name()
+}
+
+// TestSetupCmd covers:
+// 1) Cancellation via SIGINT (Ctrl+C) propagates to child process group
+// 2) Environment variables are inherited by the child process
+// 3) Child process can access files in $HOME
+func TestSetupCmd(t *testing.T) {
+	t.Run("CancelOnSIGINT", func(t *testing.T) {
+		req := require.New(t)
+		ast := assert.New(t)
+
+		cmd := exec.Command("bash", "-c", `trap 'echo gotint; exit 0' INT; sleep 60`)
+		cmd = setupCmd(cmd)
+
+		stdout, err := cmd.StdoutPipe()
+		req.NoError(err)
+
+		req.NoError(cmd.Start())
+
+		// allow process to start
+		time.Sleep(100 * time.Millisecond)
+
+		pgid, err := syscall.Getpgid(cmd.Process.Pid)
+		req.NoError(err)
+		syscall.Kill(-pgid, syscall.SIGINT)
+
+		scn := bufio.NewScanner(stdout)
+		req.True(scn.Scan(), "expected output but got none")
+		ast.Equal("gotint", scn.Text())
+
+		req.NoError(cmd.Wait())
+	})
+
+	t.Run("EnvVarPropagation", func(t *testing.T) {
+		key, val := "TEST_ENV_VAR", "42"
+		require.NoError(t, os.Setenv(key, val))
+		defer os.Unsetenv(key)
+
+		// prepare the command: wrap the var in quotes so we know it came through
+		cmd := exec.Command("bash", "-c", fmt.Sprintf("echo -n \"\\\"$%s\\\"\"", key))
+
+		// now invoke your function under test
+		cmd = setupCmd(cmd)
+
+		// run it and inspect the output
+		out, err := cmd.Output()
+		require.NoError(t, err)
+		assert.Equal(t, fmt.Sprintf("\"%s\"", val), string(out))
+	})
 }

--- a/test/multiplexer/multiplexer_test.go
+++ b/test/multiplexer/multiplexer_test.go
@@ -58,6 +58,7 @@ func execCommand(t *testing.T, cmd string, args ...string) string {
 	var out bytes.Buffer
 	var outErr bytes.Buffer
 	command := exec.Command(cmd, args...)
+	command = setupCmd(command)
 	command.Stdout = &out
 	command.Stderr = &outErr
 	err := command.Run()


### PR DESCRIPTION
## Overview

fixes #4763 
maybe also https://github.com/celestiaorg/celestia-app/issues/4932 

we might need to set the `cmd.Dir` as well 
