### PR TITLE
fix: apply v2 upgrade height to v3 binary only

### DIFF
--- a/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
+++ b/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
@@ -49,9 +49,9 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 		panic(err)
 	}
 
-	var v3Args []string
+	v3Args := defaultArgs
 	if v2UpgradeHeight != "" {
-		v3Args = append(defaultArgs, "--v2-upgrade-height="+v2UpgradeHeight)
+		v3Args = append(v3Args, "--v2-upgrade-height="+v2UpgradeHeight)
 	}
 
 	versions, err := abci.NewVersions(

--- a/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
+++ b/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
@@ -49,9 +49,9 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 		panic(err)
 	}
 
-	var extraArgs []string
+	var v3Args []string
 	if v2UpgradeHeight != "" {
-		extraArgs = append(extraArgs, "--v2-upgrade-height="+v2UpgradeHeight)
+		v3Args = append(defaultArgs, "--v2-upgrade-height="+v2UpgradeHeight)
 	}
 
 	versions, err := abci.NewVersions(
@@ -59,12 +59,12 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 			Appd:        appdV3,
 			ABCIVersion: abci.ABCIClientVersion1,
 			AppVersion:  3,
-			StartArgs:   append(defaultArgs, extraArgs...),
+			StartArgs:   v3Args,
 		}, abci.Version{
 			Appd:        appdV4,
 			ABCIVersion: abci.ABCIClientVersion2,
 			AppVersion:  4,
-			StartArgs:   append(defaultArgs, extraArgs...),
+			StartArgs:   defaultArgs,
 		})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
I was observing this message in the logs:

```
Flag --v2-upgrade-height has been deprecated, This flag is deprecated and was only useful prior to v4.
```

This was coming about because, the v2UpgradeHeight flag was being set to both the v3 and v4 binary when it only needs to be set for v3