### PR TITLE
refactor: skip BBR check on non-Linux machines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,14 @@ endif
 .PHONY: build
 
 ## install-standalone: Build and install the celestia-appd binary into the $GOPATH/bin directory. This target does not install the multiplexer.
-install-standalone: check-bbr
+install-standalone:
 	@echo "--> Installing celestia-appd"
 	@go install $(BUILD_FLAGS_STANDALONE) ./cmd/celestia-appd
 .PHONY: install-standalone
 
 ## install: Build and install the multiplexer version of celestia-appd into the $GOPATH/bin directory.
 # TODO: Improve logic here and in goreleaser to make it future proof and less expensive.
-install: check-bbr download-v3-binaries download-v4-binaries download-v5-binaries
+install: download-v3-binaries download-v4-binaries download-v5-binaries
 	@echo "--> Installing celestia-appd with multiplexer support"
 	@go install $(BUILD_FLAGS_MULTIPLEXER) ./cmd/celestia-appd
 .PHONY: install
@@ -421,7 +421,10 @@ goreleaser: prebuilt-binary
 ## check-bbr: Internal command to check if BBR congestion control is enabled on the system.
 check-bbr:
 	@echo "Checking if BBR is enabled..."
-	@if [ "$$(sysctl net.ipv4.tcp_congestion_control | awk '{print $$3}')" != "bbr" ]; then \
+	@if [ "$$(uname -s)" != "Linux" ]; then \
+		echo "BBR is not available on non-Linux systems."; \
+		exit 0; \
+	elif [ "$$(sysctl net.ipv4.tcp_congestion_control | awk '{print $$3}')" != "bbr" ]; then \
 		echo "WARNING: BBR is not enabled. Please enable BBR for optimal performance. Call make enable-bbr or see Usage section in the README."; \
 	else \
 		echo "BBR is enabled."; \
@@ -435,7 +438,10 @@ bbr-check: check-bbr
 ## enable-bbr: Enable BBR congestion control algorithm on your system. This improves network performance. Only works on Linux.
 enable-bbr:
 	@echo "Configuring system to use BBR..."
-	@if [ "$(sysctl net.ipv4.tcp_congestion_control | awk '{print $3}')" != "bbr" ]; then \
+	@if [ "$$(uname -s)" != "Linux" ]; then \
+		echo "BBR is not available on non-Linux systems."; \
+		exit 0; \
+	elif [ "$(sysctl net.ipv4.tcp_congestion_control | awk '{print $3}')" != "bbr" ]; then \
 	    echo "BBR is not enabled. Configuring BBR..."; \
 	    sudo modprobe tcp_bbr && \
             echo tcp_bbr | sudo tee -a /etc/modules && \

--- a/README.md
+++ b/README.md
@@ -84,13 +84,21 @@ See <https://docs.celestia.org/how-to-guides/celestia-app> for more information.
 
 Enable the [BBR](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-01.html) ("Bottleneck Bandwidth and Round-trip propagation time") congestion control algorithm.
 
+> Note: BBR enablement applies to Linux only. On macOS, Windows, and BSD variants, Celestia skips the BBR check automatically and will run with the OS default congestion control.
+
 ```shell
-# Check if BBR is enabled.
+# Check if BBR is enabled (Linux only).
 make bbr-check
 
-# If BBR is not enabled then enable it.
+# If BBR is not enabled then enable it (Linux only).
 make bbr-enable
 ```
+
+Platform notes:
+- Linux: Requires kernel >= 4.9. The `bbr-check` / `bbr-enable` targets use `modprobe` and `sysctl` to enable and persist BBR.
+- macOS: System-wide BBR is not available. No action is required; the node runs with the default congestion control.
+- Windows: System-wide BBR is not available. No action is required; the node runs with the default congestion control. If using WSL2, BBR can be enabled inside the Linux environment as above.
+- *BSD: Availability varies by distribution and version. If unsupported, the check is skipped automatically.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -82,9 +82,7 @@ See <https://docs.celestia.org/how-to-guides/celestia-app> for more information.
 
 ### Prerequisites
 
