### PR TITLE
docs(pkg/user): fix misleading comment

### DIFF
--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -492,7 +492,7 @@ func wasRemovedFromTxTracker(txHash string, txClient *user.TxClient) bool {
 	return !exists && seq == 0 && signer == ""
 }
 
-// asserts that a tx was indexed in the tx tracker and that the sequence increases by 1
+// assertTxInTxTracker verifies that a tx was indexed in the tx tracker and that the sequence increases by one after broadcast.
 func assertTxInTxTracker(t *testing.T, txClient *user.TxClient, txHash, expectedSigner string, seqBeforeBroadcast uint64) {
 	seqFromTxTracker, signer, exists := txClient.GetTxFromTxTracker(txHash)
 	require.True(t, exists)

--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -492,7 +492,7 @@ func wasRemovedFromTxTracker(txHash string, txClient *user.TxClient) bool {
 	return !exists && seq == 0 && signer == ""
 }
 
-// asserts that a tx was indexed in the tx tracker and that the sequence does not increase
+// asserts that a tx was indexed in the tx tracker and that the sequence increases by 1
 func assertTxInTxTracker(t *testing.T, txClient *user.TxClient, txHash, expectedSigner string, seqBeforeBroadcast uint64) {
 	seqFromTxTracker, signer, exists := txClient.GetTxFromTxTracker(txHash)
 	require.True(t, exists)
@@ -604,7 +604,7 @@ var (
 
 type broadcastTestCase struct {
 	setupMocks  func(t *testing.T) ([]*grpctest.MockTxService, []*grpc.ClientConn)
-	expectError bool // Changed from error to bool
+	expectError bool
 }
 
 func (suite *TxClientTestSuite) TestMultiConnBroadcast() {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

- Fix incorrect comment in assertTxInTxTracker function that claimed sequence does not increase, when it actually validates sequence increases by 1
- Remove leftover refactoring comment "Changed from error to bool" in broadcastTestCase struct
