### PR TITLE
fix(multiplexer): v2 upgrade height

### DIFF
--- a/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
+++ b/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
@@ -57,7 +57,7 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 	}
 
 	v3Args := defaultArgs
-	if v2UpgradeHeight != "" {
+	if v2UpgradeHeight != "" && v2UpgradeHeight != "0" {
 		v3Args = append(v3Args, "--v2-upgrade-height="+v2UpgradeHeight)
 	}
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/6177

The multiplexer was setting the v2 upgrade height to `0`. 

Short term: this PR adds a check to only append the `--v2-upgrade-height` flag if it isn't set to 0.

Long term: remove the ldflags entirely in https://github.com/celestiaorg/celestia-app/pull/6197