### PR TITLE
chore: update GitHub Action to setup-go@v6

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: "go.mod"
 


### PR DESCRIPTION
uses: actions/setup-go@v5  -> uses: actions/setup-go@v6
https://github.com/actions/setup-go/releases/tag/v6.0.0