### PR TITLE
docs: replace undefined DefaultNamespaceIDLen with share.NamespaceSize in comment

### DIFF
--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -86,7 +86,7 @@ func (c constructor) NewTree(_ rsmt2d.Axis, axisIndex uint) rsmt2d.Tree {
 }
 
 // Push adds the provided data to the underlying NamespaceMerkleTree, and
-// automatically uses the first DefaultNamespaceIDLen number of bytes as the
+// automatically uses the first share.NamespaceSize number of bytes as the
 // namespace unless the data pushed to the second half of the tree. Fulfills the
 // rsmt.Tree interface. NOTE: panics if an error is encountered while pushing or
 // if the tree size is exceeded.


### PR DESCRIPTION
The Push method comment incorrectly referenced DefaultNamespaceIDLen which doesn't exist. 
Updated to reference share.NamespaceSize which is actually used in the implementation.