### PR TITLE
fix: close appDB in chainbuilder TestRun to prevent TempDir cleanup flake

### DIFF
--- a/tools/chainbuilder/integration_test.go
+++ b/tools/chainbuilder/integration_test.go
@@ -59,6 +59,7 @@ func TestRun(t *testing.T) {
 
 	appDB, err := tmdbm.NewDB("application", tmdbm.GoLevelDBBackend, tmCfg.DBDir())
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = appDB.Close() })
 
 	app := app.New(
 		log.NewNopLogger(),


### PR DESCRIPTION
## Summary

- Close the `appDB` (GoLevelDB) in the chainbuilder `TestRun` test to prevent `t.TempDir()` cleanup failures. The database was opened but never closed, keeping lock files open and causing intermittent "TempDir RemoveAll cleanup: directory not empty" test failures.

## Test plan

- [x] Verified fix by running `TestRun` 3 times with `go test -v -run TestRun -count=3 ./tools/chainbuilder/` — all passes with no TempDir cleanup errors.

Closes #5212
Closes #5087
Closes #4679

🤖 Generated with [Claude Code](https://claude.com/claude-code)