### PR TITLE
feat(talis): add experiment conflict check

### DIFF
--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -73,6 +73,7 @@ func upCmd() *cobra.Command {
 					log.Printf("  - %s (Region: %s, IP: %s, Created: %s)", d.Name, d.Region.Slug, publicIP, d.Created)
 				}
 				log.Printf("\nTotal: %d instance(s)\n", len(runningDroplets))
+				return fmt.Errorf("existing talis experiments are running")
 			}
 
 			if err := client.Up(cmd.Context(), workers); err != nil {

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"math/rand"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -421,11 +422,8 @@ func checkForRunningExperiments(ctx context.Context, client *godo.Client) ([]god
 
 	var talisDroplets []godo.Droplet
 	for _, d := range droplets {
-		for _, tag := range d.Tags {
-			if tag == "talis" {
-				talisDroplets = append(talisDroplets, d)
-				break
-			}
+		if slices.Contains(d.Tags, "talis") {
+			talisDroplets = append(talisDroplets, d)
 		}
 	}
 


### PR DESCRIPTION
Prevents experiment conflicts by checking for other running talis instances before `talis up`.

Closes #6045