### PR TITLE
docs(x/mint): remove outdated comment about InflationCalculationFn

### DIFF
--- a/x/mint/module.go
+++ b/x/mint/module.go
@@ -35,8 +35,7 @@ type AppModule struct {
 	authKeeper types.AccountKeeper
 }
 
-// NewAppModule creates a new AppModule object. If the InflationCalculationFn
-// argument is nil, then the SDK's default inflation function will be used.
+// NewAppModule creates a new AppModule object.
 func NewAppModule(cdc codec.Codec, keeper keeper.Keeper, ak types.AccountKeeper) AppModule {
 	return AppModule{
 		cdc:        cdc,


### PR DESCRIPTION


<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The comment for NewAppModule function mentioned a non-existent InflationCalculationFn parameter and described behavior that doesn't match the actual function signature. The function only accepts three parameters: cdc, keeper, and ak.

