### PR TITLE
test: update test to use existing tastora fns

### DIFF
--- a/test/docker-e2e/dockerchain/config.go
+++ b/test/docker-e2e/dockerchain/config.go
@@ -29,8 +29,11 @@ func DefaultConfig(client *client.Client, network string) *Config {
 	tnCfg.Genesis = tnCfg.Genesis.
 		WithChainID(appconsts.TestChainID).
 		WithValidators(
-			genesis.NewDefaultValidator("val1"),
-			genesis.NewDefaultValidator("val2"),
+			// TODO: ensure names are in lexicographical order.
+			// this is because keyrings.Records() returns them this way.
+			// we should come up with a proper fix as this is a big foot gun.
+			genesis.NewDefaultValidator("validator1"),
+			genesis.NewDefaultValidator("validator2"),
 		)
 
 	cfg := &Config{}

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -4,11 +4,9 @@ go 1.24.2
 
 require (
 	cosmossdk.io/math v1.5.3
-	github.com/celestiaorg/celestia-app/v3 v3.10.3
-	github.com/celestiaorg/celestia-app/v4 v4.0.8-arabica
 	github.com/celestiaorg/celestia-app/v5 v5.0.0
 	github.com/celestiaorg/go-square/v2 v2.3.0
-	github.com/celestiaorg/tastora v0.1.1
+	github.com/celestiaorg/tastora v0.1.2
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/docker/docker v28.3.0+incompatible
@@ -276,7 +274,7 @@ replace (
 
 	github.com/celestiaorg/celestia-app/v5 => ../..
 
-	github.com/celestiaorg/tastora => ../../../tastora
+	//github.com/celestiaorg/tastora => ../../../tastora
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.56.1-tm-v0.38.17
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.29.4-sdk-v0.50.14
 

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -358,8 +358,8 @@ github.com/celestiaorg/nmt v0.24.0 h1:23u/mneledCG/6xWl1cZeTPrzRLpDTAHxMFsqoOL+B
 github.com/celestiaorg/nmt v0.24.0/go.mod h1:kYfIjRq5rmA2mJnv41GLWkxn5KyLNPlma3v5Q68rHdI=
 github.com/celestiaorg/rsmt2d v0.14.0 h1:L7XJ3tRJDY8sQcvCjzHq0L7JmsmaSD+VItymIYFLqYc=
 github.com/celestiaorg/rsmt2d v0.14.0/go.mod h1:4kxqiTdFev49sGiKXTDjohbWYOG5GlcIfftTgaBJnpc=
-github.com/celestiaorg/tastora v0.1.1 h1:wX/qWpzbN03kQBI46/x9cAKmPRtww8dZD76U2iIO+GE=
-github.com/celestiaorg/tastora v0.1.1/go.mod h1:A/DWauemWmg353BvhWYPCd8XbED12UCUiQsL+1sz9BU=
+github.com/celestiaorg/tastora v0.1.2 h1:6USWom4y+APD00MFMtPI2tmuEy29d1ZeaVlGnpt3vNE=
+github.com/celestiaorg/tastora v0.1.2/go.mod h1:A/DWauemWmg353BvhWYPCd8XbED12UCUiQsL+1sz9BU=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -896,8 +896,6 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
-github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=

--- a/test/util/genesis/genesis.go
+++ b/test/util/genesis/genesis.go
@@ -137,6 +137,7 @@ func (g *Genesis) WithKeyring(kr keyring.Keyring) *Genesis {
 // WithAppVersion sets the application version for the genesis configuration and returns the updated Genesis instance.
 func (g *Genesis) WithAppVersion(appVersion uint64) *Genesis {
 	g.appVersion = appVersion
+	g.ConsensusParams.Version.App = appVersion
 	return g
 }
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

I wasn't sure if this would work correctly so I didn't want to ask you to do these changes and waste your time.

Key points:

- don't need to use a separate function exec on running container
- fixed ordering of key names so they are mapped correctly to validators
- use the existing Exec fn (need to pass in home and node)
- removed additional entries to genesis and made it work with default
- removed pin

I think we could move the --home / --node args into a reusable fn and not need to specify them all the time.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
