### PR TITLE
docs: fix Makefile portability by using `$(shell pwd)`

### DIFF
--- a/docs/maintainers/prebuilt-binaries.md
+++ b/docs/maintainers/prebuilt-binaries.md
@@ -27,7 +27,7 @@ Prebuilt binaries are attached to each release via [GoReleaser](https://goreleas
             -e CGO_ENABLED=1 \
             --env-file .release-env \
             -v /var/run/docker.sock:/var/run/docker.sock \
-            -v `pwd`:/go/src/$(PACKAGE_NAME) \
+            -v $(shell pwd):/go/src/$(PACKAGE_NAME) \
             -w /go/src/$(PACKAGE_NAME) \
             ghcr.io/goreleaser/goreleaser-cross:${GOLANG_CROSS_VERSION} \
     -       release --clean


### PR DESCRIPTION
## Overview

replaced `pwd` with `$(shell pwd)` in the Makefile to make it more portable across different shells.
this should prevent issues when running the Makefile in environments where `pwd` behaves differently.
