### PR TITLE
refactor: replace fmt.Fprintf with fmt.Fprintln for simple string output

### DIFF
--- a/x/blob/client/cli/payforblob.go
+++ b/x/blob/client/cli/payforblob.go
@@ -288,7 +288,7 @@ func writeTx(clientCtx client.Context, txf sdktx.Factory, msgs ...sdk.Msg) ([]by
 		ok, err := input.GetConfirmation("confirm transaction before signing and broadcasting", buf, os.Stderr)
 
 		if err != nil || !ok {
-			_, _ = fmt.Fprintf(os.Stderr, "%s\n", "transaction cancelled")
+			_, _ = fmt.Fprintln(os.Stderr, "transaction cancelled")
 			return nil, err
 		}
 	}


### PR DESCRIPTION
**[MINOR REFACTOR]**: replace fmt.Fprintf(os.Stderr, "%s\n", "transaction cancelled") with fmt.Fprintln(os.Stderr, "transaction cancelled") for better performance and readability. Using fmt.Fprintln is the idiomatic Go way to print a string with a newline without