### PR TITLE
feat: support mainnet staking distribution

### DIFF
--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -106,7 +106,7 @@ func generateCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&appBinaryPath, "app-binary", "a", filepath.Join(gopath, "celestia-appd"), "app binary to include in the payload (assumes the binary is installed")
 	cmd.Flags().StringVarP(&nodeBinaryPath, "node-binary", "n", filepath.Join(gopath, "celestia"), "node binary to include in the payload (assumes the binary is installed")
 	cmd.Flags().StringVarP(&txsimBinaryPath, "txsim-binary", "t", filepath.Join(gopath, "txsim"), "txsim binary to include in the payload (assumes the binary is installed)")
-	cmd.Flags().BoolVarP(&useMainnetStakingDistribution, "mainnet-staking-distribution", "m", false, "uses a mainnet staking distribution instead of the default equitable one")
+	cmd.Flags().BoolVarP(&useMainnetStakingDistribution, "mainnet-staking-distribution", "m", false, "replace the default uniform staking distribution with the actual mainnet distribution")
 
 	return cmd
 }

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -87,14 +87,19 @@ func SetMinFee(codec codec.Codec, minFee float64) genesis.Modifier {
 // its name which is assigned by pulumi as hardware is allocated. An additional
 // account and keyring are saved to the payload directory that can be used by
 // txsim.
-func (n *Network) AddValidator(name, ip, payLoadRoot, region string) error {
+// if the stake is set to 0, a default value is used.
+func (n *Network) AddValidator(name, ip, payLoadRoot, region string, stake int64) error {
 	n.validators[name] = NodeInfo{
 		Name:   name,
 		IP:     ip,
 		Region: region,
 	}
 
-	err := n.genesis.NewValidator(genesis.NewDefaultValidator(name))
+	val := genesis.NewDefaultValidator(name)
+	if stake != 0 {
+		val.Stake = stake
+	}
+	err := n.genesis.NewValidator(val)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Overview

A nice to have to create a network similar to that of Celestia mainnet. It takes the staking amounts from the Celestia mainnet and uses them to generate the genesis.