### PR TITLE
chore: fix Tx endpoint via updating to CometBFT v0.38 protos

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -254,10 +254,10 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.30.0-sdk-v0.46.16
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.30.0-sdk-v0.46.16.0.20250623184849-41564030103e // v1.30.0-sdk-v0.46.16
 	// Replace IBC with celestiaorg fork which includes fixes for security vulnerabilities.
 	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.2.4
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
-	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35
+	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35.0.20250623165146-701d1edca3d5 // v1.52.1-tm-v0.34.35
 )

--- a/go.sum
+++ b/go.sum
@@ -318,10 +318,10 @@ github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7 h1:nxplQi8w
 github.com/celestiaorg/bittwister v0.0.0-20231213180407-65cdbaf5b8c7/go.mod h1:1EF5MfOxVf0WC51Gb7pJ6bcZxnXKNAf9pqWtjgPBAYc=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZIuyASInj1a9ExI8xOsTOw=
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
-github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35 h1:N+sJFu0h8okPkRjgQh/2iN4pi3atrR9a/vkXLwEKXfw=
-github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v1.30.0-sdk-v0.46.16 h1:ZHr6hCpaeA6Qk/BqrDknZS1pm+imO8RtMDmYuMdjLuA=
-github.com/celestiaorg/cosmos-sdk v1.30.0-sdk-v0.46.16/go.mod h1:8Wvxp2fu7ZMEz2sJVlfZiCqgdjLMNVosuE1O0X2yR5c=
+github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35.0.20250623165146-701d1edca3d5 h1:bcXich7P120D099VtC+rQbUKPRjhWqI892pDUTA45C0=
+github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35.0.20250623165146-701d1edca3d5/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
+github.com/celestiaorg/cosmos-sdk v1.30.0-sdk-v0.46.16.0.20250623184849-41564030103e h1:gXQYEiExktzAVdEWxs/rJKtDGTxF1qE2aGEmW7EaJ0E=
+github.com/celestiaorg/cosmos-sdk v1.30.0-sdk-v0.46.16.0.20250623184849-41564030103e/go.mod h1:10xBL3fny237Xw3PJS0vOlw/5jZJsQYry548qB7hH08=
 github.com/celestiaorg/go-square v1.1.1 h1:Cy3p8WVspVcyOqHM8BWFuuYPwMitO1pYGe+ImILFZRA=
 github.com/celestiaorg/go-square v1.1.1/go.mod h1:1EXMErhDrWJM8B8V9hN7dqJ2kUTClfwdqMOmF9yQUa0=
 github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=


### PR DESCRIPTION
## Overview

closes #4925 

this fix is annoying to test as we need to have a v3 embedded app running on v0.38 to hit