### PR TITLE
docs: fix typos 

### DIFF
--- a/proto/celestia/core/v1/proof/proof.proto
+++ b/proto/celestia/core/v1/proof/proof.proto
@@ -37,7 +37,7 @@ message NMTProof {
   // and min namespaces along with the actual hash, resulting in each being 48
   // bytes each
   repeated bytes nodes = 3;
-  // leafHash are nil if the namespace is present in the NMT. In case the
+  // leafHash is nil if the namespace is present in the NMT. In case the
   // namespace to be proved is in the min/max range of the tree but absent, this
   // will contain the leaf hash necessary to verify the proof of absence. Leaf
   // hashes should consist of the namespace along with the actual hash,

--- a/proto/celestia/minfee/v1/tx.proto
+++ b/proto/celestia/minfee/v1/tx.proto
@@ -11,7 +11,7 @@ option go_package = "github.com/celestiaorg/celestia-app/x/minfee/types";
 service Msg {
   option (cosmos.msg.v1.service) = true;
 
-  // UpdateMinfeeParams defines a rpc handler method for MsgUpdateMinfeeParams.
+  // UpdateMinfeeParams defines an rpc handler method for MsgUpdateMinfeeParams.
   rpc UpdateMinfeeParams(MsgUpdateMinfeeParams) returns (MsgUpdateMinfeeParamsResponse);
 }
 


### PR DESCRIPTION
## Overview

File 1: `proof.proto`
- Location: In a comment within the NMTProof message definition.
- Original: // leafHash are nil if the namespace is present in the NMT.
- Correction: // leaf_hash is nil if the namespace is present in the NMT.
- Reason: The field is named leaf_hash (singular), so the comment should also be singular ("is" instead of "are").

File 2: `tx.proto`
- Location: In a comment for the UpdateMinfeeParams RPC.
- Original: // UpdateMinfeeParams defines a rpc handler method for MsgUpdateMinfeeParams.
- Correction: // UpdateMinfeeParams defines an rpc handler method for MsgUpdateMinfeeParams.
- Reason: "a" should be "an" before a word starting with a vowel sound like "rpc" (ar-pee-see).