### PR TITLE
docs: fix comment

### DIFF
--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -24,7 +24,7 @@ const (
 	DefaultValidatorAccountName = "validator"
 	DefaultInitialBalance       = genesis.DefaultInitialBalance
 	// TimeoutCommit is a flag that can be used to override the timeout_commit.
-	// Deprecated: Use BlockTimeFlag instead.
+	// Deprecated: Use DelayedPrecommitTimeout instead.
 	TimeoutCommitFlag = "timeout-commit"
 	// DelayedPrecommitTimeout is a flag that can be used to override the DelayedPrecommitTimeout.
 	DelayedPrecommitTimeout = "delayed-precommit-timeout"


### PR DESCRIPTION
Replace the misleading deprecation comment that referenced a non-existent alternative with the correct guidance: “Use DelayedPrecommitTimeout instead.” This aligns the comment with the actual flag and configuration used across the codebase.