### PR TITLE
fix(testnode): use SDK genesis provider to handle AppGenesis format

### DIFF
--- a/test/util/testnode/comet_node.go
+++ b/test/util/testnode/comet_node.go
@@ -8,11 +8,13 @@ import (
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/privval"
 	"github.com/cometbft/cometbft/proxy"
+	cmttypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	sdkserver "github.com/cosmos/cosmos-sdk/server"
 	servercmtlog "github.com/cosmos/cosmos-sdk/server/log"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
+	genutiltypes "github.com/cosmos/cosmos-sdk/x/genutil/types"
 )
 
 // NewCometNode creates a ready to use comet node that operates a single
@@ -44,11 +46,24 @@ func NewCometNode(baseDir string, config *UniversalTestingConfig) (*node.Node, s
 		prival,
 		nodeKey,
 		proxy.NewLocalClientCreator(cmtApp),
-		node.DefaultGenesisDocProviderFunc(config.TmConfig),
+		getGenDocProvider(config.TmConfig),
 		tmconfig.DefaultDBProvider,
 		node.DefaultMetricsProvider(config.TmConfig.Instrumentation),
 		servercmtlog.CometLoggerWrapper{Logger: logger},
 	)
 
 	return cometNode, app, err
+}
+
+// getGenDocProvider returns a function that loads the genesis document from file.
+// This uses the SDK's AppGenesis format and converts it to CometBFT's GenesisDoc,
+// which properly handles the type conversion (e.g., InitialHeight as int64 vs string).
+func getGenDocProvider(cfg *tmconfig.Config) func() (*cmttypes.GenesisDoc, error) {
+	return func() (*cmttypes.GenesisDoc, error) {
+		appGenesis, err := genutiltypes.AppGenesisFromFile(cfg.GenesisFile())
+		if err != nil {
+			return nil, err
+		}
+		return appGenesis.ToGenesisDoc()
+	}
 }


### PR DESCRIPTION
## Summary
- Replace `node.DefaultGenesisDocProviderFunc` with a custom `getGenDocProvider` function that properly handles SDK-format genesis files
- Add unit tests to verify the genesis provider works with both SDK and CometBFT genesis formats

## Problem
The `node.DefaultGenesisDocProviderFunc` from CometBFT cannot parse genesis files created by the SDK's init command because:
- SDK's `AppGenesis` serializes `InitialHeight` as a JSON integer (e.g., `"initial_height": 1`)
- CometBFT's `GenesisDoc` expects `InitialHeight` as a JSON string (e.g., `"initial_height": "1"`)

While the current test infrastructure creates genesis files in CometBFT format (using `cmtjson.Marshal`), this change future-proofs the code and provides consistency with the multiplexer implementation.

## Solution
Added a custom `getGenDocProvider` function that:
1. Reads the genesis file using the SDK's `AppGenesisFromFile`
2. Converts it to CometBFT's `GenesisDoc` using `ToGenesisDoc()`

This is the same pattern already used by the multiplexer in `multiplexer/internal/utils.go:GetGenDocProvider`.

## Files Changed
- `test/util/testnode/comet_node.go` - Added `getGenDocProvider` function and replaced `DefaultGenesisDocProviderFunc`
- `test/util/testnode/comet_node_test.go` - Added unit tests for the new function
- `tools/chainbuilder/integration_test.go` - Added `getGenDocProvider` function and replaced `DefaultGenesisDocProviderFunc`

## Test Plan
- [x] `go test ./test/util/testnode/...` passes
- [x] `go test -run TestGetGenDocProvider ./test/util/testnode/...` passes
- [x] `make lint` passes (0 Go issues)
- [x] Builds successfully

## References
- Related issue in celestia-app-fibre: celestiaorg/celestia-app-fibre#164
- Related PR in celestia-app-fibre: celestiaorg/celestia-app-fibre#165

🤖 Generated with [Claude Code](https://claude.com/claude-code)