### PR TITLE
feat(tx_client): Replaced full block fetch with GetNodeInfo to acquire chainID

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -210,15 +210,15 @@ func SetupTxClient(
 	encCfg encoding.Config,
 	options ...Option,
 ) (*TxClient, error) {
-	resp, err := tmservice.NewServiceClient(conn).GetLatestBlock(
+	resp, err := tmservice.NewServiceClient(conn).GetNodeInfo(
 		ctx,
-		&tmservice.GetLatestBlockRequest{},
+		&tmservice.GetNodeInfoRequest{},
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	chainID := resp.SdkBlock.Header.ChainID
+	chainID := resp.DefaultNodeInfo.Network
 
 	records, err := keys.List()
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/celestiaorg/celestia-app/issues/4355

## Overview
1. Replaced `GetLatestBlock` with `GetNodeInfo`, in favor of the call with no byte-heavy block data
2.  Dev tested with `mocha-4` and `celestia` chain grpc URLs. Values from `SdkBlock.Header.ChainID` and `DefaultNodeInfo.Network` match
3. `appVersion` has already been replaced with the old use of `appconsts.Version`. Didn't require any changes here.
4. @evan-forbes , following your previous comment here https://github.com/celestiaorg/celestia-app/issues/4355#issuecomment-2683333790, I couldn't find the header method in celestia-app. Closest I found was GetHeader, but it's a getter method located in core repo 