### PR TITLE
ci: allow backporting to v4.x

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -23,6 +23,14 @@ pull_request_rules:
       backport:
         branches:
           - v3.x
+  - name: backport patches to v4.x branch
+    conditions:
+      - base=main
+      - label=backport:v4.x
+    actions:
+      backport:
+        branches:
+          - v4.x
   - name: forward-port patches to main branch (v1.x)
     conditions:
       - base=v1.x


### PR DESCRIPTION
I would prefer if we didn't need this yet and instead consolidated `main` and `v4.x`

Ref: https://github.com/celestiaorg/celestia-app/pull/4796#issuecomment-3008632798
