### PR TITLE
ci: run nightly tests in parallel

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -50,7 +50,6 @@ jobs:
           CELESTIA_TAG: ${{ steps.tag.outputs.value }}
 
   test-all-upgrades:
-    needs: test-state-sync-mocha
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:


### PR DESCRIPTION
test-all-upgrades had `needs: test-state-sync-mocha` which forced it to wait for state sync to finish before starting. These tests are independent — each builds its own Docker image and runs a separate E2E test — so there is no reason to serialize them. The notify-slack job already depends on both and uses `if: always()` to handle failures.

Running them in parallel cuts the nightly suite wall-clock time roughly in half.

https://claude.ai/code/session_011sZJ7UPMCS275Eefq36DYK