### PR TITLE
chore: Address legacy TODOs in blob and specs

### DIFF
--- a/specs/src/proto/wire.proto
+++ b/specs/src/proto/wire.proto
@@ -8,6 +8,9 @@ message TransactionFee {
   uint64 tip_rate = 1;
 }
 
+// Deprecated: This message is obsolete as per the decision in issue #120 to use
+// a 'string' type for decimals. It is kept for legacy purposes and will be
+// removed in a future refactor.
 message Decimal {
   // https://github.com/celestiaorg/celestia-specs/issues/120
   uint64 todo = 1;

--- a/x/blob/keeper/params.go
+++ b/x/blob/keeper/params.go
@@ -29,9 +29,3 @@ func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	bz := k.cdc.MustMarshal(&params)
 	store.Set([]byte(types.ParamsKey), bz)
 }
-
-// SetParamsLegacy sets the params in the legacy store space.
-// TODO: this can be removed in versions after migrations have run.
-func (k Keeper) SetParamsLegacy(ctx sdk.Context, params types.Params) {
-	k.legacySubspace.SetParamSet(ctx, &params)
-}


### PR DESCRIPTION
This pull request performs some code cleanup by addressing two old `TODO` comments related to legacy features.

x/blob/keeper/params.go:
- The function `SetParamsLegacy` has been removed. A `TODO` in the code indicated that this function was for past migrations and is no longer needed. A code search confirms it is not being used anywhere.

specs/src/proto/wire.proto:
- A `Deprecated` comment has been added to the `Decimal` message. This clarifies that the message is obsolete, as decided in issue #120, and helps prevent it from being used in new code.