-Enable the [BBR](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-01.html) ("Bottleneck Bandwidth and Round-trip propagation time") congestion control algorithm.
-
-> Note: BBR enablement applies to Linux only. On macOS, Windows, and BSD variants, Celestia skips the BBR check automatically and will run with the OS default congestion control.
+If you are on Linux, enable the [BBR](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-01.html) ("Bottleneck Bandwidth and Round-trip propagation time") congestion control algorithm.
 
 ```shell
 # Check if BBR is enabled (Linux only).
@@ -93,12 +91,6 @@ make bbr-check
 # If BBR is not enabled then enable it (Linux only).
 make bbr-enable
 ```
-
-Platform notes:
-- Linux: Requires kernel >= 4.9. The `bbr-check` / `bbr-enable` targets use `modprobe` and `sysctl` to enable and persist BBR.
-- macOS: System-wide BBR is not available. No action is required; the node runs with the default congestion control.
-- Windows: System-wide BBR is not available. No action is required; the node runs with the default congestion control. If using WSL2, BBR can be enabled inside the Linux environment as above.
-- BSD: System-wide BBR is not available. No action is required; the node runs with the default congestion control.
 
 ### Environment variables
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Platform notes:
 - Linux: Requires kernel >= 4.9. The `bbr-check` / `bbr-enable` targets use `modprobe` and `sysctl` to enable and persist BBR.
 - macOS: System-wide BBR is not available. No action is required; the node runs with the default congestion control.
 - Windows: System-wide BBR is not available. No action is required; the node runs with the default congestion control. If using WSL2, BBR can be enabled inside the Linux environment as above.
-- *BSD: Availability varies by distribution and version. If unsupported, the check is skipped automatically.
+- BSD: System-wide BBR is not available. No action is required; the node runs with the default congestion control.
 
 ### Environment variables
 

--- a/cmd/celestia-appd/cmd/bbr.go
+++ b/cmd/celestia-appd/cmd/bbr.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"runtime"
 
 	"cosmossdk.io/log"
 	"github.com/spf13/cobra"
@@ -19,7 +20,7 @@ func checkBBR(command *cobra.Command, logger log.Logger) error {
 The BBR (Bottleneck Bandwidth and Round-trip propagation time) congestion control algorithm is not enabled in this system's kernel.
 BBR is important for the performance of the p2p stack.
 
-To enable BBR:
+To enable BBR (Linux only):
 sudo modprobe tcp_bbr
 net.core.default_qdisc=fq
 net.ipv4.tcp_congestion_control=bbr
@@ -40,6 +41,12 @@ If you need to bypass this check use the --force-no-bbr flag.
 		return err
 	}
 	if forceNoBBR {
+		return nil
+	}
+
+	// Only enforce BBR on Linux where /proc is available and BBR is supported
+	if runtime.GOOS != "linux" {
+		// Skip check silently for non-Linux OSes (e.g., macOS, Windows, BSD)
 		return nil
 	}
 

--- a/cmd/celestia-appd/cmd/bbr.go
+++ b/cmd/celestia-appd/cmd/bbr.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"strings"
 	"runtime"
+	"strings"
 
 	"cosmossdk.io/log"
 	"github.com/spf13/cobra"

--- a/scripts/arabica.sh
+++ b/scripts/arabica.sh
@@ -57,4 +57,4 @@ echo "Downloading genesis file..."
 celestia-appd download-genesis ${CHAIN_ID}
 
 echo "Starting celestia-appd..."
-celestia-appd start --v2-upgrade-height 1751707 --force-no-bbr
+celestia-appd start --v2-upgrade-height 1751707

--- a/scripts/block-sync.sh
+++ b/scripts/block-sync.sh
@@ -68,4 +68,4 @@ echo "Downloading genesis file..."
 celestia-appd download-genesis ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
 echo "Starting celestia-appd..."
