### PR TITLE
fix(test): mocha statesync flaky nightly test

### DIFF
--- a/test/docker-e2e/e2e_state_sync_test.go
+++ b/test/docker-e2e/e2e_state_sync_test.go
@@ -204,8 +204,11 @@ func (s *CelestiaTestSuite) TestStateSyncMocha() {
 	stateSyncClient, err := fullNode.GetRPCClient()
 	s.Require().NoError(err, "failed to get state sync client")
 
+	// Wait for state sync to complete (node reaches trust height).
+	// After state sync, the node transitions to block sync to catch up to latest height,
+	// but we verify state sync was used via metrics.
 	err = s.WaitForSync(ctx, stateSyncClient, stateSyncTimeout, func(info rpctypes.SyncInfo) bool {
-		return !info.CatchingUp && info.LatestBlockHeight >= trustHeight
+		return info.LatestBlockHeight >= trustHeight
 	})
 
 	s.Require().NoError(err, "failed to wait for state sync to complete")


### PR DESCRIPTION
The test was timing out because it required the node to not be catching up (`!info.CatchingUp`) after state sync completed. However, after state sync finishes, it automatically transitions to block sync to catch up to the latest chain height, and during this block sync phase, `CatchingUp` remains `true` until fully synced.

The fix removes the `!info.CatchingUp` requirement from the sync condition. The test now only verifies that state sync completed by checking the node reached `trustHeight`. We still verify that state sync was actually used (not block sync fallback) via Prometheus metrics at the end, which will fail if state sync failed and block sync was used instead.