### PR TITLE
perf: optimize hex encoding in DataAvailabilityHeader.String()

### DIFF
--- a/pkg/da/data_availability_header.go
+++ b/pkg/da/data_availability_header.go
@@ -2,9 +2,11 @@ package da
 
 import (
 	"bytes"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/pkg/wrapper"
@@ -79,7 +81,7 @@ func (dah *DataAvailabilityHeader) String() string {
 	if dah == nil {
 		return "<nil DAHeader>"
 	}
-	return fmt.Sprintf("%X", dah.Hash())
+	return strings.ToUpper(hex.EncodeToString(dah.Hash()))
 }
 
 // Equals checks equality of two DAHeaders.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Improves performance by using specialized hex encoding functions instead of generic string formatting. The hex.EncodeToString() function is specifically designed for byte-to-hex conversion and avoids the overhead of reflection and format string parsing used by fmt.Sprintf().

The behavior is identical in all cases: both approaches produce the same uppercase hexadecimal string representation of the hash.

- Reduces memory allocations during string conversion
- Improves performance for hash string representation
- Maintains exact same output format and behavior
