### PR TITLE
fix(goreleaser): download_binary script name

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,14 +9,14 @@ before:
     - go mod tidy
     # These hooks get run once. We want to explicitly download every embedded binary so we can build the multiplexer
     # for every architecture. These versions must be updated at the same time as the version in the Makefile.
-    - ./scripts/download_v3_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.5
-    - ./scripts/download_v3_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.5
-    - ./scripts/download_v3_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.5
-    - ./scripts/download_v3_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.5
-    - ./scripts/download_v4_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v4_arm64.tar.gz v4.1.0-arabica
-    - ./scripts/download_v4_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0-arabica
-    - ./scripts/download_v4_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0-arabica
-    - ./scripts/download_v4_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v4_amd64.tar.gz v4.1.0-arabica
+    - ./scripts/download_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.5
+    - ./scripts/download_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.5
+    - ./scripts/download_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.5
+    - ./scripts/download_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.5
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v4_arm64.tar.gz v4.1.0-arabica
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0-arabica
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0-arabica
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v4_amd64.tar.gz v4.1.0-arabica
 
 builds:
   - id: darwin-amd64-multiplexer


### PR DESCRIPTION
Goreleaser is failing to attach binaries because the download_binary.sh script was renamed.

See: https://github.com/celestiaorg/celestia-app/actions/runs/16601565878/job/46962549875#step:7:74