### PR TITLE
docs: fix comment

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -109,7 +109,7 @@ type slashingModule struct {
 	slashing.AppModule
 }
 
-// DefaultGenesis returns custom x/staking module genesis state.
+// DefaultGenesis returns custom x/slashing module genesis state.
 func (slashingModule) DefaultGenesis(cdc codec.JSONCodec) json.RawMessage {
 	genesis := slashingtypes.DefaultGenesisState()
 	genesis.Params.MinSignedPerWindow = math.LegacyNewDecWithPrec(75, 2) // 75%


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The comment for slashingModule's DefaultGenesis function incorrectly stated it returns `custom x/staking module genesis state` when it actually returns `custom x/slashing module genesis state`. Updated the comment to accurately reflect that this function handles slashing module configuration, not staking.