### PR TITLE
fix(multiplexer): wait for v3 app to stop before starting v4

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 
 	"cosmossdk.io/log"
-	"github.com/celestiaorg/celestia-app/v4/multiplexer/appd"
 	"github.com/celestiaorg/celestia-app/v4/multiplexer/internal"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/node"
@@ -215,7 +214,7 @@ func (m *Multiplexer) startApp() error {
 		return fmt.Errorf("appd is nil for version %d", m.appVersion)
 	}
 
-	if currentVersion.Appd.Pid() == appd.AppdStopped {
+	if currentVersion.Appd.IsStopped() {
 		programArgs := removeStart(os.Args)
 
 		// start an embedded app.
@@ -224,7 +223,7 @@ func (m *Multiplexer) startApp() error {
 			return fmt.Errorf("failed to start app: %w", err)
 		}
 
-		if currentVersion.Appd.Pid() == appd.AppdStopped { // should never happen
+		if currentVersion.Appd.IsStopped() { // should never happen
 			return fmt.Errorf("app failed to start")
 		}
 
@@ -480,7 +479,7 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 		return fmt.Errorf("failed to stop active version: %w", err)
 	}
 
-	if version.Appd.Pid() == appd.AppdStopped {
+	if version.Appd.IsStopped() {
 		for _, preHandler := range version.PreHandlers {
 			preCmd := version.Appd.CreateExecCommand(preHandler)
 			if err := preCmd.Run(); err != nil {
@@ -497,7 +496,7 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 			return fmt.Errorf("failed to start app for version %d: %w", m.appVersion, err)
 		}
 
-		if version.Appd.Pid() == appd.AppdStopped {
+		if version.Appd.IsStopped() {
 			return fmt.Errorf("app for version %d failed to start", m.nativeApp)
 		}
 
@@ -507,9 +506,9 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 	return nil
 }
 
-// embeddedVersionRunning returns true if there is an active version specified which is not stopped.
+// embeddedVersionRunning returns true if there is an active version specified which is running.
 func (m *Multiplexer) embeddedVersionRunning() bool {
-	return m.activeVersion.Appd != nil && m.activeVersion.Appd.Pid() != appd.AppdStopped
+	return m.activeVersion.Appd != nil && m.activeVersion.Appd.IsRunning()
 }
 
 // startCmtNode initializes and starts a CometBFT node, sets up cleanup tasks, and assigns it to the Multiplexer instance.

--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -100,14 +100,13 @@ func (a *Appd) IsStopped() bool {
 	return false
 }
 
-// Stop terminates the running appd process if it exists and waits for it to fully exit.
+// Stop interrupts and then kills the running appd process if it exists and
+// waits for it to fully exit. If the process is not running, it returns nil.
 func (a *Appd) Stop() error {
 	if a.cmd == nil {
-		log.Printf("Can not stop appd because cmd is nil")
 		return nil
 	}
 	if a.cmd.Process == nil {
-		log.Printf("Can not stop appd because process is nil")
 		return nil
 	}
 

--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -103,10 +103,12 @@ func (a *Appd) IsStopped() bool {
 // Stop terminates the running appd process if it exists and waits for it to fully exit.
 func (a *Appd) Stop() error {
 	if a.cmd == nil {
-		return fmt.Errorf("can not stop appd because cmd is nil")
+		log.Printf("Can not stop appd because cmd is nil")
+		return nil
 	}
 	if a.cmd.Process == nil {
-		return fmt.Errorf("can not stop appd because process is nil")
+		log.Printf("Can not stop appd because process is nil")
+		return nil
 	}
 
 	err := a.cmd.Process.Signal(os.Interrupt)

--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -13,24 +13,18 @@ import (
 	"syscall"
 )
 
-const (
-	// AppdStopped is the process ID of the celestia-appd binary when it is not running.
-	AppdStopped = -1
-)
-
 // Appd represents a celestia-appd binary.
 type Appd struct {
 	// version is the version of the celestia-appd binary.
 	// Example: "v3.10.0-arabica"
 	version string
-	// pid is the process ID of the celestia-appd binary.
-	pid int
 	// path is the path to the celestia-appd binary.
 	path   string
 	stdin  io.Reader
 	stderr io.Writer
 	stdout io.Writer
-	cmd    *exec.Cmd
+	// cmd is the started celestia-appd binary.
+	cmd *exec.Cmd
 }
 
 // New returns a new Appd instance.
@@ -54,7 +48,6 @@ func New(version string, compressedBinary []byte) (*Appd, error) {
 
 	appd := &Appd{
 		version: version,
-		pid:     AppdStopped,
 		path:    pathToBinary,
 		stdin:   os.Stdin,
 		stdout:  os.Stdout,
@@ -83,30 +76,44 @@ func (a *Appd) Start(args ...string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start %s: %w", a.path, err)
 	}
-
-	a.pid = cmd.Process.Pid
 	a.cmd = cmd
-
 	return nil
+}
+
+func (a *Appd) IsRunning() bool {
+	return !a.IsStopped()
+}
+
+func (a *Appd) IsStopped() bool {
+	// Never started or failed to start
+	if a.cmd == nil || a.cmd.Process == nil {
+		return true
+	}
+
+	// If ProcessState is not nil, it means Wait() was called and the process has finished
+	// (either by exiting normally or being terminated by a signal)
+	if a.cmd.ProcessState != nil {
+		return true
+	}
+
+	// ProcessState is nil, which means the process is still running
+	return false
 }
 
 // Stop terminates the running appd process if it exists and waits for it to fully exit.
 func (a *Appd) Stop() error {
-	if a.pid == AppdStopped || a.cmd == nil {
-		return nil
+	if a.cmd == nil {
+		return fmt.Errorf("can not stop appd because cmd is nil")
+	}
+	if a.cmd.Process == nil {
+		return fmt.Errorf("can not stop appd because process is nil")
 	}
 
-	process, err := os.FindProcess(a.pid)
+	err := a.cmd.Process.Signal(os.Interrupt)
 	if err != nil {
-		return fmt.Errorf("failed to find process with PID %d: %w", a.pid, err)
-	}
-
-	// Send SIGTERM for graceful shutdown
-	if err := process.Signal(os.Interrupt); err != nil {
 		log.Printf("Failed to send interrupt signal, attempting to kill: %v", err)
-		// if interrupt fails, try harder with Kill
-		if err := process.Kill(); err != nil {
-			return fmt.Errorf("failed to kill process with PID %d: %w", a.pid, err)
+		if err := a.cmd.Process.Kill(); err != nil {
+			return fmt.Errorf("failed to kill process with PID %d: %w", a.cmd.Process.Pid, err)
 		}
 	}
 
@@ -116,14 +123,7 @@ func (a *Appd) Stop() error {
 	} else {
 		log.Printf("Process finished with no error\n")
 	}
-
-	a.pid = AppdStopped
 	return nil
-}
-
-// Pid returns the process ID of the appd process.
-func (a *Appd) Pid() int {
-	return a.pid
 }
 
 // CreateExecCommand creates an exec.Cmd for the appd binary.

--- a/multiplexer/appd/run_test.go
+++ b/multiplexer/appd/run_test.go
@@ -40,48 +40,85 @@ func TestCreateExecCommand(t *testing.T) {
 	assert.Contains(t, got, want)
 }
 
-// TestStart_Success ensures that the provided executable is launched and provided a pid.
-// and that the pid is reset once the process exits.
-func TestStart_Success(t *testing.T) {
-	mockBinary := createMockExecutable(t, "sleep 1")
-	defer os.Remove(mockBinary) // Cleanup after test
+func TestStart(t *testing.T) {
+	t.Run("should start the process", func(t *testing.T) {
+		mockBinary := createMockExecutable(t, "sleep 10")
+		defer os.Remove(mockBinary) // Cleanup after test
 
-	appdInstance := &Appd{
-		path:   mockBinary,
-		stdin:  os.Stdin,
-		stdout: os.Stdout,
-		stderr: os.Stderr,
-		pid:    AppdStopped,
-	}
+		appdInstance := &Appd{
+			path:   mockBinary,
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
 
-	// Start the process
-	err := appdInstance.Start()
-	require.NoError(t, err, "Start should not return an error")
+		require.True(t, appdInstance.IsStopped())
+		require.False(t, appdInstance.IsRunning())
 
-	// Ensure PID is set
-	require.Greater(t, appdInstance.Pid(), 0, "Process PID should be greater than 0")
+		err := appdInstance.Start()
+		require.NoError(t, err)
 
-	// Stop the process after the test
-	err = appdInstance.Stop()
-	require.NoError(t, err, "Stop should terminate the process")
+		require.True(t, appdInstance.IsRunning())
+		require.False(t, appdInstance.IsStopped())
+	})
+	t.Run("should return an error if the binary is non-existent", func(t *testing.T) {
+		appdInstance := &Appd{
+			path:   "/non/existent/binary",
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
+
+		err := appdInstance.Start()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to start")
+		require.True(t, appdInstance.IsStopped())
+		require.False(t, appdInstance.IsRunning())
+	})
 }
 
-// TestStart_InvalidBinary ensures that the appd instance errors out if the binary does not exist.
-func TestStart_InvalidBinary(t *testing.T) {
-	appdInstance := &Appd{
-		path:   "/non/existent/binary",
-		stdin:  os.Stdin,
-		stdout: os.Stdout,
-		stderr: os.Stderr,
-		pid:    AppdStopped,
-	}
+func TestStop(t *testing.T) {
+	t.Run("should return an error if the process is not running", func(t *testing.T) {
+		mockBinary := createMockExecutable(t, "sleep 10")
+		defer os.Remove(mockBinary) // Cleanup after test
 
-	// Start should return an error
-	err := appdInstance.Start()
-	require.Error(t, err, "Expected an error when starting a non-existent binary")
-	require.Contains(t, err.Error(), "failed to start", "Error message should contain failure reason")
+		appdInstance := &Appd{
+			path:   mockBinary,
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
 
-	require.Equal(t, AppdStopped, appdInstance.Pid(), "PID should remain AppdStopped")
+		require.True(t, appdInstance.IsStopped())
+		err := appdInstance.Stop()
+		require.Error(t, err)
+	})
+	t.Run("should stop the process", func(t *testing.T) {
+		mockBinary := createMockExecutable(t, "sleep 10")
+		defer os.Remove(mockBinary) // Cleanup after test
+
+		appdInstance := &Appd{
+			path:   mockBinary,
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
+
+		require.True(t, appdInstance.IsStopped())
+		require.False(t, appdInstance.IsRunning())
+
+		err := appdInstance.Start()
+		require.NoError(t, err)
+
+		require.True(t, appdInstance.IsRunning())
+		require.False(t, appdInstance.IsStopped())
+
+		err = appdInstance.Stop()
+		require.NoError(t, err)
+
+		require.True(t, appdInstance.IsStopped())
+		require.False(t, appdInstance.IsRunning())
+	})
 }
 
 // createMockExecutable creates a temporary mock binary that can be executed in tests.

--- a/multiplexer/appd/run_test.go
+++ b/multiplexer/appd/run_test.go
@@ -78,7 +78,7 @@ func TestStart(t *testing.T) {
 }
 
 func TestStop(t *testing.T) {
-	t.Run("should return an error if the process is not running", func(t *testing.T) {
+	t.Run("should return no error if the process is not running", func(t *testing.T) {
 		mockBinary := createMockExecutable(t, "sleep 10")
 		defer os.Remove(mockBinary) // Cleanup after test
 
@@ -90,8 +90,13 @@ func TestStop(t *testing.T) {
 		}
 
 		require.True(t, appdInstance.IsStopped())
+		require.False(t, appdInstance.IsRunning())
+
 		err := appdInstance.Stop()
-		require.Error(t, err)
+		require.NoError(t, err)
+
+		require.True(t, appdInstance.IsStopped())
+		require.False(t, appdInstance.IsRunning())
 	})
 	t.Run("should stop the process", func(t *testing.T) {
 		mockBinary := createMockExecutable(t, "sleep 10")


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5194

The problem was that v3 wasn't fully stopped before v4 started. v4 tried to access the db before v3 fully released it. The fix is to wait for v3 to fully stop in the `Stop` command.

## Testing

```
./scripts/single-node-upgrades.sh
...
8:33PM INF stopping embedded app for version active_app_version=3 module=server
Error: 130
2025/07/08 20:33:12 Process finished with error: exit status 1
8:33PM INF using latest app app_version=4 module=server
8:33PM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0x14002bc4fc0, circuit}" version=36
8:33PM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0x14002bc4fb0, consensus}" version=36
8:33PM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0x14002bc4fd0, hyperlane}" version=36
8:33PM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0x14002bc4fa0, minfee}" version=36
8:33PM INF Upgrading IAVL storage for faster queries + execution on live state. This may take a while commit=436F6D6D697449447B5B5D3A307D module=server store_key="KVStoreKey{0x14002bc4fe0, warp}" version=36
8:33PM ERR failed to get consensus params err="collections: not found: key 'no_key' of type github.com/cosmos/gogoproto/tendermint.types.ConsensusParams" module=server
8:33PM ERR failed to get consensus params err="collections: not found: key 'no_key' of type github.com/cosmos/gogoproto/tendermint.types.ConsensusParams" module=server
8:33PM INF starting gRPC server... address=localhost:9090 module=grpc-server
8:33PM INF starting API server... address=tcp://localhost:1317 module=api-server
...
```