### PR TITLE
docs(simapp): correct packet-forward middleware comments in transfer stack

### DIFF
--- a/test/interop/simapp.go
+++ b/test/interop/simapp.go
@@ -442,11 +442,11 @@ func NewSimApp(
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
 	)
 
-	// Create Transfer Keeper and pass IBCFeeKeeper as expected Channel and PortKeeper
-	// since fee middleware will wrap the IBCKeeper for underlying application.
+	// Create Transfer Keeper and pass PacketForwardKeeper as ICS4 wrapper
+	// packet-forward middleware will wrap the underlying IBC channel for forwarding.
 	app.TransferKeeper = ibctransferkeeper.NewKeeper(
 		appCodec, keys[ibctransfertypes.StoreKey], app.GetSubspace(ibctransfertypes.ModuleName),
-		app.PacketForwardKeeper, // ICS4 Wrapper: fee IBC middleware
+		app.PacketForwardKeeper, // ICS4 Wrapper: packet-forward middleware
 		app.IBCKeeper.ChannelKeeper, app.IBCKeeper.PortKeeper,
 		app.AccountKeeper, app.BankKeeper, app.ScopedTransferKeeper,
 		authtypes.NewModuleAddress(govtypes.ModuleName).String(),
@@ -455,13 +455,13 @@ func NewSimApp(
 
 	// Create Transfer Stack
 	// SendPacket, since it is originating from the application to core IBC:
-	// transferKeeper.SendPacket -> fee.SendPacket -> channel.SendPacket
+	// transferKeeper.SendPacket -> packetforward.SendPacket -> channel.SendPacket
 
 	// RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
-	// channel.RecvPacket -> fee.OnRecvPacket -> transfer.OnRecvPacket
+	// channel.RecvPacket -> packetforward.OnRecvPacket -> transfer.OnRecvPacket
 
 	// transfer stack contains (from top to bottom):
-	// - IBC Fee Middleware
+	// - Packet Forwarding Middleware
 	// - Transfer
 
 	// create IBC module from bottom to top of stack


### PR DESCRIPTION
Update comments in test/interop/simapp.go to accurately describe the packet-forward middleware (PFM) stack:
- Replace references to ICS29 fee middleware with packet-forward middleware.
- Fix SendPacket/RecvPacket call-chain examples to reflect PFM wrapping.
- Adjust stack description to “Packet Forwarding Middleware” over “IBC Fee Middleware”.

These changes are necessary because the implementation uses packet-forward middleware (via PacketForwardKeeper and packetforward.NewIBCMiddleware), while the previous comments incorrectly mentioned fee middleware. Aligning comments with the actual code prevents developer confusion, matches the main app wiring in app/app.go, and improves maintainability without changing logic.