### PR TITLE
test: Fix grammar and improve variable consistency

### DIFF
--- a/app/test/prepare_proposal_context_test.go
+++ b/app/test/prepare_proposal_context_test.go
@@ -25,7 +25,7 @@ import (
 // TestTimeInPrepareProposalContext checks for an edge case where the block time
 // needs to be included in the sdk.Context that is being used in the
 // antehandlers. If a time is not included in the context, then the second
-// transaction in this test will always be filtered out, result in vesting
+// transaction in this test will always be filtered out, resulting in vesting
 // accounts never being able to spend funds.
 func TestTimeInPrepareProposalContext(t *testing.T) {
 	if testing.Short() {

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -101,10 +101,10 @@ func createBlobTxs(t *testing.T, testApp *app.App, encConf encoding.Config, keyr
 
 func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 	numBlobTxs, numNormalTxs := 3, 3
-	accnts := testfactory.GenerateAccounts(numBlobTxs + numNormalTxs)
-	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accnts...)
+	accounts := testfactory.GenerateAccounts(numBlobTxs + numNormalTxs)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
-	infos := queryAccountInfo(testApp, accnts, kr)
+	infos := queryAccountInfo(testApp, accounts, kr)
 
 	protoBlob, err := share.NewBlob(share.RandomBlobNamespace(), []byte{1}, appconsts.DefaultShareVersion, nil)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 		enc.TxConfig,
 		kr,
 		testutil.ChainID,
-		accnts[:numBlobTxs],
+		accounts[:numBlobTxs],
 		infos[:numBlobTxs],
 		testfactory.Repeat([]*share.Blob{protoBlob}, numBlobTxs),
 	)
@@ -124,8 +124,8 @@ func TestPrepareProposalPutsPFBsAtEnd(t *testing.T) {
 		enc.TxConfig,
 		kr,
 		1000,
-		accnts[0],
-		accnts[numBlobTxs:],
+		accounts[0],
+		accounts[numBlobTxs:],
 		testutil.ChainID,
 	)
 	txs := blobTxs


### PR DESCRIPTION
app/test/prepare_proposal_test.go:
- The variable `accnts` has been renamed to `accounts`. This change ensures consistent variable naming across the test suite, where `accounts` is the standard convention.

app/test/prepare_proposal_context_test.go:
- A grammatical error in a comment has been corrected. The phrase `result in` was changed to `resulting in` to form a grammatically correct sentence describing the consequence of an action.