### PR TITLE
docs: fix outdated versioned constant references

### DIFF
--- a/app/ante/tx_size_gas.go
+++ b/app/ante/tx_size_gas.go
@@ -46,7 +46,7 @@ func init() {
 // The code was copied from celestia's fork of the cosmos-sdk:
 // https://github.com/celestiaorg/cosmos-sdk/blob/release/v0.46.x-celestia/x/auth/ante/basic.go
 // In app versions v2 and below, the txSizeCostPerByte used for gas cost estimation is taken from the auth module.
-// In app v3 and above, the versioned constant appconsts.TxSizeCostPerByte is used.
+// In app v3 and above, the constant appconsts.TxSizeCostPerByte is used.
 // In app v4 getting the account has been removed, which is in line with the cosmos-sdk v0.50.x.
 type ConsumeTxSizeGasDecorator struct {
 	ak ante.AccountKeeper


### PR DESCRIPTION
Remove incorrect `versioned constant` terminology for TxSizeCostPerByte and GasPerBlobByte. These constants were versioned in v3-v4 but the versioning was removed in v5 (commit 573b4a5).