### PR TITLE
fix(blob/ante): correct tx size formatting in BlobShareDecorator error

### DIFF
--- a/x/blob/ante/blob_share_decorator.go
+++ b/x/blob/ante/blob_share_decorator.go
@@ -32,7 +32,7 @@ func (d BlobShareDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool
 
 	txBytes := ctx.TxBytes()
 	if len(txBytes) > math.MaxUint32 {
-		return ctx, errors.Wrapf(blobtypes.ErrBlobsTooLarge, "the tx size %d exceeds the max uint32", txBytes)
+		return ctx, errors.Wrapf(blobtypes.ErrBlobsTooLarge, "the tx size %d exceeds the max uint32", len(txBytes))
 	}
 	txSize := uint32(len(txBytes))
 	maxBlobShares := d.getMaxBlobShares(ctx)


### PR DESCRIPTION
## Overview

- Pass len(txBytes) to %d instead of the []byte slice in Wrapf to avoid
  malformed output like %!d([]uint8=...).
- Aligns with size reporting patterns in app/check_tx.go and
  app/process_proposal.go.
- No behavioral change; improves error logs and observability.
