### PR TITLE
feat: reduce polling time to every second

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	DefaultPollTime          = 3 * time.Second
+	DefaultPollTime          = 1 * time.Second
 	txTrackerPruningInterval = 10 * time.Minute
 	// Gas limits for initialization transactions
 	SendGasLimit         = 100000


### PR DESCRIPTION
The reason is to reduce user latency to when a transaction is confirmed