### PR TITLE
[multiplexer]: misspell of article before "user"

### DIFF
--- a/multiplexer/README.md
+++ b/multiplexer/README.md
@@ -119,7 +119,7 @@ Note 2: The remote clients work via `gRPC` connection, when overriding the start
 ## Passthrough mode
 
 Passthrough mode is an optional command that can be added to a chain.
-It allows an user to interact via an embedded binary via CLI.
+It allows a user to interact via an embedded binary via CLI.
 
 ```bash
 appd passthrough v2 q bank balances <foo>


### PR DESCRIPTION
## Overview

[here is explanation](https://www.google.com/search?q=why+a+user+not+an+user&sca_esv=ccb8066356fd07b7&rlz=1C1CHBF_ruPL1156PL1156&sxsrf=AE3TifPM1PB-Jn9TJJTqyXZV5VTHbuWrgg%3A1750766387589&ei=M5NaaN3WI4fFwPAPvP71iAI&oq=a+user&gs_lp=Egxnd3Mtd2l6LXNlcnAiBmEgdXNlcioCCAAyChAAGLADGNYEGEcyChAAGLADGNYEGEcyChAAGLADGNYEGEcyChAAGLADGNYEGEcyChAAGLADGNYEGEcyERAAGIAEGLADGAEYQxiKBRgKMg0QABiABBiwAxhDGIoFMg0QABiABBiwAxhDGIoFMg0QABiABBiwAxhDGIoFSLsFUABYAHABeAGQAQCYAQCgAQCqAQC4AQHIAQCYAgGgAgeYAwCIBgGQBgmSBwExoAcAsgcAuAcAwgcDMi0xyAcF&sclient=gws-wiz-serp)