### PR TITLE
chore: fix talis ssh and genesis config

### DIFF
--- a/test/util/genesis/genesis.go
+++ b/test/util/genesis/genesis.go
@@ -243,6 +243,7 @@ func (g *Genesis) Export() (*coretypes.GenesisDoc, error) {
 		gentxs,
 		g.accounts,
 		g.GenesisTime,
+		g.genOps...,
 	)
 }
 

--- a/tools/talis/README.md
+++ b/tools/talis/README.md
@@ -158,6 +158,8 @@ talis genesis -s 128 -a /home/$HOSTNAME/go/src/github.com/celestiaorg/celestia-a
 
 Keep in mind that we can still edit anything in the payload before deploying the network.
 
+Note: When increasing the genesis square size, ensure you also increase the `SquareSizeUpperBound` constant to allow blocks to be created at the new size.
+
 ### deploy
 
 This step is when the network is actually started. The payload is uploaded to each instance in the network directly from the user's machine. After delivering the payload, the start script is executed in a tmux session called "app" on each machine.

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -61,7 +61,11 @@ func DOClient(token string) *godo.Client {
 // GetDOSSHKeyMeta checks if the provided raw SSH public key is registered in DigitalOcean
 // and returns its ID and Name. If not found, returns an error instructing to upload the key.
 func GetDOSSHKeyMeta(ctx context.Context, client *godo.Client, publicKey string) (godo.Key, error) {
-	publicKey = strings.TrimSpace(publicKey)
+	pubKeySplit := strings.Split(publicKey, " ")
+	if len(pubKeySplit) <= 1 {
+		return godo.Key{}, fmt.Errorf("invalid public key format")
+	}
+	publicKey = strings.Join(pubKeySplit[:2], "")
 
 	// Pagination options
 	opt := &godo.ListOptions{PerPage: 200}
@@ -73,8 +77,9 @@ func GetDOSSHKeyMeta(ctx context.Context, client *godo.Client, publicKey string)
 		}
 
 		for _, key := range keys {
-			// Compare the trimmed public key string
-			if strings.TrimSpace(key.PublicKey) == publicKey {
+			// only compare the first two parts of the public key. The third part is the host
+			// which can be ignored.
+			if strings.Join(strings.Split(key.PublicKey, " ")[:2], "") == publicKey {
 				return key, nil
 			}
 		}

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -101,7 +101,7 @@ func generateCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&chainID, chainIDFlag, "c", "", "Override the chainID in the config")
 	cmd.Flags().StringVarP(&rootDir, rootDirFlag, "d", ".", "root directory in which to initialize (default is the current directory)")
-	cmd.Flags().IntVarP(&squareSize, "ods-size", "s", appconsts.TalisSquareSizeUpperBound, "The size of the ODS for the network")
+	cmd.Flags().IntVarP(&squareSize, "ods-size", "s", appconsts.TalisSquareSizeUpperBound, "The size of the ODS for the network (make sure to also build a celestia-app binary with a greater SquareSizeUpperBound)")
 	cmd.Flags().StringVarP(&appBinaryPath, "app-binary", "a", filepath.Join(gopath, "celestia-appd"), "app binary to include in the payload (assumes the binary is installed")
 	cmd.Flags().StringVarP(&nodeBinaryPath, "node-binary", "n", filepath.Join(gopath, "celestia"), "node binary to include in the payload (assumes the binary is installed")
 	cmd.Flags().StringVarP(&txsimBinaryPath, "txsim-binary", "t", filepath.Join(gopath, "txsim"), "txsim binary to include in the payload (assumes the binary is installed)")

--- a/tools/talis/init.go
+++ b/tools/talis/init.go
@@ -65,10 +65,6 @@ func initCmd() *cobra.Command {
 			// write the default config files that will be copied to the payload
 			// for each validator unless otherwise overridden
 			consensusConfig := app.DefaultConsensusConfig()
-			consensusConfig.Mempool.MaxTxBytes = 40 * mebibyte
-			consensusConfig.Mempool.TTLNumBlocks = 50
-			consensusConfig.P2P.SendRate = 400 * mebibyte
-			consensusConfig.P2P.RecvRate = 400 * mebibyte
 			consConfig := DefaultConfigProfile(consensusConfig, tables)
 			cmtconfig.WriteConfigFile(filepath.Join(rootDir, "config.toml"), consConfig)
 
@@ -113,8 +109,8 @@ func initCmd() *cobra.Command {
 func DefaultConfigProfile(cfg *cmtconfig.Config, tables []string) *cmtconfig.Config {
 	cfg.Instrumentation.TracingTables = strings.Join(tables, ",")
 	cfg.Instrumentation.TraceType = "local"
-	cfg.P2P.SendRate = 100000000
-	cfg.P2P.RecvRate = 110000000
+	cfg.P2P.SendRate = 400_000_000
+	cfg.P2P.RecvRate = 410_000_000
 	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
 	cfg.RPC.GRPCListenAddress = "tcp://0.0.0.0:9090"
 	return cfg


### PR DESCRIPTION
## Overview

Just a couple small fixes for talis:

1. compares only the curve and the key parts of the ssh key and not the hostname too
2. apply the genesis mods when exporting to allow setting the square size