### PR TITLE
chore: bump to v3.10.4

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,10 +10,10 @@ before:
     # these hooks get run once. We want to explicitly download every embedded binary so we can build the multiplexer
     # for every arch.
     # Note: This version must be updated at the same time as the version in the Makefile.
-    - ./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.3
-    - ./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.3
-    - ./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.3
-    - ./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.3
+    - ./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.4
+    - ./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.4
+    - ./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.4
+    - ./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.4
 builds:
   - id: darwin-amd64-multiplexer
     main: ./cmd/celestia-appd

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ BUILD_FLAGS_MULTIPLEXER := -tags "ledger multiplexer" -ldflags '$(ldflags)'
 # internal/embedding/data.go
 # .goreleaser.yaml
 # docker/multiplexer.Dockerfile
-CELESTIA_V3_VERSION := v3.10.3
+CELESTIA_V3_VERSION := v3.10.4
 # TODO: update to a mainnet release
 CELESTIA_V4_VERSION := v4.0.7-mocha
 

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -18,7 +18,7 @@ ARG UPGRADE_HEIGHT_DELAY
 ARG CELESTIA_APP_REPOSITORY=ghcr.io/celestiaorg/celestia-app-standalone
 # NOTE: This version must be updated at the same time as the version in the
 # Makefile.
-ARG CELESTIA_VERSION_V3="v3.10.3"
+ARG CELESTIA_VERSION_V3="v3.10.4"
 ARG CELESTIA_VERSION_V4="v4.0.7-mocha"
 
 # Stage 1: this base image contains already released v3 binaries which can be embedded in the multiplexer.

--- a/internal/embedding/data.go
+++ b/internal/embedding/data.go
@@ -10,7 +10,7 @@ import (
 // NOTE: This version must be updated at the same time as the version in the
 // Makefile.
 const (
-	v3Version = "v3.10.3"
+	v3Version = "v3.10.4"
 	v4Version = "v4.0.7-mocha"
 )
 


### PR DESCRIPTION
So that the v3 embedded binary produces the new x/signal events.