### PR TITLE
fix(makefile): correct .PHONY declaration for build-docker-standalone…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ proto-update-deps:
 build-docker-standalone:
 	@echo "--> Building Docker image"
 	$(DOCKER) build -t celestiaorg/celestia-app -f docker/standalone.Dockerfile .
-.PHONY: build-docker
+.PHONY: build-docker-standalone
 
 ## docker-build: Build the celestia-appd docker image from the current branch. Requires docker.
 docker-build: build-docker-multiplexer


### PR DESCRIPTION
Looks like the `.PHONY` declaration for `build-docker-standalone` was mistakenly pointing to `build-docker` (which doesn't exist). Fixed it to match the actual target name.