### PR TITLE
fix: stop panicking in PrepareProposalHandler

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -40,7 +40,7 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 		appconsts.SubtreeRootThreshold,
 	)
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	txs := fsb.Fill(ctx, req.Txs)
@@ -48,7 +48,7 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 	// Build the square from the set of valid and prioritised transactions.
 	dataSquare, err := fsb.Build()
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
 	// Erasure encode the data square to create the extended data square (eds).
@@ -57,13 +57,13 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 	eds, err := da.ExtendShares(share.ToBytes(dataSquare))
 	if err != nil {
 		app.Logger().Error("failure to erasure the data square while creating a proposal block", "error", err.Error())
-		panic(err)
+		return nil, err
 	}
 
 	dah, err := da.NewDataAvailabilityHeader(eds)
 	if err != nil {
 		app.Logger().Error("failure to create new data availability header", "error", err.Error())
-		panic(err)
+		return nil, err
 	}
 
 	// Tendermint doesn't need to use any of the erasure data because only the


### PR DESCRIPTION


## Overview

Refactored the PrepareProposalHandler function to return errors instead of panicking when encountering failures during proposal preparation.
This change improves robustness and reduces the attack surface by ensuring that recoverable errors are properly propagated to the caller, rather than causing the node to crash.
Error logging is preserved where appropriate.
No changes were made to the core logic or the function signature.
This addresses issue #4992.
