### PR TITLE
Use errors.New for constant error in signer

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -205,7 +205,7 @@ func (s *Signer) findAccount(txbuilder client.TxBuilder) (*Account, error) {
 	}
 
 	if len(signers) == 0 {
-		return nil, fmt.Errorf("message has no signer")
+		return nil, errors.New("message has no signer")
 	}
 
 	signerStr, err := s.addressCodec.BytesToString(signers[0])


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Replace fmt.Errorf with errors.New for a literal-only error message in pkg/user/signer.go. This removes unnecessary formatting overhead and aligns with idiomatic Go error creation without changing behavior or messages. Verified by successful build: go build ./...