### PR TITLE
fix: pruning test assertion and improve test robustness

### DIFF
--- a/pkg/user/pruning_test.go
+++ b/pkg/user/pruning_test.go
@@ -18,8 +18,8 @@ func TestPruningInTxTracker(t *testing.T) {
 	var txsToBePruned int
 	var txsNotReadyToBePruned int
 	for i := 0; i < numTransactions; i++ {
-		// 5 transactions will be pruned
-		if i%2 == 0 {
+		// 7 transactions will be pruned
+		if i < 7 {
 			txClient.txTracker["tx"+fmt.Sprint(i)] = txInfo{
 				signer:   "signer" + fmt.Sprint(i),
 				sequence: uint64(i),
@@ -44,7 +44,7 @@ func TestPruningInTxTracker(t *testing.T) {
 	require.Equal(t, numTransactions, len(txClient.txTracker))
 	txClient.pruneTxTracker()
 	// Prunes the transactions that are 10 minutes old
-	// 5 transactions will be pruned
-	require.Equal(t, txsToBePruned, txTrackerBeforePruning-txsToBePruned)
+	// 7 transactions will be pruned
+	require.Equal(t, txsNotReadyToBePruned, txTrackerBeforePruning-txsToBePruned)
 	require.Equal(t, len(txClient.txTracker), txsNotReadyToBePruned)
 }


### PR DESCRIPTION
ref: https://github.com/celestiaorg/celestia-app/pull/5186

## Overview

Fixed a logical error in the pruning test where the assertion was incorrectly comparing the number of pruned transactions with the difference between initial count and pruned count. The correct assertion should compare the number of transactions that should remain after pruning with the actual remaining count.

Additionally, updated the test to use different values for pruned (7) and remaining (3) transactions instead of equal values (5 and 5) to make the test more robust and prevent accidental passing due to value coincidence.
