### PR TITLE
fix: update broken links in pkg/wrapper/README.md

### DIFF
--- a/pkg/wrapper/README.md
+++ b/pkg/wrapper/README.md
@@ -86,7 +86,7 @@ One namespace ID is located in the first `NamespaceIDSize` bytes, while the othe
 [nmt-hash-link]: https://github.com/celestiaorg/nmt/blob/master/docs/spec/nmt.md#namespaced-hash
 [nmt-ignoremax-link]: https://github.com/celestiaorg/nmt/blob/master/docs/spec/nmt.md#ignore-max-namespace
 [nmt-add-leaves-link]: https://github.com/celestiaorg/nmt/blob/master/docs/spec/nmt.md#add-leaves
-[celestia-constants-link]: https://github.com/celestiaorg/celestia-app/blob/c09843d07d4c3842753138de96b304b4866e8f5d/specs/src/specs/consensus.md#constants
-[celestia-consensus-link]: https://github.com/celestiaorg/celestia-app/blob/c09843d07d4c3842753138de96b304b4866e8f5d/specs/src/specs/consensus.md#reserved-namespace-ids
-[reedsolomon-link]: https://github.com/celestiaorg/celestia-app/blob/c09843d07d4c3842753138de96b304b4866e8f5d/specs/src/specs/data_structures.md#2d-reed-solomon-encoding-scheme
+[celestia-constants-link]: https://github.com/celestiaorg/celestia-app/blob/main/specs/src/consensus.md#constants
+[celestia-consensus-link]: https://github.com/celestiaorg/celestia-app/blob/main/specs/src/consensus.md#reserved-namespace-ids
+[reedsolomon-link]: https://github.com/celestiaorg/celestia-app/blob/main/specs/src/data_structures.md#2d-reed-solomon-encoding-scheme
 [originalds-link]: https://github.com/celestiaorg/celestia-app/blob/c09843d07d4c3842753138de96b304b4866e8f5d/specs/src/specs/data_structures.md?plain=1#L494


### PR DESCRIPTION


This PR fixes broken links in `pkg/wrapper/README.md` that were pointing to:
- Outdated commit hash (`c09843d0...`) 
- Incorrect file paths with duplicate `/specs` directory

### Changes
-  Updated links to use `main` branch instead of specific commit
-  Fixed file paths by removing duplicate `/specs` from URLs  
-  All three celestia-app documentation links now work correctly

### Links Fixed
- `[celestia-constants-link]` → `specs/src/consensus.md#constants`
- `[celestia-consensus-link]` → `specs/src/consensus.md#reserved-namespace-ids` 
- `[reedsolomon-link]` → `specs/src/data_structures.md#2d-reed-solomon-encoding-scheme`

