### PR TITLE
docs(pkg/wrapper): fix grammar

### DIFF
--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -87,8 +87,8 @@ func (c constructor) NewTree(_ rsmt2d.Axis, axisIndex uint) rsmt2d.Tree {
 
 // Push adds the provided data to the underlying NamespaceMerkleTree, and
 // automatically uses the first share.NamespaceSize number of bytes as the
-// namespace unless the data pushed to the second half of the tree. Fulfills the
-// rsmt.Tree interface. NOTE: panics if an error is encountered while pushing or
+// namespace unless the data is pushed to the second half of the tree. Fulfills the
+// rsmt2d.Tree interface. NOTE: returns an error if encountered while pushing or
 // if the tree size is exceeded.
 func (w *ErasuredNamespacedMerkleTree) Push(data []byte) error {
 	if w.axisIndex+1 > 2*w.squareSize || w.shareIndex+1 > 2*w.squareSize {
@@ -113,7 +113,7 @@ func (w *ErasuredNamespacedMerkleTree) Push(data []byte) error {
 	return nil
 }
 
-// Root fulfills the rsmt.Tree interface by generating and returning the
+// Root fulfills the rsmt2d.Tree interface by generating and returning the
 // underlying NamespaceMerkleTree Root.
 func (w *ErasuredNamespacedMerkleTree) Root() ([]byte, error) {
 	root, err := w.tree.Root()


### PR DESCRIPTION
- Fix grammar: `data pushed to` → `data is pushed to`
- Correct interface name: `rsmt.Tree` → `rsmt2d.Tree`
- Update function behavior description: clarify that Push() returns errors instead of panicking