### PR TITLE
chore: tier CI workflows across PR, merge queue, main, and nightly triggers

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -1,10 +1,9 @@
 name: docker-build-publish
 
-# Trigger on push events to main/release branches, new semantic version tags,
-# and all PRs. The merge_group trigger is intentionally omitted because the
-# pull_request trigger already validates Dockerfiles build, and the reusable
-# pipeline only publishes images on push to main (not during merge_group where
-# github.ref is gh-readonly-queue/...), making merge_group runs build-only waste.
+# Trigger on push events to main/release branches and new semantic version
+# tags. PR and merge_group triggers are omitted because the reusable pipeline
+# only publishes images on push to main, making PR/MQ runs build-only waste.
+# Docker build validation is covered by the E2E image build in test.yml.
 on:
   push:
     branches:
@@ -12,7 +11,6 @@ on:
       - "v*"
     tags:
       - "v*"
-  pull_request:
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   markdown-lint:
+    # Run only on PRs. Broken markdown doesn't affect the chain so it doesn't
+    # need to gate the merge queue.
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,6 +27,7 @@ jobs:
         shell: bash
 
   markdown-link-check:
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/test-coverage.yml
+++ b/.github/workflows/test-coverage.yml
@@ -1,0 +1,27 @@
+name: test-coverage
+
+# Run on push to main to track coverage trends after merging. Coverage is not a
+# merge gate so it does not need to run on PRs or in the merge queue.
+on:
+  push:
+    branches:
+      - "main"
+  workflow_dispatch:
+
+jobs:
+  test-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Generate coverage.txt
+        run: make test-coverage
+
+      - name: Upload coverage.txt
+        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
+        with:
+          files: ./coverage.txt

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -97,11 +97,35 @@ jobs:
           CELESTIA_IMAGE: ghcr.io/celestiaorg/celestia-app
           CELESTIA_TAG: ${{ needs.build-e2e-image.outputs.tag }}
 
+  test-race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run tests in race mode
+        run: make test-race
+
+  test-fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Run fuzz tests
+        run: make test-fuzz
+
   notify-slack-on-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
-    needs: [test-nightly]
-    if: ${{ always() && needs.test-nightly.result == 'failure' }}
+    needs: [test-nightly, test-race, test-fuzz]
+    if: ${{ always() && (needs.test-nightly.result == 'failure' || needs.test-race.result == 'failure' || needs.test-fuzz.result == 'failure') }}
     steps:
       - name: Slack Notification
         uses: slackapi/slack-github-action@v2.1.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,9 @@ on:
 
 jobs:
   test-short:
+    # Run only on PRs for fast feedback. The go-test matrix provides full
+    # coverage in the merge queue so test-short is redundant there.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
@@ -66,48 +69,10 @@ jobs:
           fi
           echo "All tests passed"
 
-  test-coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
-
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
-        with:
-          go-version-file: "go.mod"
-
-      - name: Generate coverage.txt
-        run: make test-coverage
-
-      - name: Upload coverage.txt
-        uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7 #v5.5.1
-        with:
-          files: ./coverage.txt
-
-  test-race:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
-
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
-        with:
-          go-version-file: "go.mod"
-
-      - name: Run tests in race mode
-        run: make test-race
-
-  test-fuzz:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
-
-      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
-        with:
-          go-version-file: "go.mod"
-
-      - name: Run fuzz tests
-        run: make test-fuzz
-
   test-multiplexer:
+    # Run only in the merge queue and on release branches. Not needed for PR
+    # feedback since unit tests already validate module correctness.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
@@ -120,6 +85,9 @@ jobs:
         run: make test-multiplexer
 
   build-e2e-image:
+    # Run only in the merge queue and on release branches since E2E tests only
+    # run there.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -147,9 +115,9 @@ jobs:
 
   test-docker-e2e:
     needs: build-e2e-image
+    # Run only in the merge queue and on release branches.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
-    # if one test fails, continue running the rest.
-    continue-on-error: true
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary

Closes #6718

Tiers CI workflows so each trigger runs only the checks appropriate to its purpose, reducing PR feedback time from ~17 min to ~8 min and eliminating redundant test runs.

### Changes by file

**test.yml**
- `test-short`: PR only (fast feedback; redundant with `go-test` in merge queue)
- `go-test` matrix: runs on both PR and merge queue (core correctness gate)
- `test-race`, `test-fuzz`, `test-coverage`: removed (moved to nightly / push-to-main)
- `test-multiplexer`: merge queue only
- `build-e2e-image` + `test-docker-e2e`: merge queue only, now **blocking** (removed `continue-on-error: true`)

**test-nightly.yml**
- Added `test-race` and `test-fuzz` jobs
- Updated Slack failure notification to include race/fuzz failures

**test-coverage.yml** (new)
- Runs on push to main only
- Generates coverage and uploads to Codecov

**markdown-linter.yml**
- Both jobs now PR-only (broken markdown doesn't affect the chain)

**docker-build-publish.yml**
- Removed `pull_request` trigger (PR runs just built and discarded images)

### Trigger matrix

| Job | PR | Merge Queue | Push to Main | Nightly |
|-----|:--:|:-----------:|:------------:|:-------:|
| lint (golangci-lint, hadolint, yamllint) | ✅ | ✅ | | |
| markdown-lint + link-check | ✅ | | | |
| build | ✅ | ✅ | | |
| test-short | ✅ | | | |
| go-test (6 matrix jobs) | ✅ | ✅ | | |
| test-multiplexer | | ✅ | | |
| E2E tests (13 matrix jobs, blocking) | | ✅ | | |
| test-race | | | | ✅ |
| test-fuzz | | | | ✅ |
| test-coverage + Codecov | | | ✅ | |
| docker-build-publish | | | ✅ | |

### Required branch protection changes

The following required status checks must be **removed** from main branch protection because they no longer run on every PR/merge queue event:

- `test / test-race` (moved to nightly)
- `test / test-coverage` (moved to push-to-main)

The following checks remain and will report correctly (skipped jobs pass required checks):

- `test / test` ✅
- `test / test-short` ✅ (skipped in MQ, passes)
- `lint / golangci-lint` ✅
- `lint / yamllint` ✅
- `markdown-linter / markdown-lint` ✅ (skipped in MQ, passes)
- `build / build` ✅

## Test plan

- [ ] Verify CI runs on this PR only include: lint, markdown-lint, build, test-short, go-test (no race/fuzz/coverage/e2e/multiplexer)
- [ ] After merge, verify push-to-main triggers test-coverage workflow
- [ ] Verify nightly workflow includes test-race and test-fuzz
- [ ] Remove `test / test-race` and `test / test-coverage` from required status checks on main branch protection
- [ ] Verify a merge queue run includes E2E tests and multiplexer tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)