### PR TITLE
chore: address PR review comments from #6441

### DIFF
--- a/app/ante/ante.go
+++ b/app/ante/ante.go
@@ -70,7 +70,7 @@ func NewAnteHandler(
 		// Ensure that the tx does not contain a MsgExec with a nested MsgExec
 		// or MsgPayForBlobs.
 		NewMsgExecDecorator(),
-		// Ensure that only utia can be sent to the fee address.
+		// Ensure that only utia can be sent to the feeaddress module account.
 		NewFeeAddressDecorator(),
 		// Ensure that the tx's gas limit is > the gas consumed based on the blob size(s).
 		// Contract: must be called after all decorators that consume gas.

--- a/app/ante/fee_address.go
+++ b/app/ante/fee_address.go
@@ -11,7 +11,7 @@ import (
 
 var _ sdk.AnteDecorator = FeeAddressDecorator{}
 
-// FeeAddressDecorator rejects transactions that send non-utia tokens to the fee address.
+// FeeAddressDecorator rejects transactions that send non-utia tokens to the fee address module account.
 // This includes messages nested inside authz.MsgExec.
 //
 // Note: ICA host executed messages bypass ante handlers. If ICA sends non-utia to the

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -7,6 +7,7 @@ import (
 
 	"cosmossdk.io/log"
 	"github.com/celestiaorg/celestia-app/v7/app"
+	"github.com/celestiaorg/celestia-app/v7/pkg/feeaddress"
 	"github.com/celestiaorg/celestia-app/v7/test/util"
 	"github.com/celestiaorg/celestia-app/v7/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v7/test/util/testnode"
@@ -133,6 +134,10 @@ func TestBlockedAddresses(t *testing.T) {
 	t.Run("blocked addresses should not contain the gov module address", func(t *testing.T) {
 		govAddress := authtypes.NewModuleAddress(govtypes.ModuleName).String()
 		assert.NotContains(t, got, govAddress)
+	})
+	t.Run("blocked addresses should not contain the feeaddress module account", func(t *testing.T) {
+		feeAddress := authtypes.NewModuleAddress(feeaddress.ModuleName).String()
+		assert.NotContains(t, got, feeAddress)
 	})
 	t.Run("blocked addresses should contain all the other module addresses", func(t *testing.T) {
 		moduleNames := []string{

--- a/pkg/feeaddress/keys_test.go
+++ b/pkg/feeaddress/keys_test.go
@@ -1,0 +1,17 @@
+package feeaddress
+
+import (
+	"testing"
+
+	_ "github.com/celestiaorg/celestia-app/v7/app/params" // import for bech32 prefix init
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFeeAddressMatchesExpected verifies that the module account address
+// derived from ModuleName matches the expected address.
+func TestFeeAddressMatchesExpected(t *testing.T) {
+	expected := "celestia18sjk23yldd9dg7j33sk24elwz2f06zt7ahx39y"
+	got := authtypes.NewModuleAddress(ModuleName).String()
+	assert.Equal(t, expected, got, "fee address module account should match expected address")
+}


### PR DESCRIPTION
## Summary

Follow-up PR to address review comments from #6441 and [CIP-43](https://github.com/celestiaorg/CIPs/pull/381#discussion_r2722630004).

## Changes

- Clarify comments to reference "feeaddress module account" instead of just "fee address"
- Add test verifying feeaddress module account is not in blocked addresses
- Add test verifying module account address matches expected value

## Linked Issues

Addresses review comments:
- https://github.com/celestiaorg/celestia-app/pull/6441#discussion_r2722496477
- https://github.com/celestiaorg/celestia-app/pull/6441#discussion_r2722584357
- https://github.com/celestiaorg/celestia-app/pull/6441#discussion_r2722605949
- https://github.com/celestiaorg/CIPs/pull/381#discussion_r2722630004

## Testing

```bash
go test ./app/... -run TestBlockedAddresses -v
go test ./pkg/feeaddress/... -v
make lint
```

All tests pass.