### PR TITLE
ci: eliminate duplicate workflow runs on merge to main

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -1,11 +1,12 @@
 name: ci-release
 
-# Run this workflow on push events (i.e. PR merge) to main or release branches,
-# push events for new semantic version tags, and all PRs.
+# Run this workflow on push events to release branches, push events for new
+# semantic version tags, and all PRs. The merge_group trigger handles main
+# branch validation via the merge queue, so a separate push trigger for main
+# is not needed and would cause duplicate CI runs.
 on:
   push:
     branches:
-      - main
       - "v*"
     tags:
       - "v*"
@@ -13,6 +14,7 @@ on:
     types: [published]
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 jobs:
   lint:

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,6 +1,10 @@
 name: docker-build-publish
 
-# Trigger on all push events, new semantic version tags, and all PRs
+# Trigger on push events to main/release branches, new semantic version tags,
+# and all PRs. The merge_group trigger is intentionally omitted because the
+# pull_request trigger already validates Dockerfiles build, and the reusable
+# pipeline only publishes images on push to main (not during merge_group where
+# github.ref is gh-readonly-queue/...), making merge_group runs build-only waste.
 on:
   push:
     branches:
@@ -9,7 +13,6 @@ on:
     tags:
       - "v*"
   pull_request:
-  merge_group:
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
Closes #6521

## Description

Both ci-release.yml and docker-build-publish.yml triggered on both `merge_group` and `push` to main. Since main uses a merge queue, every merged PR caused both events to fire on the same commit SHA, resulting in ~99 check runs where ~54 suffice.

ci-release.yml: Remove `main` from push branches. The merge_group trigger already runs the full CI suite (lint, build, test) before the commit lands on main, making the push-triggered re-run redundant. Add workflow_dispatch as a manual fallback. (-33 checks)

docker-build-publish.yml: Remove the merge_group trigger. The pull_request trigger already validates Dockerfiles build on every PR. During merge_group, the reusable pipeline cannot publish to DockerHub anyway (github.ref is gh-readonly-queue/..., not main), so the merge_group run was build-only waste. (-12 checks)

https://claude.ai/code/session_011sZJ7UPMCS275Eefq36DYK