### PR TITLE
proto: fix comment in MsgUpdateBlobParams

### DIFF
--- a/proto/celestia/blob/v1/tx.proto
+++ b/proto/celestia/blob/v1/tx.proto
@@ -51,7 +51,7 @@ message MsgPayForBlobs {
 // of a PayForBlobs
 message MsgPayForBlobsResponse {}
 
-// MsgUpdateBlobParams defines the sdk.Msg type to update the client parameters.
+// MsgUpdateBlobParams defines the sdk.Msg type to update the blob parameters.
 message MsgUpdateBlobParams {
   option (cosmos.msg.v1.signer) = "authority";
   // authority is the address of the governance account.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Changed `client parameters` to `blob parameters` to correctly reflect that MsgUpdateBlobParams is used to update blob module parameters, not client parameters. 
