### PR TITLE
chore: upgrade to alpine 3.20

### DIFF
--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -5,7 +5,7 @@
 # Separating the builder and runtime image allows the runtime image to be
 # considerably smaller because it doesn't need to have Golang installed.
 ARG BUILDER_IMAGE=docker.io/golang:1.24.6-alpine
-ARG RUNTIME_IMAGE=docker.io/alpine:3.19
+ARG RUNTIME_IMAGE=docker.io/alpine:3.20
 ARG TARGETOS
 ARG TARGETARCH
 # Use build args to override the maximum square size of the docker image e.g.

--- a/docker/standalone.Dockerfile
+++ b/docker/standalone.Dockerfile
@@ -5,7 +5,7 @@
 # Separating the builder and runtime image allows the runtime image to be
 # considerably smaller because it doesn't need to have Golang installed.
 ARG BUILDER_IMAGE=docker.io/golang:1.24.6-alpine
-ARG RUNTIME_IMAGE=docker.io/alpine:3.19
+ARG RUNTIME_IMAGE=docker.io/alpine:3.20
 ARG TARGETOS
 ARG TARGETARCH
 # Use build args to override the maximum square size of the docker image e.g.


### PR DESCRIPTION
Updates runtime base to alpine:3.20 for security fixes and consistency with txsim.