### PR TITLE
docs(scripts): fix incorrect filename in download_binary.sh usage comment

### DIFF
--- a/scripts/download_binary.sh
+++ b/scripts/download_binary.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Usage: ./scripts/download_v3_binary.sh <url> <out> <version>
+# Usage: ./scripts/download_binary.sh <url> <out> <version>
 
 set -euo pipefail
 


### PR DESCRIPTION

Corrected the usage comment on line 2 from download_v3_binary.sh to download_binary.sh to match the actual filename. This ensures accurate documentation and prevents confusion when using the script.
#5361 