### PR TITLE
ci: upgrade to Node.js 24

### DIFF
--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
-          node-version: 18
+          node-version: 24
 
       - name: Install markdownlint-cli
         run: npm install -g markdownlint-cli@0.39.0


### PR DESCRIPTION

This PR updates the GitHub Actions workflow to use Node.js 24 instead of 18.

Node.js 24 includes updated V8, npm 11, and other performance and compatibility improvements.
The node-version field in markdown-linter.yml has been changed accordingly.
No other changes were required. CI and lint checks run successfully under the new version.

Reference: [Node.js 24.4.1 release notes](https://github.com/nodejs/node/releases/tag/v24.4.1)