### PR TITLE
chore: ignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ tools/talis/talis
 .gocache
 .cache
 .gomodcache
-# Claude Code local settings
-.claude/*.local.json
+# Claude Code 
+.claude/


### PR DESCRIPTION
My .claude directory contains more than just the local settings now and it seems like none of these should be included in version control. Open to changing the .gitignore if/when we have Claude Code settings we want to share team-wide but currently that isn't the case.

```
$ ls .claude
settings.local.json skills              worktrees
```