### PR TITLE
chore(talis): fix scripts path and src-root default; e2e: sort validators

### DIFF
--- a/test/docker-e2e/dockerchain/config.go
+++ b/test/docker-e2e/dockerchain/config.go
@@ -3,6 +3,7 @@ package dockerchain
 import (
 	"fmt"
 	"os"
+	"sort"
 
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/test/util/genesis"
@@ -30,15 +31,17 @@ type Config struct {
 func DefaultConfig(client *client.Client, network string) *Config {
 	tnCfg := testnode.DefaultConfig()
 	// default + 2 extra validators.
+	// Ensure validator names are in lexicographical order to match keyrings.Records()
+	validatorNames := []string{"validator1", "validator2"}
+	sort.Strings(validatorNames)
+	validators := make([]genesis.Validator, 0, len(validatorNames))
+	for _, name := range validatorNames {
+		validators = append(validators, genesis.NewDefaultValidator(name))
+	}
+
 	tnCfg.Genesis = tnCfg.Genesis.
 		WithChainID(appconsts.TestChainID).
-		WithValidators(
-			// TODO: ensure names are in lexicographical order.
-			// this is because keyrings.Records() returns them this way.
-			// we should come up with a proper fix as this is a big foot gun.
-			genesis.NewDefaultValidator("validator1"),
-			genesis.NewDefaultValidator("validator2"),
-		)
+		WithValidators(validators...)
 
 	cfg := &Config{}
 	return cfg.

--- a/tools/talis/init.go
+++ b/tools/talis/init.go
@@ -86,8 +86,14 @@ func initCmd() *cobra.Command {
 		log.Fatalf("failed to get user home directory: %v", err)
 	}
 
+	// Determine a sensible default for src-root: $GOPATH if set, otherwise $HOME/go
+	defaultSrcRoot := os.Getenv("GOPATH")
+	if defaultSrcRoot == "" {
+		defaultSrcRoot = filepath.Join(homeDir, "go")
+	}
+
 	cmd.Flags().StringVarP(&rootDir, "directory", "d", ".", "root directory in which to initialize")
-	cmd.Flags().StringVarP(&srcRoot, "src-root", "r", homeDir, "directory from which to copy scripts") // todo: fix the default directory here
+	cmd.Flags().StringVarP(&srcRoot, "src-root", "r", defaultSrcRoot, "directory from which to copy scripts")
 	cmd.Flags().StringVarP(&chainID, "chainID", "c", "", "Chain ID (required)")
 	_ = cmd.MarkFlagRequired("chainID")
 	cmd.Flags().StringVarP(&experiment, "experiment", "e", "test", "the name of the experiment (required)")
@@ -133,8 +139,8 @@ func initDirs(rootDir string) error {
 // is copied into destDir. It first checks GOPATH/src/github.com/.../scripts,
 // and if missing, does a shallow git clone, copies the folder (including subdirectories), then cleans up.
 func CopyTalisScripts(destDir string, srcRoot string) error {
-	// todo: fix import path
-	const importPath = "celestia-app/tools/talis/scripts"
+	// use correct Go import path for local GOPATH lookup
+	const importPath = "github.com/celestiaorg/celestia-app/tools/talis/scripts"
 
 	src := filepath.Join(srcRoot, "src", importPath)
 


### PR DESCRIPTION
This PR makes two small, safe fixes:
- Talis init: corrects the scripts import path and sets a sensible default for `--src-root`.
- Docker e2e: ensures validator names are lexicographically ordered for deterministic behavior.

## Changes
- tools/talis/init.go
  - Use full Go import path for local GOPATH lookup: `github.com/celestiaorg/celestia-app/tools/talis/scripts`.
  - Default `--src-root` to `$GOPATH` if set, otherwise `$HOME/go`.
  - Retains existing fallback to shallow clone if local path is absent.

- test/docker-e2e/dockerchain/config.go
  - Build validators from a sorted list of names (`validator1`, `validator2`) and pass as a slice to `WithValidators(...)`.