### PR TITLE
docs: fix grammar and clarity in parameter and pricing specs

### DIFF
--- a/specs/src/parameters_v2.md
+++ b/specs/src/parameters_v2.md
@@ -3,7 +3,7 @@
 The parameters below represent the parameters for app version 2.
 
 Note that not all of these parameters are changeable via governance. This list
-also includes parameter that require a hardfork to change due to being manually
+also includes a parameter that requires a hardfork to change due to being manually
 hardcoded in the application or they are blocked by the `x/paramfilter` module.
 
 ## Global parameters

--- a/specs/src/parameters_v3.md
+++ b/specs/src/parameters_v3.md
@@ -3,7 +3,7 @@
 The parameters below represent the parameters for app version 3.
 
 Note that not all of these parameters are changeable via governance. This list
-also includes parameter that require a hardfork to change due to being manually
+also includes a parameter that requires a hardfork to change due to being manually
 hardcoded in the application or they are blocked by the `x/paramfilter` module.
 
 ## Global parameters

--- a/specs/src/parameters_v4.md
+++ b/specs/src/parameters_v4.md
@@ -3,7 +3,7 @@
 The parameters below represent the parameters for app version 4.
 
 Note that not all of these parameters are changeable via governance. This list
-also includes parameter that require a hardfork to change due to being manually
+also includes a parameter that requires a hardfork to change due to being manually
 hardcoded in the application or they are blocked by the `ParamFilterDecorator`.
 Parameters that are governance modifiables can be modified via a
 `MsgSubmitProposal` that contains a `moduleXYZ.MsgUpdateParams` message.

--- a/specs/src/parameters_v5.md
+++ b/specs/src/parameters_v5.md
@@ -3,7 +3,7 @@
 The parameters below represent the parameters for app version 5.
 
 Note that not all of these parameters are changeable via governance. This list
-also includes parameter that require a hardfork to change due to being manually
+also includes a parameter that requires a hardfork to change due to being manually
 hardcoded in the application or they are blocked by the `ParamFilterDecorator`.
 Parameters that are governance modifiables can be modified via a
 `MsgSubmitProposal` that contains a `moduleXYZ.MsgUpdateParams` message.

--- a/specs/src/resource_pricing.md
+++ b/specs/src/resource_pricing.md
@@ -154,7 +154,7 @@ usage.
 ## Gas Limit
 
 The gas limit must be included in each transaction. If the transaction exceeds
-this gas limit during the execution of the transaction, then the transaction
+this gas limit is used during the execution of the transaction, then the transaction
 will fail.
 
 > Note: When a transaction is submitted to the mempool, the transaction is not


### PR DESCRIPTION
Fixed incorrect phrase includes parameter → includes a parameter in:

- specs/src/parameters_v2.md
- specs/src/parameters_v3.md
- specs/src/parameters_v4.md
- specs/src/parameters_v5.md

Reworded sentence in specs/src/resource_pricing.md for clarity:

- exceeds this gas limit during the execution → this gas limit is used during the execution