### PR TITLE
chore: revert enabling the legacy block prop in update config

### DIFF
--- a/cmd/celestia-appd/cmd/update_config.go
+++ b/cmd/celestia-appd/cmd/update_config.go
@@ -211,8 +211,6 @@ func applyV6Config(cmtCfg *config.Config, appCfg *serverconfig.Config) (*config.
 		cmtCfg.P2P.RecvRate = defaultCfg.P2P.RecvRate
 	}
 
-	cmtCfg.Consensus.EnableLegacyBlockProp = true
-
 	defaultAppCfg := app.DefaultAppConfig()
 
 	// only unset the min gas price if it's the legacy default (i.e. untouched)


### PR DESCRIPTION
## Overview

This reverts the change that enabled the legacy block prop in update config. The thinking now is to do it in the binary once we want to release v6 to mainnet. Then disable it in another release.