### PR TITLE
docs: improve comment

### DIFF
--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -17,8 +17,8 @@ import (
 
 const TxInclusionQueryPath = "txInclusionProof"
 
-// Querier defines the logic performed when the ABCI client using the Query
-// method with the custom prove.QueryPath. The index of the transaction being
+// QueryTxInclusionProof defines the logic performed when the ABCI client using the Query
+// method with the custom query path. The index of the transaction being
 // proved must be appended to the path. The marshalled bytes of the transaction
 // proof (tmproto.ShareProof) are returned.
 //

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -17,7 +17,7 @@ import (
 
 const TxInclusionQueryPath = "txInclusionProof"
 
-// QueryTxInclusionProof defines the logic performed when the ABCI client using the Query
+// QueryTxInclusionProof defines the logic performed when the ABCI client uses the Query
 // method with the custom query path. The index of the transaction being
 // proved must be appended to the path. The marshalled bytes of the transaction
 // proof (tmproto.ShareProof) are returned.


### PR DESCRIPTION
Fixed comment that incorrectly referenced `Querier` instead of actual function name, and corrected non-existent `prove.QueryPath` reference.
