### PR TITLE
ci: run rust-lumina-latency-monitor only when its code changes

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -27,9 +27,6 @@ jobs:
   test:
     uses: ./.github/workflows/test.yml
 
-  rust-lumina-latency-monitor:
-    uses: ./.github/workflows/rust-lumina-latency-monitor.yml
-
   goreleaser:
     if: github.event_name == 'release'
     uses: ./.github/workflows/goreleaser.yml

--- a/.github/workflows/rust-lumina-latency-monitor.yml
+++ b/.github/workflows/rust-lumina-latency-monitor.yml
@@ -1,6 +1,14 @@
 name: rust-lumina-latency-monitor
 on:
-  workflow_call:
+  pull_request:
+    paths:
+      - tools/lumina-latency-monitor/**
+  merge_group:
+  push:
+    branches:
+      - "v*"
+    tags:
+      - "v*"
 
 jobs:
   rust-lumina-latency-monitor:


### PR DESCRIPTION
Previously, rust-lumina-latency-monitor was called from ci-release.yml as a reusable workflow, which meant it ran on every PR regardless of what files changed. A Go-only PR would still trigger a full Rust fmt/clippy/test/build cycle for tools/lumina-latency-monitor/.

Convert it from a reusable workflow (workflow_call) to a standalone workflow with a pull_request path filter on tools/lumina-latency-monitor/. It still runs unconditionally on merge_group (GitHub does not support path filters on that trigger) and on version branch/tag pushes.

https://claude.ai/code/session_011sZJ7UPMCS275Eefq36DYK