### PR TITLE
fix(fibre): submit FibreTx directly to prevent tx hash mismatch and e2e timeout

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -37,6 +37,21 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 		return app.handleBlobCheckTx(req, btx)
 	}
 
+	// FibreTx wraps a MsgPayForFibre SDK tx with its system blob. Validate the
+	// inner SDK tx bytes so the tx can enter the mempool and be tracked by hash.
+	ftx, isFibre, err := blobtx.UnmarshalFibreTx(tx)
+	if isFibre && err != nil {
+		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
+	}
+	if isFibre {
+		innerReq := &abci.RequestCheckTx{Tx: ftx.Tx, Type: req.GetType()}
+		sdkTx, err := app.encodingConfig.TxConfig.TxDecoder()(ftx.Tx)
+		if err != nil {
+			return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
+		}
+		return app.forwardCheckTx(innerReq, sdkTx)
+	}
+
 	sdkTx, err := app.encodingConfig.TxConfig.TxDecoder()(tx)
 	if err != nil {
 		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -154,33 +154,60 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte) [][]byte {
 	}
 
 	// Process pay-for-fibre transactions: validate, create system blob, wrap as FibreTx.
+	// Entries in payForFibreTxs are either already-wrapped FibreTx bytes (submitted
+	// by the fibre client directly) or plain SDK MsgPayForFibre bytes (submitted by
+	// legacy clients).
 	fibreTxs := make([][]byte, 0, len(payForFibreTxs))
 	for _, rawTx := range payForFibreTxs {
-		sdkTx, err := dec(rawTx)
+		// Check if the entry is already a FibreTx (submitted by the fibre client).
+		existingFibreTx, isAlreadyFibreTx, _ := tx.UnmarshalFibreTx(rawTx)
+
+		var sdkTxBytes []byte
+		var marshaledFibreTx []byte
+		var fibreTxToAppend *tx.FibreTx
+
+		if isAlreadyFibreTx {
+			// Already wrapped: extract inner SDK tx for ante handler validation.
+			sdkTxBytes = existingFibreTx.Tx
+			marshaledFibreTx = rawTx
+			fibreTxToAppend = existingFibreTx
+		} else {
+			// Plain SDK MsgPayForFibre: create the system blob and marshal.
+			sdkTxBytes = rawTx
+
+			sdkTx, err := dec(sdkTxBytes)
+			if err != nil {
+				logger.Error("decoding pay-for-fibre transaction", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
+				continue
+			}
+
+			// separateTxs guarantees rawTx contains MsgPayForFibre, so the bool is safe to ignore.
+			msgPayForFibre, _ := extractMsgPayForFibre(sdkTx)
+			systemBlob, err := createSystemBlobForPayForFibre(msgPayForFibre)
+			if err != nil {
+				logger.Error("creating system blob for pay-for-fibre transaction", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
+				continue
+			}
+
+			// Marshal before appending so that an encoding failure requires no builder revert.
+			marshaledFibreTx, err = tx.MarshalFibreTx(rawTx, systemBlob)
+			if err != nil {
+				logger.Error("marshaling fibre tx", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
+				continue
+			}
+
+			fibreTxToAppend = &tx.FibreTx{Tx: rawTx, SystemBlob: systemBlob}
+		}
+
+		sdkTx, err := dec(sdkTxBytes)
 		if err != nil {
-			logger.Error("decoding pay-for-fibre transaction", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
+			logger.Error("decoding inner SDK tx for pay-for-fibre", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
 			continue
 		}
 
-		// separateTxs guarantees rawTx contains MsgPayForFibre, so the bool is safe to ignore.
-		msgPayForFibre, _ := extractMsgPayForFibre(sdkTx)
-		systemBlob, err := createSystemBlobForPayForFibre(msgPayForFibre)
-		if err != nil {
-			logger.Error("creating system blob for pay-for-fibre transaction", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
-			continue
-		}
+		ctx = ctx.WithTxBytes(sdkTxBytes)
 
-		// Marshal before appending so that an encoding failure requires no builder revert.
-		marshaledFibreTx, err := tx.MarshalFibreTx(rawTx, systemBlob)
-		if err != nil {
-			logger.Error("marshaling fibre tx", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
-			continue
-		}
-
-		ctx = ctx.WithTxBytes(rawTx)
-
-		fibreTx := &tx.FibreTx{Tx: rawTx, SystemBlob: systemBlob}
-		ok, err := fsb.builder.AppendFibreTx(fibreTx)
+		ok, err := fsb.builder.AppendFibreTx(fibreTxToAppend)
 		if err != nil {
 			logger.Error("appending pay-for-fibre transaction to builder", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "error", err)
 			continue
@@ -249,6 +276,18 @@ func separateTxs(txConfig client.TxConfig, rawTxs [][]byte) (normalTxs [][]byte,
 		// in CheckTx. However in tests we're inserting too large of txs
 		// therefore also filter here.
 		if len(rawTx) > appconsts.MaxTxSize {
+			continue
+		}
+
+		// Already-wrapped FibreTx (submitted by the fibre client directly) is
+		// placed in payForFibreTxs. Fill detects the wrapping via UnmarshalFibreTx
+		// and passes it through without re-wrapping.
+		_, isFibre, err := tx.UnmarshalFibreTx(rawTx)
+		if isFibre {
+			if err != nil {
+				panic(err)
+			}
+			payForFibreTxs = append(payForFibreTxs, rawTx)
 			continue
 		}
 

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -29,6 +29,7 @@ func TestSeparateTxs(t *testing.T) {
 	normalTx := newNormalTx(t, txConfig)
 	blobTx := newBlobTx(t)
 	payForFibreTx := newPayForFibreTx(t, txConfig)
+	wrappedFibreTx := newWrappedFibreTx(t, txConfig)
 
 	tests := []struct {
 		name     string
@@ -75,6 +76,20 @@ func TestSeparateTxs(t *testing.T) {
 		{
 			name:     "two pay-for-fibre txs",
 			rawTxs:   [][]byte{payForFibreTx, payForFibreTx},
+			wantNorm: 0,
+			wantBlob: 0,
+			wantPFF:  2,
+		},
+		{
+			name:     "already-wrapped FibreTx goes to payForFibreTxs",
+			rawTxs:   [][]byte{wrappedFibreTx},
+			wantNorm: 0,
+			wantBlob: 0,
+			wantPFF:  1,
+		},
+		{
+			name:     "mix of plain and wrapped FibreTx",
+			rawTxs:   [][]byte{payForFibreTx, wrappedFibreTx},
 			wantNorm: 0,
 			wantBlob: 0,
 			wantPFF:  2,
@@ -228,6 +243,7 @@ func TestFilteredSquareBuilderFillWithPayForFibre(t *testing.T) {
 	normalTx := newNormalTx(t, txConfig)
 	blobTx := newBlobTx(t)
 	payForFibreTx := newPayForFibreTx(t, txConfig)
+	wrappedFibreTx := newWrappedFibreTx(t, txConfig)
 
 	tests := []struct {
 		name              string
@@ -290,6 +306,22 @@ func TestFilteredSquareBuilderFillWithPayForFibre(t *testing.T) {
 			anteHandler: alwaysReject,
 			txs:         [][]byte{normalTx, blobTx, payForFibreTx},
 			// normalTx and blobTx are also rejected because alwaysReject fires for every tx type.
+			wantKeptCount:     0,
+			wantFibreTxCount:  0,
+			wantFibreInSquare: false,
+		},
+		{
+			name:              "already-wrapped FibreTx passes through unchanged",
+			anteHandler:       alwaysPass,
+			txs:               [][]byte{wrappedFibreTx},
+			wantKeptCount:     1,
+			wantFibreTxCount:  1,
+			wantFibreInSquare: true,
+		},
+		{
+			name:              "already-wrapped FibreTx rejected by ante handler is excluded",
+			anteHandler:       alwaysReject,
+			txs:               [][]byte{wrappedFibreTx},
 			wantKeptCount:     0,
 			wantFibreTxCount:  0,
 			wantFibreInSquare: false,
@@ -357,6 +389,23 @@ func newBlobTx(t *testing.T) []byte {
 	blobTxBytes, err := gosquaretx.MarshalBlobTx(nil, blob)
 	require.NoError(t, err)
 	return blobTxBytes
+}
+
+// newWrappedFibreTx creates a FibreTx (already-wrapped MsgPayForFibre) for testing,
+// simulating what the fibre client submits via BroadcastTxWithWrap.
+func newWrappedFibreTx(t *testing.T, txConfig client.TxConfig) []byte {
+	t.Helper()
+	sdkTxBytes := newPayForFibreTx(t, txConfig)
+	// Decode to extract the MsgPayForFibre so we can build a matching system blob.
+	sdkTx, err := txConfig.TxDecoder()(sdkTxBytes)
+	require.NoError(t, err)
+	msg, ok := extractMsgPayForFibre(sdkTx)
+	require.True(t, ok)
+	systemBlob, err := createSystemBlobForPayForFibre(msg)
+	require.NoError(t, err)
+	wrapped, err := gosquaretx.MarshalFibreTx(sdkTxBytes, systemBlob)
+	require.NoError(t, err)
+	return wrapped
 }
 
 // newPayForFibreTx creates an unsigned SDK tx containing MsgPayForFibre for testing.

--- a/fibre/client_put.go
+++ b/fibre/client_put.go
@@ -8,6 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v8/pkg/user"
 	"github.com/celestiaorg/celestia-app/v8/x/fibre/types"
 	"github.com/celestiaorg/go-square/v4/share"
+	gosquaretx "github.com/celestiaorg/go-square/v4/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -70,13 +71,27 @@ func Put(ctx context.Context, c *Client, txClient *user.TxClient, ns share.Names
 
 	// broadcast PayForFibre transaction
 	signerAddr := txClient.DefaultAddress()
+	proto := signedPromise.ToProto()
 	msg := &types.MsgPayForFibre{
 		Signer:              signerAddr.String(),
-		PaymentPromise:      *signedPromise.ToProto(),
+		PaymentPromise:      *proto,
 		ValidatorSignatures: signedPromise.ValidatorSignatures,
 	}
 
-	broadcastResp, err := txClient.BroadcastTx(ctx, []sdk.Msg{msg})
+	// Pre-build the system blob so we can wrap the SDK tx as a FibreTx before
+	// broadcast. Submitting a FibreTx ensures the tx hash is stable: PrepareProposal
+	// detects the wrapping and passes it through unchanged, so the committed hash
+	// matches what ConfirmTx polls for (instead of creating a new hash H').
+	systemBlob, err := share.NewV2Blob(ns, proto.BlobVersion, proto.Commitment, signerAddr.Bytes())
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to create system blob for PayForFibre")
+		return result, fmt.Errorf("creating system blob for PayForFibre: %w", err)
+	}
+
+	broadcastResp, err := txClient.BroadcastTxWithWrap(ctx, []sdk.Msg{msg}, func(sdkTxBytes []byte) ([]byte, error) {
+		return gosquaretx.MarshalFibreTx(sdkTxBytes, systemBlob)
+	})
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to broadcast PayForFibre transaction")

--- a/pkg/user/tx_client.go
+++ b/pkg/user/tx_client.go
@@ -459,6 +459,15 @@ func (client *TxClient) SubmitTx(ctx context.Context, msgs []sdktypes.Msg, opts 
 }
 
 func (client *TxClient) BroadcastTx(ctx context.Context, msgs []sdktypes.Msg, opts ...TxOption) (*sdktypes.TxResponse, error) {
+	return client.BroadcastTxWithWrap(ctx, msgs, nil, opts...)
+}
+
+// BroadcastTxWithWrap signs and broadcasts a transaction, optionally applying wrap
+// to the encoded SDK tx bytes before submission. wrap may be nil.
+// This is useful for submitting FibreTx: pass a wrap function that calls
+// blobtx.MarshalFibreTx so the outer FibreTx bytes are broadcast (and thus
+// tracked by hash) instead of the plain SDK tx bytes.
+func (client *TxClient) BroadcastTxWithWrap(ctx context.Context, msgs []sdktypes.Msg, wrap func([]byte) ([]byte, error), opts ...TxOption) (*sdktypes.TxResponse, error) {
 	client.mtx.Lock()
 	defer client.mtx.Unlock()
 
@@ -524,6 +533,13 @@ func (client *TxClient) BroadcastTx(ctx context.Context, msgs []sdktypes.Msg, op
 	txBytes, err := client.signer.EncodeTx(txBuilder.GetTx())
 	if err != nil {
 		return nil, err
+	}
+
+	if wrap != nil {
+		txBytes, err = wrap(txBytes)
+		if err != nil {
+			return nil, fmt.Errorf("wrapping tx: %w", err)
+		}
 	}
 
 	return client.routeTx(ctx, txBytes, account)
@@ -635,6 +651,15 @@ func (client *TxClient) sendTxToConnection(ctx context.Context, conn *grpc.Clien
 
 // resignTransactionWithNewSequence creates a new transaction with updated sequence from existing tx bytes
 func (client *TxClient) resignTransactionWithNewSequence(txBytes []byte) ([]byte, error) {
+	// Unwrap FibreTx before resigning (checked before BlobTx since FibreTx is a distinct type).
+	fibreTx, isFibreTx, err := blobtx.UnmarshalFibreTx(txBytes)
+	if isFibreTx && err != nil {
+		return nil, err
+	}
+	if isFibreTx {
+		txBytes = fibreTx.Tx
+	}
+
 	blobTx, isBlobTx, err := blobtx.UnmarshalBlobTx(txBytes)
 	if isBlobTx && err != nil {
 		return nil, err
@@ -682,6 +707,14 @@ func (client *TxClient) resignTransactionWithNewSequence(txBytes []byte) ([]byte
 	// Rewrap the blob tx if it was originally a blob tx
 	if isBlobTx {
 		newTxBytes, err = blobtx.MarshalBlobTx(newTxBytes, blobTx.Blobs...)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Rewrap as FibreTx if it was originally a FibreTx (preserving the system blob).
+	if isFibreTx {
+		newTxBytes, err = blobtx.MarshalFibreTx(newTxBytes, fibreTx.SystemBlob)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Problem

`TestFibreE2ETestSuite/Test03Put` was timing out after 30 minutes.

**Root cause**: `fibre.Put` broadcast a plain SDK `MsgPayForFibre` tx with hash H. `PrepareProposal` then wrapped it into a `FibreTx` — a new protobuf envelope containing both the SDK tx bytes and the system blob — producing a different hash H'. Since H was never committed on-chain (the block contains H', not H), `ConfirmTx(H)` polled indefinitely.

## Fix

Have the fibre client submit an already-wrapped `FibreTx` directly. `PrepareProposal` detects the wrapping via `UnmarshalFibreTx` and passes it through unchanged. The committed tx hash is now H' (the FibreTx hash), which is the same hash returned by `BroadcastTxWithWrap`, so `ConfirmTx` finds it.

## Changes

- **`pkg/user/tx_client.go`**: Add `BroadcastTxWithWrap(ctx, msgs, wrap, opts)` — signs and broadcasts a transaction, applying an optional `wrap func([]byte) ([]byte, error)` to the encoded SDK tx bytes before submission. `BroadcastTx` now delegates to this with `nil` wrap. Also extend `resignTransactionWithNewSequence` to unwrap/rewrap `FibreTx` on sequence mismatch (same pattern as the existing `BlobTx` handling).
- **`app/check_tx.go`**: Handle `FibreTx` in `CheckTx` by validating the inner SDK tx bytes so a `FibreTx` can enter the mempool and be tracked by its inner hash.
- **`app/filtered_square_builder.go`**: `separateTxs` now detects already-wrapped `FibreTx` before the `BlobTx` check and routes them to `payForFibreTxs`. `Fill` detects already-wrapped `FibreTx` and passes them through without re-wrapping.
- **`fibre/client_put.go`**: Use `BroadcastTxWithWrap` with a closure that wraps the signed SDK tx bytes as a `FibreTx`.

## Test plan

- [ ] `go test -run TestSeparateTxs ./app/` — new cases for already-wrapped FibreTx
- [ ] `go test -run TestFilteredSquareBuilderFillWithPayForFibre ./app/` — new cases for already-wrapped FibreTx pass-through and ante rejection
- [ ] `TestFibreE2ETestSuite/Test03Put` should no longer time out

🤖 Generated with [Claude Code](https://claude.com/claude-code)