### PR TITLE
fix: resolve TOCTOU port race in TestSubmitPayForBlobWithEstimatorService

### DIFF
--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -3,7 +3,6 @@ package user_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math"
 	"net"
 	"strings"
@@ -643,18 +642,16 @@ func (m *mockEstimatorServer) stop() {
 func setupEstimatorService(t *testing.T) *mockEstimatorServer {
 	t.Helper()
 
-	freePort, err := testnode.GetFreePort()
+	lis, err := net.Listen("tcp", ":0")
 	require.NoError(t, err)
-	addr := fmt.Sprintf(":%d", freePort)
-	net, err := net.Listen("tcp", addr)
-	require.NoError(t, err)
+	addr := lis.Addr().String()
 
 	grpcServer := grpc.NewServer()
 	mes := &mockEstimatorServer{srv: grpcServer, addr: addr}
 	gasestimation.RegisterGasEstimatorServer(grpcServer, mes)
 
 	go func() {
-		err := grpcServer.Serve(net)
+		err := grpcServer.Serve(lis)
 		if err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			panic(err)
 		}


### PR DESCRIPTION
## Summary

- Fixes flaky `TestSubmitPayForBlobWithEstimatorService` failure in CI (`listen tcp :35090: bind: address already in use`)
- The test used `GetFreePort()` (UDP) then tried to bind the returned port with TCP, creating a TOCTOU race where another process could grab the port in between
- Changed to listen on `:0` directly so the OS atomically assigns a free TCP port

## Test plan

- [x] `go vet ./pkg/user/...` passes
- [ ] CI `test-short` job passes without the flaky port binding error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6749" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
