### PR TITLE
fix: double MaxAgeNumBlocks for 3s block times

### DIFF
--- a/pkg/appconsts/consensus_consts.go
+++ b/pkg/appconsts/consensus_consts.go
@@ -14,6 +14,6 @@ const (
 	MaxAgeDuration = 337 * time.Hour // (14 days + 1 hour)
 
 	// MaxAgeNumBlocks is the maximum number of blocks for which evidence can be
-	// submitted for slashing. See CIP-037.
-	MaxAgeNumBlocks = 242_640
+	// submitted for slashing. See CIP-048.
+	MaxAgeNumBlocks = 485_280
 )

--- a/test/docker-e2e/e2e_upgrade_test.go
+++ b/test/docker-e2e/e2e_upgrade_test.go
@@ -48,6 +48,7 @@ const (
 
 	EvidenceMaxAgeV5Blocks = 120960
 	EvidenceMaxAgeV6Blocks = 242640
+	EvidenceMaxAgeV8Blocks = 485280
 )
 
 // TestAllUpgrades tests all app version upgrades using the signaling mechanism.
@@ -427,6 +428,11 @@ func (s *CelestiaTestSuite) validateParameters(ctx context.Context, node tastora
 	if appVersion == AppVersionV7 {
 		s.validateMinCommissionRate(ctx, node, MinCommissionRateV7, AppVersionV7)
 		s.validateMaxCommissionRate(ctx, node, MaxCommissionRateV7, AppVersionV7)
+		return
+	}
+
+	if appVersion == AppVersionV8 {
+		s.validateEvidenceParams(ctx, node, EvidenceMaxAgeV6Hours, EvidenceMaxAgeV8Blocks, AppVersionV8)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Doubles `MaxAgeNumBlocks` from 242,640 to 485,280 to maintain the same wall-clock evidence validity window (~16.8 days) after block time is reduced from 6s to 3s per CIP-048.
- `MaxAgeDuration` remains unchanged at 337 hours.
- Adds v8 evidence param validation to the E2E upgrade test.

Closes #6645

## Test plan
- [x] `TestEvidenceParams` passes
- [x] `TestConsensusParamFilter` passes
- [x] `make build-standalone` succeeds
- [x] E2E test package compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)