### PR TITLE
feat: bump min gas price estimation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -730,7 +730,7 @@ func (app *App) getGovMaxSquareBytes() (uint64, error) {
 func (app *App) getMinGasPrice() (float64, error) {
 	localMinGasPrice, err := app.GetMinGasPrices().AmountOf(appconsts.BondDenom).Float64()
 	if err != nil {
-		localMinGasPrice = appconsts.DefaultMinGasPrice
+		localMinGasPrice = appconsts.NewDefaultMinGasPrice
 	}
 	ctx, err := app.CreateQueryContext(app.LastBlockHeight(), false)
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -728,10 +728,9 @@ func (app *App) getGovMaxSquareBytes() (uint64, error) {
 // getMinGasPrice is used by the gas estimation service to get the higher of the network minimum gas price
 // or the nodes locally configured minimum gas price.
 func (app *App) getMinGasPrice() (float64, error) {
-	localMinGasPrice, err := app.GetMinGasPrices().AmountOf(appconsts.BondDenom).Float64()
-	if err != nil {
-		localMinGasPrice = appconsts.NewDefaultMinGasPrice
-	}
+	// ignore errors as we will just use the NewDefaultMinGasPrice instead
+	localMinGasPrice, _ := app.GetMinGasPrices().AmountOf(appconsts.BondDenom).Float64()
+	localMinGasPrice = math.Max(localMinGasPrice, appconsts.NewDefaultMinGasPrice)
 	ctx, err := app.CreateQueryContext(app.LastBlockHeight(), false)
 	if err != nil {
 		return localMinGasPrice, err

--- a/app/grpc/gasestimation/gas_estimator.go
+++ b/app/grpc/gasestimation/gas_estimator.go
@@ -137,7 +137,7 @@ func (s *gasEstimatorServer) estimateGasPrice(ctx context.Context, priority TxPr
 
 	if float64(txsResp.TotalBytes) < float64(govMaxSquareBytes)*gasPriceEstimationThreshold {
 		// Return the maximum of the default min gas price and network min gas price
-		return math.Max(appconsts.DefaultMinGasPrice, minGasPrice), nil
+		return minGasPrice, nil
 	}
 	gasPrices, err := SortAndExtractGasPrices(s.txDecoder, txsResp.Txs, int64(appconsts.DefaultUpperBoundMaxBytes))
 	if err != nil {

--- a/app/grpc/gasestimation/gas_estimator_e2e_test.go
+++ b/app/grpc/gasestimation/gas_estimator_e2e_test.go
@@ -54,7 +54,7 @@ func TestGasEstimatorE2E(t *testing.T) {
 	estimatorClient := gasestimation.NewGasEstimatorClient(cctx.GRPCClient)
 	gasPriceResp, err := estimatorClient.EstimateGasPrice(ctx, &gasestimation.EstimateGasPriceRequest{})
 	require.NoError(t, err)
-	require.Equal(t, gasPriceResp.EstimatedGasPrice, appconsts.DefaultMinGasPrice)
+	require.Equal(t, gasPriceResp.EstimatedGasPrice, appconsts.NewDefaultMinGasPrice)
 
 	// Setup transaction client
 	txClient, err := user.SetupTxClient(ctx, cctx.Keyring, cctx.GRPCClient, enc)
@@ -86,7 +86,7 @@ func TestGasEstimatorE2E(t *testing.T) {
 
 	gasPriceResp, err = estimatorClient.EstimateGasPrice(ctx, &gasestimation.EstimateGasPriceRequest{})
 	require.NoError(t, err)
-	require.Equal(t, gasPriceResp.EstimatedGasPrice, appconsts.DefaultMinGasPrice)
+	require.Equal(t, gasPriceResp.EstimatedGasPrice, appconsts.NewDefaultMinGasPrice)
 }
 
 func TestGasEstimatorE2EWithNetworkMinGasPrice(t *testing.T) {

--- a/pkg/appconsts/initial_consts.go
+++ b/pkg/appconsts/initial_consts.go
@@ -20,7 +20,8 @@ const (
 	// DefaultMinGasPrice is the default min gas price that gets set in the app.toml file.
 	// The min gas price acts as a filter. Transactions below that limit will not pass
 	// a node's `CheckTx` and thus not be proposed by that node.
-	DefaultMinGasPrice = 0.002 // utia
+	DefaultMinGasPrice    = 0.002 // utia
+	NewDefaultMinGasPrice = 0.004 // utia
 
 	// DefaultUnbondingTime is the default time a validator must wait
 	// to unbond in a proof of stake system. Any validator within this

--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -347,7 +347,7 @@ func (suite *TxClientTestSuite) TestGasPriceAndUsageEstimation() {
 func (suite *TxClientTestSuite) TestGasPriceEstimation() {
 	gasPrice, err := suite.txClient.EstimateGasPrice(suite.ctx.GoContext(), 0)
 	require.NoError(suite.T(), err)
-	require.Equal(suite.T(), gasPrice, appconsts.DefaultMinGasPrice)
+	require.Equal(suite.T(), gasPrice, appconsts.NewDefaultMinGasPrice)
 }
 
 // TestGasConsumption verifies that the amount deducted from a user's balance is


### PR DESCRIPTION
Ref: https://github.com/celestiaorg/celestia-app/issues/5162

To ensure a smooth transition, we will bump the min fee on the estimation side in the v0.5.x that the v6 multiplexer imports. This way, users will already be submitting with the higher min fee prior to the upgrade to v6