### PR TITLE
fix: incorrect usage of `SetCmdServerContext`

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -169,5 +169,6 @@ func replaceLogger(cmd *cobra.Command) error {
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
-	return server.SetCmdServerContext(cmd, sctx)
+	server.SetCmdServerContext(cmd, sctx)
+	return nil
 }


### PR DESCRIPTION
## Overview

I noticed that `SetCmdServerContext` was being used as if it returned a value, which caused a compilation error.
Updated the code to call the function correctly and return `nil` afterwards.
This should resolve the issue and keep the logic intact.
