### PR TITLE
fix: apply modernize suggestions to improve code quality

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -118,6 +118,6 @@ func (nw *NoopWriter) Write(p []byte) (n int, err error) {
 // NoopAppOptions is a no-op implementation of servertypes.AppOptions.
 type NoopAppOptions struct{}
 
-func (nao NoopAppOptions) Get(string) interface{} {
+func (nao NoopAppOptions) Get(string) any {
 	return nil
 }

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -86,7 +86,7 @@ func createBlobTxs(t *testing.T, testApp *app.App, encConf encoding.Config, keyr
 	blobSize := 1 * mebibyte
 	blobCount := 1
 
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		tx := testutil.BlobTxWithManualSequence(t, encConf.TxConfig, keyring, blobSize, blobCount, testutil.ChainID, accountName, sequence, accountNumber)
 		txs = append(txs, tx)
 		sequence++
@@ -349,7 +349,7 @@ func TestPrepareProposalCappingNumberOfMessages(t *testing.T) {
 	_, err := rand.Read(randomBytes)
 	require.NoError(t, err)
 	accountIndex := 0
-	for i := 0; i < numberOfPFBs; i++ {
+	for range numberOfPFBs {
 		blob, err := share.NewBlob(share.RandomNamespace(), randomBytes, 1, accs[accountIndex].GetAddress().Bytes())
 		require.NoError(t, err)
 		tx, _, err := signers[accountIndex].CreatePayForBlobs(accounts[accountIndex], []*share.Blob{blob}, user.SetGasLimit(2549760000), user.SetFee(10000))
@@ -360,10 +360,10 @@ func TestPrepareProposalCappingNumberOfMessages(t *testing.T) {
 
 	multiPFBsPerTxs := make([][]byte, 0, numberOfPFBs)
 	numberOfMsgsPerTx := 10
-	for i := 0; i < numberOfPFBs; i++ {
+	for range numberOfPFBs {
 		msgs := make([]sdk.Msg, 0)
 		blobs := make([]*share.Blob, 0)
-		for j := 0; j < numberOfMsgsPerTx; j++ {
+		for range numberOfMsgsPerTx {
 			blob, err := share.NewBlob(share.RandomNamespace(), randomBytes, 1, accs[accountIndex].GetAddress().Bytes())
 			require.NoError(t, err)
 			msg, err := blobtypes.NewMsgPayForBlobs(addrs[accountIndex].String(), appconsts.Version, blob)
@@ -381,7 +381,7 @@ func TestPrepareProposalCappingNumberOfMessages(t *testing.T) {
 
 	numberOfMsgSends := appconsts.MaxNonPFBMessages + 500
 	msgSendTxs := make([][]byte, 0, numberOfMsgSends)
-	for i := 0; i < numberOfMsgSends; i++ {
+	for range numberOfMsgSends {
 		msg := banktypes.NewMsgSend(
 			addrs[accountIndex],
 			testnode.RandomAddress().(sdk.AccAddress),

--- a/app/test/square_size_test.go
+++ b/app/test/square_size_test.go
@@ -195,7 +195,7 @@ func (s *SquareSizeIntegrationTest) SetupBlockSizeParams(t *testing.T, squareSiz
 
 	// try to query and vote on the proposal within the voting period
 	govQueryClient := govv1.NewQueryClient(s.cctx.GRPCClient)
-	for i := 0; i < 30; i++ {
+	for range 30 {
 		// query the proposal to get the id
 		propResp, err := govQueryClient.Proposals(s.cctx.GoContext(), &govv1.QueryProposalsRequest{ProposalStatus: govv1.StatusVotingPeriod})
 		require.NoError(t, err)
@@ -226,7 +226,7 @@ func (s *SquareSizeIntegrationTest) SetupBlockSizeParams(t *testing.T, squareSiz
 	require.Equal(t, uint32(0), res.Code)
 
 	// try to query a few times until the voting period has passed
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		// check that the parameters were updated as expected
 		blobQueryClient := blobtypes.NewQueryClient(s.cctx.GRPCClient)
 		blobParamsResp, err := blobQueryClient.Params(s.cctx.GoContext(), &blobtypes.QueryParamsRequest{})

--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -8,8 +8,8 @@ import (
 
 // SetField modifies a JSON-encoded byte slice by updating or inserting a value at the given dot-delimited path.
 // Returns the updated JSON-encoded byte slice or an error if unmarshalling, marshaling, or setting the field fails.
-func SetField(bz []byte, path string, value interface{}) ([]byte, error) {
-	var doc map[string]interface{}
+func SetField(bz []byte, path string, value any) ([]byte, error) {
+	var doc map[string]any
 	if err := json.Unmarshal(bz, &doc); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal genesis: %w", err)
 	}
@@ -28,7 +28,7 @@ func RemoveField(bz []byte, path string) ([]byte, error) {
 
 // setOrDeleteNestedField modifies a nested field in a map based on a dot-delimited path or deletes it if value is nil.
 // Returns an error if the path is invalid or intermediate nodes are not maps.
-func setOrDeleteNestedField(doc map[string]interface{}, path string, value interface{}) error {
+func setOrDeleteNestedField(doc map[string]any, path string, value any) error {
 	keys := strings.Split(path, ".")
 
 	current := doc
@@ -43,7 +43,7 @@ func setOrDeleteNestedField(doc map[string]interface{}, path string, value inter
 			return nil
 		}
 
-		next, ok := current[key].(map[string]interface{})
+		next, ok := current[key].(map[string]any)
 		if !ok {
 			return fmt.Errorf("invalid path: %s is not a map", strings.Join(keys[:i+1], "."))
 		}

--- a/internal/utils/maps_test.go
+++ b/internal/utils/maps_test.go
@@ -13,7 +13,7 @@ func TestSetField(t *testing.T) {
 		name    string
 		input   string
 		path    string
-		value   interface{}
+		value   any
 		want    string
 		wantErr error
 	}{
@@ -135,7 +135,7 @@ func TestDeleteField(t *testing.T) {
 
 func mustUnmarshal(t *testing.T, s string) string {
 	t.Helper()
-	var m map[string]interface{}
+	var m map[string]any
 	err := json.Unmarshal([]byte(s), &m)
 	require.NoError(t, err, "failed to unmarshal JSON")
 

--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -342,7 +342,7 @@ func TestConstructEDS_SquareSize(t *testing.T) {
 func generateShares(count int) (shares [][]byte) {
 	ns1 := sh.MustNewV0Namespace(bytes.Repeat([]byte{1}, sh.NamespaceVersionZeroIDSize))
 
-	for i := 0; i < count; i++ {
+	for range count {
 		share := generateShare(ns1.Bytes())
 		shares = append(shares, share)
 	}

--- a/pkg/inclusion/nmt_caching_test.go
+++ b/pkg/inclusion/nmt_caching_test.go
@@ -24,7 +24,7 @@ func TestWalkCachedSubTreeRoot(t *testing.T) {
 	ns1 := share.MustNewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
 
 	data := append(ns1.Bytes(), []byte("data")...)
-	for i := 0; i < 8; i++ {
+	for range 8 {
 		err := tr.Push(data)
 		assert.NoError(t, err)
 	}
@@ -33,7 +33,7 @@ func TestWalkCachedSubTreeRoot(t *testing.T) {
 
 	// create a short sub tree
 	shortSubTree := wrapper.NewErasuredNamespacedMerkleTree(squareSize, 0)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		err := shortSubTree.Push(data)
 		assert.NoError(t, err)
 	}
@@ -42,7 +42,7 @@ func TestWalkCachedSubTreeRoot(t *testing.T) {
 
 	// create a tall sub tree root
 	tallSubTree := wrapper.NewErasuredNamespacedMerkleTree(squareSize, 0)
-	for i := 0; i < 4; i++ {
+	for range 4 {
 		err := tallSubTree.Push(data)
 		assert.NoError(t, err)
 	}
@@ -143,7 +143,7 @@ func TestEDSSubRootCacher(t *testing.T) {
 // nmt wrapper makes this difficult.
 func calculateSubTreeRoots(t *testing.T, row [][]byte, depth int) [][]byte {
 	subLeafRange := len(row)
-	for i := 0; i < depth; i++ {
+	for range depth {
 		subLeafRange /= 2
 	}
 
@@ -182,7 +182,7 @@ func chunkSlice(slice [][]byte, chunkSize int) [][][]byte {
 // of random data is of size shareSize and is prefixed with a random blob
 // namespace.
 func generateRandNamespacedRawData(count int) (result [][]byte) {
-	for i := 0; i < count; i++ {
+	for range count {
 		rawData := random.Bytes(share.ShareSize)
 		namespace := share.RandomBlobNamespace().Bytes()
 		copy(rawData, namespace)

--- a/pkg/user/e2e_test.go
+++ b/pkg/user/e2e_test.go
@@ -52,7 +52,7 @@ func TestConcurrentTxSubmission(t *testing.T) {
 			subCtx, cancel := context.WithCancel(ctx.GoContext())
 			defer cancel()
 			time.AfterFunc(time.Minute, cancel)
-			for i := 0; i < numTxs; i++ {
+			for i := range numTxs {
 				wg.Add(1)
 				go func(b *share.Blob) {
 					defer wg.Done()

--- a/pkg/user/pruning_test.go
+++ b/pkg/user/pruning_test.go
@@ -17,7 +17,7 @@ func TestPruningInTxTracker(t *testing.T) {
 	// Add 10 transactions to the tracker that are 10 and 5 minutes old
 	var txsToBePruned int
 	var txsNotReadyToBePruned int
-	for i := 0; i < numTransactions; i++ {
+	for i := range numTransactions {
 		// 5 transactions will be pruned
 		if i%2 == 0 {
 			txClient.txTracker["tx"+fmt.Sprint(i)] = txInfo{

--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -347,7 +347,7 @@ func TestEvictions(t *testing.T) {
 
 	// Submit more transactions than a single block can fit with a 1-block TTL.
 	// Txs will be evicted from the mempool and automatically resubmitted by the txClient during confirm().
-	for i := 0; i < len(responses); i++ {
+	for i := range responses {
 		blobs := blobfactory.ManyRandBlobs(random.New(), 500000, 500000) // ~1.5MiB per transaction
 		resp, err := txClient.BroadcastPayForBlob(ctx.GoContext(), blobs, fee, gas)
 		require.NoError(t, err)

--- a/pkg/wrapper/nmt_wrapper_test.go
+++ b/pkg/wrapper/nmt_wrapper_test.go
@@ -161,7 +161,7 @@ func TestErasuredNamespacedMerkleTree_ProveRange(t *testing.T) {
 		root, err := tree.Root()
 		assert.NoError(t, err)
 		// iterate over all the shares and check that the proof is non-empty and can be verified
-		for i := 0; i < len(data); i++ {
+		for i := range data {
 			proof, err := tree.ProveRange(i, i+1)
 			assert.NoError(t, err)
 			assert.NotEmpty(t, proof.Nodes())

--- a/test/txsim/account.go
+++ b/test/txsim/account.go
@@ -172,7 +172,7 @@ func (am *AccountManager) AllocateAccounts(n, balance int) []types.AccAddress {
 
 	path := hd.CreateHDPath(types.CoinType, 0, 0).String()
 	addresses := make([]types.AccAddress, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		name := am.nextAccountName()
 		record, _, err := am.keys.NewMnemonic(name, keyring.English, path, keyring.DefaultBIP39Passphrase, hd.Secp256k1)
 		if err != nil {

--- a/test/txsim/blob.go
+++ b/test/txsim/blob.go
@@ -63,7 +63,7 @@ func (s *BlobSequence) WithGasPrice(gasPrice float64) *BlobSequence {
 
 func (s *BlobSequence) Clone(n int) []Sequence {
 	sequenceGroup := make([]Sequence, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		sequenceGroup[i] = &BlobSequence{
 			namespaces:    s.namespaces,
 			sizes:         s.sizes,

--- a/test/txsim/run.go
+++ b/test/txsim/run.go
@@ -113,7 +113,7 @@ func Run(
 	}
 
 	var finalErr error
-	for i := 0; i < len(sequences); i++ {
+	for range sequences {
 		err := <-errCh
 		if err == nil { // should never happen
 			continue

--- a/test/txsim/send.go
+++ b/test/txsim/send.go
@@ -40,7 +40,7 @@ func NewSendSequence(numAccounts, sendAmount, numIterations int) *SendSequence {
 
 func (s *SendSequence) Clone(n int) []Sequence {
 	sequenceGroup := make([]Sequence, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		sequenceGroup[i] = NewSendSequence(s.numAccounts, s.sendAmount, s.numIterations)
 	}
 	return sequenceGroup

--- a/test/txsim/stake.go
+++ b/test/txsim/stake.go
@@ -32,7 +32,7 @@ func NewStakeSequence(initialStake int) *StakeSequence {
 
 func (s *StakeSequence) Clone(n int) []Sequence {
 	sequenceGroup := make([]Sequence, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		sequenceGroup[i] = NewStakeSequence(s.initialStake)
 	}
 	return sequenceGroup

--- a/test/util/blobfactory/payforblob_factory.go
+++ b/test/util/blobfactory/payforblob_factory.go
@@ -31,7 +31,7 @@ var (
 
 func RandMsgPayForBlobsWithSigner(rand *rand.Rand, signer string, size, blobCount int) (*blobtypes.MsgPayForBlobs, []*share.Blob) {
 	blobs := make([]*share.Blob, blobCount)
-	for i := 0; i < blobCount; i++ {
+	for i := range blobCount {
 		blob, err := blobtypes.NewV0Blob(testfactory.RandomBlobNamespaceWithPRG(rand), random.Bytes(size))
 		if err != nil {
 			panic(err)
@@ -105,7 +105,7 @@ func RandMsgPayForBlobs(rand *rand.Rand, size int) (*blobtypes.MsgPayForBlobs, *
 func RandBlobTxsRandomlySized(signer *user.Signer, rand *rand.Rand, count, maxSize, maxBlobs int) coretypes.Txs {
 	opts := DefaultTxOpts()
 	txs := make([]coretypes.Tx, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		// pick a random non-zero size of max maxSize
 		size := rand.Intn(maxSize)
 		if size == 0 {
@@ -152,7 +152,7 @@ func RandBlobTxsWithAccounts(
 
 	opts := DefaultTxOpts()
 	txs := make([]coretypes.Tx, len(accounts))
-	for i := 0; i < len(accounts); i++ {
+	for i := range accounts {
 		addr := testfactory.GetAddress(kr, accounts[i])
 		client, err := user.SetupTxClient(context.Background(), kr, conn, enc)
 		if err != nil {
@@ -188,7 +188,7 @@ func RandBlobTxsWithAccounts(
 func RandBlobTxs(signer *user.Signer, r *rand.Rand, count, blobsPerTx, size int) coretypes.Txs {
 	addr := signer.Account(testfactory.TestAccName).Address()
 	txs := make([]coretypes.Tx, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		_, blobs := RandMsgPayForBlobsWithSigner(r, addr.String(), size, blobsPerTx)
 		tx, _, err := signer.CreatePayForBlobs(testfactory.TestAccName, blobs, DefaultTxOpts()...)
 		if err != nil {
@@ -206,7 +206,7 @@ func ManyRandBlobs(rand *rand.Rand, sizes ...int) []*share.Blob {
 
 func Repeat[T any](s T, count int) []T {
 	ss := make([]T, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		ss[i] = s
 	}
 	return ss
@@ -291,7 +291,7 @@ func RandBlobTxsWithNamespacesAndSigner(
 	sizes []int,
 ) []coretypes.Tx {
 	txs := make([]coretypes.Tx, len(namespaces))
-	for i := 0; i < len(namespaces); i++ {
+	for i := range namespaces {
 		// take the first account the signer has
 		acc := signer.Accounts()[0]
 		_, b := RandMsgPayForBlobsWithNamespaceAndSigner(acc.Address().String(), namespaces[i], sizes[i])
@@ -351,7 +351,7 @@ func GenerateRandomBlobSizes(count int, rand *rand.Rand) []int {
 func RandMultiBlobTxsSameSigner(t *testing.T, rand *rand.Rand, signer *user.Signer, pfbCount int) []coretypes.Tx {
 	pfbTxs := make([]coretypes.Tx, pfbCount)
 	var err error
-	for i := 0; i < pfbCount; i++ {
+	for i := range pfbCount {
 		blobsPerPfb := GenerateRandomBlobCount(rand)
 		blobSizes := GenerateRandomBlobSizes(blobsPerPfb, rand)
 		blobs := ManyRandBlobs(rand, blobSizes...)

--- a/test/util/blobfactory/payforblob_factory_test.go
+++ b/test/util/blobfactory/payforblob_factory_test.go
@@ -32,7 +32,7 @@ func TestRandMultiBlobTxsSameSigner_Deterministic(t *testing.T) {
 	marshalledBlobTxs2 := blobfactory.RandMultiBlobTxsSameSigner(t, rand2, signer, pfbCount)
 
 	// additional checks for the sake of future debugging
-	for index := 0; index < pfbCount; index++ {
+	for index := range pfbCount {
 		blobTx1, isBlob := types.UnmarshalBlobTx(marshalledBlobTxs1[index])
 		assert.True(t, isBlob)
 		pfbMsgs1, err := decoder(blobTx1.Tx)

--- a/test/util/blobfactory/test_util.go
+++ b/test/util/blobfactory/test_util.go
@@ -26,7 +26,7 @@ func FeeTxOpts(gas uint64) []user.TxOption {
 
 func GenerateManyRawSendTxs(signer *user.Signer, count int) []coretypes.Tx {
 	txs := make([]coretypes.Tx, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		txs[i] = GenerateRawSendTx(signer, 100)
 	}
 	return txs
@@ -73,7 +73,7 @@ func GenerateRandomRawSendTx(rand *rand.Rand, signer *user.Signer) (rawTx []byte
 // GenerateManyRandomRawSendTxsSameSigner  generates count many random raw send txs.
 func GenerateManyRandomRawSendTxsSameSigner(rand *rand.Rand, signer *user.Signer, count int) []coretypes.Tx {
 	txs := make([]coretypes.Tx, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		txs[i] = GenerateRandomRawSendTx(rand, signer)
 	}
 	return txs

--- a/test/util/blobfactory/test_util_test.go
+++ b/test/util/blobfactory/test_util_test.go
@@ -31,7 +31,7 @@ func TestGenerateManyRandomRawSendTxsSameSigner_Deterministic(t *testing.T) {
 	encodedTxs2 := blobfactory.GenerateManyRandomRawSendTxsSameSigner(rand.New(rand.NewSource(seed)), signer, normalTxCount)
 
 	// additional check for the sake of future debugging
-	for i := 0; i < normalTxCount; i++ {
+	for i := range normalTxCount {
 		tx1, err := TxDecoder(encodedTxs1[i])
 		assert.NoError(t, err)
 		assert.NotNil(t, tx1)

--- a/test/util/direct_tx_gen.go
+++ b/test/util/direct_tx_gen.go
@@ -43,7 +43,7 @@ func RandBlobTxsWithAccounts(
 
 	txs := make([]coretypes.Tx, len(accounts))
 
-	for i := 0; i < len(accounts); i++ {
+	for i := range accounts {
 		addr := testfactory.GetAddress(kr, accounts[i])
 		acc := DirectQueryAccount(capp, addr)
 		account := user.NewAccount(accounts[i], acc.GetAccountNumber(), acc.GetSequence())
@@ -100,7 +100,7 @@ func RandBlobTxsWithManualSequence(
 
 	opts := blobfactory.DefaultTxOpts()
 	txs := make([]coretypes.Tx, len(accounts))
-	for i := 0; i < len(accounts); i++ {
+	for i := range accounts {
 		addr := testfactory.GetAddress(kr, accounts[i])
 		acc := user.NewAccount(accounts[i], accountNum, sequence)
 		signer, err := user.NewSigner(kr, cfg, chainid, acc)
@@ -172,7 +172,7 @@ func SendTxsWithAccounts(
 	opts := append(blobfactory.DefaultTxOpts(), extraOpts...)
 
 	txs := make([]coretypes.Tx, len(accounts))
-	for i := 0; i < len(accounts); i++ {
+	for i := range accounts {
 		signingAddr := getAddress(accounts[i], kr)
 
 		// update the account info in the signer so the signature is valid

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -51,7 +51,7 @@ func init() {
 type EmptyAppOptions struct{}
 
 // Get implements AppOptions
-func (ao EmptyAppOptions) Get(_ string) interface{} {
+func (ao EmptyAppOptions) Get(_ string) any {
 	return nil
 }
 

--- a/test/util/testfactory/blob.go
+++ b/test/util/testfactory/blob.go
@@ -31,7 +31,7 @@ func GenerateRandomlySizedBlobs(count, maxBlobSize int) []*share.Blob {
 // GenerateBlobsWithNamespace generates blobs with namespace share.
 func GenerateBlobsWithNamespace(count, blobSize int, ns share.Namespace) []*share.Blob {
 	blobs := make([]*share.Blob, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		blob, err := share.NewBlob(ns, random.Bytes(blobSize), appconsts.DefaultShareVersion, nil)
 		if err != nil {
 			panic(err)

--- a/test/util/testfactory/common.go
+++ b/test/util/testfactory/common.go
@@ -23,7 +23,7 @@ const (
 
 func Repeat[T any](s T, count int) []T {
 	ss := make([]T, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		ss[i] = s
 	}
 	return ss
@@ -33,7 +33,7 @@ func Repeat[T any](s T, count int) []T {
 // of random data is of size shareSize and is prefixed with a random blob
 // namespace.
 func GenerateRandNamespacedRawData(count int) (result [][]byte) {
-	for i := 0; i < count; i++ {
+	for range count {
 		rawData := random.Bytes(share.ShareSize)
 		namespace := share.RandomBlobNamespace().Bytes()
 		copy(rawData, namespace)
@@ -50,7 +50,7 @@ func sortByteArrays(src [][]byte) {
 
 func RandomAccountNames(count int) []string {
 	accounts := make([]string, 0, count)
-	for i := 0; i < count; i++ {
+	for range count {
 		accounts = append(accounts, random.Str(10))
 	}
 	return accounts
@@ -58,7 +58,7 @@ func RandomAccountNames(count int) []string {
 
 func GenerateAccounts(count int) []string {
 	accounts := make([]string, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		// Generate a random private key
 		privKey := secp256k1.GenPrivKey()
 		// Get the public key and derive the address

--- a/test/util/testfactory/namespace.go
+++ b/test/util/testfactory/namespace.go
@@ -29,7 +29,7 @@ func RandomBlobNamespaceWithPRG(rand *rand.Rand) share.Namespace {
 }
 
 func RandomBlobNamespaces(rand *rand.Rand, count int) (namespaces []share.Namespace) {
-	for i := 0; i < count; i++ {
+	for range count {
 		namespaces = append(namespaces, RandomBlobNamespaceWithPRG(rand))
 	}
 	return namespaces

--- a/test/util/testfactory/txs.go
+++ b/test/util/testfactory/txs.go
@@ -10,7 +10,7 @@ import (
 
 func GenerateRandomlySizedTxs(count, maxSize int) types.Txs {
 	txs := make(types.Txs, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		size := rand.Intn(maxSize)
 		if size == 0 {
 			size = 1
@@ -22,7 +22,7 @@ func GenerateRandomlySizedTxs(count, maxSize int) types.Txs {
 
 func GenerateRandomTxs(count, size int) types.Txs {
 	txs := make(types.Txs, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		tx := make([]byte, size)
 		_, err := crand.Read(tx)
 		if err != nil {

--- a/test/util/testnode/app_options.go
+++ b/test/util/testnode/app_options.go
@@ -6,11 +6,11 @@ import (
 )
 
 type KVAppOptions struct {
-	options map[string]interface{}
+	options map[string]any
 }
 
 // Get returns the option value for the given option key.
-func (ao *KVAppOptions) Get(option string) interface{} {
+func (ao *KVAppOptions) Get(option string) any {
 	return ao.options[option]
 }
 
@@ -20,13 +20,13 @@ func (ao *KVAppOptions) GetString(option string) string {
 }
 
 // Set sets a key-value app option.
-func (ao *KVAppOptions) Set(option string, value interface{}) {
+func (ao *KVAppOptions) Set(option string, value any) {
 	ao.options[option] = value
 }
 
 // DefaultAppOptions returns the default application options.
 func DefaultAppOptions() *KVAppOptions {
-	opts := &KVAppOptions{options: make(map[string]interface{})}
+	opts := &KVAppOptions{options: make(map[string]any)}
 	opts.Set(server.FlagPruning, pruningtypes.PruningOptionNothing)
 	return opts
 }

--- a/test/util/testnode/deterministic_port_test.go
+++ b/test/util/testnode/deterministic_port_test.go
@@ -27,11 +27,11 @@ func TestGetDeterministicPortConcurrent(t *testing.T) {
 	portChannel := make(chan int, numGoroutines*portsPerGoroutine)
 
 	// Start multiple goroutines
-	for i := 0; i < numGoroutines; i++ {
+	for range numGoroutines {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for j := 0; j < portsPerGoroutine; j++ {
+			for range portsPerGoroutine {
 				port := GetDeterministicPort()
 				portChannel <- port
 			}

--- a/test/util/testnode/network.go
+++ b/test/util/testnode/network.go
@@ -27,7 +27,7 @@ func NewNetwork(t testing.TB, config *Config) (cctx Context, rpcAddr, grpcAddr s
 func NewNetworkWithRetry(t testing.TB, config *Config, maxRetries int) (cctx Context, rpcAddr, grpcAddr string) {
 	t.Helper()
 
-	for attempt := 0; attempt < maxRetries; attempt++ {
+	for attempt := range maxRetries {
 		result, rpc, grpc, cleanup, err := tryStartNetwork(t, config)
 		if err != nil {
 			if isPortBindingError(err) {

--- a/test/util/testnode/read_test.go
+++ b/test/util/testnode/read_test.go
@@ -10,8 +10,8 @@ import (
 
 func TestReverseSlice(t *testing.T) {
 	tests := []struct {
-		input    interface{}
-		expected interface{}
+		input    any
+		expected any
 	}{
 		{[]int{1, 2, 3, 4, 5}, []int{5, 4, 3, 2, 1}},
 		{[]string{"a", "b", "c", "d"}, []string{"d", "c", "b", "a"}},

--- a/tools/blocktime/main.go
+++ b/tools/blocktime/main.go
@@ -79,7 +79,7 @@ func analyzeBlockTimes(times []time.Time) (float64, float64, float64, float64) {
 	totalTime := times[numberOfObservations].Sub(times[0])
 	averageTime := float64(totalTime.Milliseconds()) / float64(numberOfObservations)
 	variance, minTime, maxTime := float64(0), float64(0), float64(0)
-	for i := 0; i < numberOfObservations; i++ {
+	for i := range numberOfObservations {
 		diff := float64(times[i+1].Sub(times[i]).Milliseconds())
 		if minTime == 0 || diff < minTime {
 			minTime = diff

--- a/tools/talis/config.go
+++ b/tools/talis/config.go
@@ -125,7 +125,7 @@ type Config struct {
 	LinodeToken string `json:"linode_token,omitempty"`
 	// S3Config is used to configure the S3 bucket that will be used to store
 	// traces, logs, and other data.
-	S3Config S3Config `json:"s3_config,omitempty"`
+	S3Config S3Config `json:"s3_config"`
 }
 
 func NewConfig(experiment, chainID string) Config {

--- a/tools/talis/s3.go
+++ b/tools/talis/s3.go
@@ -134,7 +134,7 @@ func createS3Client(ctx context.Context, cfg Config) (*s3.Client, error) {
 	var awsCfg aws.Config
 	var err error
 	if cfg.S3Config.Endpoint != "" {
-		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...interface{}) (aws.Endpoint, error) { //nolint:staticcheck
+		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...any) (aws.Endpoint, error) { //nolint:staticcheck
 			return aws.Endpoint{ //nolint:staticcheck
 				URL:           cfg.S3Config.Endpoint,
 				SigningRegion: region,

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -232,7 +232,7 @@ func TestValidateBlobTx(t *testing.T) {
 				ns := share.RandomBlobNamespace()
 				sizes := make([]int, count)
 				namespaces := make([]share.Namespace, count)
-				for i := 0; i < count; i++ {
+				for i := range count {
 					sizes[i] = 100
 					namespaces[i] = ns
 				}

--- a/x/blob/types/estimate_gas_test.go
+++ b/x/blob/types/estimate_gas_test.go
@@ -105,7 +105,7 @@ func FuzzPFBGasEstimation(f *testing.F) {
 
 func randBlobSize(seed int64, numBlobs, maxBlobSize int) []int {
 	res := make([]int, numBlobs)
-	for i := 0; i < numBlobs; i++ {
+	for i := range numBlobs {
 		if maxBlobSize == 1 {
 			res[i] = 1
 			continue

--- a/x/blob/types/params.go
+++ b/x/blob/types/params.go
@@ -62,7 +62,7 @@ func (p Params) String() string {
 }
 
 // validateGasPerBlobByte validates the GasPerBlobByte param
-func validateGasPerBlobByte(v interface{}) error {
+func validateGasPerBlobByte(v any) error {
 	gasPerBlobByte, ok := v.(uint32)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", v)
@@ -76,7 +76,7 @@ func validateGasPerBlobByte(v interface{}) error {
 }
 
 // validateGovMaxSquareSize validates the GovMaxSquareSize param
-func validateGovMaxSquareSize(v interface{}) error {
+func validateGovMaxSquareSize(v any) error {
 	govMaxSquareSize, ok := v.(uint64)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", v)

--- a/x/blob/types/params_test.go
+++ b/x/blob/types/params_test.go
@@ -10,7 +10,7 @@ import (
 func Test_validateGovMaxSquareSize(t *testing.T) {
 	type test struct {
 		name      string
-		input     interface{}
+		input     any
 		expectErr bool
 	}
 	tests := []test{

--- a/x/minfee/types/legacy_params.go
+++ b/x/minfee/types/legacy_params.go
@@ -43,7 +43,7 @@ func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 }
 
 // validateMinGasPrice validates the param type
-func validateMinGasPrice(i interface{}) error {
+func validateMinGasPrice(i any) error {
 	_, ok := i.(math.LegacyDec)
 	if !ok {
 		return fmt.Errorf("invalid parameter type: %T", i)


### PR DESCRIPTION
This partially addresses #5709 by running the `modernize` tool and applying all its suggestions (61 fixes total). 

The changes are mostly `interface{}` → `any` replacements and modernizing `for i := 0; i < n; i++` loops to `for range n`. Also removed one ineffective `omitempty` tag on a struct field.

I verified everything still compiles and tests pass and the modernize tool reports zero remaining issues.

I haven't added the CI check or automation yet because I want to do a bit more research on the safety of auto-applying these fixes long-term. Will follow up with the CI integration after that.

Closes #5709