### PR TITLE
fix: PostData for test nodes

### DIFF
--- a/test/util/testnode/node_interaction_api.go
+++ b/test/util/testnode/node_interaction_api.go
@@ -248,7 +248,7 @@ func (c *Context) PostData(account, broadcastMode string, ns share.Namespace, bl
 	if err != nil {
 		return nil, err
 	}
-	msg, err := types.NewMsgPayForBlobs(account, 0, b)
+	msg, err := types.NewMsgPayForBlobs(addr.String(), 0, b)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Found this bug during testing arabica [v6.0.1](https://github.com/celestiaorg/celestia-node/pull/4551) release. Node tests are broken there. `NewMsgPayForBlobs` requires the signer address but not the key name.

