### PR TITLE
docs(release-notes): fix flag name for update-config

### DIFF
--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -26,14 +26,14 @@ This release introduces a new block propagation reactor and configuration change
 
 To modify your existing configs, the `celestia-appd update-configs` command can be used.
 
-```
+```shell
 celestia-appd update-config
 ```
 
 this uses version 6 and the default home (.celestia-app). Those can be changed or specified with flags as well.
 
-```
-celestia-appd update-config --version 6 --home ~/.celestia-app
+```shell
+celestia-appd update-config --app-version 6 --home ~/.celestia-app
 ```
 
 To manually modify the configs, change the following values.


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5734

The problem was that the release notes were using the incorrect flag name `--version`. The correct flag name is `--app-version`.

## Testing

```
$ celestia-appd update-config --app-version 6
updating configuration files to version 6...
Backed up /Users/rootulp/.celestia-app/config/config.toml to /Users/rootulp/.celestia-app/config/config.20250912-104019.backup..toml
Backed up /Users/rootulp/.celestia-app/config/app.toml to /Users/rootulp/.celestia-app/config/app.20250912-104019.backup..toml
Created backups with timestamp: 20250912-104019
Loaded configs successfully. Applying 6 config updates...
Applying v6 updates to configs...
Successfully updated configuration to version 6 values
```