### PR TITLE
chore: rename measure-tip-sync-speed to measure-tip-sync

### DIFF
--- a/tools/measure-tip-sync/README.md
+++ b/tools/measure-tip-sync/README.md
@@ -1,6 +1,6 @@
-# measure-tip-sync-speed
+# measure-tip-sync
 
-Measures Celestia Mocha testnet sync-to-tip speed by spinning up a full node on Digital Ocean.
+Measures Celestia Mocha testnet sync-to-tip time by spinning up a full node on Digital Ocean.
 
 ## Prerequisites
 
@@ -17,20 +17,20 @@ Measures Celestia Mocha testnet sync-to-tip speed by spinning up a full node on 
 3. **Install the tool**
 
    ```bash
-   go install ./tools/measure-tip-sync-speed
+   go install ./tools/measure-tip-sync
    ```
 
 ## Usage
 
 ```bash
 # Required: specify your SSH private key
-go run ./tools/measure-tip-sync-speed -k ~/.ssh/id_ed25519
+go run ./tools/measure-tip-sync -k ~/.ssh/id_ed25519
 
 # Multiple iterations + cooldown
-go run ./tools/measure-tip-sync-speed -k ~/.ssh/id_ed25519 -n 20 -c 30
+go run ./tools/measure-tip-sync -k ~/.ssh/id_ed25519 -n 20 -c 30
 
 # Test specific branch
-go run ./tools/measure-tip-sync-speed -k ~/.ssh/id_ed25519 -b my-branch
+go run ./tools/measure-tip-sync -k ~/.ssh/id_ed25519 -b my-branch
 ```
 
 ## Flags

--- a/tools/measure-tip-sync/main.go
+++ b/tools/measure-tip-sync/main.go
@@ -32,8 +32,8 @@ func main() {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "measure-tip-sync-speed",
-		Short: "Measure Celestia Mocha testnet sync-to-tip speed",
+		Use:   "measure-tip-sync",
+		Short: "Measure Celestia Mocha testnet sync-to-tip time",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return run(cmd.Context(), sshKeyPath, iterations, cooldown, branch, noCleanup, skipBuild)
 		},
@@ -181,7 +181,7 @@ func createDroplet(ctx context.Context, client *godo.Client, name string, sshKey
 		SSHKeys: []godo.DropletCreateSSHKey{
 			{ID: sshKey.ID, Fingerprint: sshKey.Fingerprint},
 		},
-		Tags: []string{"celestia-sync-speed", sshKey.Name},
+		Tags: []string{"celestia-tip-sync", sshKey.Name},
 	}
 
 	droplet, _, err := client.Droplets.Create(ctx, req)


### PR DESCRIPTION
## Summary
- Rename `tools/measure-tip-sync-speed` to `tools/measure-tip-sync` because the tool measures sync duration (time in seconds), not speed
- Update cobra command name, short description, DO droplet tag, and README references

## Test plan
- [x] `go build ./tools/measure-tip-sync/` compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)