### PR TITLE
refactor: remove unnecessary zero capacity from map initialization

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -770,7 +770,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 
 // AutoCliOpts returns the autocli options for the app.
 func (app *App) AutoCliOpts() autocli.AppOptions {
-	modules := make(map[string]appmodule.AppModule, 0)
+	modules := make(map[string]appmodule.AppModule)
 	for _, m := range app.ModuleManager.Modules {
 		if moduleWithName, ok := m.(module.HasName); ok {
 			moduleName := moduleWithName.Name()


### PR DESCRIPTION
Remove redundant zero capacity parameter from map initialization in **app/app.go.**

The second parameter in make(map[K]V, 0) is a capacity hint that serves no purpose when set to zero. This change follows Go idioms and removes unnecessary code without changing behavior.