### PR TITLE
fix: remove double address conversion in BlockedAddresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -648,7 +648,7 @@ func (app *App) ModuleAccountAddrs() map[string]bool {
 func (app *App) BlockedAddresses() map[string]bool {
 	modAccAddrs := make(map[string]bool)
 	for acc := range app.ModuleAccountAddrs() {
-		modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true
+		modAccAddrs[acc] = true
 	}
 
 	// allow the following addresses to receive funds


### PR DESCRIPTION
Replace https://github.com/celestiaorg/celestia-app/pull/5937

Fixed a critical bug in `BlockedAddresses()` function that was blocking wrong addresses due to double address conversion, leaving real module addresses unprotected.

The `BlockedAddresses()` function was converting addresses twice:

1. `ModuleAccountAddrs()` converts module names → addresses (returns `map[string]bool` with address strings as keys)
2. `BlockedAddresses()` was treating those address strings as module names and converting them again

**Before (buggy):**
```go
for acc := range app.ModuleAccountAddrs() {
    modAccAddrs[authtypes.NewModuleAddress(acc).String()] = true  // ❌ acc is already an address string!
}
```

**After (fixed):**
```go
for acc := range app.ModuleAccountAddrs() {
    modAccAddrs[acc] = true  // ✅ Use address directly
}
```

## Example

**Correct gov module address:** `cosmos10d07y265gmmuvt4z0w9aw880jnsr700j6zn9kn`  
**Address that was actually blocked:** `cosmos1zaglhu9dmwzt7xnn3qc8y00lhumezw9dwjhqzk`

These are completely different! Real module addresses were accepting funds when they should have been blocked.
