### PR TITLE
Fix usage comment to match actual script filename

### DIFF
--- a/scripts/download_binary.sh
+++ b/scripts/download_binary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Usage: ./scripts/download_v3_binary.sh <url> <out> <version>
+# Usage: ./scripts/download_binary.sh <url> <out> <version>
 
 set -euo pipefail
 


### PR DESCRIPTION
Updated the usage comment at the top of download_binary.sh to reference the correct script name. This change helps prevent confusion by ensuring the usage instructions accurately reflect the file's real name. No functional code changes were made.