### PR TITLE
feat(test/cmd/txsim): Allow predefined set of namespaces for blob submission

### DIFF
--- a/test/cmd/txsim/cli.go
+++ b/test/cmd/txsim/cli.go
@@ -247,7 +247,7 @@ func flags() *flag.FlagSet {
 	flags.IntVar(&blobShareVersion, "blob-share-version", -1, "optionally specify a share version to use for the blob sequences")
 	flags.Uint64Var(&gasLimit, "gas-limit", 0, "custom gas limit to use for transactions (0 = auto-estimate)")
 	flags.Float64Var(&gasPrice, "gas-price", 0, "custom gas price to use for transactions (0 = use default)")
-	flags.StringArrayVar(&namespaces, "namespaces", []string{}, "define namespace(s) to use for blob submission -- MUST BE PROVIDED IN HEX FORMAT")
+	flags.StringArrayVar(&namespaces, "namespace", []string{}, "define namespace to use for blob submission -- MUST BE PROVIDED IN HEX FORMAT. Can define multiple namespaces for submission just by passing --namespace several times. Provided namespaces will be used at random.")
 	return flags
 }
 

--- a/test/cmd/txsim/cli.go
+++ b/test/cmd/txsim/cli.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/celestiaorg/go-square/v2/share"
 	"math/rand"
 	"os"
 	"os/signal"
@@ -17,6 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+
+	"github.com/celestiaorg/go-square/v2/share"
 
 	"github.com/celestiaorg/celestia-app/v4/app"
 	"github.com/celestiaorg/celestia-app/v4/app/encoding"

--- a/test/txsim/blob.go
+++ b/test/txsim/blob.go
@@ -23,7 +23,7 @@ const fundsForGas int = 1e9 // 1000 TIA
 // BlobSequence defines a pattern whereby a single user repeatedly sends a pay for blob
 // message roughly every height. The PFB may consist of several blobs
 type BlobSequence struct {
-	namespace     share.Namespace
+	namespaces    []share.Namespace
 	sizes         Range
 	blobsPerPFB   Range
 	shareVersions []uint8
@@ -40,10 +40,10 @@ func NewBlobSequence(sizes, blobsPerPFB Range) *BlobSequence {
 	}
 }
 
-// WithNamespace provides the option of fixing a predefined namespace for
+// WithNamespaces provides the option of fixing a set of predefined namespaces for
 // all blobs.
-func (s *BlobSequence) WithNamespace(namespace share.Namespace) *BlobSequence {
-	s.namespace = namespace
+func (s *BlobSequence) WithNamespaces(namespaces []share.Namespace) *BlobSequence {
+	s.namespaces = namespaces
 	return s
 }
 
@@ -61,7 +61,7 @@ func (s *BlobSequence) Clone(n int) []Sequence {
 	sequenceGroup := make([]Sequence, n)
 	for i := 0; i < n; i++ {
 		sequenceGroup[i] = &BlobSequence{
-			namespace:     s.namespace,
+			namespaces:    s.namespaces,
 			sizes:         s.sizes,
 			blobsPerPFB:   s.blobsPerPFB,
 			shareVersions: s.shareVersions,
@@ -84,8 +84,9 @@ func (s *BlobSequence) Next(_ context.Context, _ grpc.ClientConn, rand *rand.Ran
 	sizes := make([]int, numBlobs)
 	namespaces := make([]share.Namespace, numBlobs)
 	for i := range sizes {
-		if s.namespace.Bytes() != nil {
-			namespaces[i] = s.namespace
+		if len(s.namespaces) > 0 {
+			randIdx := rand.Intn(len(s.namespaces))
+			namespaces[i] = s.namespaces[randIdx]
 		} else {
 			// generate a random namespace for the blob
 			namespace := make([]byte, share.NamespaceVersionZeroIDSize)


### PR DESCRIPTION
This PR adds a flag to allow a set of one or more predefined namespaces for txsim to use for blob submission. If more than one namespace is provided, it will choose a namespace at random for blob submission. 

```
--namespace <28 byte hex encoded V0 string> --namespace <28 byte hex encoded V0 string>
```

There is no way to currently ensure every defined namespace lands in every block (if 2 or more are provided), but we can add a feature later that disables the randomisation of `blobsPerPFB` per block.