### PR TITLE
fix: create missing intermediate maps for SetField

### DIFF
--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -43,9 +43,16 @@ func setOrDeleteNestedField(doc map[string]any, path string, value any) error {
 			return nil
 		}
 
-		next, ok := current[key].(map[string]any)
+		nextValue, exists := current[key]
+		next, ok := nextValue.(map[string]any)
 		if !ok {
-			return fmt.Errorf("invalid path: %s is not a map", strings.Join(keys[:i+1], "."))
+			// create missing intermediate map when inserting new fields
+			if value != nil && (!exists || nextValue == nil) {
+				next = make(map[string]any)
+				current[key] = next
+			} else {
+				return fmt.Errorf("invalid path: %s is not a map", strings.Join(keys[:i+1], "."))
+			}
 		}
 		current = next
 	}

--- a/internal/utils/maps_test.go
+++ b/internal/utils/maps_test.go
@@ -32,6 +32,20 @@ func TestSetField(t *testing.T) {
 			want:  `{"x": {"y": {"z": "new"}}}`,
 		},
 		{
+			name:  "add missing intermediate map",
+			input: `{"x": {}}`,
+			path:  "x.y.z",
+			value: "new",
+			want:  `{"x": {"y": {"z": "new"}}}`,
+		},
+		{
+			name:  "add entirely new branch",
+			input: `{"existing": 1}`,
+			path:  "new.y.z",
+			value: 42,
+			want:  `{"existing": 1, "new": {"y": {"z": 42}}}`,
+		},
+		{
 			name:  "overwrite existing top-level field",
 			input: `{"x": "old"}`,
 			path:  "x",
@@ -109,6 +123,12 @@ func TestDeleteField(t *testing.T) {
 		{
 			name:    "delete invalid nested path",
 			input:   `{"x": 5}`,
+			path:    "x.y.z",
+			wantErr: errors.New("invalid path"),
+		},
+		{
+			name:    "delete with missing intermediate",
+			input:   `{"x": {}}`,
 			path:    "x.y.z",
 			wantErr: errors.New("invalid path"),
 		},


### PR DESCRIPTION
Updated SetField to auto-create missing intermediate maps when inserting nested JSON fields, kept RemoveField’s error semantics unchanged, added unit tests covering both behaviors, and ran go test ./internal/utils