### PR TITLE
chore: flups for the update-config command and release notes to run it

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -264,19 +264,19 @@ func DefaultEvidenceParams() *tmproto.EvidenceParams {
 
 func DefaultConsensusConfig() *tmcfg.Config {
 	cfg := tmcfg.DefaultConfig()
-	mempoolSize := int64(appconsts.DefaultUpperBoundMaxBytes) * 3
 	// Set broadcast timeout to be 50 seconds in order to avoid timeouts for long block times
 	cfg.RPC.TimeoutBroadcastTxCommit = 50 * time.Second
 	// this value should be the same as the largest possible response. In this case, that's
-	// likely Unconfirmed txs for a full mempool
-	cfg.RPC.MaxBodyBytes = mempoolSize
+	// likely Unconfirmed txs for a full mempool and a few extra bytes.
+	cfg.RPC.MaxBodyBytes = appconsts.MempoolSize + (mebibyte * 32)
 	cfg.RPC.GRPCListenAddress = "tcp://127.0.0.1:9098"
 
 	cfg.Mempool.TTLNumBlocks = 12
-	cfg.Mempool.TTLDuration = 75 * time.Second
+	cfg.Mempool.TTLDuration = 0 * time.Second
 	cfg.Mempool.MaxTxBytes = appconsts.MaxTxSize
-	cfg.Mempool.MaxTxsBytes = mempoolSize
-	cfg.Mempool.Type = tmcfg.MempoolTypePriority
+	cfg.Mempool.MaxTxsBytes = appconsts.MempoolSize
+	cfg.Mempool.Type = tmcfg.MempoolTypeCAT
+	cfg.Mempool.MaxGossipDelay = time.Second * 60
 
 	cfg.Consensus.TimeoutPropose = appconsts.TimeoutPropose
 	cfg.Consensus.TimeoutCommit = appconsts.TimeoutCommit
@@ -285,8 +285,8 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	cfg.TxIndex.Indexer = "null"
 	cfg.Storage.DiscardABCIResponses = true
 
-	cfg.P2P.SendRate = 10 * mebibyte
-	cfg.P2P.RecvRate = 10 * mebibyte
+	cfg.P2P.SendRate = 24 * mebibyte
+	cfg.P2P.RecvRate = 24 * mebibyte
 
 	return cfg
 }

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -46,7 +46,10 @@ func (s *SquareSizeIntegrationTest) SetupSuite() {
 	t.Log("setting up square size integration test")
 
 	s.enc = encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	cp := app.DefaultConsensusParams()
+	cp.Evidence.MaxAgeNumBlocks = 1
 	cfg := testnode.DefaultConfig().
+		WithConsensusParams(cp).
 		WithModifiers(genesis.ImmediateProposals(s.enc.Codec)).
 		WithTimeoutCommit(time.Millisecond * 500). // long timeout commit to provide time for submitting txs
 		WithFundedAccounts("txsim")                // add a specific txsim account

--- a/cmd/celestia-appd/cmd/update_config.go
+++ b/cmd/celestia-appd/cmd/update_config.go
@@ -20,7 +20,7 @@ type ConfigUpdater func(*config.Config, *serverconfig.Config) (*config.Config, *
 
 // updateRegistry maps version strings to their corresponding update functions
 var updateRegistry = map[string]ConfigUpdater{
-	"v6": applyV6Config,
+	"6": applyV6Config,
 }
 
 // updateConfigCmd returns the update-config command that updates
@@ -30,7 +30,7 @@ func updateConfigCmd() *cobra.Command {
 		Use:     "update-config",
 		Short:   "Update configuration values to be that of a specific app version",
 		Long:    "Update configuration files (config.toml and app.toml) to be compatible with a specific app version.",
-		Example: "celestia-appd update-config --home ~/.celestia-app\ncelestia-appd update-config --version v6 --home ~/.celestia-app",
+		Example: "celestia-appd update-config --home ~/.celestia-app\ncelestia-appd update-config --version 6 --home ~/.celestia-app",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			homeDir, err := cmd.Flags().GetString(flags.FlagHome)

--- a/cmd/celestia-appd/cmd/update_config.go
+++ b/cmd/celestia-appd/cmd/update_config.go
@@ -54,7 +54,7 @@ func updateConfigCmd() *cobra.Command {
 
 	cmd.Flags().String(flags.FlagHome, app.NodeHome, "The application home directory")
 	cmd.Flags().Bool("backup", true, "Create backups of config files before updating them")
-	cmd.Flags().String("app-version", fmt.Sprintf("v%d", appconsts.Version), "Target version for config changes")
+	cmd.Flags().String("app-version", fmt.Sprintf("%d", appconsts.Version), "Target version for config changes")
 	return cmd
 }
 
@@ -200,7 +200,10 @@ func applyV6Config(cmtCfg *config.Config, appCfg *serverconfig.Config) (*config.
 	cmtCfg.Mempool.TTLDuration = defaultCfg.Mempool.TTLDuration
 	cmtCfg.Mempool.MaxTxBytes = defaultCfg.Mempool.MaxTxBytes
 	cmtCfg.Mempool.MaxTxsBytes = defaultCfg.Mempool.MaxTxsBytes
+	fmt.Println("mempool type", defaultCfg.Mempool.Type)
 	cmtCfg.Mempool.Type = defaultCfg.Mempool.Type
+	fmt.Println("mempool type", cmtCfg.Mempool.Type)
+
 	cmtCfg.Mempool.MaxGossipDelay = defaultCfg.Mempool.MaxGossipDelay
 
 	cmtCfg.P2P.SendRate = defaultCfg.P2P.SendRate

--- a/cmd/celestia-appd/cmd/update_config_test.go
+++ b/cmd/celestia-appd/cmd/update_config_test.go
@@ -21,12 +21,12 @@ func TestUpdateConfig(t *testing.T) {
 	}{
 		{
 			name:        "valid v6 update",
-			version:     "v6",
+			version:     "6",
 			expectError: false,
 		},
 		{
 			name:          "unsupported version",
-			version:       "v99",
+			version:       "99",
 			expectError:   true,
 			errorContains: "unsupported target version",
 		},

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -6,6 +6,42 @@ This guide provides notes for major version releases. These notes may be helpful
 
 ## v6.0.0 (Unreleased)
 
+This release targets throughput, blob size, inflation redunction, and fee changes.
+
+### Config changes
+
+It introduces a new block propagation reactor and configuration changes to accommodate the increased throughput. The relevant v6 configuration changes can be applied to existing config using the `celestia-appd update-config` command or by manually updating the config.toml and app.toml.
+
+To modify your existing configs, the `celestia-appd update-configs` command can be used.
+
+```
+celestia-appd update-config
+```
+
+this uses version 6 and the default home (.celestia-app). Those can be changed or specified with flags as well.
+
+```
+celestia-appd update-config --version 6 --home ~/.celestia-app
+```
+
+To manually modify the configs, change the following values.
+
+```toml
+[rpc]
+max_body_bytes = 436207616
+
+[p2p]
+send_rate = 25165824
+recv_rate = 25165824
+
+[mempool]
+type = "cat"
+max_tx_bytes = 8388608
+ttl-duration = "0s"
+ttl-num-blocks = 12
+max-gossip-delay = "1m0s"
+
+```
 ## v5.0.0
 
 This major upgrade is an expedited patch release, fixing the problem with failed IBC transfers caused by the incorrectly configured capability module. There should be no additional API breaking changes.

--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -39,4 +39,6 @@ const (
 	MainnetUpgradeHeightDelay = int64(100_800)
 	// Deprecated: Use MainnetUpgradeHeightDelay instead.
 	UpgradeHeightDelay = MainnetUpgradeHeightDelay
+
+	MempoolSize = int64(DefaultUpperBoundMaxBytes) * 3
 )


### PR DESCRIPTION
## Overview

part of #5316 
closes #5324 

also noticed that the mempool type doesn't get updated despite it being modified in the update command. All of the other do get modified. Not 100% sure what causes that but likely a naming conflict somewhere since that config name is just `type`.
