### PR TITLE
Remove misleading startHeight logs and clarify CheckLiveness range

### DIFF
--- a/test/docker-e2e/e2e_full_stack_pfb_test.go
+++ b/test/docker-e2e/e2e_full_stack_pfb_test.go
@@ -63,10 +63,6 @@ func (s *CelestiaTestSuite) TestE2EFullStackPFB() {
 	err = celestia.Start(ctx)
 	s.Require().NoError(err, "failed to start celestia chain")
 
-	// Record start height for liveness check
-	startHeight, err := celestia.Height(ctx)
-	s.Require().NoError(err, "failed to get start height")
-
 	// create a da network, wiring up the provided chain using the CELESTIA_CUSTOM environment variable.
 	daNetwork := s.DeployDANetwork(ctx, celestia, s.client, s.network)
 
@@ -82,7 +78,7 @@ func (s *CelestiaTestSuite) TestE2EFullStackPFB() {
 	// verify blob retrieval from light node
 	s.verifyBlobRetrieval(ctx, daNetwork, blobData)
 
-	s.T().Logf("Checking validator liveness from height %d", startHeight)
+	s.T().Log("Checking validator liveness")
 	s.Require().NoError(
 		s.CheckLiveness(ctx, celestia),
 		"validator liveness check failed",

--- a/test/docker-e2e/e2e_simple_test.go
+++ b/test/docker-e2e/e2e_simple_test.go
@@ -51,14 +51,12 @@ func (s *CelestiaTestSuite) TestE2ESimple() {
 	s.CreateTxSim(ctx, celestia)
 
 	// Record start height for liveness check
-	startHeight, err := celestia.Height(ctx)
-	s.Require().NoError(err, "failed to get start height")
 
 	assertTransactionsIncluded(ctx, t, celestia)
 
 	testBankSend(t, celestia, cfg)
 
-	s.T().Logf("Checking validator liveness from height %d", startHeight)
+	s.T().Log("Checking validator liveness")
 	s.Require().NoError(
 		s.CheckLiveness(ctx, celestia),
 		"validator liveness check failed",

--- a/test/docker-e2e/e2e_test.go
+++ b/test/docker-e2e/e2e_test.go
@@ -183,6 +183,7 @@ func (s *CelestiaTestSuite) WaitForSync(ctx context.Context, statusClient rpccli
 // CheckLiveness validates that all validators proposed blocks and no nodes halted.
 // Automatically waits for sufficient blocks (3 per validator minimum) if needed.
 //
+// Range: currently checks from height 1 up to the latest height.
 // Upgrade-agnostic: can be called before/after upgrades or spanning the entire period.
 // Call at the end of E2E tests to validate network health.
 func (s *CelestiaTestSuite) CheckLiveness(ctx context.Context, chain tastoratypes.Chain) error {

--- a/test/docker-e2e/e2e_upgrade_test.go
+++ b/test/docker-e2e/e2e_upgrade_test.go
@@ -158,7 +158,7 @@ func (s *CelestiaTestSuite) runUpgradeTest(ImageTag string, baseAppVersion, targ
 	s.T().Log("Testing PFB submission functionality after upgrade")
 	testPFBSubmission(s.T(), chain, cfg)
 
-	s.T().Logf("Checking validator liveness from height %d with minimum %d blocks per validator", startHeight, defaultBlocksPerValidator)
+	s.T().Logf("Checking validator liveness (minimum %d blocks per validator)", defaultBlocksPerValidator)
 	s.Require().NoError(
 		s.CheckLiveness(ctx, chain),
 		"validator liveness check failed",


### PR DESCRIPTION
This change removes unused and misleading startHeight variables and logs in e2e_simple_test.go and e2e_full_stack_pfb_test.go, updates the liveness log in e2e_upgrade_test.go to avoid implying a start-height-based check, and clarifies in e2e_test.go that CheckLiveness validates from height 1 to the latest height.

Why this is needed:
- CheckLiveness internally uses startHeight=1 and fetches proposers from [1, end], so logging “from height %d” with a locally computed startHeight is inaccurate.
- The startHeight variables in the simple and full-stack tests were effectively dead code, used only for misleading logs.
- Correcting the logs and documenting the actual range prevents confusion during test runs and improves maintainability and diagnostic clarity.