### PR TITLE
docs(errors): correct comments to reference ErrInsufficientFee instead of ErrInsufficientFunds

### DIFF
--- a/app/errors/insufficient_gas_price.go
+++ b/app/errors/insufficient_gas_price.go
@@ -26,7 +26,7 @@ func ParseInsufficientMinGasPrice(err error, gasPrice float64, gasLimit uint64) 
 		return 0, nil
 	}
 
-	// As there are multiple cases of ErrInsufficientFunds, we need to check the error message
+	// As there are multiple cases of ErrInsufficientFee, we need to check the error message
 	// matches the regexp
 	substr := regexpMinGasPrice.FindAllString(err.Error(), -1)
 	if len(substr) != 1 {
@@ -74,7 +74,7 @@ func IsInsufficientFee(err error) bool {
 		return false
 	}
 
-	// As there are multiple cases of ErrInsufficientFunds, we need to check the error message
+	// As there are multiple cases of ErrInsufficientFee, we need to check the error message
 	// matches the regexp
 	return regexpMinGasPrice.MatchString(err.Error())
 }


### PR DESCRIPTION
Fix incorrect terminology in comments within app/errors/insufficient_gas_price.go.
It referenced ErrInsufficientFunds, but the code checks ErrInsufficientFee and parses “insufficient fees” messages.