### PR TITLE
fix: temporarily disable vesting messages that use amino json signing

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -40,6 +40,8 @@ func NewAnteHandler(
 		ante.NewValidateBasicDecorator(),
 		// Ensure the tx has not reached a height timeout.
 		ante.NewTxTimeoutHeightDecorator(),
+		// Ensure that MsgCreateVestingAccount transactions are not signed with amino JSON.
+		NewDisableVestingDecorator(),
 		// Ensure the tx memo <= max memo characters.
 		ante.NewValidateMemoDecorator(accountKeeper),
 		// Ensure the tx's gas limit is > the gas consumed based on the tx size.

--- a/app/ante/disable_vesting.go
+++ b/app/ante/disable_vesting.go
@@ -1,0 +1,70 @@
+package ante
+
+import (
+	"cosmossdk.io/errors"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/x/auth/ante"
+	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+)
+
+var _ sdk.AnteDecorator = DisableVestingDecorator{}
+
+// DisableVestingDecorator ensures that transactions containing MsgCreateVestingAccount
+// are rejected if they were signed using amino JSON encoding.
+type DisableVestingDecorator struct{}
+
+// NewDisableVestingDecorator creates a new DisableVestingDecorator.
+func NewDisableVestingDecorator() DisableVestingDecorator {
+	return DisableVestingDecorator{}
+}
+
+// AnteHandle implements the AnteHandler interface. It checks if the transaction
+// contains a MsgCreateVestingAccount and if it was signed using amino JSON.
+// If both conditions are true, it rejects the transaction.
+func (dvd DisableVestingDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
+	// only applies to check tx
+	if !ctx.IsCheckTx() {
+		return next(ctx, tx, simulate)
+	}
+
+	// Check if any message in the transaction is MsgCreateVestingAccount
+	hasVestingMsg := false
+	for _, msg := range tx.GetMsgs() {
+		if _, ok := msg.(*vestingtypes.MsgCreateVestingAccount); ok {
+			hasVestingMsg = true
+			break
+		}
+	}
+
+	// If no vesting message found, continue to next handler
+	if !hasVestingMsg {
+		return next(ctx, tx, simulate)
+	}
+
+	// Check if transaction was signed using amino JSON
+	sigTx, ok := tx.(authsigning.SigVerifiableTx)
+	if !ok {
+		return ctx, errors.Wrap(sdkerrors.ErrTxDecode, "invalid tx type")
+	}
+
+	sigs, err := sigTx.GetSignaturesV2()
+	if err != nil {
+		return ctx, err
+	}
+
+	// Check if any signature uses amino JSON signing mode using the existing cosmos-sdk function
+	for _, sig := range sigs {
+		if ante.OnlyLegacyAminoSigners(sig.Data) {
+			return ctx, errors.Wrap(
+				sdkerrors.ErrUnauthorized,
+				"MsgCreateVestingAccount is temporarily disabled with amino JSON signing. "+
+					"It will be re-enabled when the entire network upgrades. "+
+					"MsgCreateVestingAccount transactions will work with direct sign mode.",
+			)
+		}
+	}
+
+	return next(ctx, tx, simulate)
+}

--- a/app/ante/disable_vesting_test.go
+++ b/app/ante/disable_vesting_test.go
@@ -1,0 +1,174 @@
+package ante_test
+
+import (
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v5/app"
+	"github.com/celestiaorg/celestia-app/v5/app/ante"
+	"github.com/celestiaorg/celestia-app/v5/app/encoding"
+	"github.com/celestiaorg/celestia-app/v5/pkg/appconsts"
+	testutil "github.com/celestiaorg/celestia-app/v5/test/util"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisableVestingDecorator(t *testing.T) {
+	testApp, _, _ := testutil.NewTestAppWithGenesisSet(app.DefaultConsensusParams())
+	decorator := ante.NewDisableVestingDecorator()
+
+	// Helper to create vesting message
+	createVestingMsg := func(fromIdx, toIdx int) *vestingtypes.MsgCreateVestingAccount {
+		return &vestingtypes.MsgCreateVestingAccount{
+			FromAddress: testutil.AccPubKeys[fromIdx].Address().String(),
+			ToAddress:   testutil.AccPubKeys[toIdx].Address().String(),
+			Amount:      sdk.NewCoins(sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(1000))),
+			Delayed:     true,
+			EndTime:     time.Now().Add(2 * time.Hour).Unix(),
+			StartTime:   time.Now().Add(1 * time.Hour).Unix(),
+		}
+	}
+
+	// Helper to create bank send message
+	createSendMsg := func(fromIdx, toIdx int) *banktypes.MsgSend {
+		return &banktypes.MsgSend{
+			FromAddress: testutil.AccPubKeys[fromIdx].Address().String(),
+			ToAddress:   testutil.AccPubKeys[toIdx].Address().String(),
+			Amount:      sdk.NewCoins(sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(500))),
+		}
+	}
+
+	tests := []struct {
+		name      string
+		messages  []sdk.Msg
+		signMode  signing.SignMode
+		simulate  bool
+		checkTx   bool
+		expectErr bool
+		errText   string
+	}{
+		{
+			name:      "non-vesting message with amino JSON",
+			messages:  []sdk.Msg{createSendMsg(0, 1)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: false,
+		},
+		{
+			name:      "vesting message with direct sign mode signing",
+			messages:  []sdk.Msg{createVestingMsg(0, 1)},
+			signMode:  signing.SignMode_SIGN_MODE_DIRECT,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: false,
+		},
+		{
+			name:      "vesting message with amino JSON signing",
+			messages:  []sdk.Msg{createVestingMsg(0, 1)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: true,
+			errText:   "MsgCreateVestingAccount is not supported with amino JSON signing",
+		},
+		{
+			name:      "multiple vesting messages with amino JSON",
+			messages:  []sdk.Msg{createVestingMsg(0, 1), createVestingMsg(0, 2)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: true,
+			errText:   "MsgCreateVestingAccount is not supported with amino JSON signing",
+		},
+		{
+			name:      "mixed messages (vesting + send) with protobuf",
+			messages:  []sdk.Msg{createVestingMsg(0, 1), createSendMsg(0, 2)},
+			signMode:  signing.SignMode_SIGN_MODE_DIRECT,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: false,
+		},
+		{
+			name:      "mixed messages (vesting + send) with amino JSON",
+			messages:  []sdk.Msg{createVestingMsg(0, 1), createSendMsg(0, 2)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: true,
+			errText:   "MsgCreateVestingAccount is not supported with amino JSON signing",
+		},
+		{
+			name:      "mixed messages (send + vesting) with amino JSON",
+			messages:  []sdk.Msg{createSendMsg(0, 2), createVestingMsg(0, 1)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  false,
+			checkTx:   true,
+			expectErr: true,
+			errText:   "MsgCreateVestingAccount is not supported with amino JSON signing",
+		},
+		{
+			name:      "vesting with amino JSON in simulation mode",
+			messages:  []sdk.Msg{createVestingMsg(0, 1)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  true,
+			checkTx:   true,
+			expectErr: true,
+			errText:   "MsgCreateVestingAccount is not supported with amino JSON signing",
+		},
+		{
+			name:      "vesting with amino JSON - checkTx false (decorator bypassed)",
+			messages:  []sdk.Msg{createVestingMsg(0, 1)},
+			signMode:  signing.SignMode_SIGN_MODE_LEGACY_AMINO_JSON,
+			simulate:  false,
+			checkTx:   false,
+			expectErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create context with the specified checkTx parameter
+			ctx := testApp.NewContext(tt.checkTx)
+
+			enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+			builder := enc.TxConfig.NewTxBuilder()
+			err := builder.SetMsgs(tt.messages...)
+			require.NoError(t, err)
+
+			// Set signature with the specified sign mode
+			sig := signing.SignatureV2{
+				PubKey: testutil.AccPubKeys[0],
+				Data: &signing.SingleSignatureData{
+					SignMode:  tt.signMode,
+					Signature: []byte("mock_signature"),
+				},
+				Sequence: 0,
+			}
+			err = builder.SetSignatures(sig)
+			require.NoError(t, err)
+
+			tx := builder.GetTx()
+
+			// Test the decorator
+			_, err = decorator.AnteHandle(ctx, tx, tt.simulate, func(ctx sdk.Context, tx sdk.Tx, simulate bool) (sdk.Context, error) {
+				return ctx, nil
+			})
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.errText != "" {
+					require.Contains(t, err.Error(), tt.errText)
+					require.True(t, sdkerrors.ErrUnauthorized.Is(err))
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/stretchr/testify/assert"
@@ -242,8 +243,8 @@ func TestCheckTx(t *testing.T) {
 			expectedABCICode: apperr.ErrTxExceedsMaxSize.ABCICode(),
 		},
 		{
-			// NOTE: this test is in place due to a regression where ledger via amino-json
-			// were not able to submit a MsgCreateVestingAccount transaction.
+			// NOTE: this test verifies that MsgCreateVestingAccount transactions
+			// are rejected when signed with amino-json to prevent potential security issues.
 			name:      "MsgCreateVestingAccount using amino-json",
 			checkType: abci.CheckTxType_New,
 			getTx: func() []byte {
@@ -262,7 +263,7 @@ func TestCheckTx(t *testing.T) {
 				require.NoError(t, err)
 				return tx
 			},
-			expectedABCICode: abci.CodeTypeOK,
+			expectedABCICode: sdkerrors.ErrUnauthorized.ABCICode(),
 		},
 	}
 


### PR DESCRIPTION
To safely patch the current bug that does not allow MsgCreateVestingAccount messages to be submitted, we are creating an antehandler that will reject them in CheckTx while validators slowly upgrade across the network.

Once a quorum have upgraded it is safe to cut a release that removes the disabling and thus users should now be able to submit vesting messages