### PR TITLE
ci(dependabot): reduce frequency of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,42 @@
 version: 2
 updates:
-  - package-ecosystem: docker
-    directory: "/"
-    schedule:
-      interval: daily
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-  # There are more Dockerfiles in the `docker` directory, therefore we need this one
+  # Docker
   - package-ecosystem: docker
     directory: "/docker"
     schedule:
-      interval: daily
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - dependencies
+
+  # Github Actions
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  # Go
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - dependencies
   - package-ecosystem: gomod
-    directory: "/"
+    directory: "test/interchain"
     schedule:
-      interval: daily
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+  - package-ecosystem: gomod
+    directory: "test/docker-e2e"
+    schedule:
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - dependencies


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4929
Closes https://github.com/celestiaorg/celestia-app/issues/5080

I couldn't find a native solution in Dependabot to bump dependencies in multiple `go.mod`s in one PR. Based on docs [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--) and [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/optimizing-pr-creation-version-updates).

Instead this PR:
- Decreases the frequency from daily to weekly
- Configured Dependabot to create PRs for test/docker-e2e and test/interchain. I think that we can merge those PRs before merging the one that bumps the root `go.mod`

Note: this isn't a 100% solution but should mitigate the problem.