### PR TITLE
chore: override the propagation reactors params

### DIFF
--- a/cmd/celestia-appd/cmd/override_p2p_config.go
+++ b/cmd/celestia-appd/cmd/override_p2p_config.go
@@ -50,6 +50,9 @@ func overrideP2PConfig(cmd *cobra.Command, logger log.Logger) error {
 		cfg.P2P.RecvRate = minRecvRate
 	}
 
+	cfg.Consensus.EnableLegacyBlockProp = false
+	cfg.Consensus.DisablePropagationReactor = false
+
 	// Override mempool configs
 	overrideMempoolConfig(cfg, defaultCfg, logger)
 


### PR DESCRIPTION
## Overview

to avoid relying on the configs which might not be up to date