### PR TITLE
fix(talis): set min fee via Params.NetworkMinGasPrice in SetMinFee

### DIFF
--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -77,7 +77,8 @@ func SetMinFee(codec codec.Codec, minFee float64) genesis.Modifier {
 		if err != nil {
 			panic(err)
 		}
-		minFeeGenState.NetworkMinGasPrice = gasPrice
+		// Write into params because InitGenesis reads min fee from Params only.
+        minFeeGenState.Params.NetworkMinGasPrice = gasPrice
 		state[minfeetypes.ModuleName] = codec.MustMarshalJSON(minFeeGenState)
 		return state
 	}


### PR DESCRIPTION


### Summary
Ensure `SetMinFee` writes the network minimum gas price into `Params`, which is what `InitGenesis` actually reads.

### Context
- `tools/talis/network.go::SetMinFee` previously wrote to `GenesisState.NetworkMinGasPrice`.
- `x/minfee/keeper/genesis.go::InitGenesis` only uses `genState.Params`, so the value was silently ignored.

### Changes
- Write to `minFeeGenState.Params.NetworkMinGasPrice` instead of the top-level field.

