### PR TITLE
feat: add log to download-genesis after init

### DIFF
--- a/cmd/celestia-appd/cmd/init.go
+++ b/cmd/celestia-appd/cmd/init.go
@@ -136,6 +136,10 @@ func initCmd(basicManager module.BasicManager, defaultNodeHome string) *cobra.Co
 				return errorsmod.Wrap(err, "Failed to export genesis file")
 			}
 
+			if isKnownChainID(chainID) {
+				fmt.Printf("The chain ID %s is a public network.\nPlease download the genesis file via:\n\tcelestia-appd download-genesis %s\n", chainID, chainID)
+			}
+
 			cometconfig.WriteConfigFile(filepath.Join(config.RootDir, "config", "config.toml"), config)
 
 			toPrint := newPrintInfo(config.Moniker, chainID, nodeID, "", appState)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/4891 by implementing option 1 from https://github.com/celestiaorg/celestia-app/issues/4891#issuecomment-3000526542

## Testing

```
$ celestia-appd init foo --chain-id celestia
The chain ID celestia is a public network.
Please download the genesis file via:
	celestia-appd download-genesis celestia
...
```