### PR TITLE
fix: replace nil parameter with valid MsgTryUpgrade in signal integration test

### DIFF
--- a/x/signal/integration_test.go
+++ b/x/signal/integration_test.go
@@ -74,7 +74,9 @@ func TestUpgradeIntegration(t *testing.T) {
 
 	// Verify that if a subsequent call to TryUpgrade is made, it returns an
 	// error because an upgrade is already pending.
-	_, err = app.SignalKeeper.TryUpgrade(ctx, nil)
+	_, err = app.SignalKeeper.TryUpgrade(ctx, &types.MsgTryUpgrade{
+		Signer: valAddr.String(),
+	})
 	require.Error(t, err)
 	require.ErrorIs(t, err, types.ErrUpgradePending)
 


### PR DESCRIPTION
The test was passing nil to TryUpgrade which would cause a panic due to nil 
pointer dereference when accessing req.Signer. This masked the actual test 
intention of verifying that a second TryUpgrade call returns ErrUpgradePending.

Replace nil with a valid MsgTryUpgrade message to ensure the test properly 
validates the upgrade pending logic without causing panics.

.