### PR TITLE
fix: correct version check in verifyUpdatedConfigs test

### DIFF
--- a/cmd/celestia-appd/cmd/update_config_test.go
+++ b/cmd/celestia-appd/cmd/update_config_test.go
@@ -128,7 +128,7 @@ func verifyUpdatedConfigs(t *testing.T, configDir, version string) {
 	cometConfigPath := filepath.Join(configDir, "config.toml")
 	appConfigPath := filepath.Join(configDir, "app.toml")
 
-	if version == "v6" {
+	if version == "6" {
 		cometConfig, err := loadCometBFTConfig(cometConfigPath, filepath.Dir(configDir))
 		require.NoError(t, err)
 


### PR DESCRIPTION
Fix mismatch between test version (6) and verifyUpdatedConfigs check (v6),
which prevented assertions from running.
