### PR TITLE
fix: allow equal gas prices in TestPriorityByGasPrice

### DIFF
--- a/app/test/priority_test.go
+++ b/app/test/priority_test.go
@@ -135,7 +135,7 @@ func sortByIndex(txs []*rpctypes.ResultTx) []*rpctypes.ResultTx {
 
 func isSortedByFee(t *testing.T, ecfg encoding.Config, responses []*rpctypes.ResultTx) bool {
 	for i := 0; i < len(responses)-1; i++ {
-		if getGasPrice(t, ecfg, responses[i]) <= getGasPrice(t, ecfg, responses[i+1]) {
+		if getGasPrice(t, ecfg, responses[i]) < getGasPrice(t, ecfg, responses[i+1]) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary

- Fixes flaky `TestPriorityByGasPrice` failure in CI
- The `isSortedByFee` helper used strict descending comparison (`<=`) which fails when two transactions have the same random gas price
- With `rand.Intn(1000)+1` and 10 accounts, the birthday problem gives a ~4.5% chance of a gas price collision per run
- Transactions with equal gas prices can be ordered arbitrarily by the mempool, so changed to non-strict comparison (`<`) to tolerate ties

## Test plan

- [x] `go vet ./app/test/...` passes
- [ ] CI `go-test` job for `TestPriority.*` passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6750" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
