### PR TITLE
feat: add a cli sub command to migrate configs for specific versions

### DIFF
--- a/cmd/celestia-appd/cmd/migrate_config.go
+++ b/cmd/celestia-appd/cmd/migrate_config.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/cometbft/cometbft/config"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/celestiaorg/celestia-app/v6/app"
+)
+
+// ConfigMigrator defines a function type for applying version-specific migrations
+type ConfigMigrator func(*config.Config, *serverconfig.Config) (*config.Config, *serverconfig.Config)
+
+// migrationRegistry maps version strings to their corresponding migration functions
+var migrationRegistry = map[string]ConfigMigrator{
+	"v6": applyV6Migrations,
+}
+
+// migrateConfigCmd returns the migrate-config command that migrates
+// configuration files based on the target version.
+func migrateConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "migrate-config [version]",
+		Short:   "Migrate configuration files to a target version",
+		Long:    "Migrate configuration files (config.toml and app.toml) to be compatible with a target application version.",
+		Example: "celestia-appd migrate-config v6 --home ~/.celestia-app",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			homeDir, err := cmd.Flags().GetString(flags.FlagHome)
+			if err != nil {
+				return err
+			}
+
+			targetVersion := args[0]
+			return migrateConfig(homeDir, targetVersion)
+		},
+	}
+
+	cmd.Flags().String(flags.FlagHome, app.NodeHome, "The application home directory")
+	return cmd
+}
+
+// migrateConfig performs the actual migration of configuration files.
+func migrateConfig(homeDir, targetVersion string) error {
+	fmt.Printf("Migrating configuration files to version %s...\n", targetVersion)
+
+	migrator, exists := migrationRegistry[targetVersion]
+	if !exists {
+		return fmt.Errorf("unsupported target version: %s. Supported versions: %v", targetVersion, getSupportedVersions())
+	}
+
+	configDir := filepath.Join(homeDir, "config")
+	cometConfigPath := filepath.Join(configDir, "config.toml")
+	appConfigPath := filepath.Join(configDir, "app.toml")
+
+	cometConfig, err := loadCometBFTConfig(cometConfigPath, homeDir)
+	if err != nil {
+		return fmt.Errorf("failed to load CometBFT config: %w", err)
+	}
+
+	serverConfig, err := loadServerConfig(appConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to load server config: %w", err)
+	}
+
+	fmt.Printf("Loaded configs successfully. Applying %s migrations...\n", targetVersion)
+
+	cometConfig, serverConfig = migrator(cometConfig, serverConfig)
+
+	config.WriteConfigFile(cometConfigPath, cometConfig)
+	serverconfig.WriteConfigFile(appConfigPath, serverConfig)
+
+	fmt.Printf("Successfully migrated configuration files to version %s\n", targetVersion)
+	return nil
+}
+
+// loadCometBFTConfig loads the CometBFT configuration from config.toml
+func loadCometBFTConfig(configPath, homeDir string) (*config.Config, error) {
+	cfg := app.DefaultConsensusConfig()
+	cfg.SetRoot(homeDir)
+
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	v.SetConfigType("toml")
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
+	}
+
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// loadServerConfig loads the Cosmos SDK server configuration from app.toml
+func loadServerConfig(configPath string) (*serverconfig.Config, error) {
+	cfg := app.DefaultAppConfig()
+
+	v := viper.New()
+	v.SetConfigFile(configPath)
+	v.SetConfigType("toml")
+
+	if err := v.ReadInConfig(); err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", configPath, err)
+	}
+
+	if err := v.Unmarshal(cfg); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	return cfg, nil
+}
+
+// getSupportedVersions returns a list of supported migration versions
+func getSupportedVersions() []string {
+	versions := make([]string, 0, len(migrationRegistry))
+	for version := range migrationRegistry {
+		versions = append(versions, version)
+	}
+	return versions
+}
+
+// applyV6Migrations applies configuration changes needed for v6
+func applyV6Migrations(cmtCfg *config.Config, appCfg *serverconfig.Config) (*config.Config, *serverconfig.Config) {
+	fmt.Println("Applying v6 configuration migrations...")
+
+	defaultCfg := app.DefaultConsensusConfig()
+	cmtCfg.RPC.MaxBodyBytes = defaultCfg.RPC.MaxBodyBytes
+
+	cmtCfg.Mempool.TTLNumBlocks = defaultCfg.Mempool.TTLNumBlocks
+	cmtCfg.Mempool.TTLDuration = defaultCfg.Mempool.TTLDuration
+	cmtCfg.Mempool.MaxTxBytes = defaultCfg.Mempool.MaxTxBytes
+	cmtCfg.Mempool.MaxTxsBytes = defaultCfg.Mempool.MaxTxsBytes
+	cmtCfg.Mempool.Type = defaultCfg.Mempool.Type
+	cmtCfg.Mempool.MaxGossipDelay = defaultCfg.Mempool.MaxGossipDelay
+
+	cmtCfg.P2P.SendRate = defaultCfg.P2P.SendRate
+	cmtCfg.P2P.RecvRate = defaultCfg.P2P.RecvRate
+
+	defaultAppCfg := app.DefaultAppConfig()
+	appCfg.MinGasPrices = defaultAppCfg.MinGasPrices
+	appCfg.GRPC.MaxRecvMsgSize = defaultAppCfg.GRPC.MaxRecvMsgSize
+
+	return cmtCfg, appCfg
+}

