### PR TITLE
chore: remove duplicate minfee DefaultNetworkMinGasPrice init

### DIFF
--- a/x/minfee/types/legacy_params.go
+++ b/x/minfee/types/legacy_params.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"cosmossdk.io/math"
-	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
@@ -13,14 +12,6 @@ import (
 var _ paramtypes.ParamSet = (*Params)(nil)
 
 var KeyNetworkMinGasPrice = []byte("NetworkMinGasPrice")
-
-func init() {
-	DefaultNetworkMinGasPriceDec, err := math.LegacyNewDecFromStr(fmt.Sprintf("%f", appconsts.DefaultNetworkMinGasPrice))
-	if err != nil {
-		panic(err)
-	}
-	DefaultNetworkMinGasPrice = DefaultNetworkMinGasPriceDec
-}
 
 // RegisterMinFeeParamTable returns a subspace with a key table attached.
 func RegisterMinFeeParamTable(subspace paramtypes.Subspace) paramtypes.Subspace {


### PR DESCRIPTION
Cleaned up x/minfee legacy params: dropped the duplicate init of DefaultNetworkMinGasPrice (same logic lives in params.go) and removed the now-unused appconsts import. Behaviour stays the same, less dead code to maintain.