### PR TITLE
chore: rename test cases for clarity

### DIFF
--- a/app/ante/fee_test.go
+++ b/app/ante/fee_test.go
@@ -120,7 +120,7 @@ func TestValidateTxFee(t *testing.T) {
 			minGasPrice: validatorMinGasPriceCoin,
 		},
 		{
-			name:        "min gas price is empty",
+			name:        "good tx; min gas price is empty",
 			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, feeAmount)),
 			gasLimit:    uint64(float64(feeAmount) / appconsts.DefaultMinGasPrice),
 			isCheckTx:   true,
@@ -128,7 +128,7 @@ func TestValidateTxFee(t *testing.T) {
 			minGasPrice: "", // should use the default min gas price
 		},
 		{
-			name:        "min gas price is empty",
+			name:        "bad tx; min gas price is empty",
 			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, feeAmount-1)),
 			gasLimit:    uint64(float64(feeAmount) / appconsts.DefaultMinGasPrice),
 			isCheckTx:   true,


### PR DESCRIPTION


**Test Case Duplication:**
There are two test cases named exactly **`"min gas price is empty"`**.
**Impact:** If the second one fails, your test output will show two identical names, making it harder to distinguish which logic failed (the "good tx" path or the "bad tx" path).


