### PR TITLE
fix: v6 upgrade handler logs

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -133,7 +133,7 @@ func (app App) SetUnbondingTime(ctx context.Context) error {
 		return err
 	}
 
-	sdkCtx.Logger().Info("Setting unbonding time to %v.", appconsts.UnbondingTime)
+	sdkCtx.Logger().Info(fmt.Sprintf("Setting unbonding time to %v.", appconsts.UnbondingTime))
 	params.UnbondingTime = appconsts.UnbondingTime
 
 	err = app.StakingKeeper.SetParams(ctx, params)
@@ -153,10 +153,10 @@ func (app App) SetEvidenceParams(ctx context.Context) error {
 		return err
 	}
 
-	sdkCtx.Logger().Info("Setting evidence MaxAgeDuration to %v.", appconsts.MaxAgeDuration)
+	sdkCtx.Logger().Info(fmt.Sprintf("Setting evidence MaxAgeDuration to %v.", appconsts.MaxAgeDuration))
 	params.Evidence.MaxAgeDuration = appconsts.MaxAgeDuration
 
-	sdkCtx.Logger().Info("Setting evidence MaxAgeNumBlocks to %v.", appconsts.MaxAgeNumBlocks)
+	sdkCtx.Logger().Info(fmt.Sprintf("Setting evidence MaxAgeNumBlocks to %v.", appconsts.MaxAgeNumBlocks))
 	params.Evidence.MaxAgeNumBlocks = appconsts.MaxAgeNumBlocks
 
 	err = app.ConsensusKeeper.ParamsStore.Set(ctx, params)
@@ -195,7 +195,7 @@ func (a App) SetMinCommissionRate(ctx context.Context) error {
 
 	params.MinCommissionRate = appconsts.MinCommissionRate
 
-	sdkCtx.Logger().Info("Setting the staking params min commission rate to %v.\n", appconsts.MinCommissionRate)
+	sdkCtx.Logger().Info(fmt.Sprintf("Setting the staking params min commission rate to %v.\n", appconsts.MinCommissionRate))
 	err = a.StakingKeeper.SetParams(ctx, params)
 	if err != nil {
 		sdkCtx.Logger().Error("failed to set staking params", "error", err)


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/6198

## Testing

```
1:06PM INF applying upgrade "v6" at height: 14 module=x/upgrade
1:06PM INF running upgrade handler module=server start=2025-11-13T13:06:03-05:00 upgrade-name=v6
1:06PM INF Setting unbonding time to 337h0m0s. module=server
1:06PM INF Setting evidence MaxAgeDuration to 337h0m0s. module=server
1:06PM INF Setting evidence MaxAgeNumBlocks to 242640. module=server
1:06PM INF Setting the staking params min commission rate to 0.100000000000000000.
 module=server
1:06PM INF finished to upgrade duration-sec=0.000410333 module=server upgrade-name=v6
```