--- a/cmd/celestia-appd/cmd/migrate_config.go
+++ b/cmd/celestia-appd/cmd/migrate_config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/celestiaorg/celestia-app/v6/app"
+	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 )
 
 // ConfigMigrator defines a function type for applying version-specific migrations
@@ -27,11 +28,11 @@ var migrationRegistry = map[string]ConfigMigrator{
 // configuration files based on the target version.
 func migrateConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "migrate-config [version]",
+		Use:     "migrate-config",
 		Short:   "Migrate configuration files to a target version",
 		Long:    "Migrate configuration files (config.toml and app.toml) to be compatible with a target application version.",
-		Example: "celestia-appd migrate-config v6 --home ~/.celestia-app",
-		Args:    cobra.ExactArgs(1),
+		Example: "celestia-appd migrate-config --home ~/.celestia-app\ncelestia-appd migrate-config --version v5 --home ~/.celestia-app",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			homeDir, err := cmd.Flags().GetString(flags.FlagHome)
 			if err != nil {
@@ -43,13 +44,17 @@ func migrateConfigCmd() *cobra.Command {
 				return err
 			}
 
-			targetVersion := args[0]
+			targetVersion, err := cmd.Flags().GetString("version")
+			if err != nil {
+				return err
+			}
 			return migrateConfig(homeDir, targetVersion, backup)
 		},
 	}
 
 	cmd.Flags().String(flags.FlagHome, app.NodeHome, "The application home directory")
 	cmd.Flags().Bool("backup", false, "Create backups of config files before migrating")
+	cmd.Flags().String("version", fmt.Sprintf("v%d", appconsts.Version), "Target version for migration")
 	return cmd
 }
 

