### PR TITLE
fix!: set ICA params during v6 upgrade handler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PACKAGE_NAME := github.com/celestiaorg/celestia-app/v6
 # See https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross
 GOLANG_CROSS_VERSION  ?= v1.24.2
 # Set this to override v2 upgrade height for the v3 embedded binaries
-V2_UPGRADE_HEIGHT ?= 2
+V2_UPGRADE_HEIGHT ?= 0
 
 # process linker flags
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app \

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ PACKAGE_NAME := github.com/celestiaorg/celestia-app/v6
 # See https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross
 GOLANG_CROSS_VERSION  ?= v1.24.2
 # Set this to override v2 upgrade height for the v3 embedded binaries
-V2_UPGRADE_HEIGHT ?= 0
+V2_UPGRADE_HEIGHT ?= 2
 
 # process linker flags
 ldflags = -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app \
@@ -52,7 +52,7 @@ build: mod
 ifeq ($(DOWNLOAD),true)
 	@$(MAKE) download-v3-binaries
 	@$(MAKE) download-v4-binaries
-	@$(MAKE) download-v5-binaries	
+	@$(MAKE) download-v5-binaries
 endif
 	@mkdir -p build/
 	@echo "--> Building build/celestia-appd with multiplexer enabled"

--- a/app/app.go
+++ b/app/app.go
@@ -449,7 +449,6 @@ func New(
 		panic(err)
 	}
 
-	// RegisterUpgradeHandlers is used for registering any on-chain upgrades.
 	app.RegisterUpgradeHandlers() // must be called after module manager & configurator are initialized
 
 	// Initialize the KV stores for the base modules (e.g. params). The base modules will be included in every app version.

