### PR TITLE
docs: fix typo

### DIFF
--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -289,7 +289,7 @@ func (suite *TxClientTestSuite) TestGasPriceEstimation() {
 // TestGasConsumption verifies that the amount deducted from a user's balance is
 // based on the fee provided in the tx instead of the gas used by the tx. This
 // behavior leads to poor UX because tx submitters must over-estimate the amount
-// of gas that their tx will consume and they are not refunded for the excessuite.
+// of gas that their tx will consume and they are not refunded for the excess.
 func (suite *TxClientTestSuite) TestGasConsumption() {
 	t := suite.T()
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The word `excessuite` is not a valid English word — it's unclear and likely a typo . It should be `excess` (imo).

