### PR TITLE
docs: fix typos

### DIFF
--- a/docs/architecture/adr-022-multi-versioned-state-machine.md
+++ b/docs/architecture/adr-022-multi-versioned-state-machine.md
@@ -60,7 +60,7 @@ app.mm, err = module.NewManager([]module.VersionedModule{
 
 ### Configurator Changes
 
-The configurator is an object that is used upon initialisation to register the msg server, query server and migrations. In order to know what `sdk.Msg`s corresponded with which app version, a wrapper was added to the configurator that would scrape all the `sdk.Msg`s from the msg server as they were being registered and add them to a map:
+The configurator is an object that is used upon initialization to register the msg server, query server and migrations. In order to know what `sdk.Msg`s corresponded with which app version, a wrapper was added to the configurator that would scrape all the `sdk.Msg`s from the msg server as they were being registered and add them to a map:
 
 ```go
 // acceptedMsgs is a map from appVersion -> msgTypeURL -> struct{}.

--- a/tools/latency-monitor/main.go
+++ b/tools/latency-monitor/main.go
@@ -25,7 +25,7 @@ const (
 	defaultEndpoint     = "localhost:9090"
 	defaultKeyringDir   = "~/.celestia-app"
 	defaultSubmitRate   = 1.0    // KB per second
-	defaultBlobSize     = 1      // bytes
+	defaultBlobSize     = 1      // KB
 	defaultNamespaceStr = "test" // default namespace for blobs
 )
 

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -392,7 +392,7 @@ func listAllDroplets(ctx context.Context, client *godo.Client) ([]godo.Droplet, 
 			break
 		}
 		pageNum, _ := resp.Links.CurrentPage()
-		opt.Page = pageNum + 1.
+		opt.Page = pageNum + 1
 	}
 	return all, nil
 }

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -111,7 +111,7 @@ func generateCmd() *cobra.Command {
 	return cmd
 }
 
-// createPayload takes ips created by pulumi the path to the payload directory
+// createPayload takes ips created by pulumi and the path to the payload directory
 // to create the payload required for the experiment.
 func createPayload(ips []Instance, chainID, ppath string, squareSize int, useMainnetDistribution bool, mods ...genesis.Modifier) error {
 	n, err := NewNetwork(chainID, squareSize, mods...)


### PR DESCRIPTION
## Overview

docs/architecture/adr-022-multi-versioned-state-machine.md
`initialisation` - `initialization` -- _fix typo_

tools/latency-monitor/main.go
`bytes` -  `KB`  -- _Comment says "bytes" but code uses value as kilobytes (KBs) in both blob creation and flag description_

tools/talis/digital_ocean.go
`opt.Page = pageNum + 1.` - `opt.Page = pageNum + 1` -- _deleted extra ._

tools/talis/genesis.go
`pulumi the path` - `pulumi and the path` -- _Added "and" to connect two parameters in function description, making it grammatically correct_