### PR TITLE
Fix typo in TxClient struct comment

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -144,7 +144,7 @@ type TxClient struct {
 	cdc      codec.Codec
 	signer   *Signer
 	registry codectypes.InterfaceRegistry
-	// list of core endpoints for tx submission (primary + additionals)
+	// list of core endpoints for tx submission (primary + additional)
 	conns []*grpc.ClientConn
 	// how often to poll the network for confirmation of a transaction
 	pollTime time.Duration


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the comment for the TxClient struct, changing "additionals" to "additional" for improved clarity and consistency. 