### PR TITLE
chore: set min retain blocks to 3000

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -300,6 +300,8 @@ func DefaultAppConfig() *serverconfig.Config {
 	// snapshots to nodes that state sync
 	cfg.StateSync.SnapshotInterval = 1500
 	cfg.StateSync.SnapshotKeepRecent = 2
+	// Set the MinRetainBlocks to 3000 blocks so that all blocks in the snapshot window are retained.
+	cfg.MinRetainBlocks = 3000
 	// this is set to an empty string. As an empty string, the binary will use
 	// the hardcoded default gas price. To override this, the user must set the
 	// minimum gas prices in the app.toml file.

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -55,6 +55,7 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, "", cfg.MinGasPrices)
 
 	assert.Equal(t, appconsts.DefaultUpperBoundMaxBytes*2, cfg.GRPC.MaxRecvMsgSize)
+	assert.Equal(t, uint64(3000), cfg.MinRetainBlocks)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/6315

## Testing

```
make install
./scripts/single-node.sh
```

Verified the app.toml has:

```
min-retain-blocks = 3000
```