### PR TITLE
refactor(test): replace Stop() with Remove() in docker-e2e cleanup

### DIFF
--- a/test/docker-e2e/e2e_block_sync_test.go
+++ b/test/docker-e2e/e2e_block_sync_test.go
@@ -3,12 +3,12 @@ package docker_e2e
 import (
 	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 	"context"
-	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	"testing"
 	"time"
 
 	addressutil "github.com/celestiaorg/tastora/framework/testutil/address"
 	"github.com/celestiaorg/tastora/framework/testutil/config"
+	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	cometcfg "github.com/cometbft/cometbft/config"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 
@@ -33,7 +33,7 @@ func (s *CelestiaTestSuite) TestBlockSync() {
 	s.Require().NoError(err, "failed to create chain")
 
 	t.Cleanup(func() {
-		if err := celestia.Stop(ctx); err != nil {
+		if err := celestia.Remove(ctx); err != nil {
 			t.Logf("Error stopping chain: %v", err)
 		}
 	})

--- a/test/docker-e2e/e2e_full_stack_pfb_test.go
+++ b/test/docker-e2e/e2e_full_stack_pfb_test.go
@@ -55,7 +55,7 @@ func (s *CelestiaTestSuite) TestE2EFullStackPFB() {
 	s.Require().NoError(err, "failed to build celestia chain")
 
 	t.Cleanup(func() {
-		if err := celestia.Stop(ctx); err != nil {
+		if err := celestia.Remove(ctx); err != nil {
 			t.Logf("Error stopping celestia chain: %v", err)
 		}
 	})
@@ -199,7 +199,7 @@ func (s *CelestiaTestSuite) DeployDANetwork(ctx context.Context, celestia *tasto
 
 	// cleanup DA network when test is done
 	t.Cleanup(func() {
-		if err := stopDANetwork(ctx, daNetwork); err != nil {
+		if err := removeDANetwork(ctx, daNetwork); err != nil {
 			t.Logf("Error stopping DA network: %v", err)
 		}
 	})
@@ -313,23 +313,23 @@ func (s *CelestiaTestSuite) getGenesisHash(ctx context.Context, celestia *tastor
 	return genesisHash, nil
 }
 
-// stopDANetwork stops all nodes in the Data Availability Network, including bridge, full, and light nodes.
-// Returns an error if any node fails to stop.
-func stopDANetwork(ctx context.Context, daNetwork *da.Network) error {
+// removeDANetwork removes all nodes in the Data Availability Network, including bridge, full, and light nodes.
+// Returns an error if any node fails to remove.
+func removeDANetwork(ctx context.Context, daNetwork *da.Network) error {
 	var errs []error
 	for _, node := range daNetwork.GetBridgeNodes() {
-		if err := node.Stop(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("failed to stop bridge node: %w", err))
+		if err := node.Remove(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove bridge node: %w", err))
 		}
 	}
 	for _, node := range daNetwork.GetFullNodes() {
-		if err := node.Stop(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("failed to stop full node: %w", err))
+		if err := node.Remove(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove full node: %w", err))
 		}
 	}
 	for _, node := range daNetwork.GetLightNodes() {
-		if err := node.Stop(ctx); err != nil {
-			errs = append(errs, fmt.Errorf("failed to stop light node: %w", err))
+		if err := node.Remove(ctx); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove light node: %w", err))
 		}
 	}
 	return errors.Join(errs...)

--- a/test/docker-e2e/e2e_ibc_test.go
+++ b/test/docker-e2e/e2e_ibc_test.go
@@ -1,28 +1,28 @@
 package docker_e2e
 
 import (
-	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 	"context"
 	"fmt"
-	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
-	tastoracontainertypes "github.com/celestiaorg/tastora/framework/docker/container"
-	"github.com/celestiaorg/tastora/framework/testutil/query"
-	"github.com/celestiaorg/tastora/framework/testutil/sdkacc"
-	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"testing"
 	"time"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v6/app"
 	"github.com/celestiaorg/celestia-app/v6/app/encoding"
+	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/pkg/user"
+	tastoracontainertypes "github.com/celestiaorg/tastora/framework/docker/container"
 	"github.com/celestiaorg/tastora/framework/docker/cosmos"
 	"github.com/celestiaorg/tastora/framework/docker/ibc"
 	"github.com/celestiaorg/tastora/framework/docker/ibc/relayer"
+	"github.com/celestiaorg/tastora/framework/testutil/query"
+	"github.com/celestiaorg/tastora/framework/testutil/sdkacc"
 	"github.com/celestiaorg/tastora/framework/testutil/wait"
+	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	sdktx "github.com/cosmos/cosmos-sdk/client/tx"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/module/testutil"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	icacontrollertypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/controller/types"
 	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
@@ -30,6 +30,8 @@ import (
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/errgroup"
+
+	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 )
 
 func TestIBCTestSuite(t *testing.T) {
@@ -90,7 +92,7 @@ func (s *IBCTestSuite) setupIBCInfrastructure(appVersion uint64) {
 	s.hermes, err = relayer.NewHermes(ctx, s.client, t.Name(), s.network, 0, s.logger)
 	s.Require().NoError(err, "failed to create hermes")
 
-	err = s.hermes.Init(ctx, s.chainA, s.chainB)
+	err = s.hermes.Init(ctx, []tastoratypes.Chain{s.chainA, s.chainB})
 	s.Require().NoError(err, "failed to initialize hermes")
 
 	// create IBC clients

--- a/test/docker-e2e/e2e_simple_test.go
+++ b/test/docker-e2e/e2e_simple_test.go
@@ -1,7 +1,6 @@
 package docker_e2e
 
 import (
-	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 	"context"
 	"fmt"
 	"testing"
@@ -10,6 +9,7 @@ import (
 	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v6/pkg/user"
 	"github.com/celestiaorg/celestia-app/v6/test/util/testfactory"
+	"github.com/celestiaorg/celestia-app/v6/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v6/x/blob/types"
 	"github.com/celestiaorg/go-square/v3/share"
 	tastoradockertypes "github.com/celestiaorg/tastora/framework/docker/cosmos"
@@ -18,7 +18,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/require"
 
-	"github.com/celestiaorg/celestia-app/v6/test/util/testnode"
+	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 )
 
 func (s *CelestiaTestSuite) TestE2ESimple() {
@@ -38,7 +38,7 @@ func (s *CelestiaTestSuite) TestE2ESimple() {
 
 	// Cleanup resources when the test is done
 	t.Cleanup(func() {
-		if err := celestia.Stop(ctx); err != nil {
+		if err := celestia.Remove(ctx); err != nil {
 			t.Logf("Error stopping chain: %v", err)
 		}
 	})

--- a/test/docker-e2e/e2e_state_sync_test.go
+++ b/test/docker-e2e/e2e_state_sync_test.go
@@ -1,8 +1,6 @@
 package docker_e2e
 
 import (
-	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
-	"celestiaorg/celestia-app/test/docker-e2e/networks"
 	"context"
 	"fmt"
 	"strings"
@@ -18,6 +16,9 @@ import (
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	servercfg "github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/stretchr/testify/require"
+
+	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
+	"celestiaorg/celestia-app/test/docker-e2e/networks"
 )
 
 const (
@@ -45,7 +46,7 @@ func (s *CelestiaTestSuite) TestStateSync() {
 
 	// Cleanup resources when the test is done
 	t.Cleanup(func() {
-		if err := celestia.Stop(ctx); err != nil {
+		if err := celestia.Remove(ctx); err != nil {
 			t.Logf("Error stopping chain: %v", err)
 		}
 	})
@@ -188,7 +189,7 @@ func (s *CelestiaTestSuite) TestStateSyncMocha() {
 	s.Require().NoError(err, "failed to start chain")
 
 	t.Cleanup(func() {
-		if err := mochaChain.Stop(ctx); err != nil {
+		if err := mochaChain.Remove(ctx); err != nil {
 			t.Logf("Error stopping chain: %v", err)
 		}
 	})

--- a/test/docker-e2e/e2e_state_sync_upgrade_test.go
+++ b/test/docker-e2e/e2e_state_sync_upgrade_test.go
@@ -1,7 +1,6 @@
 package docker_e2e
 
 import (
-	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 	"context"
 	"fmt"
 	"strings"
@@ -14,6 +13,8 @@ import (
 	"github.com/celestiaorg/tastora/framework/testutil/wait"
 	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
+
+	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 )
 
 // TestStateSyncWithAppUpgrade verifies that a full node can state-sync across app version
@@ -42,7 +43,7 @@ func (s *CelestiaTestSuite) TestStateSyncWithAppUpgrade() {
 	s.Require().NoError(err, "failed to build chain")
 
 	t.Cleanup(func() {
-		if err := chain.Stop(ctx); err != nil {
+		if err := chain.Remove(ctx); err != nil {
 			t.Logf("Error stopping chain: %v", err)
 		}
 	})

--- a/test/docker-e2e/e2e_upgrade_test.go
+++ b/test/docker-e2e/e2e_upgrade_test.go
@@ -5,16 +5,15 @@ import (
 	"fmt"
 	"testing"
 
-	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
-
-	signaltypes "github.com/celestiaorg/celestia-app/v6/x/signal/types"
-
 	"github.com/celestiaorg/celestia-app/v6/pkg/user"
+	signaltypes "github.com/celestiaorg/celestia-app/v6/x/signal/types"
 	tastoradockertypes "github.com/celestiaorg/tastora/framework/docker/cosmos"
 	"github.com/celestiaorg/tastora/framework/testutil/wait"
 	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 )
 
 // TestCelestiaAppUpgrade tests app version upgrade using the signaling mechanism.
@@ -101,7 +100,7 @@ func (s *CelestiaTestSuite) runUpgradeTest(ImageTag string, baseAppVersion, targ
 	s.Require().NoError(err)
 
 	s.T().Cleanup(func() {
-		if err := chain.Stop(ctx); err != nil {
+		if err := chain.Remove(ctx); err != nil {
 			s.T().Logf("Error stopping chain: %v", err)
 		}
 	})

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/math v1.5.3
 	github.com/celestiaorg/celestia-app/v6 v6.0.0-rc0
 	github.com/celestiaorg/go-square/v3 v3.0.2
-	github.com/celestiaorg/tastora v0.5.1
+	github.com/celestiaorg/tastora v0.7.1
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/cosmos/ibc-go/v8 v8.7.0

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -794,8 +794,8 @@ github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpch
 github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
 github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
-github.com/celestiaorg/tastora v0.5.1 h1:lFaJ6q8jUyK7iUL0hBwbS93DMp5jM1kDEp2EiAPlm4w=
-github.com/celestiaorg/tastora v0.5.1/go.mod h1:Xw44XeRN2T/kSdopVCJjNhwFwRSO58wTW8GrVP7OWFI=
+github.com/celestiaorg/tastora v0.7.1 h1:fqPsio32g6GQZCoFgIEU7vZPXCbeePPechKhBnQZ2+g=
+github.com/celestiaorg/tastora v0.7.1/go.mod h1:Xw44XeRN2T/kSdopVCJjNhwFwRSO58wTW8GrVP7OWFI=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
## Refactor docker-e2e test cleanup: Replace Stop() with Remove()

Updates all docker-e2e test cleanup functions to use `Remove()` instead of `Stop()` following Tastora framework upgrade to v0.7.1. The new `Remove()` method ensures complete resource cleanup including Docker volumes, preventing resource accumulation in CI environments.