### PR TITLE
refactor(multiplexer): improve error message

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -497,7 +497,7 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 		}
 
 		if version.Appd.IsStopped() {
-			return fmt.Errorf("app for version %d failed to start", version.AppVersion)
+			return fmt.Errorf("app for version %d stopped", version.AppVersion)
 		}
 
 		m.activeVersion = version

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -497,7 +497,7 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 		}
 
 		if version.Appd.IsStopped() {
-			return fmt.Errorf("app for version %d failed to start", m.nativeApp)
+			return fmt.Errorf("app for version %d failed to start", version.AppVersion)
 		}
 
 		m.activeVersion = version


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Replace m.nativeApp with version.AppVersion in error message on line 500 of multiplexer.go. The %d format specifier requires a numeric value, but m.nativeApp is an application object