### PR TITLE
fix: correct shell variable escaping in enable-bbr target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -446,7 +446,7 @@ enable-bbr:
 	@if [ "$$(uname -s)" != "Linux" ]; then \
 		echo "BBR is not available on non-Linux systems."; \
 		exit 0; \
-	elif [ "$(sysctl net.ipv4.tcp_congestion_control | awk '{print $3}')" != "bbr" ]; then \
+	elif [ "$$(sysctl net.ipv4.tcp_congestion_control | awk '{print $$3}')" != "bbr" ]; then \
 	    echo "BBR is not enabled. Configuring BBR..."; \
 	    sudo modprobe tcp_bbr && \
             echo tcp_bbr | sudo tee -a /etc/modules && \


### PR DESCRIPTION
Found inconsistent shell variable escaping on line 449. Initially wasn't sure if this was actually a bug, so I tested the behavior.

Created test Makefiles and discovered the key issue:
- $(shell sysctl ...) executes during Makefile parsing
- $$(sysctl ...) executes during target execution  

For BBR status checking, this is critical - we need to check system state at runtime, not when reading the file.

Verified the rest of the code - lines 432 and 470 already use correct $$ escaping. Line 449 was the only exception.

Tested the fix - `make enable-bbr` works correctly.