### PR TITLE
fix: remove duplicate RPC endpoint in mocha testnet config

### DIFF
--- a/test/docker-e2e/networks/config.go
+++ b/test/docker-e2e/networks/config.go
@@ -15,7 +15,7 @@ func NewMochaConfig() *Config {
 	return &Config{
 		Name:    "mocha",
 		ChainID: appconsts.MochaChainID,
-		RPCs:    []string{"https://celestia-testnet-rpc.itrocket.net:443", "https://celestia-testnet-rpc.itrocket.net:443"},
+		RPCs:    []string{"https://celestia-testnet-rpc.itrocket.net:443", "https://celestia-mocha-rpc.publicnode.com:443"},
 		Seeds:   "5d0bf034d6e6a8b5ee31a2f42f753f1107b3a00e@celestia-testnet-seed.itrocket.net:11656",
 	}
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Replace duplicate itrocket.net RPC with publicnode.com alternative  to provide redundancy and improve fault tolerance for mocha testnet configuration in docker e2e tests.

Or should I delete it?
