### PR TITLE
revert: downgrade sdk to v0.51.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -275,7 +275,7 @@ replace (
 	cosmossdk.io/log => github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.23
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.51.9
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.51.8
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/celestiaorg/celestia-core v0.39.23 h1:KplYquU0fT4BAtbMOY4mdvYXVqWvgQO
 github.com/celestiaorg/celestia-core v0.39.23/go.mod h1:MrIC32WAb4CJvfrLbiZV8SfbdGakA/9fVmzZLMusZ2g=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v0.51.9 h1:8d02icIQdjMcNft2avHgt/o8G4s7CA0zxj4FSpfQV6w=
-github.com/celestiaorg/cosmos-sdk v0.51.9/go.mod h1:5CTcSAmHZvRwl9eeHHRYjv0IMauzG5adnHOoO5Cuo3I=
+github.com/celestiaorg/cosmos-sdk v0.51.8 h1:kU86k7Vf/WynGIpoGbPn42X5ww/4A75K4ldKXn4TlJY=
+github.com/celestiaorg/cosmos-sdk v0.51.8/go.mod h1:z5sV0ONMM7Qww3FuLZ2xmqjFblbivkb/jmwQfnHAxrE=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -272,7 +272,7 @@ replace (
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/celestiaorg/celestia-app/v6 => ../..
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.23
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.51.9
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.51.8
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -770,8 +770,8 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.39.23 h1:KplYquU0fT4BAtbMOY4mdvYXVqWvgQOkACaMu8AoXis=
 github.com/celestiaorg/celestia-core v0.39.23/go.mod h1:MrIC32WAb4CJvfrLbiZV8SfbdGakA/9fVmzZLMusZ2g=
-github.com/celestiaorg/cosmos-sdk v0.51.9 h1:8d02icIQdjMcNft2avHgt/o8G4s7CA0zxj4FSpfQV6w=
-github.com/celestiaorg/cosmos-sdk v0.51.9/go.mod h1:5CTcSAmHZvRwl9eeHHRYjv0IMauzG5adnHOoO5Cuo3I=
+github.com/celestiaorg/cosmos-sdk v0.51.8 h1:kU86k7Vf/WynGIpoGbPn42X5ww/4A75K4ldKXn4TlJY=
+github.com/celestiaorg/cosmos-sdk v0.51.8/go.mod h1:z5sV0ONMM7Qww3FuLZ2xmqjFblbivkb/jmwQfnHAxrE=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=


### PR DESCRIPTION
I think the cosmos-sdk bump caused https://github.com/celestiaorg/celestia-app/issues/6476 so reverting 