### PR TITLE
docs(multiplexer): correct errgroup comment; CometBFT is not added to the group

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -78,7 +78,9 @@ type Multiplexer struct {
 	conn *grpc.ClientConn
 	// ctx is the context which is passed to the comet, grpc and api server starting functions.
 	ctx context.Context
-	// g is the waitgroup to which the comet, grpc and api server init functions are added to.
+	// g is the errgroup that manages goroutines started by the multiplexer
+	// (signal listener, gRPC server, API server, and block event listener).
+	// CometBFT is started synchronously and is not added to this group.
 	g *errgroup.Group
 	// traceWriter is the trace writer for the multiplexer.
 	traceWriter io.WriteCloser


### PR DESCRIPTION
fix #5199

Why this is correct:
- getCtx adds the quit-signal listener to the errgroup.
- startGRPCServer and startAPIServer each add goroutines via m.g.Go(...).
- blockAPI.StartNewBlockEventListener is also added via m.g.Go(...).
- startCmtNode starts CometBFT synchronously and does not add it to m.g.