### PR TITLE
fix: correct .PHONY target name for goreleaser-dry-run in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -412,7 +412,7 @@ goreleaser-dry-run:
 		-w /go/src/$(PACKAGE_NAME) \
 		ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
 		release --snapshot --clean --parallelism 4
-.PHONY: go-releaser-dry-run
+.PHONY: goreleaser-dry-run
 
 ## goreleaser: Create prebuilt binaries and attach them to GitHub release. Requires Docker.
 goreleaser: prebuilt-binary


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fixed typo in .PHONY declaration on line 415 where "go-releaser-dry-run" was incorrectly specified instead of "goreleaser-dry-run" to match the actual target name defined on line 402