### PR TITLE
chore: split slow test packages into separate CI matrix entries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,9 @@ jobs:
             pattern: "TestSquareSize.*|TestPriority.*"
           - package: "github.com/celestiaorg/celestia-app/v8/test/txsim"
           - package: "github.com/celestiaorg/celestia-app/v8/pkg/user"
+          - package: "github.com/celestiaorg/celestia-app/v8/test/ledger"
+          - package: "github.com/celestiaorg/celestia-app/v8/fibre"
+          - package: "github.com/celestiaorg/celestia-app/v8/tools/chainbuilder"
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 #v6.0.0
 
@@ -47,7 +50,7 @@ jobs:
         run: |
           if [ "${{ matrix.package }}" = "unit" ]; then
             # run all packages except the heavy ones
-            make test PACKAGES="$(go list ./... | grep -v 'app/test$' | grep -v 'test/txsim$' | grep -v 'pkg/user$' | tr '\n' ' ')"
+            make test PACKAGES="$(go list ./... | grep -v 'app/test$' | grep -v 'test/txsim$' | grep -v 'pkg/user$' | grep -v 'test/ledger$' | grep -v 'celestia-app/v8/fibre$' | grep -v 'tools/chainbuilder$' | tr '\n' ' ')"
           elif [ -n "${{ matrix.pattern }}" ]; then
             # run specific test patterns
             go test -timeout 30m -run "${{ matrix.pattern }}" ${{ matrix.package }}


### PR DESCRIPTION
## Summary

- Split `test/ledger` (99s), `fibre` (84s), and `tools/chainbuilder` (61s) out of the catch-all `unit` test job into their own parallel CI matrix entries
- Updated the `unit` job's package exclusion filter to skip these three packages

## Results

The `unit` job dropped from **8m45s to 4m2s** (54% faster). The new bottleneck is now `pkg/user` at 5m14s. The three split-out packages run in parallel and finish quickly:

| Job | Before (PR #6724) | After (this PR) |
|-----|-------------------|-----------------|
| **go-test (unit)** | **8m45s** | **4m2s** |
| go-test (test/ledger) | _(included in unit)_ | 1m37s |
| go-test (fibre) | _(included in unit)_ | 27s |
| go-test (tools/chainbuilder) | _(included in unit)_ | 1m18s |
| go-test (pkg/user) | 7m57s | 5m14s |
| go-test (test/txsim) | 6m53s | 3m54s |

Overall CI wall-clock time improved because the bottleneck job is now shorter.

## Context

Analysis of [CI run #22731651014](https://github.com/celestiaorg/celestia-app/actions/runs/22731651014/job/65922008882?pr=6724) showed `test / go-test (unit)` was the slowest job at 8m45s. The top 3 slowest packages inside that job ran sequentially. Splitting them into separate matrix entries lets them run in parallel on their own runners.

## Test plan

- [x] CI passes on this PR
- [x] `unit` job duration reduced from ~8m45s to ~4m02s

🤖 Generated with [Claude Code](https://claude.com/claude-code)