### PR TITLE
fix: UnpackAny limit for historical blocks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -253,7 +253,7 @@ require (
 )
 
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.31.1-sdk-v0.46.16
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.31.2-sdk-v0.46.16
 	// Replace IBC with celestiaorg fork which includes fixes for security vulnerabilities.
 	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.3.0
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1

--- a/go.sum
+++ b/go.sum
@@ -320,8 +320,8 @@ github.com/celestiaorg/blobstream-contracts/v3 v3.1.0 h1:h1Y4V3EMQ2mFmNtWt2sIhZI
 github.com/celestiaorg/blobstream-contracts/v3 v3.1.0/go.mod h1:x4DKyfKOSv1ZJM9NwV+Pw01kH2CD7N5zTFclXIVJ6GQ=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v1.31.1-sdk-v0.46.16 h1://lhd7SXtuNVuzRvz02GCBsOvob9yamdDq+EI8IrTO4=
-github.com/celestiaorg/cosmos-sdk v1.31.1-sdk-v0.46.16/go.mod h1:oai4Oc0YKYc7RMRi4mbXfR3aeSu2/P5LhqW/P10IAJI=
+github.com/celestiaorg/cosmos-sdk v1.31.2-sdk-v0.46.16 h1:CSv7rI3Ua1izQRuhEYk0op0eHKuJtngr+wAXMIr+P9U=
+github.com/celestiaorg/cosmos-sdk v1.31.2-sdk-v0.46.16/go.mod h1:oai4Oc0YKYc7RMRi4mbXfR3aeSu2/P5LhqW/P10IAJI=
 github.com/celestiaorg/go-square v1.1.1 h1:Cy3p8WVspVcyOqHM8BWFuuYPwMitO1pYGe+ImILFZRA=
 github.com/celestiaorg/go-square v1.1.1/go.mod h1:1EXMErhDrWJM8B8V9hN7dqJ2kUTClfwdqMOmF9yQUa0=
 github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=

--- a/test/interchain/go.mod
+++ b/test/interchain/go.mod
@@ -223,7 +223,7 @@ replace (
 
 // These replace statements were inspired by celestia-app.
 replace (
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.31.1-sdk-v0.46.16
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v1.31.2-sdk-v0.46.16
 	// Replace IBC with celestiaorg fork which includes fixes for security vulnerabilities.
 	github.com/cosmos/ibc-go/v6 => github.com/celestiaorg/ibc-go/v6 v6.2.4
 	github.com/docker/docker => github.com/docker/docker v24.0.1+incompatible

--- a/test/interchain/go.sum
+++ b/test/interchain/go.sum
@@ -251,8 +251,8 @@ github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pY
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35 h1:N+sJFu0h8okPkRjgQh/2iN4pi3atrR9a/vkXLwEKXfw=
 github.com/celestiaorg/celestia-core v1.52.1-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v1.31.1-sdk-v0.46.16 h1://lhd7SXtuNVuzRvz02GCBsOvob9yamdDq+EI8IrTO4=
-github.com/celestiaorg/cosmos-sdk v1.31.1-sdk-v0.46.16/go.mod h1:oai4Oc0YKYc7RMRi4mbXfR3aeSu2/P5LhqW/P10IAJI=
+github.com/celestiaorg/cosmos-sdk v1.31.2-sdk-v0.46.16 h1:CSv7rI3Ua1izQRuhEYk0op0eHKuJtngr+wAXMIr+P9U=
+github.com/celestiaorg/cosmos-sdk v1.31.2-sdk-v0.46.16/go.mod h1:oai4Oc0YKYc7RMRi4mbXfR3aeSu2/P5LhqW/P10IAJI=
 github.com/celestiaorg/ibc-go/v6 v6.2.4 h1:S9jH7e+faYWF9PgDQAQnHxgm+FeDWTKcOF99Zez40bA=
 github.com/celestiaorg/ibc-go/v6 v6.2.4/go.mod h1:XLsARy4Y7+GtAqzMcxNdlQf6lx+ti1e8KcMGv5NIK7A=
 github.com/celestiaorg/nmt v0.23.0 h1:cfYy//hL1HeDSH0ub3CPlJuox5U5xzgg4JGZrw23I/I=


### PR DESCRIPTION
Part of https://github.com/celestiaorg/celestia-app/issues/4370

Upgrades to a Cosmos SDK release with
https://github.com/celestiaorg/cosmos-sdk/pull/635 to hopefully restore the ability to sync from genesis with a single binary (the latest multiplexer binary) with a v3 embedded binary cut after this merges.