### PR TITLE
docs: fix inconsistencies in ADR documentation

### DIFF
--- a/docs/architecture/adr-006-non-interactive-defaults.md
+++ b/docs/architecture/adr-006-non-interactive-defaults.md
@@ -70,7 +70,7 @@ To recap the default constraints of arranging a square:
 - All messages must be ordered lexicographically by namespace.
 - The commitments signed over in each `MsgPayForBlob` must consist only of subtree roots of the data square.
 - If a `MsgPayForBlob` is added to the square, then its corresponding message must also be included.
-- There must not be a message without a `MsgPayForBlob` (does this need to be a rule? cc @adlerjohn).
+- There must not be a message without a `MsgPayForBlob`.
 - Transactions with higher fees should be prioritized by default.
 - The square should be filled as optimally as possible.
 

--- a/docs/architecture/adr-008-square-size-independent-message-commitments.md
+++ b/docs/architecture/adr-008-square-size-independent-message-commitments.md
@@ -39,7 +39,7 @@ If the message starting point index is larger than the row of `msgMinSquareSize`
 
 ## Alternative Approaches
 
-- [rollmint/adr-007](https://github.com/celestiaorg/rollmint/blob/cb5c7440a8e879778e71097e254c3dd692c39d14/docs/lazy-adr/adr-007-header-commit-to-shares.md)
+- [rollmint/adr-007](https://github.com/rollkit/rollkit/blob/f85b994e81bcacf33d187b2dcf2d40657f152408/specs/lazy-adr/adr-007-header-commit-to-shares.md)
 
 ## Decision
 

--- a/docs/architecture/adr-008-square-size-independent-message-commitments.md
+++ b/docs/architecture/adr-008-square-size-independent-message-commitments.md
@@ -39,7 +39,7 @@ If the message starting point index is larger than the row of `msgMinSquareSize`
 
 ## Alternative Approaches
 
-- [rollmint/adr-007](https://github.com/rollkit/rollkit/blob/f85b994e81bcacf33d187b2dcf2d40657f152408/specs/lazy-adr/adr-007-header-commit-to-shares.md)
+- [ev-node/adr-007](https://github.com/evstack/ev-node/blob/f85b994e81bcacf33d187b2dcf2d40657f152408/specs/lazy-adr/adr-007-header-commit-to-shares.md)
 
 ## Decision
 

--- a/docs/architecture/adr-008-square-size-independent-message-commitments.md
+++ b/docs/architecture/adr-008-square-size-independent-message-commitments.md
@@ -81,7 +81,7 @@ Therefore the height of the tree over the subtree roots is in this implementatio
 ### Positive Rollmint changes
 
 1. A Rollup can include the commitment in the block header *before* posting to Celestia because it is size-independent and does not have to wait for Celestia to confirm the square size. In general, the roll-up needs access to this commitment in some form to verify a message inclusion proof guaranteeing data availability, which Rollmint currently does not have access to.
-2. In turn, this would serve as an alternative to [rollmint/adr-007](https://github.com/rollkit/rollkit/blob/f85b994e81bcacf33d187b2dcf2d40657f152408/specs/lazy-adr/adr-007-header-commit-to-shares.md)
+2. In turn, this would serve as an alternative to [ev-node/adr-007](https://github.com/evstack/ev-node/blob/f85b994e81bcacf33d187b2dcf2d40657f152408/specs/lazy-adr/adr-007-header-commit-to-shares.md)
 3. Here is one scheme on how a Rollup might use this new commitment in the block header. Let's assume a Rollup that looks like this:
   BH1 <-- BH2 <-- BH3 <-- BH4
   The Messages that are submitted to Celestia could look like this:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

1. Removes a development comment in ADR-006 (line 73) that was not meant to be included in the final version. The comment was asking whether a specific rule should be included and tagging a contributor for feedback.

2. Fixes inconsistent repository links in ADR-008. Updates an outdated link to the celestiaorg/rollmint repository to point to the current rollkit/rollkit repository, ensuring both references in the document point to the same location.

