### PR TITLE
fix(scripts): remove duplicate apt commands in validator init script

### DIFF
--- a/tools/talis/scripts/validator_init.sh
+++ b/tools/talis/scripts/validator_init.sh
@@ -4,10 +4,6 @@ MONIKER="validator"
 ARCHIVE_NAME="payload.tar.gz"
 
 export DEBIAN_FRONTEND=noninteractive
-
-apt update -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
-
-export DEBIAN_FRONTEND=noninteractive
 apt-get update -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 apt-get install git build-essential ufw curl jq chrony snapd btop nethogs --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Remove redundant DEBIAN_FRONTEND export and apt update command that were being executed twice in the validator initialization script. This improves script performance and reduces unnecessary network calls during setup
