### PR TITLE
fix(statesync): download the standalone v4 binary instead

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,10 +94,10 @@ download-v4-binaries:
 	@mkdir -p internal/embedding
 	@os=$$(go env GOOS); arch=$$(go env GOARCH); \
 	case "$$os-$$arch" in \
-		darwin-arm64) url=celestia-app_Darwin_arm64.tar.gz; out=celestia-app_darwin_v4_arm64.tar.gz ;; \
-		linux-arm64) url=celestia-app_Linux_arm64.tar.gz; out=celestia-app_linux_v4_arm64.tar.gz ;; \
-		darwin-amd64) url=celestia-app_Darwin_x86_64.tar.gz; out=celestia-app_darwin_v4_amd64.tar.gz ;; \
-		linux-amd64) url=celestia-app_Linux_x86_64.tar.gz; out=celestia-app_linux_v4_amd64.tar.gz ;; \
+		darwin-arm64) url=celestia-app-standalone_Darwin_arm64.tar.gz; out=celestia-app_darwin_v4_arm64.tar.gz ;; \
+		linux-arm64) url=celestia-app-standalone_Linux_arm64.tar.gz; out=celestia-app_linux_v4_arm64.tar.gz ;; \
+		darwin-amd64) url=celestia-app-standalone_Darwin_x86_64.tar.gz; out=celestia-app_darwin_v4_amd64.tar.gz ;; \
+		linux-amd64) url=celestia-app-standalone_Linux_x86_64.tar.gz; out=celestia-app_linux_v4_amd64.tar.gz ;; \
 		*) echo "Unsupported platform: $$os-$$arch"; exit 1 ;; \
 	esac; \
 	bash scripts/download_binary.sh "$$url" "$$out" "$(CELESTIA_V4_VERSION)"


### PR DESCRIPTION
Closes: https://github.com/celestiaorg/celestia-app/issues/5222

Because I was foolish and ignorant, in my earlier v5 PR, I downloaded the multiplexer binary of v4 instead of the standalone one. When running v5, it recognised it was v4 and tried to run the v4 multiplexer. We had multiplexers within multiplexers

<img width="527" height="200" alt="image" src="https://github.com/user-attachments/assets/8445591a-8ba2-42f1-8d75-3d4a2248f6c2" />

Fortunately, this was an easy fix. I've tested manually and it seems to be working.