### PR TITLE
docs: fix tokenfilter link

### DIFF
--- a/specs/src/state_machine_modules_v1.md
+++ b/specs/src/state_machine_modules_v1.md
@@ -8,7 +8,7 @@ The modules used in app version 1 are:
 - [blobstream](https://github.com/celestiaorg/celestia-app/tree/06f24f5dbe48c29964e1d8cfb030cffd90797ded/x/blobstream)
 - [mint](https://github.com/celestiaorg/celestia-app/blob/main/x/mint/README.md)
 - [paramfilter](https://github.com/celestiaorg/celestia-app/blob/e293a5ed5ed8e7d35d609bf12a9754fc45463a39/x/paramfilter/README.md)
-- [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/tokenfilter/README.md)
+- [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/b6386d4bbbe9722964b54446269b6a4a4afdd5d6/x/tokenfilter/README.md)
 
 ## `cosmos-sdk` modules
 

--- a/specs/src/state_machine_modules_v2.md
+++ b/specs/src/state_machine_modules_v2.md
@@ -9,7 +9,7 @@ The modules used in app version 2 are:
 - [mint](https://github.com/celestiaorg/celestia-app/blob/main/x/mint/README.md)
 - [paramfilter](https://github.com/celestiaorg/celestia-app/blob/e293a5ed5ed8e7d35d609bf12a9754fc45463a39/x/paramfilter/README.md)
 - [signal](https://github.com/celestiaorg/celestia-app/blob/main/x/signal/README.md)
-- [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/tokenfilter/README.md)
+- [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/b6386d4bbbe9722964b54446269b6a4a4afdd5d6/x/tokenfilter/README.md)
 
 ## `cosmos-sdk` modules
 

--- a/specs/src/state_machine_modules_v3.md
+++ b/specs/src/state_machine_modules_v3.md
@@ -9,7 +9,7 @@ The modules used in app version 3 are:
 - [mint](https://github.com/celestiaorg/celestia-app/blob/main/x/mint/README.md)
 - [paramfilter](https://github.com/celestiaorg/celestia-app/blob/e293a5ed5ed8e7d35d609bf12a9754fc45463a39/x/paramfilter/README.md)
 - [signal](https://github.com/celestiaorg/celestia-app/blob/main/x/signal/README.md)
-- [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/main/x/tokenfilter/README.md)
+- [tokenfilter](https://github.com/celestiaorg/celestia-app/blob/b6386d4bbbe9722964b54446269b6a4a4afdd5d6/x/tokenfilter/README.md)
 
 ## `cosmos-sdk` modules
 


### PR DESCRIPTION
A recent PR deleted x/tokenfilter from main which caused the links in the specs to break. This should fix markdown-link-check by using permalinks to the x/tokenfilter README.m