### PR TITLE
docs(x/mint): fix comment 

### DIFF
--- a/x/mint/types/minter.go
+++ b/x/mint/types/minter.go
@@ -39,7 +39,7 @@ func (m Minter) Validate() error {
 }
 
 // CalculateInflationRate returns the inflation rate for the current year depending on
-// the current block height in context. The inflation rate is expected to
+// the current block time in context. The inflation rate is expected to
 // decrease every year according to the schedule specified in the README.
 func (m Minter) CalculateInflationRate(ctx sdk.Context, genesisTime time.Time) math.LegacyDec {
 	yearsSinceGenesis := yearsSinceGenesis(genesisTime, ctx.BlockTime())


### PR DESCRIPTION
The comment for the CalculateInflationRate function incorrectly referenced "block height" as the basis for inflation calculation. This has been updated to "block time" to accurately reflect the function's logic, which uses the current block time from the context. This change improves code clarity and helps prevent confusion for future maintainers. No functional code changes were made.