### PR TITLE
chore: bump tastora to v0.8.0

### DIFF
--- a/test/docker-e2e/dockerchain/config.go
+++ b/test/docker-e2e/dockerchain/config.go
@@ -2,12 +2,12 @@ package dockerchain
 
 import (
 	"fmt"
+	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	"os"
 
 	"github.com/celestiaorg/celestia-app/v6/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v6/test/util/genesis"
 	"github.com/celestiaorg/celestia-app/v6/test/util/testnode"
-	"github.com/moby/moby/client"
 )
 
 const (
@@ -22,12 +22,12 @@ type Config struct {
 	*testnode.Config
 	Image           string
 	Tag             string
-	DockerClient    *client.Client
+	DockerClient    tastoratypes.TastoraDockerClient
 	DockerNetworkID string
 }
 
 // DefaultConfig returns a configured instance of Config with a custom genesis and validators.
-func DefaultConfig(client *client.Client, network string) *Config {
+func DefaultConfig(client tastoratypes.TastoraDockerClient, network string) *Config {
 	tnCfg := testnode.DefaultConfig()
 	// default + 2 extra validators.
 	tnCfg.Genesis = tnCfg.Genesis.
@@ -68,7 +68,7 @@ func (c *Config) WithTag(tag string) *Config {
 }
 
 // WithDockerClient sets the docker client and returns the Config.
-func (c *Config) WithDockerClient(client *client.Client) *Config {
+func (c *Config) WithDockerClient(client tastoratypes.TastoraDockerClient) *Config {
 	c.DockerClient = client
 	return c
 }

--- a/test/docker-e2e/e2e_full_stack_pfb_test.go
+++ b/test/docker-e2e/e2e_full_stack_pfb_test.go
@@ -19,7 +19,6 @@ import (
 	da "github.com/celestiaorg/tastora/framework/docker/dataavailability"
 	"github.com/celestiaorg/tastora/framework/testutil/wait"
 	tastoratypes "github.com/celestiaorg/tastora/framework/types"
-	dockerclient "github.com/moby/moby/client"
 )
 
 const (
@@ -92,7 +91,7 @@ func (s *CelestiaTestSuite) TestE2EFullStackPFB() {
 }
 
 // DeployDANetwork deploys a data availability network with bridge, full, and light nodes
-func (s *CelestiaTestSuite) DeployDANetwork(ctx context.Context, celestia *tastoradockertypes.Chain, dockerClient *dockerclient.Client, networkID string) *da.Network {
+func (s *CelestiaTestSuite) DeployDANetwork(ctx context.Context, celestia *tastoradockertypes.Chain, dockerClient tastoratypes.TastoraDockerClient, networkID string) *da.Network {
 	t := s.T()
 
 	// Create node configurations

--- a/test/docker-e2e/e2e_test.go
+++ b/test/docker-e2e/e2e_test.go
@@ -17,7 +17,6 @@ import (
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/docker/docker/api/types/network"
-	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
@@ -39,7 +38,7 @@ func TestCelestiaTestSuite(t *testing.T) {
 type CelestiaTestSuite struct {
 	suite.Suite
 	logger      *zap.Logger
-	client      *client.Client
+	client      tastoratypes.TastoraDockerClient
 	network     string
 	celestiaCfg *dockerchain.Config // Config used to build the celestia chain, needed for upgrades
 }
@@ -47,7 +46,7 @@ type CelestiaTestSuite struct {
 func (s *CelestiaTestSuite) SetupSuite() {
 	s.logger = zaptest.NewLogger(s.T())
 	s.logger.Info("Setting up Celestia test suite: " + s.T().Name())
-	s.client, s.network = tastoradockertypes.DockerSetup(s.T())
+	s.client, s.network = tastoradockertypes.Setup(s.T())
 }
 
 // CreateTxSim deploys and starts a txsim container to simulate transactions against the given celestia chain in the test environment.
@@ -98,7 +97,7 @@ func (s *CelestiaTestSuite) CreateTxSim(ctx context.Context, chain tastoratypes.
 }
 
 // getNetworkNameFromID resolves the network name given its ID.
-func getNetworkNameFromID(ctx context.Context, cli *client.Client, networkID string) (string, error) {
+func getNetworkNameFromID(ctx context.Context, cli tastoratypes.TastoraDockerClient, networkID string) (string, error) {
 	network, err := cli.NetworkInspect(ctx, networkID, network.InspectOptions{})
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect network %s: %w", networkID, err)

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -6,12 +6,11 @@ require (
 	cosmossdk.io/math v1.5.3
 	github.com/celestiaorg/celestia-app/v6 v6.0.0-rc0
 	github.com/celestiaorg/go-square/v3 v3.0.2
-	github.com/celestiaorg/tastora v0.7.5
+	github.com/celestiaorg/tastora v0.8.0
 	github.com/cometbft/cometbft v0.38.17
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/cosmos/ibc-go/v8 v8.7.0
 	github.com/docker/docker v28.5.2+incompatible
-	github.com/moby/moby v28.5.2+incompatible
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.27.0
 	golang.org/x/sync v0.18.0
@@ -194,6 +193,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
+	github.com/moby/moby v28.5.2+incompatible // indirect
 	github.com/moby/sys/sequential v0.6.0 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -794,8 +794,8 @@ github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpch
 github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
 github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
-github.com/celestiaorg/tastora v0.7.5 h1:LT1MPpRB7Jd2LcBBoVwtimBh1NIxueG7c5DQwfTpZ0g=
-github.com/celestiaorg/tastora v0.7.5/go.mod h1:Xw44XeRN2T/kSdopVCJjNhwFwRSO58wTW8GrVP7OWFI=
+github.com/celestiaorg/tastora v0.8.0 h1:+FWAIsP2onwwqPTGzBLIBtx8B1h9sImdx4msv2N4DsI=
+github.com/celestiaorg/tastora v0.8.0/go.mod h1:9b5GsL/+pKEw3HZG/nd3qhnGadUnNNoTBygy9HeGIyw=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -860,8 +860,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/cometbft/cometbft-db v1.0.4 h1:cezb8yx/ZWcF124wqUtAFjAuDksS1y1yXedvtprUFxs=
 github.com/cometbft/cometbft-db v1.0.4/go.mod h1:M+BtHAGU2XLrpUxo3Nn1nOCcnVCiLM9yx5OuT0u5SCA=
-github.com/consensys/gnark-crypto v0.18.0 h1:vIye/FqI50VeAr0B3dx+YjeIvmc3LWz4yEfbWBpTUf0=
-github.com/consensys/gnark-crypto v0.18.0/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
+github.com/consensys/gnark-crypto v0.18.1 h1:RyLV6UhPRoYYzaFnPQA4qK3DyuDgkTgskDdoGqFt3fI=
+github.com/consensys/gnark-crypto v0.18.1/go.mod h1:L3mXGFTe1ZN+RSJ+CLjUt9x7PNdx8ubaYfDROyp2Z8c=
 github.com/containerd/continuity v0.4.2 h1:v3y/4Yz5jwnvqPKJJ+7Wf93fyWoCB3F5EclWG023MDM=
 github.com/containerd/continuity v0.4.2/go.mod h1:F6PTNCKepoxEaXLQp3wDAjygEnImnZ/7o4JzpodfroQ=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/test/docker-e2e/networks/networks.go
+++ b/test/docker-e2e/networks/networks.go
@@ -3,22 +3,22 @@ package networks
 import (
 	"celestiaorg/celestia-app/test/docker-e2e/dockerchain"
 	"fmt"
+	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	"io"
 	"net/http"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v6/app"
 	"github.com/celestiaorg/celestia-app/v6/test/util/testnode"
-	celestiadockertypes "github.com/celestiaorg/tastora/framework/docker/cosmos"
 	tastoracontainertypes "github.com/celestiaorg/tastora/framework/docker/container"
+	celestiadockertypes "github.com/celestiaorg/tastora/framework/docker/cosmos"
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
 	"github.com/cosmos/cosmos-sdk/types/module/testutil"
-	"github.com/moby/moby/client"
 	"github.com/stretchr/testify/require"
 )
 
 // NewConfig returns a configured instance of dockerchain.Config for the specified chain.
-func NewConfig(networkCfg *Config, client *client.Client, network string) (*dockerchain.Config, error) {
+func NewConfig(networkCfg *Config, client tastoratypes.TastoraDockerClient, network string) (*dockerchain.Config, error) {
 	// create minimal config - the genesis will be downloaded by the NewChainBuilder
 	tnCfg := testnode.DefaultConfig()
 	tnCfg.Genesis = tnCfg.Genesis.WithChainID(networkCfg.ChainID)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

[v0.8.0](https://github.com/celestiaorg/tastora/releases/tag/v0.8.0) contains some fixes to ensure resources are cleaned up properly after test runs.

There is dedicated type for the tastora client instead of using the docker client directly. 

There was some flakiness in `TestStateSyncWithAppUpgrade`, it passed locally every time for me and passed after a re-run, not sure if this has been an issue, but I can look into it if it becomes an issue.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
