### PR TITLE
fix: add missing nextAnteHandler function in ante_test.go

### DIFF
--- a/app/ante/ante_test.go
+++ b/app/ante/ante_test.go
@@ -87,3 +87,7 @@ func getMsg(t *testing.T, account sdk.AccountI) sdk.Msg {
 
 	return msg
 }
+
+func nextAnteHandler(ctx sdk.Context, _ sdk.Tx, _ bool) (sdk.Context, error) {
+	return ctx, nil
+}


### PR DESCRIPTION
Add missing nextAnteHandler function that was referenced but not defined in TestSigVerificationDecorator, causing compilation error.

This follows the same pattern already used in params_test.go in the same package, where nextAnteHandler is defined as a simple test helper function that returns the context without modifications.