### PR TITLE
chore: upgrade to alpine 3.22

### DIFF
--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -5,7 +5,7 @@
 # Separating the builder and runtime image allows the runtime image to be
 # considerably smaller because it doesn't need to have Golang installed.
 ARG BUILDER_IMAGE=docker.io/golang:1.24.6-alpine
-ARG RUNTIME_IMAGE=docker.io/alpine:3.20
+ARG RUNTIME_IMAGE=docker.io/alpine:3.22
 ARG TARGETOS
 ARG TARGETARCH
 # Use build args to override the maximum square size of the docker image e.g.

--- a/docker/standalone.Dockerfile
+++ b/docker/standalone.Dockerfile
@@ -5,7 +5,7 @@
 # Separating the builder and runtime image allows the runtime image to be
 # considerably smaller because it doesn't need to have Golang installed.
 ARG BUILDER_IMAGE=docker.io/golang:1.24.6-alpine
-ARG RUNTIME_IMAGE=docker.io/alpine:3.20
+ARG RUNTIME_IMAGE=docker.io/alpine:3.22
 ARG TARGETOS
 ARG TARGETARCH
 # Use build args to override the maximum square size of the docker image e.g.

--- a/docker/txsim/Dockerfile
+++ b/docker/txsim/Dockerfile
@@ -22,7 +22,7 @@ RUN uname -a &&\
     make txsim-build
 
 # Stage 2: create a minimal image with the binary
-FROM docker.io/alpine:3.20
+FROM docker.io/alpine:3.22
 
 # Use UID 10,001 because UIDs below 10,000 are a security risk.
 # Ref: https://github.com/hexops/dockerfile/blob/main/README.md#do-not-use-a-uid-below-10000


### PR DESCRIPTION
## Description

Update runtime base to alpine:3.22 across standalone, multiplexer, and txsim.