### PR TITLE
fix: deprecated note in testnode config to reference WithDelayedPrecommitTimeout

### DIFF
--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -87,7 +87,7 @@ func (c *Config) WithSuppressLogs(sl bool) *Config {
 
 // WithTimeoutCommit sets the timeout commit in the cometBFT config and returns
 // the Config. For backward compatibility, it also sets the app's block time.
-// Deprecated: Use WithBlockTime instead.
+// Deprecated: Use WithDelayedPrecommitTimeout instead.
 func (c *Config) WithTimeoutCommit(d time.Duration) *Config {
 	c.TmConfig.Consensus.TimeoutCommit = d
 	// For backward compatibility, also set the app option so existing tests continue to work


### PR DESCRIPTION


### Description
- Replace outdated deprecation comment in `test/util/testnode/config.go`:
  - from “Deprecated: Use WithBlockTime instead.”
  - to “Deprecated: Use WithDelayedPrecommitTimeout instead.”


### Rationale
- The referenced `WithBlockTime` does not exist. Pointing to `WithDelayedPrecommitTimeout` prevents confusion and misuse.

