### PR TITLE
Avoid redundant slice allocation in removeDir

### DIFF
--- a/test/util/testnode/utils.go
+++ b/test/util/testnode/utils.go
@@ -177,7 +177,7 @@ func removeDir(rootDir string) error {
 		return err
 	}
 	for _, d := range dir {
-		path := path.Join([]string{rootDir, d.Name()}...)
+		path := path.Join(rootDir, d.Name())
 		err := os.RemoveAll(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
call `path.Join` with the direct arguments instead of creating an intermediate slice
drop an unnecessary allocation in `removeDir`, keeping the helper’s behavior identical
