### PR TITLE
chore(x/blob): Fix typos and improve comments

### DIFF
--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -167,16 +167,16 @@ func getBlobFromArguments(namespaceIDArg, blobArg string, namespaceVersion, shar
 		return nil, err
 	}
 	hexStr := strings.TrimPrefix(blobArg, "0x")
-	rawblob, err := hex.DecodeString(hexStr)
+	rawBlob, err := hex.DecodeString(hexStr)
 	if err != nil {
 		return nil, fmt.Errorf("failure to decode hex blob value %s: %s", hexStr, err.Error())
 	}
 
 	switch shareVersion {
 	case share.ShareVersionZero:
-		return types.NewV0Blob(namespace, rawblob)
+		return types.NewV0Blob(namespace, rawBlob)
 	case share.ShareVersionOne:
-		return types.NewV1Blob(namespace, rawblob, signer)
+		return types.NewV1Blob(namespace, rawBlob, signer)
 	default:
 		return nil, fmt.Errorf("share version %d is not supported", shareVersion)
 	}
@@ -198,7 +198,7 @@ func getNamespace(namespaceID []byte, namespaceVersion uint8) (share.Namespace, 
 }
 
 // broadcastPFB creates the new PFB message type that will later be broadcast to tendermint nodes
-// this private func is used in CmdPayForBlob
+// this private function is used in CmdPayForBlob
 func broadcastPFB(cmd *cobra.Command, b ...*share.Blob) error {
 	clientCtx, err := client.GetClientTxContext(cmd)
 	if err != nil {
@@ -243,7 +243,7 @@ func broadcastPFB(cmd *cobra.Command, b ...*share.Blob) error {
 // cosmos-sdk cli argument parsing code with the given set of messages. It will also simulate gas
 // requirements if necessary. It will return an error upon failure.
 //
-// NOTE: Copy paste forked from the cosmos-sdk so that we can wrap the PFB with
+// NOTE: Copy-paste forked from the cosmos-sdk so that we can wrap the PFB with
 // a blob while still using all of the normal cli parsing code
 func writeTx(clientCtx client.Context, txf sdktx.Factory, msgs ...sdk.Msg) ([]byte, error) {
 	if clientCtx.GenerateOnly {
@@ -288,7 +288,7 @@ func writeTx(clientCtx client.Context, txf sdktx.Factory, msgs ...sdk.Msg) ([]by
 		ok, err := input.GetConfirmation("confirm transaction before signing and broadcasting", buf, os.Stderr)
 
 		if err != nil || !ok {
-			_, _ = fmt.Fprintf(os.Stderr, "%s\n", "cancelled transaction")
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", "transaction cancelled")
 			return nil, err
 		}
 	}

--- a/x/blob/client/cli/util.go
+++ b/x/blob/client/cli/util.go
@@ -5,7 +5,7 @@ import (
 	"os"
 )
 
-// Define the raw content from the file input.
+// blobs defines the structure of the JSON file input for multiple blobs.
 type blobs struct {
 	Blobs []blobJSON
 }

--- a/x/blob/keeper/keeper.go
+++ b/x/blob/keeper/keeper.go
@@ -43,7 +43,7 @@ func NewKeeper(
 	}
 }
 
-// GetAuthority returns the client submodule's authority.
+// GetAuthority returns the blob module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
 }

--- a/x/blob/keeper/params.go
+++ b/x/blob/keeper/params.go
@@ -10,7 +10,7 @@ func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 	store := ctx.KVStore(k.storeKey)
 	bz := store.Get([]byte(types.ParamsKey))
 	if len(bz) == 0 {
-		// fallback to legacy store space
+		// fallback to legacy subspace
 		// this is required because the prepare proposal handler
 		// makes use of this value before the params are migrated.
 		var params types.Params


### PR DESCRIPTION
x/blob/client/cli/payforblob.go
- `rawblob` to `rawBlob`

- Corrected a factual error in the `GetAuthority` function comment to specify `blob module's authority` instead of the incorrect `client submodule's authority`.

x/blob/keeper/params.go
- `legacy store space` to `legacy subspace`

- Improved the clarity of the comment for the `blobs` struct in `x/blob/client/cli/util.go` to be more descriptive.

- `Copy paste` -> `Copy-paste`, `func` -> `function`

- Adjusted a user-facing message from `"cancelled transaction"` to `"transaction cancelled"` for more natural wording.