### PR TITLE
docs: fix filename mismatch in proposal submission

### DIFF
--- a/docs/maintainers/modify-param.md
+++ b/docs/maintainers/modify-param.md
@@ -87,7 +87,7 @@ params:
     export GAS_ADJUSTMENT="1.5"
 
     # Submit the proposal
-    celestia-appd tx gov submit-proposal gov-proposal.json --from $FROM --fees $FEES --gas $GAS --gas-adjustment $GAS_ADJUSTMENT
+    celestia-appd tx gov submit-proposal proposal.json --from $FROM --fees $FEES --gas $GAS --gas-adjustment $GAS_ADJUSTMENT
 
     # Query the proposals
     celestia-appd query gov proposals --output json | jq .


### PR DESCRIPTION
## Overview

 `submit-proposal` command was using `gov-proposal.json` instead of the expected `proposal.json`.

this update renames the file to match the command and ensures submissions work correctly.