--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -148,7 +148,7 @@ type icaModule struct {
 // DefaultGenesis returns custom ica module genesis state.
 func (icaModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	gs := icagenesistypes.DefaultGenesis()
-	gs.HostGenesisState.Params.AllowMessages = icaAllowMessages()
+	gs.HostGenesisState.Params.AllowMessages = IcaAllowMessages()
 	gs.HostGenesisState.Params.HostEnabled = true
 	gs.ControllerGenesisState.Params.ControllerEnabled = false
 	return cdc.MustMarshalJSON(gs)

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -105,7 +105,7 @@ func Test_icaDefaultGenesis(t *testing.T) {
 	got := icagenesistypes.GenesisState{}
 	enc.Codec.MustUnmarshalJSON(raw, &got)
 
-	assert.Equal(t, got.HostGenesisState.Params.AllowMessages, icaAllowMessages())
+	assert.Equal(t, got.HostGenesisState.Params.AllowMessages, IcaAllowMessages())
 	assert.True(t, got.HostGenesisState.Params.HostEnabled)
 	assert.False(t, got.ControllerGenesisState.Params.ControllerEnabled)
 }

--- a/app/ica_host.go
+++ b/app/ica_host.go
@@ -1,6 +1,7 @@
 package app
 
-func icaAllowMessages() []string {
+// IcaAllowMessages returns the list of messages that are allowed to be sent via ICA.
+func IcaAllowMessages() []string {
 	return []string{
 		"/ibc.applications.transfer.v1.MsgTransfer",
 		"/cosmos.bank.v1beta1.MsgSend",

--- a/app/ica_host_test.go
+++ b/app/ica_host_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_icaAllowMessages(t *testing.T) {
-	got := icaAllowMessages()
+func TestIcaAllowMessages(t *testing.T) {
+	got := IcaAllowMessages()
 	want := []string{
 		"/ibc.applications.transfer.v1.MsgTransfer",
 		"/cosmos.bank.v1beta1.MsgSend",

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -28,6 +28,7 @@ import (
 	ibcexported "github.com/cosmos/ibc-go/v8/modules/core/exported"
 )
 
+// RegisterUpgradeHandlers is used for registering any on-chain upgrades.
 func (app App) RegisterUpgradeHandlers() {
 	for _, subspace := range app.ParamsKeeper.GetSubspaces() {
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -30,8 +30,6 @@ import (
 // RegisterUpgradeHandlers is used for registering any on-chain upgrades.
 func (app App) RegisterUpgradeHandlers() {
 	for _, subspace := range app.ParamsKeeper.GetSubspaces() {
-		fmt.Printf("subspace.Name(): %s\n", subspace.Name())
-
 		var keyTable paramstypes.KeyTable
 		var set bool
 
@@ -56,7 +54,6 @@ func (app App) RegisterUpgradeHandlers() {
 		case ibctransfertypes.ModuleName:
 			keyTable, set = ibctransfertypes.ParamKeyTable(), true //nolint:staticcheck
 		case icahosttypes.SubModuleName:
-			fmt.Printf("icahosttypes.ParamKeyTable(): %+v\n", icahosttypes.ParamKeyTable())
 			keyTable, set = icahosttypes.ParamKeyTable(), true //nolint:staticcheck
 		case blobtypes.ModuleName:
 			keyTable, set = blobtypes.ParamKeyTable(), true //nolint:staticcheck

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -102,6 +102,9 @@ func (app App) RegisterUpgradeHandlers() {
 // migrateICAHostParams sets the ICA host params to the default values for
 // Celestia. This is needed because the ICA host params were previously stored
 // in x/params and in ibc-go v8 they were migrated to use a self-managed store.
+//
+// The default migrator included in ibc-go v8 does not work because it sets the
+// params to the defaults which were overriden by Celestia.
 func (a App) migrateICAHostParams(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	params := icahosttypes.Params{

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -20,6 +20,7 @@ import (
 	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	icahostkeeper "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/keeper"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	ibctransfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
 	ibcclienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
@@ -76,7 +77,11 @@ func (app App) RegisterUpgradeHandlers() {
 
 			start := time.Now()
 			sdkCtx.Logger().Info("running upgrade handler", "upgrade-name", upgradeName, "start", start)
-			// TODO: Add any upgrade logic here
+
+			sdkCtx.Logger().Info("migrating ica/host submodule params from x/params to self-manage params")
+			icaMigrator := icahostkeeper.NewMigrator(&app.ICAHostKeeper)
+			icaMigrator.MigrateParams(sdkCtx)
+
 			sdkCtx.Logger().Info("finished to upgrade", "upgrade-name", upgradeName, "duration-sec", time.Since(start).Seconds())
 
 			return fromVM, nil

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -100,12 +100,13 @@ func (app App) RegisterUpgradeHandlers() {
 	}
 }
 
-// setICAHostParams sets the ICA host params to the default values for
-// Celestia. This is needed because the ICA host params were previously stored
-// in x/params and in ibc-go v8 they were migrated to use a self-managed store.
+// setICAHostParams sets the ICA host params to the values defined in CIP-14.
+// This is needed because the ICA host params were previously stored in x/params
+// and in ibc-go v8 they were migrated to use a self-managed store.
 //
-// The default migrator included in ibc-go v8 does not work because it sets the
-// params to the defaults which were overriden by Celestia.
+// NOTE: the param migrator included in ibc-go v8 does not work as expected
+// because it sets the params to the default values which do not match the
+// values defined in CIP-14.
 func (a App) setICAHostParams(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	params := icahosttypes.Params{

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -80,7 +80,11 @@ func (app App) RegisterUpgradeHandlers() {
 
 			sdkCtx.Logger().Info("migrating ica/host submodule params from x/params to self-manage params")
 			icaMigrator := icahostkeeper.NewMigrator(&app.ICAHostKeeper)
-			icaMigrator.MigrateParams(sdkCtx)
+			err := icaMigrator.MigrateParams(sdkCtx)
+			if err != nil {
+				sdkCtx.Logger().Error("failed to migrate ica/host submodule params", "error", err)
+				return nil, err
+			}
 
 			sdkCtx.Logger().Info("finished to upgrade", "upgrade-name", upgradeName, "duration-sec", time.Since(start).Seconds())
 

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -77,7 +77,11 @@ func (app App) RegisterUpgradeHandlers() {
 			start := time.Now()
 			sdkCtx.Logger().Info("running upgrade handler", "upgrade-name", upgradeName, "start", start)
 
-			app.migrateICAHostParams(sdkCtx)
+			err := app.setICAHostParams(sdkCtx)
+			if err != nil {
+				sdkCtx.Logger().Error("failed to set ica/host submodule params", "error", err)
+				return nil, err
+			}
 			// TODO: add any other migrations here.
 
 			sdkCtx.Logger().Info("finished to upgrade", "upgrade-name", upgradeName, "duration-sec", time.Since(start).Seconds())
@@ -96,13 +100,13 @@ func (app App) RegisterUpgradeHandlers() {
 	}
 }
 
-// migrateICAHostParams sets the ICA host params to the default values for
+// setICAHostParams sets the ICA host params to the default values for
 // Celestia. This is needed because the ICA host params were previously stored
 // in x/params and in ibc-go v8 they were migrated to use a self-managed store.
 //
 // The default migrator included in ibc-go v8 does not work because it sets the
 // params to the defaults which were overriden by Celestia.
-func (a App) migrateICAHostParams(ctx context.Context) error {
+func (a App) setICAHostParams(ctx context.Context) error {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
 	params := icahosttypes.Params{
 		HostEnabled:   true,

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1,27 +1,55 @@
 package app_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"cosmossdk.io/log"
+	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/celestiaorg/celestia-app/v6/app"
+	"github.com/celestiaorg/celestia-app/v6/test/util"
 	"github.com/celestiaorg/celestia-app/v6/test/util/testfactory"
 	tmdb "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/stretchr/testify/require"
 )
 
-func TestRegisterUpgradeHandlers(t *testing.T) {
-	logger := log.NewNopLogger()
-	db := tmdb.NewMemDB()
-	traceStore := &NoopWriter{}
-	timeoutCommit := time.Second
-	appOptions := NoopAppOptions{}
+func TestUpgrades(t *testing.T) {
+	t.Run("app.New() should register a v6 upgrade handler", func(t *testing.T) {
+		logger := log.NewNopLogger()
+		db := tmdb.NewMemDB()
+		traceStore := &NoopWriter{}
+		timeoutCommit := time.Second
+		appOptions := NoopAppOptions{}
 
-	// app.New() should invoke RegisterUpgradeHandlers.
-	testApp := app.New(logger, db, traceStore, timeoutCommit, appOptions, baseapp.SetChainID(testfactory.ChainID))
+		testApp := app.New(logger, db, traceStore, timeoutCommit, appOptions, baseapp.SetChainID(testfactory.ChainID))
 
-	require.False(t, testApp.UpgradeKeeper.HasHandler("v5"))
-	require.True(t, testApp.UpgradeKeeper.HasHandler("v6"))
+		require.False(t, testApp.UpgradeKeeper.HasHandler("v5"))
+		require.True(t, testApp.UpgradeKeeper.HasHandler("v6"))
+	})
+}
+
+func TestApplyUpgrade(t *testing.T) {
+	t.Run("ICA host params should have an allowlist of messages before and after ApplyUpgrade", func(t *testing.T) {
+		testApp, _, _ := util.NewTestAppWithGenesisSet(app.DefaultConsensusParams())
+		require.True(t, testApp.UpgradeKeeper.HasHandler("v6"))
+		plan := upgradetypes.Plan{
+			Name:   "v6",
+			Time:   time.Now(),
+			Height: 1,
+			Info:   "info",
+		}
+
+		ctx := testApp.NewContext(false)
+		params := testApp.ICAHostKeeper.GetParams(ctx)
+		fmt.Printf("params before upgrade: %+v\n", params)
+
+		err := testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
+		require.NoError(t, err)
+
+		ctx = testApp.NewContext(false)
+		params = testApp.ICAHostKeeper.GetParams(ctx)
+		fmt.Printf("params after upgrade: %+v\n", params)
+	})
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1,7 +1,6 @@
 package app_test
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -45,7 +44,6 @@ func TestApplyUpgrade(t *testing.T) {
 		params := testApp.ICAHostKeeper.GetParams(ctx)
 		require.True(t, params.HostEnabled)
 		require.Equal(t, params.AllowMessages, app.IcaAllowMessages())
-		fmt.Printf("params before upgrade: %+v\n", params)
 
 		err := testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
 		require.NoError(t, err)
@@ -54,6 +52,5 @@ func TestApplyUpgrade(t *testing.T) {
 		params = testApp.ICAHostKeeper.GetParams(ctx)
 		require.True(t, params.HostEnabled)
 		require.Equal(t, params.AllowMessages, app.IcaAllowMessages())
-		fmt.Printf("params after upgrade: %+v\n", params)
 	})
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -43,6 +43,8 @@ func TestApplyUpgrade(t *testing.T) {
 
 		ctx := testApp.NewContext(false)
 		params := testApp.ICAHostKeeper.GetParams(ctx)
+		require.True(t, params.HostEnabled)
+		require.Equal(t, params.AllowMessages, app.IcaAllowMessages())
 		fmt.Printf("params before upgrade: %+v\n", params)
 
 		err := testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
@@ -50,6 +52,8 @@ func TestApplyUpgrade(t *testing.T) {
 
 		ctx = testApp.NewContext(false)
 		params = testApp.ICAHostKeeper.GetParams(ctx)
+		require.True(t, params.HostEnabled)
+		require.Equal(t, params.AllowMessages, app.IcaAllowMessages())
 		fmt.Printf("params after upgrade: %+v\n", params)
 	})
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -31,7 +31,7 @@ func TestUpgrades(t *testing.T) {
 }
 
 func TestApplyUpgrade(t *testing.T) {
-	t.Run("ICA host params should have an allowlist of messages before and after ApplyUpgrade", func(t *testing.T) {
+	t.Run("ICA host params should have an explicit allowlist of messages before and after ApplyUpgrade", func(t *testing.T) {
 		testApp, _, _ := util.NewTestAppWithGenesisSet(app.DefaultConsensusParams())
 		require.True(t, testApp.UpgradeKeeper.HasHandler("v6"))
 		plan := upgradetypes.Plan{

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -1,0 +1,27 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	"github.com/celestiaorg/celestia-app/v6/app"
+	"github.com/celestiaorg/celestia-app/v6/test/util/testfactory"
+	tmdb "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterUpgradeHandlers(t *testing.T) {
+	logger := log.NewNopLogger()
+	db := tmdb.NewMemDB()
+	traceStore := &NoopWriter{}
+	timeoutCommit := time.Second
+	appOptions := NoopAppOptions{}
+
+	// app.New() should invoke RegisterUpgradeHandlers.
+	testApp := app.New(logger, db, traceStore, timeoutCommit, appOptions, baseapp.SetChainID(testfactory.ChainID))
+
+	require.False(t, testApp.UpgradeKeeper.HasHandler("v5"))
+	require.True(t, testApp.UpgradeKeeper.HasHandler("v6"))
+}

--- a/scripts/single-node-all-upgrades.sh
+++ b/scripts/single-node-all-upgrades.sh
@@ -262,5 +262,5 @@ startUpgrades() {
 
 deleteCelestiaAppHome
 createGenesis
-startUpgrades & # Upgrade to app version 3, 4, 5, and 6 in the background.
+# startUpgrades & # Upgrade to app version 3, 4, 5, and 6 in the background.
 startCelestiaApp # Start celestia-app in the foreground.

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# This script starts a single node testnet on app version 4.
+# This script starts a single node testnet on the latest app version.
 
 # Stop script execution if an error is encountered
 set -o errexit
@@ -76,7 +76,7 @@ createGenesis() {
     sed -i.bak 's#discard_abci_responses = true#discard_abci_responses = false#g' "${APP_HOME}"/config/config.toml
 
     # Override the log level to reduce noisy logs
-    sed -i.bak 's#log_level = "info"#log_level = "*:error,p2p:info,state:info"#g' "${APP_HOME}"/config/config.toml
+    # sed -i.bak 's#log_level = "info"#log_level = "*:error,p2p:info,state:info"#g' "${APP_HOME}"/config/config.toml
 
     # Override the VotingPeriod from 1 week to 1 minute
     sed -i.bak 's#"604800s"#"60s"#g' "${APP_HOME}"/config/genesis.json

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -76,7 +76,7 @@ createGenesis() {
     sed -i.bak 's#discard_abci_responses = true#discard_abci_responses = false#g' "${APP_HOME}"/config/config.toml
 
     # Override the log level to reduce noisy logs
-    # sed -i.bak 's#log_level = "info"#log_level = "*:error,p2p:info,state:info"#g' "${APP_HOME}"/config/config.toml
+    sed -i.bak 's#log_level = "info"#log_level = "*:error,p2p:info,state:info"#g' "${APP_HOME}"/config/config.toml
 
     # Override the VotingPeriod from 1 week to 1 minute
     sed -i.bak 's#"604800s"#"60s"#g' "${APP_HOME}"/config/genesis.json

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -91,7 +91,6 @@ func initialiseTestApp(testApp *app.App, valSet *tmtypes.ValidatorSet) {
 
 // NewTestApp creates a new app instance with an empty memDB and a no-op logger.
 func NewTestApp() *app.App {
-	// var anteOpt = func(bapp *baseapp.BaseApp) { bapp.SetAnteHandler(nil) }
 	db := dbm.NewMemDB()
 
 	return app.New(


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5400

## Testing

###  `./scripts/single-node-upgrade.sh`

On v5
```
$ celestia-appd query ica host params
Error: rpc error: code = Unknown desc = unknown query path: unknown request
```

On v6
```
$ celestia-appd query ica host params
Error: rpc error: code = Unknown desc = unknown query path: unknown request
$ celestia-appd query ica host params
allow_messages:
- /ibc.applications.transfer.v1.MsgTransfer
- /cosmos.bank.v1beta1.MsgSend
- /cosmos.staking.v1beta1.MsgDelegate
- /cosmos.staking.v1beta1.MsgBeginRedelegate
- /cosmos.staking.v1beta1.MsgUndelegate
- /cosmos.staking.v1beta1.MsgCancelUnbondingDelegation
- /cosmos.distribution.v1beta1.MsgSetWithdrawAddress
- /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward
- /cosmos.distribution.v1beta1.MsgFundCommunityPool
- /cosmos.gov.v1.MsgVote
- /cosmos.feegrant.v1beta1.MsgGrantAllowance
- /cosmos.feegrant.v1beta1.MsgRevokeAllowance
host_enabled: true
```

### `./scripts/single-node-all-upgrades.sh`

On v6

```
$ celestia-appd query ica host params
Error: rpc error: code = Unknown desc = unknown query path: unknown request
$ celestia-appd query ica host params
allow_messages:
- /ibc.applications.transfer.v1.MsgTransfer
- /cosmos.bank.v1beta1.MsgSend
- /cosmos.staking.v1beta1.MsgDelegate
- /cosmos.staking.v1beta1.MsgBeginRedelegate
- /cosmos.staking.v1beta1.MsgUndelegate
- /cosmos.staking.v1beta1.MsgCancelUnbondingDelegation
- /cosmos.distribution.v1beta1.MsgSetWithdrawAddress
- /cosmos.distribution.v1beta1.MsgWithdrawDelegatorReward
- /cosmos.distribution.v1beta1.MsgFundCommunityPool
- /cosmos.gov.v1.MsgVote
- /cosmos.feegrant.v1beta1.MsgGrantAllowance
- /cosmos.feegrant.v1beta1.MsgRevokeAllowance
host_enabled: true
```