### PR TITLE
chore: add TestSubmitPayForBlobWithEstimatorService to test-race skip list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ test-race:
 # TODO: Remove the -skip flag once the following tests no longer contain data races.
 # https://github.com/celestiaorg/celestia-app/issues/1369
 	@echo "--> Running tests in race mode"
-	@go test -timeout 15m ./... -v -race -skip "TestPrepareProposalConsistency|TestIntegrationTestSuite|TestSquareSizeIntegrationTest|TestStandardSDKIntegrationTestSuite|TestTxsimCommandFlags|TestTxsimCommandEnvVar|TestPriorityTestSuite|TestTimeInPrepareProposalContext|TestTxClientTestSuite|TestEvictions|TestEstimateGasUsed|TestPrepareProposalCappingNumberOfMessages|TestRejections|TestClaimRewardsAfterFullUndelegation|TestParallelTxSubmission|TestBigBlobSuite|TestTxsimDefaultKeypath|TestGasEstimatorE2E|TestMintIntegrationTestSuite"
+	@go test -timeout 15m ./... -v -race -skip "TestPrepareProposalConsistency|TestIntegrationTestSuite|TestSquareSizeIntegrationTest|TestStandardSDKIntegrationTestSuite|TestTxsimCommandFlags|TestTxsimCommandEnvVar|TestPriorityTestSuite|TestTimeInPrepareProposalContext|TestTxClientTestSuite|TestEvictions|TestEstimateGasUsed|TestPrepareProposalCappingNumberOfMessages|TestRejections|TestClaimRewardsAfterFullUndelegation|TestParallelTxSubmission|TestBigBlobSuite|TestTxsimDefaultKeypath|TestGasEstimatorE2E|TestMintIntegrationTestSuite|TestSubmitPayForBlobWithEstimatorService"
 .PHONY: test-race
 
 ## test-bench: Run benchmark unit tests.


### PR DESCRIPTION
## Summary
- Add `TestSubmitPayForBlobWithEstimatorService` to the test-race skip list in the Makefile.
- This test has the same data race as the other gas estimation tests already in the skip list (`TestEstimateGasPrice`, `TestWithEstimatorService`, `TestGasEstimatorE2E`, etc.) but was missed when those were added.
- The race is between the gas estimation gRPC handler (`simulateFn` / `minGasPriceFn` in `app/grpc/gasestimation/gas_estimator.go`) and the consensus engine's `Commit()` path in the upstream cosmos-sdk/store layer.

## Test plan
- [ ] CI `test-race` job passes without this test causing flaky failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)