### PR TITLE
docs(txsim): correct Run function documentation to reflect actual gRPC-only usage

### DIFF
--- a/test/txsim/run.go
+++ b/test/txsim/run.go
@@ -30,7 +30,7 @@ const (
 var defaultTLSConfig = &tls.Config{InsecureSkipVerify: true}
 
 // Run is the entrypoint function for starting the txsim client. The lifecycle of the client is managed
-// through the context. At least one grpc and rpc endpoint must be provided. The client relies on a
+// through the context. A grpc endpoint must be provided. The client relies on a
 // single funded master account present in the keyring. The client allocates subaccounts for sequences
 // at runtime. A seed can be provided for deterministic randomness. The pollTime dictates the frequency
 // that the client should check for updates from state and that transactions have been committed.


### PR DESCRIPTION
Remove incorrect RPC endpoint requirement from Run function documentation.
Function only accepts grpcEndpoint parameter and uses gRPC for all operations.
RPC is only used in tests for validation, not in main function logic.