### PR TITLE
fix: remove network suffix from version if multiple tags point to the same commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-VERSION := $(shell echo $(shell git describe --tags --always --match "v*") | sed 's/^v//')
+VERSION := $(shell \
+	if [ $$(git tag --points-at HEAD | wc -l) -gt 1 ]; then \
+		git describe --tags --always --match "v*" | cut -d'-' -f1 | sed 's/^v//'; \
+	else \
+		git describe --tags --always --match "v*" | sed 's/^v//'; \
+	fi \
+)
 COMMIT := $(shell git rev-parse --short HEAD)
 CELESTIA_TAG := $(shell git rev-parse --short=8 HEAD)
 export CELESTIA_TAG


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/5272

## Overview

This PR brings a solution to the bad version issue, (ref. #5272 and others). 
Main issue being that it is **currently not reliable** the idea of automatically detecting which tag was checked out when multiple tags point to the same commit, and this often leads to confusion, e.g mocha build reporting as arabica. 
The fix relies on removing the suffix upon multiple tags and retain the current behavior otherwise.  

Tested checking out to `v6.0.5-mocha` and building locally:

**without the fix**: `celestia-appd version` returns `v6.0.5-arabica`
**with the fix**: `celestia-appd version` returns `v6.0.5` 
