### PR TITLE
docs(data_structures): Correct grammar and constant name inconsistency

### DIFF
--- a/specs/src/data_structures.md
+++ b/specs/src/data_structures.md
@@ -335,7 +335,7 @@ Then,
     1. For each request in the list:
         1. [Serialize](#serialization) the request (individually).
         1. Compute the length of each serialized request, [serialize the length](#serialization), and prepend the serialized request with its serialized length.
-    1. Split up the length/request pairs into [`SHARE_SIZE`](./consensus.md#constants)`-`[`NAMESPACE_ID_BYTES`](./consensus.md#constants)`-`[`SHARE_RESERVED_BYTES`](./consensus.md#constants)-byte chunks.
+    1. Split up the length/request pairs into [`SHARE_SIZE`](./consensus.md#constants)`-`[`NAMESPACE_ID_SIZE`](./consensus.md#constants)`-`[`SHARE_RESERVED_BYTES`](./consensus.md#constants)-byte chunks.
     1. Create a [share](./shares.md) out of each chunk. This data has a _reserved_ namespace ID, so the first [`NAMESPACE_SIZE`](./consensus.md#constants)`+`[`SHARE_RESERVED_BYTES`](./consensus.md#constants) bytes for these shares must be set specially.
 1. Concatenate the lists of shares in the order: transactions, intermediate state roots, PayForBlob transactions.
 
@@ -377,7 +377,7 @@ Celestia transactions are Cosmos SDK [transactions](https://github.com/cosmos/co
 
 ### IndexWrapper
 
-IndexWrapper are wrappers around PayForBlob transactions. They include additional metadata by the block proposer that is committed to in the [available data matrix](#arranging-available-data-into-shares).
+IndexWrappers are wrappers around PayForBlob transactions. They include additional metadata by the block proposer that is committed to in the [available data matrix](#arranging-available-data-into-shares).
 
 | name            | type       | description                                                                                                                                            |
 |-----------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Overview

1.  **Grammar Correction:**
    The description for `IndexWrapper` contained a subject-verb agreement error. It has been corrected from "IndexWrapper are..." to "IndexWrappers are...".

2.  **Constant Name Consistency:**
    The document referred to the constant `NAMESPACE_ID_BYTES`. This has been updated to `NAMESPACE_ID_SIZE` to align with the naming used in `consensus.md`, ensuring consistency across the specification.
