### PR TITLE
refactor: avoid duplicate filepath.Ext call in payforblob validation

### DIFF
--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -85,8 +85,8 @@ The blob must be a hex encoded string of non-zero length.
 			}
 
 			if path != "" {
-				if filepath.Ext(path) != FileInputExtension {
-					return fmt.Errorf("invalid file extension %v. The only supported extension is %s", filepath.Ext(path), FileInputExtension)
+				if ext := filepath.Ext(path); ext != FileInputExtension {
+					return fmt.Errorf("invalid file extension %v. The only supported extension is %s", ext, FileInputExtension)
 				}
 
 				return nil


### PR DESCRIPTION
## Overview

- Store filepath.Ext(path) result in 'ext' variable
- Use 'ext' variable in both condition check and error message
- Reduces function calls from 2 to 1 per validation