### PR TITLE
refactor: preallocate slice capacity in Versions.Sorted()

### DIFF
--- a/multiplexer/abci/versions.go
+++ b/multiplexer/abci/versions.go
@@ -30,7 +30,7 @@ type Versions []Version
 // Sorted returns a sorted slice of Versions, sorted by AppVersion (ascending).
 func (v Versions) Sorted() Versions {
 	// convert map to slice
-	versionList := make([]Version, 0)
+	versionList := make([]Version, 0, len(v))
 	for _, ver := range v {
 		versionList = append(versionList, ver)
 	}


### PR DESCRIPTION
Preallocate slice capacity when we know the final size to avoid unnecessary reallocations during append operations.