### PR TITLE
chore: talis should kill all sessions

### DIFF
--- a/tools/talis/reset.go
+++ b/tools/talis/reset.go
@@ -53,7 +53,9 @@ func resetCmd() *cobra.Command {
 			}
 
 			cleanupScript := `
-				tmux kill-session -t app && tmux kill-session -t txsim && tmux kill-session -t latency-monitor
+				tmux kill-session -t app 2>/dev/null || true
+				tmux kill-session -t txsim 2>/dev/null || true
+				tmux kill-session -t latency-monitor 2>/dev/null || true
 				rm -rf .celestia-app logs payload payload.tar.gz /bin/celestia* /bin/txsim
 			`
 			// Run cleanup on each validator


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

With the `&&` command I experienced the issue where if txsim session didn't exist it would not kill latency-monitor.
