### PR TITLE
ci: add path filter to github-pages pull_request trigger

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -7,6 +7,8 @@ on:
     paths:
       - specs/**
   pull_request:
+    paths:
+      - specs/**
   merge_group:
     paths:
       - specs/**


### PR DESCRIPTION
The push and merge_group triggers already have `paths: specs/**` but the pull_request trigger was missing it. This caused every PR to build mdBook and run the PR preview action even when no specs files changed.

https://claude.ai/code/session_011sZJ7UPMCS275Eefq36DYK