### PR TITLE
ci: use actions/checkout@v5 

### DIFF
--- a/.github/copilot-setup-steps.yml
+++ b/.github/copilot-setup-steps.yml
@@ -18,7 +18,7 @@ jobs:
     # If you do not check out your code, Copilot will do this for you.
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
Upgrade to actions/checkout@v5 for improved performance and stability.