--- a/cmd/celestia-appd/cmd/migrate_config_test.go
+++ b/cmd/celestia-appd/cmd/migrate_config_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cometbft/cometbft/config"
+	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/celestiaorg/celestia-app/v6/app"
+)
+
+func TestMigrateConfig(t *testing.T) {
+	tests := []struct {
+		name          string
+		version       string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "valid v6 migration",
+			version:     "v6",
+			expectError: false,
+		},
+		{
+			name:          "unsupported version",
+			version:       "v99",
+			expectError:   true,
+			errorContains: "unsupported target version",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temporary directory for test
+			tempDir := t.TempDir()
+			configDir := filepath.Join(tempDir, "config")
+			require.NoError(t, os.MkdirAll(configDir, 0755))
+
+			// Create test config files
+			setupTestConfigFiles(t, configDir)
+
+			// Run migration
+			err := migrateConfig(tempDir, tt.version)
+
+			if tt.expectError {
+				require.Error(t, err)
+				if tt.errorContains != "" {
+					assert.Contains(t, err.Error(), tt.errorContains)
+				}
+			} else {
+				require.NoError(t, err)
+
+				// Verify configs were updated
+				verifyMigratedConfigs(t, configDir, tt.version)
+			}
+		})
+	}
+}
+
+func TestLoadAndWriteConfigs(t *testing.T) {
+	tempDir := t.TempDir()
+	configDir := filepath.Join(tempDir, "config")
+	require.NoError(t, os.MkdirAll(configDir, 0755))
+
+	cometConfigPath := filepath.Join(configDir, "config.toml")
+	appConfigPath := filepath.Join(configDir, "app.toml")
+
+	// Create test configs
+	setupTestConfigFiles(t, configDir)
+
+	t.Run("load and write CometBFT config", func(t *testing.T) {
+		cfg, err := loadCometBFTConfig(cometConfigPath, tempDir)
+		require.NoError(t, err)
+		assert.NotNil(t, cfg)
+
+		originalTimeout := cfg.RPC.TimeoutBroadcastTxCommit
+		cfg.RPC.TimeoutBroadcastTxCommit = 60000000000
+
+		config.WriteConfigFile(cometConfigPath, cfg)
+
+		// Load again and verify change persisted
+		reloadedCfg, err := loadCometBFTConfig(cometConfigPath, tempDir)
+		require.NoError(t, err)
+		assert.NotEqual(t, originalTimeout, reloadedCfg.RPC.TimeoutBroadcastTxCommit)
+		assert.Equal(t, cfg.RPC.TimeoutBroadcastTxCommit, reloadedCfg.RPC.TimeoutBroadcastTxCommit)
+	})
+
+	t.Run("load and write server config", func(t *testing.T) {
+		cfg, err := loadServerConfig(appConfigPath)
+		require.NoError(t, err)
+		assert.NotNil(t, cfg)
+
+		cfg.API.Enable = !cfg.API.Enable
+		originalAPIEnable := cfg.API.Enable
+
+		serverconfig.WriteConfigFile(appConfigPath, cfg)
+
+		// Load again and verify change persisted
+		reloadedCfg, err := loadServerConfig(appConfigPath)
+		require.NoError(t, err)
+		assert.Equal(t, originalAPIEnable, reloadedCfg.API.Enable)
+	})
+}
+
+// setupTestConfigFiles creates test config files with default configurations
+func setupTestConfigFiles(t *testing.T, configDir string) {
+	t.Helper()
+
+	cometConfigPath := filepath.Join(configDir, "config.toml")
+	appConfigPath := filepath.Join(configDir, "app.toml")
+
+	// Create CometBFT config
+	cometConfig := app.DefaultConsensusConfig()
+	config.WriteConfigFile(cometConfigPath, cometConfig)
+
+	// Create server config
+	serverConfig := app.DefaultAppConfig()
+	serverconfig.WriteConfigFile(appConfigPath, serverConfig)
+}
+
+// verifyMigratedConfigs verifies that configs were properly migrated for the given version
+func verifyMigratedConfigs(t *testing.T, configDir, version string) {
+	t.Helper()
+
+	cometConfigPath := filepath.Join(configDir, "config.toml")
+	appConfigPath := filepath.Join(configDir, "app.toml")
+
+	switch version {
+	case "v6":
+		// Load and verify CometBFT config has v6 changes
+		cometConfig, err := loadCometBFTConfig(cometConfigPath, filepath.Dir(configDir))
+		require.NoError(t, err)
+
+		expectedCometConfig := app.DefaultConsensusConfig()
+		assert.Equal(t, expectedCometConfig.Mempool.Type, cometConfig.Mempool.Type)
+
+		// Load and verify server config has v6 changes
+		serverConfig, err := loadServerConfig(appConfigPath)
+		require.NoError(t, err)
+
+		expectedServerConfig := app.DefaultAppConfig()
+		assert.Equal(t, expectedServerConfig.MinGasPrices, serverConfig.MinGasPrices)
+	}
+}

--- a/cmd/celestia-appd/cmd/migrate_config_test.go
+++ b/cmd/celestia-appd/cmd/migrate_config_test.go
@@ -44,7 +44,7 @@ func TestMigrateConfig(t *testing.T) {
 			setupTestConfigFiles(t, configDir)
 
 			// Run migration
-			err := migrateConfig(tempDir, tt.version)
+			err := migrateConfig(tempDir, tt.version, false)
 
 			if tt.expectError {
 				require.Error(t, err)

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -125,6 +125,7 @@ func initRootCommand(rootCommand *cobra.Command, capp *app.App) {
 		txCommand(capp.BasicManager),
 		keys.Commands(),
 		snapshot.Cmd(NewAppServer),
+		migrateConfigCmd(),
 	)
 
 	modifyRootCommand(rootCommand)


### PR DESCRIPTION
## Overview

adds a quick cli command to migrate. Might be over-engineered, but also adds a way to keep track of configs / migrations per version. tbh, not sure that's needed.

closes #5366 but note that I'm not sure this includes all the configs that we need to modify