### PR TITLE
chore: bump core to v0.39.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ require (
 replace (
 	cosmossdk.io/api => github.com/celestiaorg/cosmos-sdk/api v0.7.6
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
-	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.6
+	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.7
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.51.3
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/bytedance/sonic v1.14.1/go.mod h1:gi6uhQLMbTdeP0muCnrjHLeCUPyb70ujhnN
 github.com/bytedance/sonic/loader v0.3.0 h1:dskwH8edlzNMctoruo8FPTJDF3vLtDT0sXZwvZJyqeA=
 github.com/bytedance/sonic/loader v0.3.0/go.mod h1:N8A3vUdtUebEY2/VQC0MyhYeKUFosQU6FxH2JmUe6VI=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v0.39.6 h1:5QZUJBw1uQaw1M/1quA59GCOCAawgm720DwvSFlboYA=
-github.com/celestiaorg/celestia-core v0.39.6/go.mod h1:PKAwAsKDbnYCilrWKTYwZhiUlMLjVFImcIJLLVmCKTU=
+github.com/celestiaorg/celestia-core v0.39.7 h1:EiVFgnluLHDkLxz5iECHKmDz+XM9D0DTd9loA0umg3g=
+github.com/celestiaorg/celestia-core v0.39.7/go.mod h1:PKAwAsKDbnYCilrWKTYwZhiUlMLjVFImcIJLLVmCKTU=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
 github.com/celestiaorg/cosmos-sdk v0.51.3 h1:uZLe3lP5BaLTQqTCI0Kv3JxPIcAdvKSaPnDIvtCZYRE=


### PR DESCRIPTION
## Overview

This PR adds support for a mechanism to start/stop the legacy block prop mechanism. It introduces a param in `config.toml` called `enable_legacy_block_prop` which is set to `false` by default.

With this PR, we will the following params to control block prop:

```
enable_legacy_block_prop = false
disable_propagation_reactor = false
```

By default, these allow the new recovery reactor to run without the legacy block prop mechanism. However, in emergencies, we can ask nodes to set `enable_legacy_block_prop` to true to enable the legacy mechanism. And if needed, also disable the new recovery reactor.

I don't think it's worth adding flags like `celestia-appd start --enable-legacy-block-prop` because node operators can just change these in the config and restart.

Let me know if you agree or if we want the flags.