### PR TITLE
chore(deps): upgrade actions/setup-go from v4 to v5

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
 


### PR DESCRIPTION
Changes Made:
Updated from actions/setup-go@v4 to actions/setup-go@v5

For full details, see: https://github.com/actions/setup-go/releases/tag/v5.5.0