### PR TITLE
fix: correct error message in prepare proposal handler

### DIFF
--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -56,7 +56,7 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 	// pkg/wrapper/nmt_wrapper.go for more information.
 	eds, err := da.ExtendShares(share.ToBytes(dataSquare))
 	if err != nil {
-		app.Logger().Error("failure to erasure the data square while creating a proposal block", "error", err.Error())
+		app.Logger().Error("failure to erasure encode the data square while creating a proposal block", "error", err.Error())
 		return nil, fmt.Errorf("failure to erasure the data square while creating a proposal block: %w", err)
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fix missing word "encode" in error message when erasure encoding
fails during proposal block creation. The error message now correctly
reads "failure to erasure encode the data square" instead of 
"failure to erasure the data square".