### PR TITLE
docs: fix comments

### DIFF
--- a/pkg/appconsts/prepare_proposal_consts.go
+++ b/pkg/appconsts/prepare_proposal_consts.go
@@ -7,9 +7,9 @@ package appconsts
 // These numbers softly constrain the processing time of blocks to 0.25sec.
 // The benchmarks used to find these limits can be found in `app/benchmarks`.
 const (
-	// MaxPFBMessages is the maximum number of SDK messages, aside from PFBs, that a block can contain.
+	// MaxPFBMessages is the maximum number of PFB messages that a block can contain.
 	MaxPFBMessages = 200
 
-	// MaxNonPFBMessages is the maximum number of PFB messages a block can contain.
+	// MaxNonPFBMessages is the maximum number of SDK messages, aside from PFBs, that a block can contain.
 	MaxNonPFBMessages = 600
 )


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

MaxPFBMessages and MaxNonPFBMessages constants were swapped, causing confusion about their actual purpose. This commit fixes the documentation to accurately reflect that MaxPFBMessages refers to the maximum number of PayForBlob messages in a block, while MaxNonPFBMessages refers to the maximum number of non-PFB SDK messages in a block
