### PR TITLE
fix(minfee): correct GetAuthority method comment

### DIFF
--- a/x/minfee/keeper/keeper.go
+++ b/x/minfee/keeper/keeper.go
@@ -41,7 +41,7 @@ func (k Keeper) GetParamsKeeper() params.Keeper {
 	return k.paramsKeeper
 }
 
-// GetAuthority returns the client submodule's authority.
+// GetAuthority returns the minfee module's authority.
 func (k Keeper) GetAuthority() string {
 	return k.authority
 }


### PR DESCRIPTION
Fix incorrect comment that referred to "client submodule" instead of "minfee module"