### PR TITLE
fix(Makefile): populate the build tags in version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,8 @@ GOLANG_CROSS_VERSION  ?= v1.24.2
 # Set this to override v2 upgrade height for the v3 embedded binaries
 V2_UPGRADE_HEIGHT ?= 0
 
-BUILD_TAGS_STANDALONE := "ledger"
-BUILD_TAGS_MULTIPLEXER := "ledger,multiplexer"
+BUILD_TAGS_STANDALONE := ledger
+BUILD_TAGS_MULTIPLEXER := ledger,multiplexer
 
 LDFLAGS_COMMON := -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app -X github.com/cosmos/cosmos-sdk/version.AppName=celestia-appd -X github.com/cosmos/cosmos-sdk/version.Version=$(VERSION) -X github.com/cosmos/cosmos-sdk/version.Commit=$(COMMIT) -X github.com/celestiaorg/celestia-app/v6/cmd/celestia-appd/cmd.v2UpgradeHeight=$(V2_UPGRADE_HEIGHT)
 LDFLAGS_STANDALONE := $(LDFLAGS_COMMON) -X github.com/cosmos/cosmos-sdk/version.BuildTags=$(BUILD_TAGS_STANDALONE)

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ build-standalone: mod
 	@cd ./cmd/celestia-appd
 	@mkdir -p build/
 	@echo "--> Building build/celestia-appd"
-	@go build $(BUILD_FLAGS_STANDALONE) -o build/ ./cmd/celestia-appd
+	@go build $(BUILD_FLAGS_STANDALONE) -o build/celestia-appd ./cmd/celestia-appd
 .PHONY: build-standalone
 
 DOWNLOAD ?= true

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ LDFLAGS_COMMON := -X github.com/cosmos/cosmos-sdk/version.Name=celestia-app -X g
 LDFLAGS_STANDALONE := $(LDFLAGS_COMMON) -X github.com/cosmos/cosmos-sdk/version.BuildTags=$(BUILD_TAGS_STANDALONE)
 LDFLAGS_MULTIPLEXER := $(LDFLAGS_COMMON) -X github.com/cosmos/cosmos-sdk/version.BuildTags=$(BUILD_TAGS_MULTIPLEXER)
 
-BUILD_FLAGS_STANDALONE := -tags '$(BUILD_TAGS_STANDALONE)' -ldflags '$(LDFLAGS_STANDALONE)'
-BUILD_FLAGS_MULTIPLEXER := -tags '$(BUILD_TAGS_MULTIPLEXER)' -ldflags '$(LDFLAGS_MULTIPLEXER)'
+BUILD_FLAGS_STANDALONE := -tags=$(BUILD_TAGS_STANDALONE) -ldflags '$(LDFLAGS_STANDALONE)'
+BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_MULTIPLEXER)'
 
 # NOTE: This version must be updated at the same time as the version in:
 # internal/embedding/data.go


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5510

## Testing

```
make install
celestia-appd version --long
...
build_tags: ledger,multiplexer
```

```
make install-standalone
celestia-appd version --long
...
build_tags: ledger
```