### PR TITLE
fix: correct inflation rate comment in mint CLI test

### DIFF
--- a/x/mint/client/testutil/suite_test.go
+++ b/x/mint/client/testutil/suite_test.go
@@ -46,7 +46,7 @@ func (s *IntegrationTestSuite) textArgs() []string {
 
 // TestGetCmdQueryInflationRate tests that the CLI query command for inflation
 // rate returns the correct value. This test assumes that the initial inflation
-// rate is 0.08.
+// rate is 0.0536 (as defined in CIP-29).
 func (s *IntegrationTestSuite) TestGetCmdQueryInflationRate() {
 	testCases := []struct {
 		name string


### PR DESCRIPTION
Update the comment in TestGetCmdQueryInflationRate to reflect the correct 
initial inflation rate of 0.0536 as defined in CIP-29, instead of the 
incorrect value of 0.08.

The test was already using the correct expected value (0.0536), but the 
comment was misleading and could confuse developers about the actual 
inflation rate being tested.