### PR TITLE
fix: update tastora to latest tag to fix flaky tests

### DIFF
--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/math v1.5.3
 	github.com/celestiaorg/celestia-app/v6 v6.0.0-rc0
 	github.com/celestiaorg/go-square/v3 v3.0.0
-	github.com/celestiaorg/tastora v0.4.0
+	github.com/celestiaorg/tastora v0.4.1
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/cosmos/ibc-go/v8 v8.7.0

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -791,8 +791,8 @@ github.com/celestiaorg/nmt v0.24.1 h1:MhGKqp257eq2EQQKcva1H/BSYFqIt0Trk8/t3IWfWS
 github.com/celestiaorg/nmt v0.24.1/go.mod h1:IhLnJDgCdP70crZFpgihFmU6G+PGeXN37tnMRm+/4iU=
 github.com/celestiaorg/rsmt2d v0.15.0 h1:iCw+ghtH+xUK0dFIVZv4dGptoXJK/76UBj6aVsu9h7w=
 github.com/celestiaorg/rsmt2d v0.15.0/go.mod h1:E1GzIiYgMw1mPVWXyQSCSOFVGXoTMHQouh4C6fj5IT0=
-github.com/celestiaorg/tastora v0.4.0 h1:9HDPE/Nc5WdDwtZL6voAPpOKs1ejZsXT3FvscGjW0X8=
-github.com/celestiaorg/tastora v0.4.0/go.mod h1:BicIJEfk3udsScvSYwFNcDe2FMbW6M7EjtcodS16V14=
+github.com/celestiaorg/tastora v0.4.1 h1:49/yKDKS5NZtonGqHRsXcS7jwwqG7Tn8NCLaYl+aa90=
+github.com/celestiaorg/tastora v0.4.1/go.mod h1:BicIJEfk3udsScvSYwFNcDe2FMbW6M7EjtcodS16V14=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
**Fix flaky tests by updating tastora framework**

Updates tastora to latest version which includes a mutex fix for port allocation race conditions that were causing `TestE2EFullStackPFB` to fail randomly. This fix might resolve some other flaky tests as well.