### PR TITLE
fix: remove stale rsema1d dependency from test/docker-e2e

### DIFF
--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -87,7 +87,6 @@ require (
 	github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 // indirect
 	github.com/celestiaorg/nmt v0.24.2 // indirect
 	github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 // indirect
-	github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0 // indirect
 	github.com/celestiaorg/rsmt2d v0.15.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -804,8 +804,6 @@ github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpch
 github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0 h1:nM6tHBLW1Uej4VKe6Zm3+kYnOrvcQ1Q4I1qFBIbC+EU=
 github.com/celestiaorg/reedsolomon v1.12.6-0.20250824224240-8b66bda83fd0/go.mod h1:39naxIQYdj/oxjNZVvWvhRreh3uguAq4v6Ke7mI9cDI=
-github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0 h1:G7ctPrCA0y6zIN2CtWNz8Z37c1fwqDRj8GvX+5/PyFw=
-github.com/celestiaorg/rsema1d v0.0.0-20260113121834-51e6165619b0/go.mod h1:WtDhTrN17IA6ZBLEIZsXv+IAQJD4grchKeodmLbjt+g=
 github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
 github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
 github.com/celestiaorg/tastora v0.15.0 h1:rpXX/y19BzZ6Qf3pCc2YxJid2uwIJbTFf+BgBruOD34=


### PR DESCRIPTION
## Summary

- Removes stale `github.com/celestiaorg/rsema1d` indirect dependency from `test/docker-e2e/go.mod` and `go.sum`. This package lives in-repo at `pkg/rsema1d/` and is resolved via the `replace` directive, so the external module reference is unnecessary.
- Fixes the `lint / go-mod-tidy-check` CI failure on main: https://github.com/celestiaorg/celestia-app/actions/runs/22756658926/job/66002821423
- `lint / go-mod-tidy-check` is now a required status check (added by @rootulp) so this class of issue will block PRs going forward.

## Test plan

- [x] `go mod tidy -diff` produces no changes in `test/docker-e2e`
- [ ] CI `lint / go-mod-tidy-check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
