### PR TITLE
typo: Remove development note from section header

### DIFF
--- a/docs/architecture/adr-002-qgb-valset.md
+++ b/docs/architecture/adr-002-qgb-valset.md
@@ -85,7 +85,7 @@ message MsgSetOrchestratorAddress {
 }
 ```
 
-#### ValSetConfirmfix last e2e tests
+#### ValSetConfirm
 
 `MsgValsetConfirm` is the message sent by the validators when they wish to submit their signatures over the validator set at a given block height. A validator must first call `SetOrchestratorAddress` to set their Ethereum's address to be used for signing. Then, using `EndBlocker()`, the protocol makes a `ValsetRequest`, the request is essentially a messaging mechanism to determine which block all validators should submit signatures over. Finally, validators sign the `validator set`, `powers`, and `Ethereum addresses` of the entire validator set at the height of a `Valset` and submit that signature with this message.
 


### PR DESCRIPTION
Remove "fix last e2e tests" text from the ValSetConfirm section header that was accidentally included in the documentation