### PR TITLE
fix: remove incorrect nolint:unused annotation from defaultBroadcastHandler

### DIFF
--- a/pkg/user/mock_tx_server_test.go
+++ b/pkg/user/mock_tx_server_test.go
@@ -67,7 +67,6 @@ func (m *mockTxServer) defaultTxStatusHandler(ctx context.Context, req *tx.TxSta
 	}, nil
 }
 
-// nolint:unused
 // defaultBroadcastHandler implements the original default behavior for BroadcastTx
 func (m *mockTxServer) defaultBroadcastHandler(ctx context.Context, req *sdktx.BroadcastTxRequest) (*sdktx.BroadcastTxResponse, error) {
 	// Default behavior: same hash for all broadcast calls


### PR DESCRIPTION
Function is actually used in mock server setup and parallel tests