### PR TITLE
fix(ante): correct comment in PFB gas test to match actual blob size logic

### DIFF
--- a/x/blob/ante/ante_test.go
+++ b/x/blob/ante/ante_test.go
@@ -61,7 +61,7 @@ func TestPFBAnteHandler(t *testing.T) {
 		{
 			name: "pfb single blob not enough gas",
 			pfb: &blob.MsgPayForBlobs{
-				// 2 share = 1024 bytes = 10240 gas
+				// blob size > 1 share, requires 2 shares = 1024 bytes = 10240 gas
 				BlobSizes: []uint32{uint32(share.AvailableBytesFromSparseShares(1) + 1)},
 			},
 			txGas: func(testGasPerBlobByte uint32) uint32 {


### PR DESCRIPTION
The test "pfb single blob not enough gas" uses a blob size of 
share.AvailableBytesFromSparseShares(1) + 1, which is greater than 1 share 
and requires 2 shares for storage. However, the original comment incorrectly 
stated "2 share = 1024 bytes = 10240 gas" without explaining why 2 shares 
are needed.

Updated the comment to "blob size > 1 share, requires 2 shares = 1024 bytes = 10240 gas" 
to accurately reflect that the blob size exceeds 1 share capacity, thus requiring 
2 shares for proper storage allocation.
