### PR TITLE
chore: remove redundant float conversions in gas estimation

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -879,7 +879,7 @@ func (client *TxClient) EstimateGasPriceAndUsage(
 		return 0, 0, fmt.Errorf("failed to estimate gas price and usage: %w", err)
 	}
 
-	gasUsed = uint64(float64(resp.EstimatedGasUsed))
+	gasUsed = resp.EstimatedGasUsed
 	span.AddEvent("txclient/EstimateGasPriceAndUsage: estimation successful", trace.WithAttributes(
 		attribute.Int64("gas_used", int64(gasUsed)),
 		attribute.Int64("gas_price", int64(resp.EstimatedGasPrice)),
@@ -920,7 +920,7 @@ func (client *TxClient) estimateGas(ctx context.Context, txBuilder client.TxBuil
 		return 0, err
 	}
 
-	gasLimit := uint64(float64(resp.EstimatedGasUsed))
+	gasLimit := resp.EstimatedGasUsed
 
 	span := trace.SpanFromContext(ctx)
 	span.AddEvent("txclient/estimateGas: estimation successful",


### PR DESCRIPTION
The gas estimation response already exposes `EstimatedGasUsed` as a uint64. Previously we were round-tripping it through float64 before storing it, which adds no value and can lose precision for very large numbers. This change removes the redundant casts and keeps the uint64 value as-is.