### PR TITLE
ci: run required checks on merge group

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -12,6 +12,7 @@ on:
   release:
     types: [published]
   pull_request:
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -9,6 +9,7 @@ on:
     tags:
       - "v*"
   pull_request:
+  merge_group:
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - specs/**
   pull_request:
+  merge_group:
     paths:
       - specs/**
   workflow_dispatch:

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - "proto/**"
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Motivation

We want to try a merge queue in celestia-app. This adds a trigger so that required checks run in the merge queue.

Ref: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions