### PR TITLE
fix: register the ICA module

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -417,7 +417,7 @@ func New(
 		signal.NewAppModule(app.SignalKeeper),
 		minfee.NewAppModule(encodingConfig.Codec, app.MinFeeKeeper),
 		pfm{packetforward.NewAppModule(app.PacketForwardKeeper, app.GetSubspace(packetforwardtypes.ModuleName))},
-		ica.NewAppModule(nil, &app.ICAHostKeeper), // The first argument is nil because the ICA controller is not enabled on celestia-app.
+		icaModule{ica.NewAppModule(nil, &app.ICAHostKeeper)}, // The first argument is nil because the ICA controller is not enabled on celestia-app.
 		// ensure the light client module types are registered.
 		ibctm.NewAppModule(),
 		solomachine.NewAppModule(),


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5423

## Testing

Now the CLI has a query command for interchain-accounts.
 
```
$ celestia-appd query interchain-accounts host params
allow_messages:
- /ibc.applications.transfer.v1.MsgTransfer
- /cosmos.bank.v1beta1.MsgSend
- /cosmos.staking.v1beta1.MsgDelegate
- /cosmos.staking.v1beta1.MsgBeginRedelegate
- /cosmos.staking.v1beta1.MsgUndelegate
- /cosmos.staking.v1beta1.MsgCancelUnbondingDelegation
- /cosmos.distribution.v1beta1.MsgSetWithdrawAddress
- /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward
- /cosmos.distribution.v1beta1.MsgFundCommunityPool
- /cosmos.gov.v1.MsgVote
- /cosmos.feegrant.v1beta1.MsgGrantAllowance
- /cosmos.feegrant.v1beta1.MsgRevokeAllowance
host_enabled: true
```
