### PR TITLE
fix: make help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -336,9 +336,9 @@ prebuilt-binary:
 		release --clean --parallelism 2
 .PHONY: prebuilt-binary
 
-## go-releaser-dry-run ensures that the go releaser tool and build all the artefacts correctly.
-## specifies parallelism as 4 so should be run locally. On the regular github runners 2 should be the max.
-go-releaser-dry-run:
+## goreleaser-dry-run: ensures that the go releaser tool can build all the artefacts correctly.
+goreleaser-dry-run:
+# Specifies parallelism as 4 so should be run locally. On the regular github runners 2 should be the max.
 	@echo "Running GoReleaser in dry-run mode..."
 	docker run \
 		--rm \


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5054

## Testing

```
$ make
 Choose a command run in celestia-app:
  adr-gen                    Download the ADR template from the celestiaorg/.github repo.
  bbr-check                  Check if your system uses BBR congestion control algorithm. Only works on Linux.
  bbr-disable                Disable BBR congestion control algorithm and revert to default.
  bbr-enable                 Enable BBR congestion control algorithm. Only works on Linux.
  build-docker-multiplexer   Build the celestia-appd docker image with Multiplexer support from the current branch. Requires docker.
  build-docker               Build the celestia-appd Docker image using the local Dockerfile.
  build-ghcr-docker          Build the celestia-appd Docker image tagged with the current commit hash for GitHub Container Registry.
  build-standalone           Build the celestia-appd binary into the ./build directory.
  build                      Build the celestia-appd binary into the ./build directory.
  check-bbr                  Internal command to check if BBR congestion control is enabled on the system.
  disable-bbr                Disable BBR congestion control algorithm and revert to default (Cubic). Only works on Linux.
  disable-mptcp              Disable Multi-Path TCP and revert to standard TCP. Removes all MPTCP settings from system. Only works on Linux Kernel 5.6+.
  docker-build-ghcr          Build the celestia-appd docker image from the last commit. Requires docker.
  docker-build               Build the celestia-appd docker image from the current branch. Requires docker.
  docker-publish             Publish the celestia-appd docker image. Requires docker.
  download-v3-binaries       Download the celestia-app v3 binary for the current platform.
  enable-bbr                 Enable BBR congestion control algorithm on your system. This improves network performance. Only works on Linux.
  enable-mptcp               Enable Multi-Path TCP over multiple ports (not interfaces). Improves connection reliability and throughput. Only works on Linux Kernel 5.6+.
  fmt                        Format Go code with golangci-lint and markdown files with markdownlint.
  goreleaser-check           Check the .goreleaser.yaml config file.
  goreleaser-dry-run         ensures that the go releaser tool can build all the artefacts correctly.
  goreleaser                 Create prebuilt binaries and attach them to GitHub release. Requires Docker.
  help                       Get more info on make commands.
  install-standalone         Build and install the celestia-appd binary into the $GOPATH/bin directory. This target does not install the multiplexer.
  install                    Build and install the multiplexer version of celestia-appd into the $GOPATH/bin directory.
  lint-fix                   Format files per linters golangci-lint and markdownlint.
  lint-links                 Check all markdown links.
  lint                       Run all linters; golangci-lint, markdownlint, hadolint, yamllint.
  markdown-link-check        Check all links in markdown files for validity.
  mod-verify                 Verify dependencies have expected content.
  mod                        Update all go.mod files.
  mptcp-disable              Disable mptcp over multiple ports. Only works on Linux Kernel 5.6 and above.
  mptcp-enable               Enable mptcp over multiple ports (not interfaces). Only works on Linux Kernel 5.6 and above.
  prebuilt-binary            Create prebuilt binaries for all supported platforms using goreleaser. Used by the goreleaser target.
  proto-all                  Format, lint and generate Protobuf files
  proto-check-breaking       Check if Protobuf file contains breaking changes.
  proto-deps                 Install Protobuf local dependencies
  proto-format               Format Protobuf files.
  proto-gen                  Generate Protobuf files.
  proto-lint                 Lint Protobuf files.
  proto-update-deps          Update Protobuf dependencies.
  publish-ghcr-docker        Push the celestia-appd Docker image to GitHub Container Registry with the current commit tag.
  test-bench                 Run benchmark unit tests.
  test-coverage              Generate test coverage.txt
  test-docker-e2e            Run end to end tests via docker.
  test-e2e                   Run end to end tests via knuu. This command requires a kube/config file to configure kubernetes.
  test-fuzz                  Run all fuzz tests.
  test-multiplexer           Run unit tests for the multiplexer package.
  test-race                  Run tests in race mode.
  test-short                 Run tests in short mode.
  test                       Run tests.
  txsim-build-docker         Build the tx simulator Docker image. Requires Docker.
  txsim-build                Build the tx simulator binary into the ./build directory.
  txsim-install              Install the tx simulator.

```