### PR TITLE
fix: use shared mebibyte constant in default overrides

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -36,9 +36,7 @@ import (
 	ibctypes "github.com/cosmos/ibc-go/v8/modules/core/types"
 )
 
-const (
-	mebibyte = 1048576
-)
+const mebibyte = appconsts.DefaultUpperBoundMaxBytes / 128
 
 var (
 	_ module.HasGenesisBasics = bankModule{}


### PR DESCRIPTION
Replace the hard-coded `mebibyte` literal in `app/default_overrides.go` with a value derived from `appconsts.DefaultUpperBoundMaxBytes`, keeping configuration limits in sync with global constants.

