### PR TITLE
fix(app): use proper logger.With key/value and correct comments

### DIFF
--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 // FilteredSquareBuilder filters txs and blobs using a copy of the state and tx validity
-// rules before adding it the square.
+// rules before adding it to the square.
 type FilteredSquareBuilder struct {
 	handler  sdk.AnteHandler
 	txConfig client.TxConfig
@@ -45,7 +45,7 @@ func (fsb *FilteredSquareBuilder) Builder() *square.Builder {
 }
 
 func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte) [][]byte {
-	logger := ctx.Logger().With("app/filtered-square-builder")
+	logger := ctx.Logger().With("module", "app/filtered-square-builder")
 
 	// note that there is an additional filter step for tx size of raw txs here
 	normalTxs, blobTxs := separateTxs(fsb.txConfig, txs)

--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -95,7 +95,7 @@ func NewMultiplexer(svrCtx *server.Context, svrCfg serverconfig.Config, clientCt
 		svrCfg:        svrCfg,
 		clientContext: clientCtx,
 		appCreator:    appCreator,
-		logger:        svrCtx.Logger.With("multiplexer"),
+		logger:        svrCtx.Logger.With("module", "multiplexer"),
 		nativeApp:     nil, // app will be initialized if required by the multiplexer.
 		versions:      versions,
 		chainID:       chainID,


### PR DESCRIPTION
- **filtered_square_builder.go**
  - Replaced `With("app/filtered-square-builder")` → `With("module", "app/filtered-square-builder")`.
  - Fixed minor grammar in comment (`adding it the square` → `adding it to the square`).
- **multiplexer/abci/multiplexer.go**
  - Replaced `With("multiplexer")` → `With("module", "multiplexer")`.

### Impact
- Standardizes logging: always `With("module", "...")` for structured logs.
- Improves readability and consistency across modules.
- No runtime or consensus logic changes.
