### PR TITLE
feat!: implement CIP-41

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -95,6 +95,12 @@ func (app App) RegisterUpgradeHandlers() {
 				return nil, err
 			}
 
+			err = app.SetMinCommisionRate(sdkCtx)
+			if err != nil {
+				sdkCtx.Logger().Error("failed to set min commission rate", "error", err)
+				return nil, err
+			}
+
 			sdkCtx.Logger().Info("finished to upgrade", "upgrade-name", upgradeName, "duration-sec", time.Since(start).Seconds())
 
 			return fromVM, nil
@@ -168,5 +174,25 @@ func (a App) setICAHostParams(ctx context.Context) error {
 		AllowMessages: IcaAllowMessages(),
 	}
 	a.ICAHostKeeper.SetParams(sdkCtx, params)
+	return nil
+}
+
+func (a App) SetMinCommisionRate(ctx context.Context) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	params, err := a.StakingKeeper.GetParams(ctx)
+	if err != nil {
+		sdkCtx.Logger().Error("failed to get staking params", "error", err)
+		return err
+	}
+
+	params.MinCommissionRate = appconsts.MinCommissionRate
+
+	fmt.Printf("Setting the staking params min commission rate to %v.\n", appconsts.MinCommissionRate)
+	err = a.StakingKeeper.SetParams(ctx, params)
+	if err != nil {
+		sdkCtx.Logger().Error("failed to set staking params", "error", err)
+		return err
+	}
 	return nil
 }

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -194,7 +194,7 @@ func (a App) SetMinCommisionRate(ctx context.Context) error {
 
 	params.MinCommissionRate = appconsts.MinCommissionRate
 
-	fmt.Printf("Setting the staking params min commission rate to %v.\n", appconsts.MinCommissionRate)
+	sdkCtx.Logger().Info("Setting the staking params min commission rate to %v.\n", appconsts.MinCommissionRate)
 	err = a.StakingKeeper.SetParams(ctx, params)
 	if err != nil {
 		sdkCtx.Logger().Error("failed to set staking params", "error", err)

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -103,7 +103,7 @@ func (app App) RegisterUpgradeHandlers() {
 
 			err = app.UpdateValidatorCommissionRates(sdkCtx)
 			if err != nil {
-				sdkCtx.Logger().Error("failed to update validator comission rates ", "error", err)
+				sdkCtx.Logger().Error("failed to update validator commission rates", "error", err)
 				return nil, err
 			}
 
@@ -222,7 +222,7 @@ func (a App) UpdateValidatorCommissionRates(ctx context.Context) error {
 		sdkCtx.Logger().Info("updating validator commission rate", "validator", validator.GetOperator(), "old-commission", validator.Commission.Rate, "new-commission", appconsts.MinCommissionRate)
 		_, err := a.StakingKeeper.UpdateValidatorCommission(ctx, validator, appconsts.MinCommissionRate)
 		if err != nil {
-			// log the error and continue attempting to update the comission rate for the remaining validators
+			// log the error and continue attempting to update the commission rate for the remaining validators
 			sdkCtx.Logger().Error("failed to update validator commission rate", "error", err)
 		}
 	}

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -213,6 +213,7 @@ func (a App) UpdateValidatorCommissionRates(ctx context.Context) error {
 	}
 
 	for _, validator := range validators {
+		fmt.Printf("validator commission rate: %v\n", validator.Commission.Rate)
 		if validator.Commission.Rate.GTE(appconsts.MinCommissionRate) {
 			sdkCtx.Logger().Debug("validator commission rate is greater than or equal to the minimum commission rate, skipping", "validator", validator.GetOperator())
 			continue
@@ -221,8 +222,8 @@ func (a App) UpdateValidatorCommissionRates(ctx context.Context) error {
 		sdkCtx.Logger().Info("updating validator commission rate", "validator", validator.GetOperator(), "old-commission", validator.Commission.Rate, "new-commission", appconsts.MinCommissionRate)
 		_, err := a.StakingKeeper.UpdateValidatorCommission(ctx, validator, appconsts.MinCommissionRate)
 		if err != nil {
+			// log the error and continue attempting to update the comission rate for the remaining validators
 			sdkCtx.Logger().Error("failed to update validator commission rate", "error", err)
-			return err
 		}
 	}
 	return nil

--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -213,7 +213,6 @@ func (a App) UpdateValidatorCommissionRates(ctx context.Context) error {
 	}
 
 	for _, validator := range validators {
-		fmt.Printf("validator commission rate: %v\n", validator.Commission.Rate)
 		if validator.Commission.Rate.GTE(appconsts.MinCommissionRate) {
 			sdkCtx.Logger().Debug("validator commission rate is greater than or equal to the minimum commission rate, skipping", "validator", validator.GetOperator())
 			continue
@@ -237,8 +236,7 @@ func (a App) UpdateValidatorCommissionRates(ctx context.Context) error {
 		}
 
 		validator.Commission = commission
-		err = a.StakingKeeper.SetValidator(ctx, validator)
-		if err != nil {
+		if err = a.StakingKeeper.SetValidator(ctx, validator); err != nil {
 			sdkCtx.Logger().Error("failed to set validator", "error", err)
 			continue
 		}

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -122,10 +122,10 @@ func TestApplyUpgrade(t *testing.T) {
 			Height: 1,
 			Info:   "info",
 		}
-		// Set the block time to 25 hours in the future to ensure the commission
-		// rate can be updated. If the block time is within 24 hours of the
-		// genesis block, the commission rate will fail to update due to
-		// ErrCommissionUpdateTime.
+		// Set the block time to 25 hours ahead of the genesis block to ensure
+		// the commission rate can be updated. If the block time is within 24
+		// hours of the genesis block, the commission rate will fail to update
+		// due to ErrCommissionUpdateTime.
 		ctx = testApp.NewContext(false).WithBlockTime(util.GenesisTime.Add(time.Hour * 25))
 		err = testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
 		require.NoError(t, err)

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -5,12 +5,15 @@ import (
 	"time"
 
 	"cosmossdk.io/log"
+	"cosmossdk.io/math"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
 	"github.com/celestiaorg/celestia-app/v6/app"
+	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/test/util"
 	"github.com/celestiaorg/celestia-app/v6/test/util/testfactory"
 	tmdb "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	"github.com/stretchr/testify/require"
 )
@@ -63,5 +66,35 @@ func TestApplyUpgrade(t *testing.T) {
 		got = testApp.ICAHostKeeper.GetParams(ctx)
 		require.True(t, got.HostEnabled)
 		require.Equal(t, got.AllowMessages, app.IcaAllowMessages())
+	})
+	t.Run("apply upgrade should set the min commission rate to 10%", func(t *testing.T) {
+		consensusParams := app.DefaultConsensusParams()
+		consensusParams.Version.App = 5
+		testApp, _, _ := util.NewTestAppWithGenesisSet(consensusParams)
+		require.True(t, testApp.UpgradeKeeper.HasHandler("v6"))
+
+		ctx := testApp.NewContext(false)
+		// Set the min commission rate to 5% because that is what is on Mainnet since genesis.
+		testApp.StakingKeeper.SetParams(ctx, stakingtypes.Params{
+			MinCommissionRate: math.LegacyNewDecWithPrec(5, 2),
+		})
+		params, err := testApp.StakingKeeper.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, math.LegacyNewDecWithPrec(5, 2), params.MinCommissionRate)
+
+		// Apply the upgrade.
+		plan := upgradetypes.Plan{
+			Name:   "v6",
+			Time:   time.Now(),
+			Height: 1,
+			Info:   "info",
+		}
+		err = testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
+		require.NoError(t, err)
+
+		ctx = testApp.NewContext(false)
+		got, err := testApp.StakingKeeper.GetParams(ctx)
+		require.NoError(t, err)
+		require.Equal(t, appconsts.MinCommissionRate, got.MinCommissionRate)
 	})
 }

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -77,9 +77,10 @@ func TestApplyUpgrade(t *testing.T) {
 		oldMinComissionRate, err := math.LegacyNewDecFromStr("0.05")
 		require.NoError(t, err)
 		// Set the min commission rate to 5% because that is what is on Mainnet since genesis.
-		testApp.StakingKeeper.SetParams(ctx, stakingtypes.Params{
+		err = testApp.StakingKeeper.SetParams(ctx, stakingtypes.Params{
 			MinCommissionRate: oldMinComissionRate,
 		})
+		require.NoError(t, err)
 		params, err := testApp.StakingKeeper.GetParams(ctx)
 		require.NoError(t, err)
 		require.Equal(t, oldMinComissionRate, params.MinCommissionRate)

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -130,6 +130,7 @@ func TestApplyUpgrade(t *testing.T) {
 		err = testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
 		require.NoError(t, err)
 
+		ctx = testApp.NewContext(false)
 		validators, err = testApp.StakingKeeper.GetAllValidators(ctx)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(validators))

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v6/test/util/testfactory"
 	tmdb "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	"github.com/stretchr/testify/require"
@@ -137,4 +138,145 @@ func TestApplyUpgrade(t *testing.T) {
 		validator = validators[0]
 		require.Equal(t, appconsts.MinCommissionRate, validator.Commission.Rate)
 	})
+}
+
+func TestUpdateValidatorCommissionRates(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		initialRate          string
+		initialMaxRate       string
+		initialMaxChangeRate string
+		wantRate             string
+		wantMaxRate          string
+		wantMaxChangeRate    string
+		shouldUpdate         bool
+	}{
+		{
+			name:                 "should increase rate and max rate to min commission rate",
+			initialRate:          "0.05", // 5%
+			initialMaxRate:       "0.08", // 8%
+			initialMaxChangeRate: "0.01", // 1%
+			wantRate:             "0.10", // 10% (MinCommissionRate)
+			wantMaxRate:          "0.10", // 10% (MinCommissionRate)
+			wantMaxChangeRate:    "0.01", // unchanged
+			shouldUpdate:         true,
+		},
+		{
+			name:                 "should increase rate to min commission rate and leave max rate unchanged",
+			initialRate:          "0.03", // 3%
+			initialMaxRate:       "0.15", // 15%
+			initialMaxChangeRate: "0.02", // 2%
+			wantRate:             "0.10", // 10% (MinCommissionRate)
+			wantMaxRate:          "0.15", // unchanged
+			wantMaxChangeRate:    "0.02", // unchanged
+			shouldUpdate:         true,
+		},
+		{
+			name:                 "should increase max rate to min commission rate and leave initial rate unchanged even though this can't happen in practice",
+			initialRate:          "0.12", // 12%
+			initialMaxRate:       "0.07", // 7%
+			initialMaxChangeRate: "0.03", // 3%
+			wantRate:             "0.12", // unchanged
+			wantMaxRate:          "0.10", // 10% (MinCommissionRate)
+			wantMaxChangeRate:    "0.03", // unchanged
+			shouldUpdate:         true,
+		},
+		{
+			name:                 "should not update if both rate and max rate are above min commission rate",
+			initialRate:          "0.15", // 15%
+			initialMaxRate:       "0.20", // 20%
+			initialMaxChangeRate: "0.05", // 5%
+			wantRate:             "0.15", // unchanged
+			wantMaxRate:          "0.20", // unchanged
+			wantMaxChangeRate:    "0.05", // unchanged
+			shouldUpdate:         false,
+		},
+		{
+			name:                 "should not update if both rate and max rate are exactly at min commission rate",
+			initialRate:          "0.10", // 10% (exactly minimum)
+			initialMaxRate:       "0.10", // 10% (exactly minimum)
+			initialMaxChangeRate: "0.10", // 10%
+			wantRate:             "0.10", // unchanged
+			wantMaxRate:          "0.10", // unchanged
+			wantMaxChangeRate:    "0.10", // unchanged
+			shouldUpdate:         false,
+		},
+		{
+			name:                 "zero commission rate - should be updated to minimum",
+			initialRate:          "0.0",  // 0%
+			initialMaxRate:       "0.05", // 5%
+			initialMaxChangeRate: "0.1",  // 10%
+			wantRate:             "0.1",  // 10% (MinCommissionRate)
+			wantMaxRate:          "0.1",  // 10% (MinCommissionRate)
+			wantMaxChangeRate:    "0.1",  // unchanged
+			shouldUpdate:         true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			consensusParams := app.DefaultConsensusParams()
+			testApp, _, _ := util.NewTestAppWithGenesisSet(consensusParams)
+
+			ctx := testApp.NewContext(false).WithBlockTime(util.GenesisTime.Add(time.Hour * 25))
+
+			validator := createValidatorWithCommission(t, testApp, ctx, tc.initialRate, tc.initialMaxRate, tc.initialMaxChangeRate)
+
+			valAddr, err := sdk.ValAddressFromBech32(validator.GetOperator())
+			require.NoError(t, err)
+			validatorBefore, err := testApp.StakingKeeper.GetValidator(ctx, valAddr)
+			require.NoError(t, err)
+
+			assertCommissionRates(t, validatorBefore, tc.initialRate, tc.initialMaxRate, tc.initialMaxChangeRate)
+
+			err = testApp.UpdateValidatorCommissionRates(ctx)
+			require.NoError(t, err)
+
+			validatorAfter, err := testApp.StakingKeeper.GetValidator(ctx, valAddr)
+			require.NoError(t, err)
+
+			assertCommissionRates(t, validatorAfter, tc.wantRate, tc.wantMaxRate, tc.wantMaxChangeRate)
+
+			if tc.shouldUpdate {
+				require.Equal(t, ctx.BlockTime(), validatorAfter.Commission.UpdateTime, "UpdateTime should be set to current block time")
+			}
+		})
+	}
+}
+
+// createValidatorWithCommission creates a validator with specific commission
+// rates for testing
+func createValidatorWithCommission(t *testing.T, testApp *app.App, ctx sdk.Context, rate, maxRate, maxChangeRate string) stakingtypes.Validator {
+	commissionRate, err := math.LegacyNewDecFromStr(rate)
+	require.NoError(t, err)
+	commissionMaxRate, err := math.LegacyNewDecFromStr(maxRate)
+	require.NoError(t, err)
+	commissionMaxChangeRate, err := math.LegacyNewDecFromStr(maxChangeRate)
+	require.NoError(t, err)
+
+	validators, err := testApp.StakingKeeper.GetAllValidators(ctx)
+	require.NoError(t, err)
+	require.Greater(t, len(validators), 0, "Should have at least one validator")
+
+	validator := validators[0]
+	validator.Commission = stakingtypes.NewCommission(commissionRate, commissionMaxRate, commissionMaxChangeRate)
+
+	err = testApp.StakingKeeper.SetValidator(ctx, validator)
+	require.NoError(t, err)
+
+	return validator
+}
+
+// assertCommissionRates verifies that a validator has the expected commission rates
+func assertCommissionRates(t *testing.T, validator stakingtypes.Validator, expectedRate, expectedMaxRate, expectedMaxChangeRate string) {
+	wantRate, err := math.LegacyNewDecFromStr(expectedRate)
+	require.NoError(t, err)
+	wantMaxRate, err := math.LegacyNewDecFromStr(expectedMaxRate)
+	require.NoError(t, err)
+	wantMaxChangeRate, err := math.LegacyNewDecFromStr(expectedMaxChangeRate)
+	require.NoError(t, err)
+
+	require.Equal(t, wantRate, validator.Commission.Rate)
+	require.Equal(t, wantMaxRate, validator.Commission.MaxRate)
+	require.Equal(t, wantMaxChangeRate, validator.Commission.MaxChangeRate)
 }

--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -55,8 +55,6 @@ const (
 
 )
 
-var (
-	// MinCommissionRate is the minimum commission rate for a validator as
-	// defined in CIP-41.
-	MinCommissionRate = math.LegacyNewDecWithPrec(1, 1) // 10%
-)
+// MinCommissionRate is the minimum commission rate for a validator as
+// defined in CIP-41.
+var MinCommissionRate = math.LegacyNewDecWithPrec(1, 1) // 10%

--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -1,6 +1,10 @@
 package appconsts
 
-import "time"
+import (
+	"time"
+
+	"cosmossdk.io/math"
+)
 
 const (
 	// Version is the current application version.
@@ -48,4 +52,11 @@ const (
 	//
 	// Modified from 3 weeks to 14 days + 1 hour in CIP-037.
 	UnbondingTime = 337 * time.Hour // (14 days + 1 hour)
+
+)
+
+var (
+	// MinCommissionRate is the minimum commission rate for a validator as
+	// defined in CIP-41.
+	MinCommissionRate = math.LegacyNewDecWithPrec(1, 2) // 10%
 )

--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -58,5 +58,5 @@ const (
 var (
 	// MinCommissionRate is the minimum commission rate for a validator as
 	// defined in CIP-41.
-	MinCommissionRate = math.LegacyNewDecWithPrec(1, 2) // 10%
+	MinCommissionRate = math.LegacyNewDecWithPrec(1, 1) // 10%
 )

--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -55,6 +55,6 @@ const (
 
 )
 
-// MinCommissionRate is the minimum commission rate for a validator as
-// defined in CIP-41.
-var MinCommissionRate = math.LegacyNewDecWithPrec(1, 1) // 10%
+// MinCommissionRate is 10%. It is the minimum commission rate for a validator
+// as defined in CIP-41.
+var MinCommissionRate = math.LegacyNewDecWithPrec(1, 1)

--- a/scripts/min-commission-rate-proposal-v1.json
+++ b/scripts/min-commission-rate-proposal-v1.json
@@ -1,0 +1,21 @@
+{
+  "messages": [
+    {
+      "@type": "/cosmos.staking.v1beta1.MsgUpdateParams",
+      "authority": "celestia10d07y265gmmuvt4z0w9aw880jnsr700jtgz4v7",
+      "params": {
+        "unbonding_time": "337h0m0s",
+        "max_validators": 100,
+        "max_entries": 7,
+        "historical_entries": 10000,
+        "bond_denom": "utia",
+        "min_commission_rate": "0.100000000000000000"
+      }
+    }
+  ],
+  "metadata": "ipfs://QmYourMetadataHashHere",
+  "deposit": "10000000000utia",
+  "title": "Set MinCommissionRate to 10%",
+  "summary": "This proposal aims to update the min_commission_rate staking parameter from 5% to 10%. This change will set a minimum commission rate that all validators must charge, helping to prevent a race to the bottom on validator commissions and ensuring validators can maintain sustainable operations.",
+  "expedited": false
+}

--- a/scripts/min-commission-rate.sh
+++ b/scripts/min-commission-rate.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# This script modifies the min comission rate via a governance proposal.
+# Prerequisites: start single-node.sh in another terminal.
+
+set -o errexit # Stop script execution if an error is encountered
+set -o nounset # Stop script execution if an undefined variable is used
+
+echo "Querying staking params..."
+celestia-appd query staking params
+
+echo "Querying staking validators..."
+celestia-appd query staking validators
+
+export FROM=$(celestia-appd keys show validator --address)
+echo "Submitting a governance proposal to increase the min commission rate..."
+celestia-appd tx gov submit-proposal ./scripts/min-commission-rate-proposal-v1.json --from $FROM --fees 210000utia --gas 1000000 --yes
+
+sleep 3
+echo "Voting for the proposal..."
+celestia-appd tx gov vote 1 yes --from $FROM --fees 210000utia --yes --gas 1000000
+
+sleep 3
+echo "Querying governance proposals..."
+celestia-appd query gov proposals
+
+echo "Waiting 30 seconds for the voting period to end..."
+sleep 30
+
+echo "Querying staking params..."
+celestia-appd query staking params
+
+echo "Querying staking validators..."
+celestia-appd query staking validators

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -2,10 +2,8 @@
 
 # This script starts a single node testnet on the latest app version.
 
-# Stop script execution if an error is encountered
-set -o errexit
-# Stop script execution if an undefined variable is used
-set -o nounset
+set -o errexit # Stop script execution if an error is encountered
+set -o nounset # Stop script execution if an undefined variable is used
 
 if ! [ -x "$(command -v celestia-appd)" ]
 then
@@ -59,6 +57,9 @@ createGenesis() {
       --keyring-backend=${KEYRING_BACKEND} \
       --chain-id ${CHAIN_ID} \
       --home "${APP_HOME}" \
+      --commission-rate=0.05 \
+      --commission-max-rate=1.0 \
+      --commission-max-change-rate=1.0 \
       > /dev/null 2>&1 # Hide output to reduce terminal noise
 
     echo "Collecting genesis txs..."
@@ -78,8 +79,8 @@ createGenesis() {
     # Override the log level to reduce noisy logs
     sed -i.bak 's#log_level = "info"#log_level = "*:error,p2p:info,state:info"#g' "${APP_HOME}"/config/config.toml
 
-    # Override the VotingPeriod from 1 week to 1 minute
-    sed -i.bak 's#"604800s"#"60s"#g' "${APP_HOME}"/config/genesis.json
+    # Override the VotingPeriod from 1 week to 30 seconds
+    sed -i.bak 's#"604800s"#"30s"#g' "${APP_HOME}"/config/genesis.json
 
     trace_type="local"
     sed -i.bak -e "s/^trace_type *=.*/trace_type = \"$trace_type\"/" ${APP_HOME}/config/config.toml

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -215,6 +215,18 @@ func genesisStateWithValSet(
 		if err != nil {
 			panic(err)
 		}
+		rate, err := math.LegacyNewDecFromStr("0.05")
+		if err != nil {
+			panic(err)
+		}
+		maxRate, err := math.LegacyNewDecFromStr("0.2")
+		if err != nil {
+			panic(err)
+		}
+		maxChangeRate, err := math.LegacyNewDecFromStr("1")
+		if err != nil {
+			panic(err)
+		}
 		validator := stakingtypes.Validator{
 			OperatorAddress:   sdk.ValAddress(val.Address).String(),
 			ConsensusPubkey:   pkAny,
@@ -225,7 +237,7 @@ func genesisStateWithValSet(
 			Description:       stakingtypes.Description{},
 			UnbondingHeight:   int64(0),
 			UnbondingTime:     time.Unix(0, 0).UTC(),
-			Commission:        stakingtypes.NewCommission(math.LegacyZeroDec(), math.LegacyZeroDec(), math.LegacyZeroDec()),
+			Commission:        stakingtypes.NewCommission(rate, maxRate, maxChangeRate),
 			MinSelfDelegation: math.ZeroInt(),
 		}
 		validators = append(validators, validator)

--- a/x/mint/README.md
+++ b/x/mint/README.md
@@ -8,33 +8,27 @@ celestia-app's `x/mint` is a fork of the Cosmos SDK [`x/mint`](https://github.co
 
 [CIP-29](https://github.com/celestiaorg/CIPs/blob/94aa5ad39aa3aba41bf143e6d7324839509b5b93/cips/cip-029.md) reduced two constants (`InitialInflationRate` and `DisinflationRate`) which impacts the inflation schedule. These constants will take effect at the v4 activation height part way through year 1. As a result:
 
-- Inflation for year 0 is calculated based on the [original constants](https://github.com/celestiaorg/celestia-app/blame/93a5c4b85414d811d5ee6d617aaf71bf9d560fbb/x/mint/types/constants.go#L17-L20).
-- Inflation for year 1 is a time-weighted average of the pre- and post-CIP-29 inflation rates.
-- Inflation for years >= 2 is calculated based on the post [CIP-29 constants](https://github.com/celestiaorg/celestia-app/blob/6a2e7513dbb2c11808c1e8c99d35532d4d946aa1/x/mint/types/constants.go#L19-L22).
+[CIP-41](https://github.com/celestiaorg/CIPs/blob/533a133b3c2a5f6dd54934bab30729c1515e6bd0/cips/cip-041.md) also reduced the `InitialInflationRate`.
 
-| Year | Inflation (%)      | Notes                                                                                           |
-|------|--------------------|-------------------------------------------------------------------------------------------------|
-| 0    | 8.00               | Based on original constants                                                                     |
-| 1    | ~6.1               | This is an approximate value. The actual value depends on when the v4 activation height occurs. |
-| 2    | 4.66582104         | Based on CIP-29 constants                                                                       |
-| 3    | 4.35321103032      | Based on CIP-29 constants                                                                       |
-| 4    | 4.06154589128856   | Based on CIP-29 constants                                                                       |
-| 5    | 3.789422316572227  | Based on CIP-29 constants                                                                       |
-| 6    | 3.5355310213618873 | Based on CIP-29 constants                                                                       |
-| 7    | 3.298650442930641  | Based on CIP-29 constants                                                                       |
-| 8    | 3.0776408632542877 | Based on CIP-29 constants                                                                       |
-| 9    | 2.8714389254162507 | Based on CIP-29 constants                                                                       |
-| 10   | 2.6790525174133616 | Based on CIP-29 constants                                                                       |
-| 11   | 2.4995559987466665 | Based on CIP-29 constants                                                                       |
-| 12   | 2.3320857468306398 | Based on CIP-29 constants                                                                       |
-| 13   | 2.175836001792987  | Based on CIP-29 constants                                                                       |
-| 14   | 2.0300549896728567 | Based on CIP-29 constants                                                                       |
-| 15   | 1.8940413053647756 | Based on CIP-29 constants                                                                       |
-| 16   | 1.7671405379053356 | Based on CIP-29 constants                                                                       |
-| 17   | 1.6487421218656782 | Based on CIP-29 constants                                                                       |
-| 18   | 1.5382763997006776 | Based on CIP-29 constants                                                                       |
-| 19   | 1.50               | Based on CIP-29 constants                                                                       |
-| 20   | 1.50               | Based on CIP-29 constants                                                                       |
+- Inflation for year 0 is calculated based on the [original constants](https://github.com/celestiaorg/celestia-app/blame/93a5c4b85414d811d5ee6d617aaf71bf9d560fbb/x/mint/types/constants.go#L17-L20).
+- Inflation for year 1 is a time-weighted average of the original, CIP-29, and CIP-41 inflation rates.
+- Inflation for years >= 2 is calculated based on the post [CIP-41 constants](https://github.com/celestiaorg/CIPs/blob/533a133b3c2a5f6dd54934bab30729c1515e6bd0/cips/cip-041.md).
+
+| Year   | Inflation | Notes                                       |
+|--------|-----------|---------------------------------------------|
+| 0      | 8.00%     | Genesis year used original constants        |
+| 1      | 7.20%     | Year 1 started with original constants      |
+| 1 (v4) | 5.00%     | After CIP-29 reduction                      |
+| 1 (v6) | 2.50%     | After CIP-41 reduction                      |
+| 2      | 2.33%     | Regular annual disinflation applied (6.7%)  |
+| 3      | 2.17%     | Regular annual disinflation applied (6.7%)  |
+| 4      | 2.02%     | Regular annual disinflation applied (6.7%)  |
+| 5      | 1.88%     | Regular annual disinflation applied (6.7%)  |
+| 6      | 1.75%     | Regular annual disinflation applied (6.7%)  |
+| 7      | 1.63%     | Regular annual disinflation applied (6.7%)  |
+| 8      | 1.52%     | Regular annual disinflation applied (6.7%)  |
+| 9      | 1.50%     | Target inflation reached                    |
+| 10     | 1.50%     | Inflation will remain at 1.50% indefinitely |
 
 - **Year** indicates the number of years elapsed since chain genesis.
 - **Inflation (%)** indicates the percentage of the total supply that will be minted in the next year.

--- a/x/mint/client/testutil/grpc_test.go
+++ b/x/mint/client/testutil/grpc_test.go
@@ -16,6 +16,8 @@ func (s *IntegrationTestSuite) TestQueryGRPC() {
 	baseURL := s.cctx.APIAddress()
 	baseURL = strings.Replace(baseURL, "tcp", "http", 1)
 	expectedAnnualProvision := mint.InitialInflationRateAsDec().MulInt(math.NewInt(testnode.DefaultInitialBalance))
+	want, err := math.LegacyNewDecFromStr("0.0267")
+	s.Require().NoError(err)
 	testCases := []struct {
 		name     string
 		url      string
@@ -29,7 +31,7 @@ func (s *IntegrationTestSuite) TestQueryGRPC() {
 			map[string]string{},
 			&mint.QueryInflationRateResponse{},
 			&mint.QueryInflationRateResponse{
-				InflationRate: math.LegacyNewDecWithPrec(536, 4),
+				InflationRate: want,
 			},
 		},
 		{

--- a/x/mint/client/testutil/suite_test.go
+++ b/x/mint/client/testutil/suite_test.go
@@ -56,12 +56,12 @@ func (s *IntegrationTestSuite) TestGetCmdQueryInflationRate() {
 		{
 			name: "json output",
 			args: s.jsonArgs(),
-			want: "0.053600000000000000",
+			want: "0.026700000000000000",
 		},
 		{
 			name: "text output",
 			args: s.textArgs(),
-			want: "0.053600000000000000",
+			want: "0.026700000000000000",
 		},
 	}
 

--- a/x/mint/keeper/abci_test.go
+++ b/x/mint/keeper/abci_test.go
@@ -37,29 +37,29 @@ func TestInflationRate(t *testing.T) {
 
 	testCases := []testCase{
 		{
-			name: "inflation rate is 0.0536 for year zero",
+			name: "inflation rate is 0.0267 for year zero",
 			ctx:  ctx.WithBlockTime(*genesisTime),
-			want: math.LegacyMustNewDecFromStr("0.0536"),
+			want: math.LegacyMustNewDecFromStr("0.0267"),
 		},
 		{
-			name: "inflation rate is 0.0536 for year one minus one second",
+			name: "inflation rate is 0.0267 for year one minus one second",
 			ctx:  ctx.WithBlockTime(yearOneMinusOneSecond),
-			want: math.LegacyMustNewDecFromStr("0.0536"),
+			want: math.LegacyMustNewDecFromStr("0.0267"),
 		},
 		{
-			name: "inflation rate is 0.0500088 for year one",
+			name: "inflation rate is 0.0249111 for year one",
 			ctx:  ctx.WithBlockTime(yearOne),
-			want: math.LegacyMustNewDecFromStr("0.0500088"),
+			want: math.LegacyMustNewDecFromStr("0.0249111"),
 		},
 		{
-			name: "inflation rate is 0.0466582104 for year two",
+			name: "inflation rate is 0.0232420563 for year two",
 			ctx:  ctx.WithBlockTime(yearTwo),
-			want: math.LegacyMustNewDecFromStr("0.0466582104"),
+			want: math.LegacyMustNewDecFromStr("0.0232420563"),
 		},
 		{
-			name: "inflation rate is 0.018940413053647755 for year fifteen",
+			name: "inflation rate is 0.015 for year fifteen",
 			ctx:  ctx.WithBlockTime(yearFifteen),
-			want: math.LegacyMustNewDecFromStr("0.018940413053647755"),
+			want: math.LegacyMustNewDecFromStr("0.015"),
 		},
 		{
 			name: "inflation rate is 0.015 for year twenty",

--- a/x/mint/types/constants.go
+++ b/x/mint/types/constants.go
@@ -16,8 +16,8 @@ const (
 	SecondsPerYear     = int64(SecondsPerMinute * MinutesPerHour * HoursPerDay * DaysPerYear) // 31,556,952
 	NanosecondsPerYear = NanosecondsPerSecond * SecondsPerYear                                // 31,556,952,000,000,000
 
-	// InitialInflationRate is the inflation rate as defined in CIP-29.
-	InitialInflationRate = 0.0536
+	// InitialInflationRate is the inflation rate as defined in CIP-41.
+	InitialInflationRate = 0.0267
 	// DisinflationRate is the rate at which the inflation rate decreases each year as defined in CIP-29.
 	DisinflationRate = 0.067
 	// TargetInflationRate is the inflation rate that the network aims to

--- a/x/mint/types/minter_test.go
+++ b/x/mint/types/minter_test.go
@@ -25,27 +25,17 @@ func TestCalculateInflationRate(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{0, 0.0536},    // NOTE: this value won't be used in production because CIP-29 has been introduced after year 0 (see CIP-29 for details).
-		{1, 0.0500088}, // Note: this value won't manifest as the observed inflation rate for year 1 because CIP-29 was introduced part way through year 1.
-		{2, 0.0466582104},
-		{3, 0.0435321103032},
-		{4, 0.0406154589128856},
-		{5, 0.03789422316572227},
-		{6, 0.035355310213618873},
-		{7, 0.03298650442930641},
-		{8, 0.030776408632542877},
-		{9, 0.028714389254162507},
-		{10, 0.026790525174133616},
-		{11, 0.024995559987466665},
-		{12, 0.023320857468306398},
-		{13, 0.02175836001792987},
-		{14, 0.020300549896728567},
-		{15, 0.018940413053647756},
-		{16, 0.017671405379053356},
-		{17, 0.016487421218656782},
-		{18, 0.015382763997006776},
-		{19, 0.015},
-		{20, 0.015},
+		{0, 0.0267},    // NOTE: this value won't be used in production because CIP-29 and CIP-41 were introduced after year 0.
+		{1, 0.0249111}, // Note: this value won't manifest as the observed inflation rate for year 1 because CIP-29 and CIP-41 were introduced part way through year 1.
+		{2, 0.0232420563},
+		{3, 0.0216848385279},
+		{4, 0.0202319543465307},
+		{5, 0.018876413405313142},
+		{6, 0.017611693707157164},
+		{7, 0.016431710228777634},
+		{8, 0.015330785643449531},
+		{9, 0.015},
+		{10, 0.015},
 	}
 
 	for i, tc := range testCases {
@@ -83,16 +73,14 @@ func TestCalculateBlockProvision(t *testing.T) {
 			annualProvisions: annualProvisions,
 			current:          current,
 			previous:         current.Add(-blockInterval),
-			// 53.6 billion utia (annual provisions) * 15 (seconds) / 31,556,952 (seconds per year) = 25477 utia (truncated)
-			want: sdk.NewCoin(params.BondDenom, math.NewInt(25477)),
+			want:             sdk.NewCoin(params.BondDenom, math.NewInt(12691)),
 		},
 		{
 			name:             "one 30 second block during the first year",
 			annualProvisions: annualProvisions,
 			current:          current,
 			previous:         current.Add(-2 * blockInterval),
-			// 53.6 billion utia (annual provisions) * 30 (seconds) / 31,556,952 (seconds per year) = 50955 utia (truncated)
-			want: sdk.NewCoin(params.BondDenom, math.NewInt(50955)),
+			want:             sdk.NewCoin(params.BondDenom, math.NewInt(25382)),
 		},
 		{
 			name:             "want error when current time is before previous time",


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5435

## Description
1. Decrease inflation
2. Increase MinComissionRate from 5% to 10%

## Notes
The upgrade handler in this PR will attempt to update the commission rate for validators to the new min commission rate if the validator's commission rate was previously below that. However, the update will fail for certain validators (example: [SmartStake](https://celenium.io/validator/82827?tab=Delegators)) who have set a max rate that is lower than the new min rate. I also expect it to fail for validators with a small `MaxChangeRate`.

## Follow ups
1. https://github.com/celestiaorg/celestia-app/issues/5528