### PR TITLE
ci: fix docker multi-platform build

### DIFF
--- a/docker/standalone.Dockerfile
+++ b/docker/standalone.Dockerfile
@@ -20,6 +20,9 @@ ARG UPGRADE_HEIGHT_DELAY
 # See https://github.com/hadolint/hadolint/issues/339
 # hadolint ignore=DL3006
 FROM --platform=$BUILDPLATFORM ${BUILDER_IMAGE} AS builder
+ARG TARGETOS
+ARG TARGETARCH
+
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 # hadolint ignore=DL3018


### PR DESCRIPTION
Right now ARM64 images are broken (they have the x86 binary)

How to reproduce : run this command on an ARM64 platform :

```bash
docker run  ghcr.io/celestiaorg/celestia-app
Starting celestia-appd with command:
/bin/celestia-appd 

/opt/entrypoint.sh: line 22: /bin/celestia-appd: cannot execute binary file: Exec format error
/opt/entrypoint.sh: line 22: /bin/celestia-appd: No error information
```

The root cause is that `TARGETOS` and `TARGETARCH` args are not defined in the build stage in `standalone.dockerfile` ; the docker build step for arm64 is in fact building a x86 binary.

After the fix :
```bash
docker run  ghcr.io/auricom/celestia-app
Starting celestia-appd with command:
/bin/celestia-appd 

Usage:
  celestia-appd [command]
[...]
```