### PR TITLE
docs(docker-e2e): fix image constructor in comment example

### DIFF
--- a/test/docker-e2e/dockerchain/testchain.go
+++ b/test/docker-e2e/dockerchain/testchain.go
@@ -127,7 +127,7 @@ func SetupTxClient(ctx context.Context, cn *tastoradockertypes.ChainNode, cfg *C
 //
 //	for i, nodeBuilder := range nodeBuilders {
 //	    version := getVersionForIndex(i)
-//		nodeBuilder.WithImage(tastoradockertypes.NewDockerImage(cfg.Image, version, "10001:10001")
+//		nodeBuilder.WithImage(tastoracontainertypes.NewImage(cfg.Image, version, "10001:10001"))
 //	}
 func NodeConfigBuilders(cfg *Config) ([]*tastoradockertypes.ChainNodeConfigBuilder, error) {
 	kr := cfg.Genesis.Keyring()


### PR DESCRIPTION
Update the comment example in test/docker-e2e/dockerchain/testchain.go to use tastoracontainertypes.NewImage(...) instead of the non-existent NewDockerImage(...), and fix the missing closing parenthesis. This avoids misleading readers toward an API that doesn’t exist and aligns the example with the actual tastora container API used across the codebase.