### PR TITLE
fix: prevent duplicate celestia-app startup in single-node.sh

### DIFF
--- a/scripts/single-node.sh
+++ b/scripts/single-node.sh
@@ -115,10 +115,11 @@ if [ -f $GENESIS_FILE ]; then
   if [ "$response" = "y" ]; then
     deleteCelestiaAppHome
     createGenesis
+    startCelestiaApp
   else
     startCelestiaApp
   fi
 else
   createGenesis
+  startCelestiaApp
 fi
-startCelestiaApp


### PR DESCRIPTION
Fix logic error where startCelestiaApp() was called twice when genesis file exists and user chooses not to recreate testnet. Since celestia-app start is a blocking operation, the second call was unreachable dead code.