### PR TITLE
docs: correct module references in function comments

### DIFF
--- a/x/minfee/module.go
+++ b/x/minfee/module.go
@@ -55,7 +55,7 @@ func (AppModule) Name() string {
 	return types.ModuleName
 }
 
-// RegisterLegacyAminoCodec registers the blob module's types on the LegacyAmino codec.
+// RegisterLegacyAminoCodec registers the minfee module's types on the LegacyAmino codec.
 func (AppModule) RegisterLegacyAminoCodec(_ *codec.LegacyAmino) {}
 
 // RegisterInterfaces registers interfaces and implementations of the minfee module.

--- a/x/signal/module.go
+++ b/x/signal/module.go
@@ -29,7 +29,7 @@ var (
 	_ appmodule.HasServices = AppModule{}
 )
 
-// AppModule implements the AppModule interface for the blobstream module.
+// AppModule implements the AppModule interface for the signal module.
 type AppModule struct {
 	keeper Keeper
 }
@@ -47,17 +47,17 @@ func (AppModule) IsAppModule() {}
 
 func (AppModule) IsOnePerModuleType() {}
 
-// RegisterLegacyAminoCodec registers the blob module's types on the LegacyAmino codec.
+// RegisterLegacyAminoCodec registers the signal module's types on the LegacyAmino codec.
 func (AppModule) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	types.RegisterLegacyAminoCodec(cdc)
 }
 
-// RegisterInterfaces registers interfaces and implementations of the blob module.
+// RegisterInterfaces registers interfaces and implementations of the signal module.
 func (AppModule) RegisterInterfaces(reg cdctypes.InterfaceRegistry) {
 	types.RegisterInterfaces(reg)
 }
 
-// RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the upgrade module.
+// RegisterGRPCGatewayRoutes registers the gRPC Gateway routes for the signal module.
 func (AppModule) RegisterGRPCGatewayRoutes(clientCtx client.Context, mux *runtime.ServeMux) {
 	if err := types.RegisterQueryHandlerClient(context.Background(), mux, types.NewQueryClient(clientCtx)); err != nil {
 		panic(err)
@@ -75,7 +75,7 @@ func (AppModule) GetTxCmd() *cobra.Command {
 	return cli.GetTxCmd()
 }
 
-// DefaultGenesis returns the blob module's default genesis state.
+// DefaultGenesis returns the signal module's default genesis state.
 func (am AppModule) DefaultGenesis(_ codec.JSONCodec) json.RawMessage {
 	return []byte("{}")
 }

--- a/x/signal/types/codec.go
+++ b/x/signal/types/codec.go
@@ -14,7 +14,7 @@ func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
 	cdc.RegisterConcrete(&MsgSignalVersion{}, URLMsgSignalVersion, nil)
 }
 
-// RegisterInterfaces registers the upgrade module types on the provided
+// RegisterInterfaces registers the signal module types on the provided
 // registry.
 func RegisterInterfaces(registry codectypes.InterfaceRegistry) {
 	registry.RegisterImplementations((*sdk.Msg)(nil), &MsgTryUpgrade{})


### PR DESCRIPTION
Fix incorrect module references in function comments that were copied from blob module

- x/minfee/module.go: Fix "blob module" → "minfee module" in RegisterLegacyAminoCodec comment
- x/signal/module.go: Fix multiple "blob module" → "signal module" references in comments
- x/signal/types/codec.go: Fix "upgrade module" → "signal module" in RegisterInterfaces comment

