### PR TITLE
docs: add horcrux deprecation notice to v7 release notes

### DIFF
--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -22,6 +22,10 @@ Non-compliant validators will have their rates **automatically adjusted** at the
 
 No manual action is required, but validators should be aware of this change.
 
+#### Horcrux Deprecation
+
+Horcrux is deprecated starting in v7. Future upgrades will require validator keys for fibre, which demands very low signing latency. Horcrux adds signing latency due to threshold signing and network round trips between cosigner nodes, which may be incompatible with upcoming latency requirements. Validators using horcrux should plan to migrate to a local signing setup.
+
 #### Config Changes
 
 No configuration changes are required for v7. Existing v6 configurations remain compatible.


### PR DESCRIPTION
## Summary
- Adds a horcrux deprecation notice to the v7.0.0 release notes under Node Operators
- Explains that future upgrades will require validator keys for fibre with very low signing latency, making horcrux incompatible
- Advises validators to plan migration to a local signing setup

Closes https://github.com/celestiaorg/celestia-app/issues/6485

## Test plan
- [ ] Verify markdown renders correctly in the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)