### PR TITLE
fix(test): remove duplicate parameter in require.EqualValues assertion

### DIFF
--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -221,7 +221,7 @@ func TestTallyingLogic(t *testing.T) {
 		Version: 2,
 	})
 	require.NoError(t, err)
-	require.EqualValues(t, 100, res.VotingPower, res.VotingPower)
+	require.EqualValues(t, 100, res.VotingPower)
 	require.EqualValues(t, 100, res.ThresholdPower)
 	require.EqualValues(t, 120, res.TotalVotingPower)
 


### PR DESCRIPTION
Remove redundant third parameter in keeper_test.go that was duplicating the actual value instead of providing an error message. The third parameter in require.EqualValues should be a format string for error messages, not a repetition of the value being tested