### PR TITLE
fix: correct find command syntax in protocgen.sh script

### DIFF
--- a/scripts/protocgen.sh
+++ b/scripts/protocgen.sh
@@ -3,7 +3,7 @@
 set -e
 
 cd proto
-proto_dirs=$(find . -path -prune -o -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
+proto_dirs=$(find . -name '*.proto' -print0 | xargs -0 -n1 dirname | sort | uniq)
 for dir in $proto_dirs; do
   for file in $(find "${dir}" -maxdepth 1 -name '*.proto'); do
       echo "Generating gogo proto code for ${file}"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Remove invalid "-path -prune" syntax from the find command that was causing a syntax error. The command now properly finds all .proto files in the directory structure without the malformed path filtering.
