### PR TITLE
docs: fix incomplete comment for canClimbRight function

### DIFF
--- a/pkg/inclusion/paths.go
+++ b/pkg/inclusion/paths.go
@@ -30,7 +30,8 @@ func (c coord) climb() coord {
 
 // canClimbRight uses the current position to calculate the direction of the next
 // climb. Returns true if the next climb is right (if the position (index) is
-// even). please see depth and position example map in docs for coord.
+// even) AND the current depth is greater than minDepth. please see depth and 
+// position example map in docs for coord.
 func (c coord) canClimbRight(minDepth int) bool {
 	return c.position%2 == 0 && c.depth > minDepth
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Add missing condition check (depth > minDepth) to canClimbRight function comment. The function checks both position evenness and minimum depth constraint, but the comment only mentioned the position check
