### PR TITLE
fix: AddAccount address error message placeholder

### DIFF
--- a/pkg/user/signer.go
+++ b/pkg/user/signer.go
@@ -257,7 +257,7 @@ func (s *Signer) AddAccount(acc *Account) error {
 
 	addr, err := record.GetAddress()
 	if err != nil {
-		return fmt.Errorf("getting address for key %s: %w", acc.pubKey, err)
+		return fmt.Errorf("getting address for account %s: %w", acc.name, err)
 	}
 
 	pk, err := record.GetPubKey()


### PR DESCRIPTION
## Overview

This change corrects the error formatting in AddAccount when retrieving an address from the keyring by replacing the incorrect placeholder and argument; previously the message said “getting address for key %s” and interpolated acc.pubKey, which is misleading and may print an unhelpful value, while the surrounding code and repository convention use the account name to identify failures, now report “getting address for account %s” with acc.name to provide clear, actionable diagnostics consistent with the adjacent public key error message and other address error patterns in the codebase.
