### PR TITLE
fix: incorrect assertion in pruning test

### DIFF
--- a/pkg/user/pruning_test.go
+++ b/pkg/user/pruning_test.go
@@ -45,6 +45,6 @@ func TestPruningInTxTracker(t *testing.T) {
 	txClient.pruneTxTracker()
 	// Prunes the transactions that are 10 minutes old
 	// 5 transactions will be pruned
-	require.Equal(t, txsToBePruned, txTrackerBeforePruning-txsToBePruned)
+	require.Equal(t, txsNotReadyToBePruned, txTrackerBeforePruning-txsToBePruned)
 	require.Equal(t, len(txClient.txTracker), txsNotReadyToBePruned)
 }


### PR DESCRIPTION
Fixed a logical error in the pruning test where the assertion was comparing the number of pruned transactions with the difference between initial count and pruned count. The correct assertion should compare the number of transactions that should remain after pruning with the actual remaining count.