### PR TITLE
fix: correct base image in multiplexer docker file

### DIFF
--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -86,7 +86,7 @@ RUN tar -cvzf internal/embedding/celestia-app_${TARGETOS}_v5_${TARGETARCH}.tar.g
     && rm /tmp/celestia-appd-v5
 
 # Copy v6 binary from base-v6 and compress it
-COPY --from=base-v5 /bin/celestia-appd /tmp/celestia-appd-v6
+COPY --from=base-v6 /bin/celestia-appd /tmp/celestia-appd-v6
 RUN tar -cvzf internal/embedding/celestia-app_${TARGETOS}_v6_${TARGETARCH}.tar.gz /tmp/celestia-appd-v6 \
     && rm /tmp/celestia-appd-v6
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The multiplexer docker image was using the wrong base image to pull the v6 binary, so the "v6" embedded binary, was actually v5.

should resolve some of #6394

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
