### PR TITLE
fix: flaky e2e-tests due to port conflicts 

### DIFF
--- a/test/docker-e2e/networks/networks.go
+++ b/test/docker-e2e/networks/networks.go
@@ -40,12 +40,16 @@ func NewChainBuilder(t *testing.T, chainConfig *Config, cfg *dockerchain.Config)
 
 	encodingConfig := testutil.MakeTestEncodingConfig(app.ModuleEncodingRegisters...)
 
+	// Use dynamic port allocation to avoid conflicts in parallel tests
+	port := testnode.GetDeterministicPort()
+	portMapping := fmt.Sprintf("%d:10001", port)
+
 	return celestiadockertypes.NewChainBuilder(t).
 		WithName(chainConfig.Name).
 		WithChainID(chainConfig.ChainID).
 		WithDockerClient(cfg.DockerClient).
 		WithDockerNetworkID(cfg.DockerNetworkID).
-		WithImage(tastoracontainertypes.NewImage(cfg.Image, cfg.Tag, "10001:10001")).
+		WithImage(tastoracontainertypes.NewImage(cfg.Image, cfg.Tag, portMapping)).
 		WithAdditionalStartArgs("--force-no-bbr").
 		WithEncodingConfig(&encodingConfig).
 		WithGenesis(genesisBz)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Close #5671 

### Root Cause:
Docker containers were using hardcoded port mapping "10001:10001", causing conflicts when multiple tests run simultaneously.

### Solution:
- Replaced hardcoded ports with dynamic allocation using testnode.GetDeterministicPort()
- Updated all Docker image configurations in:
1. test/docker-e2e/dockerchain/testchain.go
2. test/docker-e2e/networks/networks.go
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