-celestia-appd start --force-no-bbr
+celestia-appd start

--- a/scripts/build-run-single-node.sh
+++ b/scripts/build-run-single-node.sh
@@ -32,4 +32,4 @@ sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' ${HOME_DIR}/con
 sed -i'.bak' 's#"null"#"kv"#g' ${HOME_DIR}/config/config.toml
 
 # Start the celestia-app
-${BIN_PATH} start --home ${HOME_DIR} --api.enable --force-no-bbr
+${BIN_PATH} start --home ${HOME_DIR} --api.enable

--- a/scripts/mainnet.sh
+++ b/scripts/mainnet.sh
@@ -55,4 +55,4 @@ echo "Downloading genesis file..."
 celestia-appd download-genesis ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
 echo "Starting celestia-appd..."
-celestia-appd start --force-no-bbr
+celestia-appd start

--- a/scripts/mocha-halt.sh
+++ b/scripts/mocha-halt.sh
@@ -33,4 +33,4 @@ echo "Setting halt height to 5..."
 sed -i.bak -e "s/^halt-height *=.*/halt-height = 5/" $CELESTIA_APP_HOME/config/app.toml
 
 echo "Starting celestia-appd..."
-celestia-appd start --force-no-bbr
+celestia-appd start

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -57,4 +57,4 @@ echo "Downloading genesis file..."
 celestia-appd download-genesis ${CHAIN_ID} > /dev/null 2>&1 # Hide output to reduce terminal noise
 
 echo "Starting celestia-appd..."
-celestia-appd start --force-no-bbr
+celestia-appd start

--- a/scripts/single-node-all-upgrades.sh
+++ b/scripts/single-node-all-upgrades.sh
@@ -101,8 +101,7 @@ startCelestiaApp() {
     --api.enable \
     --grpc.enable \
     --grpc-web.enable \
-    --timeout-commit 1s \
-    --force-no-bbr
+    --timeout-commit 1s
 }
 
 # Function to perform upgrade to a specific version

--- a/scripts/single-node-halt.sh
+++ b/scripts/single-node-halt.sh
@@ -79,8 +79,7 @@ startCelestiaApp() {
     --api.enable \
     --grpc.enable \
     --grpc-web.enable \
-    --timeout-commit 1s \
-    --force-no-bbr # no need to require BBR usage on a local node
+    --timeout-commit 1s
 }
 
 deleteCelestiaAppHome

--- a/scripts/single-node-upgrades.sh
+++ b/scripts/single-node-upgrades.sh
@@ -97,8 +97,7 @@ startCelestiaApp() {
     --api.enable \
     --grpc.enable \
     --grpc-web.enable \
-    --timeout-commit 1s \
-    --force-no-bbr
+    --timeout-commit 1s
 }
 
 upgrade() {

--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -106,8 +106,7 @@ startCelestiaApp() {
     --api.enable \
     --grpc.enable \
     --grpc-web.enable \
-    --timeout-commit 1s \
-    --force-no-bbr # no need to require BBR usage on a local node
+    --timeout-commit 1s
 }
 
 if [ -f $GENESIS_FILE ]; then


### PR DESCRIPTION
Closes #3853 

## Testing

On MacOS

```
$ make check-bbr
Checking if BBR is enabled...
BBR is not available on non-Linux systems.
$ make enable-bbr
Configuring system to use BBR...
BBR is not available on non-Linux systems.
```

On Linux

```shell
root@rootulp-scaleway:~/celestia-app# make enable-bbr
Configuring system to use BBR...
BBR is not enabled. Configuring BBR...
tcp_bbr
net.core.default_qdisc=fq
net.ipv4.tcp_congestion_control=bbr
net.core.default_qdisc = fq
net.ipv4.tcp_congestion_control = bbr
BBR has been enabled.

root@rootulp-scaleway:~/celestia-app# make check-bbr
Checking if BBR is enabled...
BBR is enabled.
```