### PR TITLE
feat: add make modernize-fix command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,6 +251,12 @@ fmt:
 lint-fix: fmt
 .PHONY: lint-fix
 
+## modernize-fix: Apply modernize suggestions automatically.
+modernize-fix:
+	@echo "--> Applying modernize fixes"
+	@bash scripts/modernize.sh
+.PHONY: modernize-fix
+
 ## test: Run tests.
 test:
 	@echo "--> Running tests"

--- a/scripts/modernize.sh
+++ b/scripts/modernize.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Modernize script for celestia-app
+# Follow-up to issue #5709 and PR #5852
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "Running Go modernize tool..."
+go run golang.org/x/tools/gopls/internal/analysis/modernize/cmd/modernize@latest -fix -test ./...
+
+echo "Modernize fixes applied successfully!"


### PR DESCRIPTION
Adds `make modernize-fix` command that automatically applies Go modernization suggestions using the official modernize tool.

Closes #5854

Usage:

```bash
make modernize-fix
```