### PR TITLE
fix: comment to reference share.NamespaceSize in NMT wrapper

### DIFF
--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -49,7 +49,7 @@ type Tree interface {
 }
 
 // NewErasuredNamespacedMerkleTree creates a new ErasuredNamespacedMerkleTree
-// with an underlying NMT of namespace size `appconsts.NamespaceSize` and with
+// with an underlying NMT of namespace size `share.NamespaceSize` and with
 // `ignoreMaxNamespace=true`. axisIndex is the index of the row or column that
 // this tree is committing to. squareSize must be greater than zero.
 func NewErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint, options ...nmt.Option) ErasuredNamespacedMerkleTree {


### PR DESCRIPTION
## Overview

The NMT wrapper’s constructor comment incorrectly referenced appconsts.NamespaceSize, but the implementation and codebase consistently use share.NamespaceSize from go-square. This change updates the comment to avoid confusion and align documentation with the actual source of truth.