### PR TITLE
fix: use go-square to unmarshal blob tx instead of tendermint

### DIFF
--- a/app/encoding/blob_tx_decoder.go
+++ b/app/encoding/blob_tx_decoder.go
@@ -2,12 +2,16 @@ package encoding
 
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	coretypes "github.com/tendermint/tendermint/types"
+	coretypes "github.com/celestiaorg/go-square/v2/tx"
 )
 
 func blobTxDecoder(decoder sdk.TxDecoder) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
-		if blobTx, isBlobTx := coretypes.UnmarshalBlobTx(txBytes); isBlobTx {
+		blobTx, isBlobTx, err := coretypes.UnmarshalBlobTx(txBytes)
+		if err != nil {
+			return nil, err
+		}
+		if isBlobTx {
 			return decoder(blobTx.Tx)
 		}
 		return decoder(txBytes)

--- a/app/encoding/blob_tx_decoder.go
+++ b/app/encoding/blob_tx_decoder.go
@@ -1,17 +1,17 @@
 package encoding
 
 import (
+	"github.com/celestiaorg/go-square/v2/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	coretypes "github.com/celestiaorg/go-square/v2/tx"
 )
 
 func blobTxDecoder(decoder sdk.TxDecoder) sdk.TxDecoder {
 	return func(txBytes []byte) (sdk.Tx, error) {
-		blobTx, isBlobTx, err := coretypes.UnmarshalBlobTx(txBytes)
-		if err != nil {
-			return nil, err
-		}
+		blobTx, isBlobTx, err := tx.UnmarshalBlobTx(txBytes)
 		if isBlobTx {
+			if err != nil {
+				return nil, err
+			}
 			return decoder(blobTx.Tx)
 		}
 		return decoder(txBytes)


### PR DESCRIPTION
Noticed that we were using an outdated version of decoding the blob tx (which now resides in go-square instead of tendermint)
