### PR TITLE
chore!: undeprecate v2 upgrade height

### DIFF
--- a/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
+++ b/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
@@ -12,13 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// v2UpgradeHeight is the block height at which the v2 upgrade occurred.
-// this can be overridden at build time using ldflags:
-// -ldflags="-X 'github.com/celestiaorg/celestia-app/v6/cmd/celestia-appd/cmd.v2UpgradeHeight=1751707'" for arabica
-// -ldflags="-X 'github.com/celestiaorg/celestia-app/v6/cmd/celestia-appd/cmd.v2UpgradeHeight=2585031'" for mocha
-// -ldflags="-X 'github.com/celestiaorg/celestia-app/v6/cmd/celestia-appd/cmd.v2UpgradeHeight=2371495'" for mainnet
-var v2UpgradeHeight = ""
-
 var defaultArgs = []string{
 	"--with-tendermint=false",
 	"--transport=grpc",
@@ -56,17 +49,12 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 		panic(err)
 	}
 
-	v3Args := defaultArgs
-	if v2UpgradeHeight != "" {
-		v3Args = append(v3Args, "--v2-upgrade-height="+v2UpgradeHeight)
-	}
-
 	versions, err := abci.NewVersions(
 		abci.Version{
 			Appd:        appdV3,
 			ABCIVersion: abci.ABCIClientVersion1,
 			AppVersion:  3,
-			StartArgs:   v3Args,
+			StartArgs:   defaultArgs,
 		}, abci.Version{
 			Appd:        appdV4,
 			ABCIVersion: abci.ABCIClientVersion2,

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -144,9 +144,6 @@ func initRootCommand(rootCommand *cobra.Command, capp *app.App) {
 // addStartFlags adds flags to the start command.
 func addStartFlags(startCmd *cobra.Command) {
 	startCmd.Flags().Int64(UpgradeHeightFlag, 0, "Upgrade height to switch from v1 to v2. Must be coordinated amongst all validators")
-	if err := startCmd.Flags().MarkDeprecated(UpgradeHeightFlag, "This flag is deprecated and was only useful prior to v4."); err != nil {
-		panic(err)
-	}
 
 	startCmd.Flags().Duration(TimeoutCommitFlag, 0, "Override the application configured timeout_commit. Note: only for testing purposes.")
 	if err := startCmd.Flags().MarkDeprecated(TimeoutCommitFlag, "Use --delayed-precommit-timeout instead."); err != nil {


### PR DESCRIPTION
While working on https://github.com/celestiaorg/celestia-app/issues/6177 I realized it is cumbersome to set the `--v2-upgrade-height` via ldflags.

This change reverts the deprecation for the `--v2-upgrade-height`. If a user passes the `--v2-upgrade-height` to the multiplexer, it forwards that to the embedded binaries. 

Note for reviewers: we don't strictly need this change. 

## Testing

```
./scripts/single-node-all-upgrades.sh

...
Upgrade to version 6 complete!
```