### PR TITLE
docs: fix typos

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -143,7 +143,7 @@ type TxClient struct {
 	cdc      codec.Codec
 	signer   *Signer
 	registry codectypes.InterfaceRegistry
-	// list of core endpoints for tx submission (primary + additionals)
+	// list of core endpoints for tx submission (primary + additional endpoints)
 	conns []*grpc.ClientConn
 	// how often to poll the network for confirmation of a transaction
 	pollTime time.Duration
@@ -772,7 +772,7 @@ func QueryMinimumGasPrice(ctx context.Context, grpcConn *grpc.ClientConn) (float
 
 func QueryNetworkMinGasPrice(ctx context.Context, grpcConn *grpc.ClientConn) (float64, error) {
 	paramsClient := paramtypes.NewQueryClient(grpcConn)
-	// NOTE: that we don't prove that this is the correct value
+	// NOTE: we don't prove that this is the correct value
 	paramResponse, err := paramsClient.Params(ctx, &paramtypes.QueryParamsRequest{Subspace: minfeetypes.ModuleName, Key: string(minfeetypes.KeyNetworkMinGasPrice)})
 	if err != nil {
 		return 0, fmt.Errorf("querying params module: %w", err)

--- a/test/docker-e2e/e2e_simple_test.go
+++ b/test/docker-e2e/e2e_simple_test.go
@@ -95,7 +95,7 @@ func assertTransactionsIncluded(ctx context.Context, t *testing.T, celestia *tas
 func testBankSend(t *testing.T, chain *tastoradockertypes.Chain, cfg *dockerchain.Config) {
 	ctx := context.Background()
 
-	// The key-ring stores wallets by name. Re-using a name causes
+	// The key-ring stores wallets by name. Reusing a name causes
 	// 'celestia-appd keys add' to fail with "key already exists", which would
 	// break repeated or parallel test runs.  A timestamp keeps the name unique.
 	recipientWalletName := fmt.Sprintf("recipient-%d", time.Now().UnixNano())


### PR DESCRIPTION


---


## Description
- Corrected the word "additionals" to "additional endpoints" in `TxClient` struct comment.
- Improved English in a note about value validation in `QueryNetworkMinGasPrice`.
- Fixed the spelling of "Re-using" to "Reusing" in the e2e test comment.



---