### PR TITLE
chore: remove redundant require.Error assertion

### DIFF
--- a/x/zkism/types/genesis_test.go
+++ b/x/zkism/types/genesis_test.go
@@ -144,7 +144,6 @@ func TestGenesisStateValidate(t *testing.T) {
 
 			err := gs.Validate()
 			if tc.expErr != nil {
-				require.Error(t, err)
 				require.ErrorIs(t, err, tc.expErr)
 			} else {
 				require.NoError(t, err)


### PR DESCRIPTION
require.ErrorIs already checks that the error is non-nil, so the additional require.Error assertion is redundant.
