### PR TITLE
fix: talis txsim number of instances

### DIFF
--- a/tools/talis/txsim.go
+++ b/tools/talis/txsim.go
@@ -52,7 +52,7 @@ func startTxsimCmd() *cobra.Command {
 			// only spin up txsim on the number of instances that were specified.
 			insts := []Instance{}
 			for i, val := range cfg.Validators {
-				if i >= seqCount || i >= len(cfg.Validators) {
+				if i >= instances || i >= len(cfg.Validators) {
 					break
 				}
 				insts = append(insts, val)


### PR DESCRIPTION
## Overview

Currently, Talis txsim command takes a number of instances and number of blob sequences. However, it uses the sequences also as the number of instances.

So, if you run: `talis txsim -i 2 -s 2`, it will spin up 2 instances with each having 2 blobs sequences.

But if you run: `talis txsim -i 2 -s 20`, it will run 20 instances with 20 blob sequences, while it should run 2 instances with 20 sequences.