### PR TITLE
fix: protect stopEmbeddedApp with mutex in Stop method

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -552,7 +552,11 @@ func (m *Multiplexer) Stop() error {
 	if err := m.stopNativeApp(); err != nil {
 		fmt.Println(err)
 	}
-	if err := m.stopEmbeddedApp(); err != nil {
+	// Protect stopEmbeddedApp with mutex to prevent race conditions with ABCI methods
+	m.mu.Lock()
+	err := m.stopEmbeddedApp()
+	m.mu.Unlock()
+	if err != nil {
 		fmt.Println(err)
 	}
 	if err := m.stopGRPCConnection(); err != nil {


### PR DESCRIPTION
## Problem

The `Stop()` method accesses `activeVersion` and `started` fields without mutex protection, creating a race condition when called concurrently with ABCI methods. ABCI handlers call `getApp()` which can modify these fields while `Stop()` is reading them, leading to potential data races and undefined behavior.

## Solution

Added mutex protection around the `stopEmbeddedApp()` call in `Stop()` method. This ensures that access to `activeVersion` and `started` fields is synchronized with concurrent ABCI method calls that use the same mutex in `getApp()`.