### PR TITLE
fix: add missing string type in MockIBCModule.OnChanOpenTry

### DIFF
--- a/x/tokenfilter/ibc_middleware_test.go
+++ b/x/tokenfilter/ibc_middleware_test.go
@@ -92,7 +92,7 @@ func (m *MockIBCModule) OnChanOpenTry(
 	_ sdk.Context,
 	_ channeltypes.Order,
 	_ []string,
-	_,
+	_ string,
 	_ string,
 	_ *capabilitytypes.Capability,
 	_ channeltypes.Counterparty,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fix syntax error where portID parameter was missing its string type in the OnChanOpenTry method signature.