### PR TITLE
refactor: rename accnts to accounts in tests for clarity

### DIFF
--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -101,10 +101,10 @@ func createBlobTxs(t *testing.T, testApp *app.App, encConf encoding.Config, keyr
 
 func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 	numBlobTxs, numNormalTxs := 3, 3
-	accnts := testfactory.GenerateAccounts(numBlobTxs + numNormalTxs)
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accnts...)
+	accounts := testfactory.GenerateAccounts(numBlobTxs + numNormalTxs)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
-	infos := queryAccountInfo(testApp, accnts, kr)
+	infos := queryAccountInfo(testApp, accounts, kr)
 
 	protoBlob, err := share.NewBlob(share.RandomBlobNamespace(), []byte{1}, appconsts.DefaultShareVersion, nil)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 		enc.TxConfig,
 		kr,
 		testutil.ChainID,
-		accnts[:numBlobTxs],
+		accounts[:numBlobTxs],
 		infos[:numBlobTxs],
 		testfactory.Repeat([]*share.Blob{protoBlob}, numBlobTxs),
 	)
@@ -124,8 +124,8 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 		enc.TxConfig,
 		kr,
 		1000,
-		accnts[0],
-		accnts[numBlobTxs:],
+		accounts[0],
+		accounts[numBlobTxs:],
 		testutil.ChainID,
 	)
 	txs := blobTxs

--- a/x/blob/types/estimate_gas_test.go
+++ b/x/blob/types/estimate_gas_test.go
@@ -37,13 +37,13 @@ func TestPFBGasEstimation(t *testing.T) {
 	}
 	for idx, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d", idx), func(t *testing.T) {
-			accnts := testfactory.GenerateAccounts(1)
-			testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accnts...)
-			signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, user.NewAccount(accnts[0], 1, 0))
+			accounts := testfactory.GenerateAccounts(1)
+			testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+			signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, user.NewAccount(accounts[0], 1, 0))
 			require.NoError(t, err)
 			blobs := blobfactory.ManyRandBlobs(rnd, tc.blobSizes...)
 			gas := blobtypes.DefaultEstimateGas(toUint32(tc.blobSizes))
-			tx, _, err := signer.CreatePayForBlobs(accnts[0], blobs, user.SetGasLimitAndGasPrice(gas, appconsts.DefaultMinGasPrice))
+			tx, _, err := signer.CreatePayForBlobs(accounts[0], blobs, user.SetGasLimitAndGasPrice(gas, appconsts.DefaultMinGasPrice))
 			require.NoError(t, err)
 			blobTx, ok, err := blobtx.UnmarshalBlobTx(tx)
 			require.NoError(t, err)
@@ -83,16 +83,16 @@ func FuzzPFBGasEstimation(f *testing.F) {
 		}
 		blobSizes := randBlobSize(seed, numBlobs, maxBlobSize)
 
-		accnts := testfactory.GenerateAccounts(1)
-		testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accnts...)
-		signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, user.NewAccount(accnts[0], 1, 0))
+		accounts := testfactory.GenerateAccounts(1)
+		testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+		signer, err := user.NewSigner(kr, encCfg.TxConfig, testutil.ChainID, user.NewAccount(accounts[0], 1, 0))
 		require.NoError(t, err)
 
 		rnd := random.New()
 		rnd.Seed(seed)
 		blobs := blobfactory.ManyRandBlobs(rnd, blobSizes...)
 		gas := blobtypes.DefaultEstimateGas(toUint32(blobSizes))
-		tx, _, err := signer.CreatePayForBlobs(accnts[0], blobs, user.SetGasLimitAndGasPrice(gas, appconsts.DefaultMinGasPrice))
+		tx, _, err := signer.CreatePayForBlobs(accounts[0], blobs, user.SetGasLimitAndGasPrice(gas, appconsts.DefaultMinGasPrice))
 		require.NoError(t, err)
 		blobTx, ok, err := blobtx.UnmarshalBlobTx(tx)
 		require.NoError(t, err)


### PR DESCRIPTION
### 📝 Description:
Renames variable `accnts` to `accounts` 