### PR TITLE
test(passthrough): return stdout from executeCommand instead of command name

### DIFF
--- a/multiplexer/cmd/passthrough_test.go
+++ b/multiplexer/cmd/passthrough_test.go
@@ -69,11 +69,16 @@ func newVersion(appVersion uint64, app *appd.Appd) abci.Version {
 
 // executeCommand executes the cobra command with the specified args.
 func executeCommand(t *testing.T, cmd *cobra.Command, args ...string) (string, error) {
+	to := &bytes.Buffer{}
+	te := &bytes.Buffer{}
+
 	t.Helper()
+	cmd.SetOut(to)
+	cmd.SetErr(te)
 	cmd.SetArgs(args)
-	output, err := cmd.ExecuteC()
+	_, err := cmd.ExecuteC()
 	if err != nil {
-		return "", err
+		return to.String(), err
 	}
-	return output.Name(), nil
+	return to.String(), nil
 }


### PR DESCRIPTION
The test helper executeCommand was returning output.Name() (the command’s name), making output assertions ineffective.
Now the helper captures stdout/stderr via cmd.SetOut/cmd.SetErr and returns the stdout string. On error, it returns the captured stdout alongside the error to aid debugging.
This enables meaningful checks of command output in passthrough tests without altering production code.