### PR TITLE
chore: handle all transaction deserialization errors

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -26,7 +26,7 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 
 	// check if the transaction contains blobs
 	btx, isBlob, err := blobtx.UnmarshalBlobTx(tx)
-	if isBlob && err != nil {
+	if err != nil {
 		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 	}
 


### PR DESCRIPTION
errors were being ignored if `isBlob` was false, which could crash later on bad transactions.
now all deserialization errors get caught, no matter the type.