### PR TITLE
feat: set the default min gas price to an empty string

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -2,7 +2,6 @@ package app
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"cosmossdk.io/math"
@@ -301,7 +300,10 @@ func DefaultAppConfig() *serverconfig.Config {
 	// snapshots to nodes that state sync
 	cfg.StateSync.SnapshotInterval = 1500
 	cfg.StateSync.SnapshotKeepRecent = 2
-	cfg.MinGasPrices = fmt.Sprintf("%v%s", appconsts.DefaultMinGasPrice, params.BondDenom)
+	// this is set to an empty string. As an empty string, the binary will use
+	// the hardcoded default gas price. To override this, the user must set the
+	// minimum gas prices in the app.toml file.
+	cfg.MinGasPrices = ""
 	cfg.GRPC.MaxRecvMsgSize = appconsts.DefaultUpperBoundMaxBytes * 2
 	cfg.GRPC.MaxSendMsgSize = appconsts.DefaultUpperBoundMaxBytes * 2
 	return cfg

--- a/cmd/celestia-appd/cmd/migrate_config.go
+++ b/cmd/celestia-appd/cmd/migrate_config.go
@@ -30,7 +30,7 @@ func updateConfigCmd() *cobra.Command {
 		Use:     "update-config",
 		Short:   "Update configuration values to be that of a specific app version",
 		Long:    "Update configuration files (config.toml and app.toml) to be compatible with a specific app version.",
-		Example: "celestia-appd update-config --home ~/.celestia-app\ncelestia-appd update-config --version v6 --home ~/.celestia-app",
+		Example: "celestia-appd update-config --home ~/.celestia-app\ncelestia-appd update-config --app-version v6 --home ~/.celestia-app --backup false",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			homeDir, err := cmd.Flags().GetString(flags.FlagHome)


### PR DESCRIPTION
Depends on https://github.com/celestiaorg/cosmos-sdk/pull/662

This also will mean that the update-config command will set the users min gas price to an empty string only if it was using the older min gas price