### PR TITLE
fix(ante): add nil check in FormatTx to prevent panic

### DIFF
--- a/app/ante/panic.go
+++ b/app/ante/panic.go
@@ -24,6 +24,10 @@ func (d HandlePanicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 }
 
 func FormatTx(tx sdk.Tx) string {
+	if tx == nil {
+		return "\ncaused by nil transaction"
+	}
+
 	output := "\ncaused by transaction:\n"
 	for _, msg := range tx.GetMsgs() {
 		output += fmt.Sprintf("%T{%s}\n", msg, msg)

--- a/app/ante/panic_test.go
+++ b/app/ante/panic_test.go
@@ -36,3 +36,9 @@ type mockPanicDecorator struct{}
 func (d mockPanicDecorator) AnteHandle(_ sdk.Context, _ sdk.Tx, _ bool, _ sdk.AnteHandler) (newCtx sdk.Context, err error) {
 	panic("mock panic")
 }
+
+func TestFormatTxWithNilTransaction(t *testing.T) {
+	result := ante.FormatTx(nil)
+	expected := "\ncaused by nil transaction"
+	require.Equal(t, expected, result)
+}


### PR DESCRIPTION
Add nil transaction check in FormatTx function to prevent panic

- Added nil check for tx parameter in FormatTx function
- Returns appropriate message when tx is nil instead of panicking
- Added test case to verify nil transaction handling
- Fixes potential runtime panic when HandlePanicDecorator processes nil transactions