### PR TITLE
Security: Add strict mode and proper quoting to Docker entrypoint scripts

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
+set -Ee -o pipefail
 
-# This script creates the necessary files before starting celestia-appd
+: "${CELESTIA_APP_HOME:?CELESTIA_APP_HOME must be set}"
 
 # only create the priv_validator_state.json if it doesn't exist and the command is start
-if [[ $1 == "start" && ! -f ${CELESTIA_APP_HOME}/data/priv_validator_state.json ]]
+if [[ "${1:-}" == "start" && ! -f "${CELESTIA_APP_HOME}/data/priv_validator_state.json" ]]
 then
-    mkdir -p ${CELESTIA_APP_HOME}/data
-    cat <<EOF > ${CELESTIA_APP_HOME}/data/priv_validator_state.json
+    mkdir -p "${CELESTIA_APP_HOME}/data"
+    cat <<EOF > "${CELESTIA_APP_HOME}/data/priv_validator_state.json"
 {
   "height": "0",
   "round": 0,
@@ -16,7 +17,7 @@ EOF
 fi
 
 echo "Starting celestia-appd with command:"
-echo "/bin/celestia-appd $@"
+echo "/bin/celestia-appd $*"
 echo ""
 
-exec /bin/celestia-appd $@
+exec /bin/celestia-appd "$@"

--- a/docker/txsim/entrypoint.sh
+++ b/docker/txsim/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
+set -Ee -o pipefail
 
 echo "Starting txsim with command:"
-echo "/bin/txsim $@"
+echo "/bin/txsim $*"
 echo ""
 
-exec /bin/txsim $@
+exec /bin/txsim "$@"


### PR DESCRIPTION


### Description

This PR improves the security and robustness of Docker entrypoint scripts by:

- **Adding strict error handling**: `set -Ee -o pipefail` ensures scripts fail fast on any error
- **Proper argument quoting**: Using `"$@"` prevents word splitting and glob expansion issues
- **Environment validation**: Validates `CELESTIA_APP_HOME` is set before execution
- **Safe variable expansion**: All variables are now properly quoted to handle paths with spaces

### Changes

- `docker/entrypoint.sh`: Added strict mode, environment validation, and proper quoting
- `docker/txsim/entrypoint.sh`: Added strict mode and proper argument handling

