### PR TITLE
chore: upgrade multiplexer to v5.0.10

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,10 +17,10 @@ before:
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0
     - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v4_amd64.tar.gz v4.1.0
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v5_arm64.tar.gz v5.0.7
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v5_arm64.tar.gz v5.0.7
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v5_amd64.tar.gz v5.0.7
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v5_amd64.tar.gz v5.0.7
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v5_arm64.tar.gz v5.0.9
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v5_arm64.tar.gz v5.0.9
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v5_amd64.tar.gz v5.0.9
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v5_amd64.tar.gz v5.0.9
 
 builds:
   - id: darwin-amd64-multiplexer

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,10 +17,10 @@ before:
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0
     - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v4_amd64.tar.gz v4.1.0
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v5_arm64.tar.gz v5.0.9
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v5_arm64.tar.gz v5.0.9
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v5_amd64.tar.gz v5.0.9
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v5_amd64.tar.gz v5.0.9
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v5_arm64.tar.gz v5.0.10
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v5_arm64.tar.gz v5.0.10
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v5_amd64.tar.gz v5.0.10
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v5_amd64.tar.gz v5.0.10
 
 builds:
   - id: darwin-amd64-multiplexer

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_M
 # dockerchain/config.go
 CELESTIA_V3_VERSION := v3.10.6
 CELESTIA_V4_VERSION := v4.1.0
-CELESTIA_V5_VERSION := v5.0.9
+CELESTIA_V5_VERSION := v5.0.10
 
 ## help: Get more info on make commands.
 help: Makefile

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_M
 # dockerchain/config.go
 CELESTIA_V3_VERSION := v3.10.6
 CELESTIA_V4_VERSION := v4.1.0
-CELESTIA_V5_VERSION := v5.0.7
+CELESTIA_V5_VERSION := v5.0.9
 
 ## help: Get more info on make commands.
 help: Makefile

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -20,7 +20,7 @@ ARG CELESTIA_APP_REPOSITORY=ghcr.io/celestiaorg/celestia-app-standalone
 # Makefile.
 ARG CELESTIA_VERSION_V3="v3.10.6"
 ARG CELESTIA_VERSION_V4="v4.1.0"
-ARG CELESTIA_VERSION_V5="v5.0.7"
+ARG CELESTIA_VERSION_V5="v5.0.9"
 
 # Stage 1: this base image contains already released v3 binaries which can be embedded in the multiplexer.
 FROM ${CELESTIA_APP_REPOSITORY}:${CELESTIA_VERSION_V3} AS base-v3

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -20,7 +20,7 @@ ARG CELESTIA_APP_REPOSITORY=ghcr.io/celestiaorg/celestia-app-standalone
 # Makefile.
 ARG CELESTIA_VERSION_V3="v3.10.6"
 ARG CELESTIA_VERSION_V4="v4.1.0"
-ARG CELESTIA_VERSION_V5="v5.0.9"
+ARG CELESTIA_VERSION_V5="v5.0.10"
 
 # Stage 1: this base image contains already released v3 binaries which can be embedded in the multiplexer.
 FROM ${CELESTIA_APP_REPOSITORY}:${CELESTIA_VERSION_V3} AS base-v3

--- a/internal/embedding/data.go
+++ b/internal/embedding/data.go
@@ -12,7 +12,7 @@ import (
 const (
 	v3Version = "v3.10.6"
 	v4Version = "v4.1.0"
-	v5Version = "v5.0.7"
+	v5Version = "v5.0.10"
 )
 
 // CelestiaAppV3 returns the compressed platform specific Celestia binary and

--- a/test/docker-e2e/dockerchain/config.go
+++ b/test/docker-e2e/dockerchain/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	multiplexerImage    = "ghcr.io/celestiaorg/celestia-app"
-	defaultCelestiaTag  = "v5.0.9"
+	defaultCelestiaTag  = "v5.0.10"
 	celestiaTagEnvVar   = "CELESTIA_TAG"
 	celestiaImageEnvVar = "CELESTIA_IMAGE"
 )

--- a/test/docker-e2e/dockerchain/config.go
+++ b/test/docker-e2e/dockerchain/config.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	multiplexerImage    = "ghcr.io/celestiaorg/celestia-app"
-	defaultCelestiaTag  = "v5.0.7"
+	defaultCelestiaTag  = "v5.0.9"
 	celestiaTagEnvVar   = "CELESTIA_TAG"
 	celestiaImageEnvVar = "CELESTIA_IMAGE"
 )


### PR DESCRIPTION
Upgrade multiplexer to the latest v5.x release