### PR TITLE
fix incorrect description of top/bottom 10% gas price slicing

### DIFF
--- a/docs/architecture/adr-023-gas-used-and-gas-price-estimation.md
+++ b/docs/architecture/adr-023-gas-used-and-gas-price-estimation.md
@@ -70,7 +70,7 @@ func Median(gasPrices []float64) (float64, error) {
 }
 ```
 
-For the top/bottom 10%, they will be extracted after sorting the list of gas prices incrementally, and slicing `gasPrices[:len(gasPrices)*10/100]` and `gasPrices[len(gasPrices)*90/100:]` respectively.
+For the bottom/top 10%, they will be extracted after sorting the list of gas prices incrementally, and slicing `gasPrices[:len(gasPrices)*10/100]` and `gasPrices[len(gasPrices)*90/100:]` respectively.
 
 ## Alternative Approaches
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Corrected the description order from "top/bottom 10%" to "bottom/top 10%" to match the actual slice operations that follow in the document
