### PR TITLE
docs(minfee): fix module name in comments

### DIFF
--- a/x/minfee/keeper/genesis.go
+++ b/x/minfee/keeper/genesis.go
@@ -8,7 +8,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// InitGenesis initializes the blob module's state from a provided genesis state.
+// InitGenesis initializes the minfee module's state from a provided genesis state.
 func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 
@@ -20,7 +20,7 @@ func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) er
 	return nil
 }
 
-// ExportGenesis returns the blob module's exported genesis.
+// ExportGenesis returns the minfee module's exported genesis.
 func (k Keeper) ExportGenesis(ctx context.Context) *types.GenesisState {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	genesis := types.DefaultGenesis()


### PR DESCRIPTION
## Overview
Replace incorrect references to "blob module" with "minfee module" in the comments of InitGenesis and ExportGenesis functions