### PR TITLE
ci(goreleaser): reduce disk space usage

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -33,6 +33,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Free disk space
+        run: |
+          set -euxo pipefail
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android || true
+          docker system prune -af || true
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #v5.0.0
         with:
           fetch-depth: 0
@@ -42,6 +47,11 @@ jobs:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
         with:
           go-version-file: 'go.mod'
+      - name: Ephemeral Go caches
+        run: |
+          echo "GOMODCACHE=$(mktemp -d)" >> $GITHUB_ENV
+          echo "GOCACHE=$(mktemp -d)" >> $GITHUB_ENV
+          echo "GOTMPDIR=$(mktemp -d)" >> $GITHUB_ENV
       - name: Create .release-env file
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' >> .release-env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -38,10 +38,14 @@ builds:
     tags:
       - ledger
       - multiplexer
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -61,10 +65,14 @@ builds:
     tags:
       - ledger
       - multiplexer
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -84,10 +92,14 @@ builds:
     tags:
       - ledger
       - multiplexer
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -107,10 +119,14 @@ builds:
     tags:
       - ledger
       - multiplexer
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -129,10 +145,14 @@ builds:
       - darwin
     tags:
       - ledger
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -151,10 +171,14 @@ builds:
       - darwin
     tags:
       - ledger
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -172,10 +196,14 @@ builds:
       - linux
     tags:
       - ledger
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
@@ -193,10 +221,14 @@ builds:
       - linux
     tags:
       - ledger
+    flags:
+      - -trimpath
     ldflags:
       # Ref: https://goreleaser.com/customization/templates/#common-fields
       # .Version is the version being released
       # .FullCommit is git commit hash goreleaser is using for the release
+      - -s
+      - -w
       - -X "{{ .Env.SDKPath }}.Name=celestia-app"
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"


### PR DESCRIPTION
Attempts to close https://github.com/celestiaorg/celestia-app/issues/5848

## Testing

I tested on my fork: https://github.com/rootulp/celestia-app/releases/tag/v6.0.0-rc1 and goreleaser was able to produce binaries and the binary still works on MacOS. 

Note: This isn't a 100% guarantee to always resolve the disk space issue.