### PR TITLE
refactor(wrapper): remove unused options fields from NMT wrappers

### DIFF
--- a/pkg/wrapper/buffered_tree.go
+++ b/pkg/wrapper/buffered_tree.go
@@ -78,7 +78,6 @@ var _ rsmt2d.Tree = &resizeableBufferTree{}
 type resizeableBufferTree struct {
 	squareSize    uint // note: this refers to the width of the original square before erasure-coded
 	maxSquareSize uint // maximum square size this tree's buffer can handle without reallocation
-	options       []nmt.Option
 	tree          *nmt.NamespacedMerkleTree
 	// axisIndex is the index of the axis (row or column) that this tree is on. This is passed
 	// by rsmt2d and used to help determine which quadrant each leaf belongs to.
@@ -113,7 +112,6 @@ func newResizeableBufferTree(maxSquareSize uint, axisIndex uint, pool *TreePool,
 	return &resizeableBufferTree{
 		squareSize:      maxSquareSize,
 		maxSquareSize:   maxSquareSize,
-		options:         options,
 		tree:            tree,
 		pool:            pool,
 		bufferEntrySize: entrySize,

--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -25,7 +25,6 @@ var (
 // library sufficiently general
 type ErasuredNamespacedMerkleTree struct {
 	squareSize uint64 // note: this refers to the width of the original square before erasure-coded
-	options    []nmt.Option
 	tree       Tree
 	// axisIndex is the index of the axis (row or column) that this tree is on. This is passed
 	// by rsmt2d and used to help determine which quadrant each leaf belongs to.
@@ -59,7 +58,7 @@ func NewErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint, options 
 	options = append(options, nmt.NamespaceIDSize(share.NamespaceSize))
 	options = append(options, nmt.IgnoreMaxNamespace(true))
 	tree := nmt.New(appconsts.NewBaseHashFunc(), options...)
-	return ErasuredNamespacedMerkleTree{squareSize: squareSize, options: options, tree: tree, axisIndex: uint64(axisIndex), shareIndex: 0}
+    return ErasuredNamespacedMerkleTree{squareSize: squareSize, tree: tree, axisIndex: uint64(axisIndex), shareIndex: 0}
 }
 
 type constructor struct {

--- a/pkg/wrapper/nmt_wrapper.go
+++ b/pkg/wrapper/nmt_wrapper.go
@@ -58,7 +58,7 @@ func NewErasuredNamespacedMerkleTree(squareSize uint64, axisIndex uint, options 
 	options = append(options, nmt.NamespaceIDSize(share.NamespaceSize))
 	options = append(options, nmt.IgnoreMaxNamespace(true))
 	tree := nmt.New(appconsts.NewBaseHashFunc(), options...)
-    return ErasuredNamespacedMerkleTree{squareSize: squareSize, tree: tree, axisIndex: uint64(axisIndex), shareIndex: 0}
+	return ErasuredNamespacedMerkleTree{squareSize: squareSize, tree: tree, axisIndex: uint64(axisIndex), shareIndex: 0}
 }
 
 type constructor struct {


### PR DESCRIPTION
- Remove options []nmt.Option from ErasuredNamespacedMerkleTree and resizeableBufferTree.
- The nmt.Options are applied at construction time to nmt.New(...) and are never read afterward; the stored fields were dead state.
- This eliminates confusion about dynamic option use, reduces struct size, and prevents potential divergence between stored options and the actual NMT configuration.
- Matches how callers use the API (construction-time only), aligns with docs/tests, and introduces no behavioral change.