### PR TITLE
test: rename test function to match tested function

### DIFF
--- a/multiplexer/abci/multiplexer_test.go
+++ b/multiplexer/abci/multiplexer_test.go
@@ -13,7 +13,7 @@ func TestOpenTraceWriter(t *testing.T) {
 	})
 }
 
-func Test_getProgramArgs(t *testing.T) {
+func TestRemoveStart(t *testing.T) {
 	type testCase struct {
 		name  string
 		input []string


### PR DESCRIPTION
Rename Test_getProgramArgs to TestRemoveStart to accurately reflect
that the test is testing the removeStart function, not getProgramArgs.