### PR TITLE
Remove deprecated UpgradeHeightDelay constant

### DIFF
--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -47,8 +47,6 @@ const (
 	// after a MsgTryUpgrade to activate the next version. Assuming a block
 	// interval of 6 seconds, this is 7 days.
 	MainnetUpgradeHeightDelay = int64(100_800)
-	// Deprecated: Use MainnetUpgradeHeightDelay instead.
-	UpgradeHeightDelay = MainnetUpgradeHeightDelay
 	// MempoolSize determines the default max mempool size. This is determined
 	// using a multiple of the max possible bytes in a block.
 	MempoolSize = int64(DefaultUpperBoundMaxBytes) * 3


### PR DESCRIPTION
clean up pkg/appconsts/app_consts.go by removing the dead UpgradeHeightDelay constant

the alias has been deprecated for a while and isn’t referenced anywhere, so carrying it around just invites accidental use
