### PR TITLE
chore(deps): upgrade embedded binary to celestia-app v4.1.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -13,10 +13,10 @@ before:
     - ./scripts/download_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.5
     - ./scripts/download_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.5
     - ./scripts/download_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.5
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v4_arm64.tar.gz v4.1.0-arabica
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0-arabica
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0-arabica
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v4_amd64.tar.gz v4.1.0-arabica
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v4_arm64.tar.gz v4.1.0
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v4_amd64.tar.gz v4.1.0
 
 builds:
   - id: darwin-amd64-multiplexer

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ BUILD_FLAGS_MULTIPLEXER := -tags "ledger multiplexer" -ldflags '$(ldflags)'
 # .goreleaser.yaml
 # docker/multiplexer.Dockerfile
 CELESTIA_V3_VERSION := v3.10.5
-CELESTIA_V4_VERSION := v4.1.0-arabica
+CELESTIA_V4_VERSION := v4.1.0
 
 ## help: Get more info on make commands.
 help: Makefile

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -19,7 +19,7 @@ ARG CELESTIA_APP_REPOSITORY=ghcr.io/celestiaorg/celestia-app-standalone
 # NOTE: This version must be updated at the same time as the version in the
 # Makefile.
 ARG CELESTIA_VERSION_V3="v3.10.5"
-ARG CELESTIA_VERSION_V4="v4.1.0-arabica"
+ARG CELESTIA_VERSION_V4="v4.1.0"
 
 # Stage 1: this base image contains already released v3 binaries which can be embedded in the multiplexer.
 FROM ${CELESTIA_APP_REPOSITORY}:${CELESTIA_VERSION_V3} AS base-v3

--- a/internal/embedding/data.go
+++ b/internal/embedding/data.go
@@ -11,7 +11,7 @@ import (
 // Makefile.
 const (
 	v3Version = "v3.10.5"
-	v4Version = "v4.1.0-arabica"
+	v4Version = "v4.1.0"
 )
 
 // CelestiaAppV3 returns the compressed platform specific Celestia binary and

--- a/test/docker-e2e/dockerchain/config.go
+++ b/test/docker-e2e/dockerchain/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	multiplexerImage    = "ghcr.io/celestiaorg/celestia-app"
-	defaultCelestiaTag  = "v4.1.0-arabica"
+	defaultCelestiaTag  = "v4.1.0"
 	celestiaTagEnvVar   = "CELESTIA_TAG"
 	celestiaImageEnvVar = "CELESTIA_IMAGE"
 )

--- a/test/docker-e2e/e2e_test.go
+++ b/test/docker-e2e/e2e_test.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	txsimImage = "ghcr.io/celestiaorg/txsim"
-	txSimTag   = "v4.0.7-mocha"
+	txSimTag   = "v4.1.0"
 	homeDir    = "/var/cosmos-chain/celestia"
 )
 


### PR DESCRIPTION
## Overview

v4.1.0-arabica -> v4.1.0

also noticed a v4.0.7-mocha instance in the e2e test which has been switched as well
