### PR TITLE
fix: add error checking for file Close() operations

### DIFF
--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -242,10 +242,14 @@ func ensureBinaryDecompressed(version string, binary []byte) error {
 		}
 
 		if _, err := io.Copy(f, tarReader); err != nil {
-			f.Close()
+			if closeErr := f.Close(); closeErr != nil {
+				log.Printf("failed to close file during error handling: %v", closeErr)
+			}
 			return fmt.Errorf("failed to copy file contents to %s: %w", filePath, err)
 		}
-		f.Close()
+		if err := f.Close(); err != nil {
+			return fmt.Errorf("failed to close file %s: %w", filePath, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The file close operation in extractTarFile was not checking for errors, which could potentially mask I/O issues during file finalization.Added proper error handling to ensure file close failures are caught and reported, improving reliability of the binary extraction process.
