### PR TITLE
fix: use correct p2p port for state sync peer

### DIFF
--- a/scripts/single-node-state-sync.sh
+++ b/scripts/single-node-state-sync.sh
@@ -45,7 +45,7 @@ s|^(rpc_servers[[:space:]]+=[[:space:]]+).*$|\1\"$RPC,$RPC\"| ; \
 s|^(trust_height[[:space:]]+=[[:space:]]+).*$|\1$BLOCK_HEIGHT| ; \
 s|^(trust_hash[[:space:]]+=[[:space:]]+).*$|\1\"$TRUST_HASH\"|" $CELESTIA_APP_HOME/config/config.toml
 
-PEER=$(curl -s http://${RPC}/status | jq -r '.result.node_info.id + "@127.0.0.1:26656"')
+PEER=$(curl -s http://${RPC}/status | jq -r '.result.node_info.id + "@127.0.0.1:36656"')
 echo "Setting persistent peer to ${PEER}"
 
 createGenesis() {


### PR DESCRIPTION
Fix incorrect persistent peer port for local state sync node. The state-sync node listens on 36656 but the script was connecting to 127.0.0.1:26656, causing state sync to fail or hang in local setups.