### PR TITLE
refactor: extract database name constant in multiplexer

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -39,8 +39,9 @@ import (
 )
 
 const (
-	flagTraceStore = "trace-store"
-	flagGRPCOnly   = "grpc-only"
+	flagTraceStore    = "trace-store"
+	flagGRPCOnly      = "grpc-only"
+	ApplicationDBName = "application"
 )
 
 // Multiplexer is responsible for managing multiple versions of applications and coordinating their lifecycle.
@@ -401,7 +402,7 @@ func getTraceWriter(svrCtx *server.Context) (traceWriter io.WriteCloser, err err
 
 func openDB(rootDir string, backendType db.BackendType) (db.DB, error) {
 	dataDir := filepath.Join(rootDir, "data")
-	return db.NewDB("application", backendType, dataDir)
+	return db.NewDB(ApplicationDBName, backendType, dataDir)
 }
 
 // openTraceWriter opens a trace writer for the given file.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Replace hardcoded "application" string with ApplicationDBName constant in openDB function to improve code maintainability and reduce magic strings
