### PR TITLE
fix: improve accuracy of subtree depth comment in nmt caching test

### DIFF
--- a/pkg/inclusion/nmt_caching_test.go
+++ b/pkg/inclusion/nmt_caching_test.go
@@ -128,8 +128,10 @@ func TestEDSSubRootCacher(t *testing.T) {
 	for i := range dah.RowRoots[:squareSize] {
 		expectedSubTreeRoots := calculateSubTreeRoots(t, eds.Row(uint(i))[:squareSize], 2)
 		require.NotNil(t, expectedSubTreeRoots)
-		// note: the depth is one greater than expected because we're dividing
-		// the row in half when we calculate the expected roots.
+		// note: the walk path has 3 elements (depth 3) while calculateSubTreeRoots
+		// uses depth 2, so we're comparing subtree roots at different depths.
+		// The walk path [false, false, false] corresponds to the leftmost subtree
+		// at depth 3, which should match the first subtree root calculated at depth 2.
 		result, err := stc.getSubTreeRoot(dah, i, []WalkInstruction{false, false, false})
 		require.NoError(t, err)
 		assert.Equal(t, expectedSubTreeRoots[0], result)


### PR DESCRIPTION
The comment in TestEDSSubRootCacher was inaccurate and misleading. 
It claimed that "the depth is one greater than expected because we're 
dividing the row in half when we calculate the expected roots", which 
was not correct.

The actual logic is:
- calculateSubTreeRoots uses depth 2 to generate subtree roots
- The walk path [false, false, false] has 3 elements (depth 3)
- We compare subtree roots at different depths, where the leftmost 
  subtree at depth 3 should match the first subtree root calculated 
  at depth 2
