### PR TITLE
test(pkg/proof): fix test name

### DIFF
--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -154,7 +154,7 @@ func TestNewShareInclusionProof(t *testing.T) {
 			expectErr:     true,
 		},
 		{
-			name:          "ending share higher than number of shares available in square size of 32",
+			name:          "ending share higher than number of shares available in square size of 64",
 			startingShare: 0,
 			endingShare:   4097,
 			namespaceID:   share.TxNamespace,


### PR DESCRIPTION
Update the test case name from “square size of 32” to “square size of 64”. The test uses endingShare 4097, which is just beyond 4096 (64×64), not 1024 (32×32). The previous label was misleading and could confuse readers about the intended boundary condition being tested.