### PR TITLE
test: skip TestCLITestSuite in race mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,7 +320,7 @@ test-race:
 # TODO: Remove the -skip flag once the following tests no longer contain data races.
 # https://github.com/celestiaorg/celestia-app/issues/1369
 	@echo "--> Running tests in race mode"
-	@go test -timeout 15m ./... -v -race -skip "TestPrepareProposalConsistency|TestIntegrationTestSuite|TestSquareSizeIntegrationTest|TestStandardSDKIntegrationTestSuite|TestTxsimCommandFlags|TestTxsimCommandEnvVar|TestPriorityTestSuite|TestTimeInPrepareProposalContext|TestTxClientTestSuite|TestEvictions|TestEstimateGasUsed|TestPrepareProposalCappingNumberOfMessages|TestRejections|TestClaimRewardsAfterFullUndelegation|TestParallelTxSubmission|TestBigBlobSuite|TestTxsimDefaultKeypath|TestGasEstimatorE2E|TestMintIntegrationTestSuite|TestSubmitPayForBlobWithEstimatorService|TestSendToSelfWithLargeFee|TestV2SubmitMethods"
+	@go test -timeout 15m ./... -v -race -skip "TestPrepareProposalConsistency|TestIntegrationTestSuite|TestSquareSizeIntegrationTest|TestStandardSDKIntegrationTestSuite|TestTxsimCommandFlags|TestTxsimCommandEnvVar|TestPriorityTestSuite|TestTimeInPrepareProposalContext|TestTxClientTestSuite|TestEvictions|TestEstimateGasUsed|TestPrepareProposalCappingNumberOfMessages|TestRejections|TestClaimRewardsAfterFullUndelegation|TestParallelTxSubmission|TestBigBlobSuite|TestTxsimDefaultKeypath|TestGasEstimatorE2E|TestMintIntegrationTestSuite|TestSubmitPayForBlobWithEstimatorService|TestSendToSelfWithLargeFee|TestV2SubmitMethods|TestCLITestSuite"
 .PHONY: test-race
 
 ## test-bench: Run benchmark unit tests.


### PR DESCRIPTION
TestCLITestSuite fails under `-race` due to a data race in `cosmossdk.io/store/rootmulti` between gRPC query handlers reading `LastCommitID()` and the consensus `Commit()` path writing to it concurrently. This race was supposed to be fixed in cosmos-sdk v0.52.1 but persists under certain timing conditions. Skip the test until the upstream race is fixed in `cosmossdk.io/store`.

## Details

The race occurs when:
1. A gRPC query handler calls `CreateQueryContext()` → `LatestVersion()` → `LastCommitID()`
2. Concurrently, the consensus engine calls `Commit()`, which updates `lastCommitInfo` on the store
3. Both access the unsynchronized `lastCommitInfo` field in `rootmulti.Store`

See upstream fix plan in `.context/upstream-cosmos-sdk-race-fix-plan.md` for details on how to fix this in the Cosmos SDK.

Related: #6614, #2938, #1369

🤖 Generated with Claude Code