### PR TITLE
chore: enable the legacy block prop

### DIFF
--- a/cmd/celestia-appd/cmd/override_p2p_config.go
+++ b/cmd/celestia-appd/cmd/override_p2p_config.go
@@ -53,6 +53,9 @@ func overrideP2PConfig(cmd *cobra.Command, logger log.Logger) error {
 	// Override mempool configs
 	overrideMempoolConfig(cfg, defaultCfg, logger)
 
+	// enable the legacy block prop
+	cfg.Consensus.EnableLegacyBlockProp = true
+
 	return nil
 }
 


### PR DESCRIPTION
## Overview

Enables the legacy block prop by default for the mainnet release. We will disable it after the v6 upgrade passes and we want to bump to 32mb/6s