### PR TITLE
refactor: use strings.builder

### DIFF
--- a/app/ante/panic.go
+++ b/app/ante/panic.go
@@ -2,6 +2,7 @@ package ante
 
 import (
 	"fmt"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -24,9 +25,10 @@ func (d HandlePanicDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 }
 
 func FormatTx(tx sdk.Tx) string {
-	output := "\ncaused by transaction:\n"
+	var output strings.Builder
+	output.WriteString("\ncaused by transaction:\n")
 	for _, msg := range tx.GetMsgs() {
-		output += fmt.Sprintf("%T{%s}\n", msg, msg)
+		output.WriteString(fmt.Sprintf("%T{%s}\n", msg, msg))
 	}
-	return output
+	return output.String()
 }

--- a/tools/blockscan/main.go
+++ b/tools/blockscan/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 
 	"github.com/celestiaorg/celestia-app/v6/test/util/testnode"
 	"github.com/cometbft/cometbft/rpc/client/http"
@@ -157,9 +158,9 @@ func PrintTx(tx authsigning.Tx) {
 }
 
 func printMessages(msgs []sdk.Msg) string {
-	output := ""
+	var output strings.Builder
 	for _, msg := range msgs {
-		output += fmt.Sprintf("  - %s\n", sdk.MsgTypeURL(msg))
+		output.WriteString(fmt.Sprintf("  - %s\n", sdk.MsgTypeURL(msg)))
 	}
-	return output
+	return output.String()
 }

--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -205,11 +205,12 @@ func deployPayloadDirect(
 		errs = append(errs, e)
 	}
 	if len(errs) > 0 {
-		sb := "deployment errors:\n"
+		var sb strings.Builder
+		sb.WriteString("deployment errors:\n")
 		for _, e := range errs {
-			sb += "- " + e.Error() + "\n"
+			sb.WriteString("- " + e.Error() + "\n")
 		}
-		return errors.New(sb)
+		return errors.New(sb.String())
 	}
 	return nil
 }
@@ -292,11 +293,12 @@ func deployPayloadViaS3(
 		errs = append(errs, e)
 	}
 	if len(errs) > 0 {
-		sb := "deployment errors:\n"
+		var sb strings.Builder
+		sb.WriteString("deployment errors:\n")
 		for _, e := range errs {
-			sb += "- " + e.Error() + "\n"
+			sb.WriteString("- " + e.Error() + "\n")
 		}
-		return errors.New(sb)
+		return errors.New(sb.String())
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

The modernize  has added an analyzer for using `strings.Builder` for string construction. `strings.Builder` has fewer memory allocations and better performance.

More info: https://github.com/golang/go/issues/75190
