### PR TITLE
chore: use math.ZeroInt() instead of math.NewInt(0) in signal keeper

### DIFF
--- a/x/signal/keeper.go
+++ b/x/signal/keeper.go
@@ -148,7 +148,7 @@ func (k Keeper) VersionTally(ctx context.Context, req *types.QueryVersionTallyRe
 	if err != nil {
 		return nil, err
 	}
-	currentVotingPower := math.NewInt(0)
+	currentVotingPower := math.ZeroInt()
 	store := sdkCtx.KVStore(k.storeKey)
 	iterator := store.Iterator(types.FirstSignalKey, nil)
 	defer iterator.Close()


### PR DESCRIPTION
### Motivation

This change improves code quality by eliminating minor inconsistencies. In large projects, maintaining consistency in API usage reduces cognitive load, improves readability, and prevents technical debt accumulation.

### Overview
Replace `math.NewInt(0)` with `math.ZeroInt()` in `x/signal/keeper.go:151` within the `VersionTally` function.
