### PR TITLE
chore: use a more straightforward error return value

### DIFF
--- a/test/docker-e2e/dockerchain/testchain.go
+++ b/test/docker-e2e/dockerchain/testchain.go
@@ -166,5 +166,5 @@ func getPrivValidatorKeyJsonBytes(key privval.FilePVKey) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("marshaling priv_validator_key.json: %w", err)
 	}
-	return privValidatorKeyBz, err
+	return privValidatorKeyBz, nil
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


 Since err has already been checked earlier and must be nil here, directly returning nil makes the code more readable.

