### PR TITLE
refactor(minfee): remove duplicate default init from legacy_params.go

### DIFF
--- a/x/minfee/types/legacy_params.go
+++ b/x/minfee/types/legacy_params.go
@@ -1,11 +1,10 @@
 package types
 
 import (
-	"fmt"
+    "fmt"
 
-	"cosmossdk.io/math"
-	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
-	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
+    "cosmossdk.io/math"
+    paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 // TODO: this file can be removed once the upgrade to self managed modules has been completed.
@@ -14,13 +13,7 @@ var _ paramtypes.ParamSet = (*Params)(nil)
 
 var KeyNetworkMinGasPrice = []byte("NetworkMinGasPrice")
 
-func init() {
-	DefaultNetworkMinGasPriceDec, err := math.LegacyNewDecFromStr(fmt.Sprintf("%f", appconsts.DefaultNetworkMinGasPrice))
-	if err != nil {
-		panic(err)
-	}
-	DefaultNetworkMinGasPrice = DefaultNetworkMinGasPriceDec
-}
+// DefaultNetworkMinGasPrice is initialized in params.go; do not duplicate here.
 
 // RegisterMinFeeParamTable returns a subspace with a key table attached.
 func RegisterMinFeeParamTable(subspace paramtypes.Subspace) paramtypes.Subspace {


### PR DESCRIPTION


### Summary
Remove the redundant initialization of `DefaultNetworkMinGasPrice` from `legacy_params.go`; keep a single source of truth in `params.go`.

### Context
- `DefaultNetworkMinGasPrice` was initialized twice via `init()` in the same package, which is unnecessary and can cause confusion about init ordering.

### Changes
- Delete duplicate `init()` from `x/minfee/types/legacy_params.go`.
- Remove unused import.

