### PR TITLE
fix: use proper key-value pair in logger.With for filtered-square-builder

### DIFF
--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	log "cosmossdk.io/log"
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	square "github.com/celestiaorg/go-square/v3"
 	"github.com/celestiaorg/go-square/v3/tx"
@@ -45,7 +46,7 @@ func (fsb *FilteredSquareBuilder) Builder() *square.Builder {
 }
 
 func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte) [][]byte {
-	logger := ctx.Logger().With("app/filtered-square-builder")
+	logger := ctx.Logger().With(log.ModuleKey, "filtered-square-builder")
 
 	// note that there is an additional filter step for tx size of raw txs here
 	normalTxs, blobTxs := separateTxs(fsb.txConfig, txs)


### PR DESCRIPTION
Replace odd-arg With("app/filtered-square-builder") with With(log.ModuleKey, "filtered-square-builder").
Reason: cosmossdk.io/log delegates to zerolog.With().Fields(...), which trims the last element when the keyvals length is odd, so the module field was not being applied. This fix ensures the module field is attached for proper log scoping and filtering.