### PR TITLE
chore(talis): remove celestia-node

### DIFF
--- a/tools/talis/docker/Dockerfile
+++ b/tools/talis/docker/Dockerfile
@@ -14,7 +14,3 @@ COPY . .
 
 RUN GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 go build -tags="ledger" -ldflags="${LDFLAGS}" -o /out/txsim ./test/cmd/txsim \
  && GOOS=${GOOS} GOARCH=${GOARCH} CGO_ENABLED=0 GOOS=linux go build -tags="ledger" -ldflags="${LDFLAGS}" -o /out/celestia-appd ./cmd/celestia-appd 
- 
-RUN git clone https://github.com/celestiaorg/celestia-node.git /tmp/celestia-node \
- && cd /tmp/celestia-node \
- && go build -o /out/celestia ./cmd/celestia


### PR DESCRIPTION
Because it takes a lot of time to regenerate celestia-node Docker image and it is currently unused
