### PR TITLE
docs: fix fetchValidatorSets comment

### DIFF
--- a/test/docker-e2e/e2e_test.go
+++ b/test/docker-e2e/e2e_test.go
@@ -253,7 +253,7 @@ func (s *CelestiaTestSuite) ensureMinimumBlocks(ctx context.Context, chain tasto
 	return finalStatus.SyncInfo.LatestBlockHeight, nil
 }
 
-// fetchValidatorSets retrieves validator sets at both start and end heights
+// fetchValidatorSets retrieves the validator set at the provided end height
 func (s *CelestiaTestSuite) fetchValidatorSets(ctx context.Context, rpcClient rpcclient.Client, endHeight int64) (*coretypes.ResultValidators, error) {
 	endValidators, err := rpcClient.Validators(ctx, &endHeight, nil, nil)
 	if err != nil {


### PR DESCRIPTION
Update the fetchValidatorSets comment to match the implementation and usage.
The liveness check only needs the validator set at the end height; start-height retrieval is not used.