### PR TITLE
chore: rate limit creation/destruction of DO droplets

### DIFF
--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -132,10 +132,15 @@ func deployPayload(
 
 	counter := atomic.Uint32{}
 
+	workers := make(chan struct{}, 10)
 	for _, inst := range ips {
+		workers <- struct{}{}
 		wg.Add(1)
 		go func(inst Instance) {
-			defer wg.Done()
+			defer func() {
+				<-workers
+				wg.Done()
+			}()
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
 

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -125,11 +125,10 @@ func CreateDroplets(ctx context.Context, client *godo.Client, insts []Instance, 
 	wg.Add(total)
 
 	for _, v := range insts {
-		v := v // Create new v for goroutine
 		go func() {
-			workers <- struct{}{} // Acquire worker
+			workers <- struct{}{}
 			defer func() {
-				<-workers // Release worker
+				<-workers
 				wg.Done()
 			}()
 
@@ -265,15 +264,15 @@ func DestroyDroplets(ctx context.Context, client *godo.Client, insts []Instance)
 	}
 
 	results := make(chan result, total)
-	workers := make(chan struct{}, 10) // Limit to 10 concurrent workers
+	workers := make(chan struct{}, 10)
 	var wg sync.WaitGroup
 	wg.Add(total)
 
 	for _, v := range insts {
 		go func(inst Instance) {
-			workers <- struct{}{} // Acquire worker
+			workers <- struct{}{} 
 			defer func() {
-				<-workers // Release worker
+				<-workers
 				wg.Done()
 			}()
 			start := time.Now()

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -270,7 +270,7 @@ func DestroyDroplets(ctx context.Context, client *godo.Client, insts []Instance)
 
 	for _, v := range insts {
 		go func(inst Instance) {
-			workers <- struct{}{} 
+			workers <- struct{}{}
 			defer func() {
 				<-workers
 				wg.Done()

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -120,12 +120,18 @@ func CreateDroplets(ctx context.Context, client *godo.Client, insts []Instance, 
 	}
 
 	results := make(chan result, total)
+	workers := make(chan struct{}, 10) // Limit to 10 concurrent workers
 	var wg sync.WaitGroup
 	wg.Add(total)
 
 	for _, v := range insts {
+		v := v // Create new v for goroutine
 		go func() {
-			defer wg.Done()
+			workers <- struct{}{} // Acquire worker
+			defer func() {
+				<-workers // Release worker
+				wg.Done()
+			}()
 
 			ctx, cancel := context.WithTimeout(ctx, 7*time.Minute)
 			defer cancel()
@@ -259,12 +265,17 @@ func DestroyDroplets(ctx context.Context, client *godo.Client, insts []Instance)
 	}
 
 	results := make(chan result, total)
+	workers := make(chan struct{}, 10) // Limit to 10 concurrent workers
 	var wg sync.WaitGroup
 	wg.Add(total)
 
 	for _, v := range insts {
 		go func(inst Instance) {
-			defer wg.Done()
+			workers <- struct{}{} // Acquire worker
+			defer func() {
+				<-workers // Release worker
+				wg.Done()
+			}()
 			start := time.Now()
 
 			fmt.Println("⏳ Deleting droplet", inst.Name, inst.PublicIP)


### PR DESCRIPTION

## Overview

Without this rate limiting, DO rejects requests for networks > 20 validators because of too many requests. This limits the number of requests to 10 a time.
