### PR TITLE
chore: switch to go latency monitor

### DIFF
--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -757,18 +757,6 @@ func (client *TxClient) ConfirmTx(ctx context.Context, txHash string) (*TxRespon
 	defer pollTicker.Stop()
 	var evictionPollTimeStart *time.Time
 
-	txStatusBatchRequest := &tx.TxStatusBatchRequest{
-		TxIds: []string{txHash, txHash, txHash, txHash},
-	}
-	txStatusBatchResponse, err := txClient.TxStatusBatch(ctx, txStatusBatchRequest)
-	if err != nil {
-		return nil, err
-	}
-	
-	for _, resp := range txStatusBatchResponse.Responses {
-		fmt.Println("resp from batch: ", resp.TxHash, resp.Status.Status)
-	}
-
 	for {
 		span.AddEvent("txclient/ConfirmTx: polling for TxStatus")
 		resp, err := txClient.TxStatus(ctx, &tx.TxStatusRequest{TxId: txHash})


### PR DESCRIPTION
## Overview

After bumping the app version rust latency monitor stopped working presumably because of lumina. Switching it back to go latency monitor for now. It's better this way because we get the flexibility of changing things locally on the fly.
