### PR TITLE
docs: fix dead link

### DIFF
--- a/tools/blocktime/README.md
+++ b/tools/blocktime/README.md
@@ -2,7 +2,7 @@
 
 `blocktime` is a simple tool to analyze block production rates of a chain. It scrapes the latest headers through the RPC endpoint of a provided node and calculates the average, min, max and standard deviation of the intervals between the last `n` blocks (default: 100).
 
-To start a consensus node and expose the RPC endpoint, see the [docs](https://docs.celestia.org/how-to-guides/consensus-node).
+To start a consensus node and expose the RPC endpoint, see the [docs](https://docs.celestia.org/operate/consensus-validators/consensus-node/).
 
 ## Usage
 


### PR DESCRIPTION
`https://docs.celestia.org/how-to-guides/consensus-node` updated to `https://docs.celestia.org/operate/consensus-validators/consensus-node/`
