### PR TITLE
feat: halt-disabled flag

### DIFF
--- a/cmd/celestia-appd/cmd/app_server.go
+++ b/cmd/celestia-appd/cmd/app_server.go
@@ -55,6 +55,7 @@ func NewAppServer(logger log.Logger, db dbm.DB, traceStore io.Writer, appOptions
 		baseapp.SetPruning(pruningOpts),
 		baseapp.SetMinGasPrices(cast.ToString(appOptions.Get(server.FlagMinGasPrices))),
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOptions.Get(server.FlagMinRetainBlocks))),
+		baseapp.SetHaltDisabled(cast.ToBool(appOptions.Get(server.FlagHaltDisabled))),
 		baseapp.SetHaltHeight(cast.ToUint64(appOptions.Get(server.FlagHaltHeight))),
 		baseapp.SetHaltTime(cast.ToUint64(appOptions.Get(server.FlagHaltTime))),
 		baseapp.SetMinRetainBlocks(cast.ToUint64(appOptions.Get(server.FlagMinRetainBlocks))),

--- a/cmd/celestia-appd/cmd/start.go
+++ b/cmd/celestia-appd/cmd/start.go
@@ -165,6 +165,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().String(flagTraceStore, "", "Enable KVStore tracing to an output file")
 	cmd.Flags().String(server.FlagMinGasPrices, "", "Minimum gas prices to accept for transactions; Any fee in a tx must meet this minimum (e.g. 0.01photino;0.0001stake)")
 	cmd.Flags().IntSlice(server.FlagUnsafeSkipUpgrades, []int{}, "Skip a set of upgrade heights to continue the old binary")
+	cmd.Flags().Bool(server.FlagHaltDisabled, false, "Disable halt functionality")
 	cmd.Flags().Uint64(server.FlagHaltHeight, 0, "Block height at which to gracefully halt the chain and shutdown the node")
 	cmd.Flags().Uint64(server.FlagHaltTime, 0, "Minimum block time (in Unix seconds) at which to gracefully halt the chain and shutdown the node")
 	cmd.Flags().Bool(server.FlagInterBlockCache, true, "Enable inter-block caching")

--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.31.0-sdk-v0.46.16
+	github.com/cosmos/cosmos-sdk => ../cosmos-sdk
 	// Replace IBC with celestiaorg fork which includes fixes for security vulnerabilities.
 	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.3.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,6 @@ github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZI
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v1.31.0-sdk-v0.46.16 h1:kJRiFVBiAkqAJvcJesYT8qmnFhXQvpIq7xaTWK13N+g=
-github.com/celestiaorg/cosmos-sdk v1.31.0-sdk-v0.46.16/go.mod h1:EMxw97dX/lq2vuiP28bgYsog2jn4gV7bnRhHhjcsu3M=
 github.com/celestiaorg/go-square v1.1.1 h1:Cy3p8WVspVcyOqHM8BWFuuYPwMitO1pYGe+ImILFZRA=
 github.com/celestiaorg/go-square v1.1.1/go.mod h1:1EXMErhDrWJM8B8V9hN7dqJ2kUTClfwdqMOmF9yQUa0=
 github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/pull/5094

Add a halt-disabled flag to v0.46.x-celestia for use in celestia-app v3.x.x so that the multiplexer can disable the halt functionality in the Cosmos SDK and control the lifecycle of the state machine and CometBFT.

## Testing

Modified single-node.sh 

```diff
  celestia-appd start \
    --home "${CELESTIA_APP_HOME}" \
    --api.enable \
    --grpc.enable \
    --grpc-web.enable \
    --timeout-commit 1s \
+    --halt-disabled true \
+    --halt-height 10 \
    --force-no-bbr # no need to require BBR usage on a local node
```

and observed that the node does not halt at height 10. It does halt at height 10 with just

```diff
  celestia-appd start \
    --home "${CELESTIA_APP_HOME}" \
    --api.enable \
    --grpc.enable \
    --grpc-web.enable \
    --timeout-commit 1s \
+    --halt-height 10 \
    --force-no-bbr # no need to require BBR usage on a local node
```