### PR TITLE
docs: fix comment

### DIFF
--- a/test/util/malicious/out_of_order_builder.go
+++ b/test/util/malicious/out_of_order_builder.go
@@ -146,9 +146,9 @@ func OutOfOrderExport(b *square.Builder) (square.Square, error) {
 		}
 	}
 
-	// defensively check that the counter is always greater in share count than the pfbTxWriter.
+	// defensively check that the counter is always greater in share count than the pfbWriter.
 	if b.PfbCounter.Size() < pfbWriter.Count() {
-		return nil, fmt.Errorf("pfbCounter.Size() < pfbTxWriter.Count(): %d < %d", b.PfbCounter.Size(), pfbWriter.Count())
+		return nil, fmt.Errorf("pfbCounter.Size() < pfbWriter.Count(): %d < %d", b.PfbCounter.Size(), pfbWriter.Count())
 	}
 
 	// Write out the square


### PR DESCRIPTION
## Overview

The variable is named pfbWriter, but the surrounding comment and error string referred to pfbTxWriter.
The codebase consistently uses pfbWriter elsewhere; no pfbTxWriter symbol exists.