### PR TITLE
chore(golangci-lint): remove duplicate gocritic linter from config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,7 +11,6 @@ linters:
     - revive
     - staticcheck
     - unconvert
-    - gocritic
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Remove duplicate gocritic entry from linters.enable section.
The linter was listed twice which, while not breaking functionality, creates unnecessary redundancy in the configuration file.