### PR TITLE
docs: fix comments

### DIFF
--- a/x/blob/types/genesis.go
+++ b/x/blob/types/genesis.go
@@ -1,9 +1,9 @@
 package types
 
-// DefaultIndex is the default capability global index
+// DefaultIndex is the default global index
 const DefaultIndex uint64 = 1
 
-// DefaultGenesis returns the default Capability genesis state
+// DefaultGenesis returns the default genesis state
 func DefaultGenesis() *GenesisState {
 	return &GenesisState{
 		Params: DefaultParams(),


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fix incorrect documentation in blob/types/genesis.go by removing references to "capability" module from comments. These comments were incorrectly copied from the capability module and should refer only to the blob module functionality
