### PR TITLE
fix: correct error type in HashLeaf comment

### DIFF
--- a/test/util/malicious/hasher.go
+++ b/test/util/malicious/hasher.go
@@ -180,7 +180,7 @@ func (n *NmtHasher) ValidateLeaf(data []byte) (err error) {
 // HashLeaf computes namespace hash of the namespaced data item `ndata` as
 // ns(ndata) || ns(ndata) || hash(leafPrefix || ndata), where ns(ndata) is the
 // namespaceID inside the data item namely leaf[:n.NamespaceLen]). Note that for
-// leaves minNs = maxNs = ns(leaf) = leaf[:NamespaceLen]. HashLeaf can return the ErrInvalidNodeLen error if the input is not namespaced.
+// leaves minNs = maxNs = ns(leaf) = leaf[:NamespaceLen]. HashLeaf can return the ErrInvalidLeafLen error if the input is not namespaced.
 //
 //nolint:errcheck
 func (n *NmtHasher) HashLeaf(ndata []byte) ([]byte, error) {


### PR DESCRIPTION
HashLeaf comment incorrectly referenced ErrInvalidNodeLen but the function actually returns ErrInvalidLeafLen through ValidateLeaf. This ensures documentation matches actual implementation behavior.