### PR TITLE
fix(signal): correct FirstSignalKey value to actually differ from UpgradeKey

### DIFF
--- a/x/signal/types/keys.go
+++ b/x/signal/types/keys.go
@@ -7,6 +7,7 @@ var (
 
 	// FirstSignalKey is used as a divider to separate the UpgradeKey from all
 	// the keys associated with signals from validators. In practice, this key
-	// isn't expected to be set or retrieved.
-	FirstSignalKey = []byte{0x000}
+	// isn't expected to be set or retrieved. It must be lexicographically
+	// greater than UpgradeKey (1 byte) but less than any 20-byte validator address.
+	FirstSignalKey = []byte{0x00, 0x00}
 )


### PR DESCRIPTION
Found that `FirstSignalKey` was set to `[]byte{0x000}` which is identical to `UpgradeKey` (`[]byte{0x00}`) - in Go, `0x000` equals `0x00` equals `0`.

The comment says FirstSignalKey should be a "divider" separating UpgradeKey from validator signal keys, but both had the same value. The code worked only because of an explicit `bytes.Equal` check that skipped UpgradeKey during iteration.

Changed FirstSignalKey to `[]byte{0x00, 0x00}` (2 bytes) which is:
1 lexicographically greater than UpgradeKey (1 byte)
2 lexicographically less than any 20-byte validator address

