### PR TITLE
ci: skip protobuf checks in merge queue when proto files unchanged

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -11,7 +11,26 @@ permissions:
   contents: read
 
 jobs:
+  # GitHub does not support native path filters on merge_group, so use
+  # dorny/paths-filter to detect proto changes and gate the lint/break-check
+  # jobs. On pull_request the native path filter already handles this, but
+  # the changes job is harmless and keeps the logic consistent.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      proto: ${{ steps.filter.outputs.proto }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 #v3.0.2
+        id: filter
+        with:
+          filters: |
+            proto:
+              - 'proto/**'
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.proto == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -24,6 +43,8 @@ jobs:
           input: "proto"
 
   break-check:
+    needs: changes
+    if: needs.changes.outputs.proto == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The pull_request trigger already has a native `paths: proto/**` filter, but the merge_group trigger does not — GitHub does not support native path filters on merge_group events. This means every merge queue entry ran buf lint and breaking-change checks even when no proto files changed.

Add a dorny/paths-filter preliminary job to detect proto changes and gate the lint and break-check jobs behind it. The changes job is cheap (just a checkout + diff) and skips the heavier buf jobs when unneeded.

https://claude.ai/code/session_011sZJ7UPMCS275Eefq36DYK