### PR TITLE
fix: Add missing mebibyte constant definition in big_blob_test.go

### DIFF
--- a/app/test/big_blob_test.go
+++ b/app/test/big_blob_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const mebibyte = 1_048_576 // 1 MiB
+
 func TestBigBlobSuite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping big blob suite in short mode.")


### PR DESCRIPTION
The file was using the mebibyte constant but it wasn't defined in the file scope.
Change adds the constant definition (1_048_576 bytes = 1 MiB) consistent with other files in the project.