### PR TITLE
test(wrapper): use appconsts.NewBaseHashFunc() instead of sha256.New() in NMT root test

### DIFF
--- a/pkg/wrapper/nmt_wrapper_test.go
+++ b/pkg/wrapper/nmt_wrapper_test.go
@@ -2,7 +2,6 @@ package wrapper_test
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"sort"
 	"testing"
 
@@ -50,7 +49,7 @@ func TestRootErasuredNamespacedMerkleTree(t *testing.T) {
 	size := 8
 	data := testfactory.GenerateRandNamespacedRawData(size)
 	nmtErasured := wrapper.NewErasuredNamespacedMerkleTree(uint64(size), 0)
-	nmtStandard := nmt.New(sha256.New(), nmt.NamespaceIDSize(share.NamespaceSize), nmt.IgnoreMaxNamespace(true))
+	nmtStandard := nmt.New(appconsts.NewBaseHashFunc(), nmt.NamespaceIDSize(share.NamespaceSize), nmt.IgnoreMaxNamespace(true))
 
 	for _, d := range data {
 		err := nmtErasured.Push(d)


### PR DESCRIPTION
 The wrapper uses appconsts.NewBaseHashFunc() for NMT. For consistency and future-proofing, the test comparing roots should use the same base hasher.
Replaced sha256.New() with appconsts.NewBaseHashFunc() in TestRootErasuredNamespacedMerkleTree.
Removed the now-unused crypto/sha256 import.