### PR TITLE
chore: bump celestiaorg/cosmos-sdk to v0.52.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -457,7 +457,7 @@ replace (
 	cosmossdk.io/log => github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.25
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.2
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.3-0.20260310003748-7e4bb576f17d
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/go.sum
+++ b/go.sum
@@ -870,8 +870,8 @@ github.com/celestiaorg/celestia-core v0.39.25 h1:aA8rx5LoTrQd85GVw77tfOSo0rmRY3L
 github.com/celestiaorg/celestia-core v0.39.25/go.mod h1:Lx/ykikvZF3ZMHUDEPtAXYP/6a6y8n9Eh0YIVpO0RyQ=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v0.52.2 h1:v6oZDt3GVV46C0MdNC7Q3ke6yv1R7SUP9KHq4V3cdpE=
-github.com/celestiaorg/cosmos-sdk v0.52.2/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
+github.com/celestiaorg/cosmos-sdk v0.52.3-0.20260310003748-7e4bb576f17d h1:60ogaxAAcT6fJO8ecQF3cMdaHZCJh8rdV929Bo/0QVA=
+github.com/celestiaorg/cosmos-sdk v0.52.3-0.20260310003748-7e4bb576f17d/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -301,7 +301,7 @@ replace (
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/celestiaorg/celestia-app/v8 => ../..
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.25
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.2
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.3-0.20260310003748-7e4bb576f17d
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -782,8 +782,8 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.39.25 h1:aA8rx5LoTrQd85GVw77tfOSo0rmRY3LAioXu8sVYhK4=
 github.com/celestiaorg/celestia-core v0.39.25/go.mod h1:Lx/ykikvZF3ZMHUDEPtAXYP/6a6y8n9Eh0YIVpO0RyQ=
-github.com/celestiaorg/cosmos-sdk v0.52.2 h1:v6oZDt3GVV46C0MdNC7Q3ke6yv1R7SUP9KHq4V3cdpE=
-github.com/celestiaorg/cosmos-sdk v0.52.2/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
+github.com/celestiaorg/cosmos-sdk v0.52.3-0.20260310003748-7e4bb576f17d h1:60ogaxAAcT6fJO8ecQF3cMdaHZCJh8rdV929Bo/0QVA=
+github.com/celestiaorg/cosmos-sdk v0.52.3-0.20260310003748-7e4bb576f17d/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=


### PR DESCRIPTION
## Summary

- Bumps `celestiaorg/cosmos-sdk` to commit `7e4bb576f17d` (on top of `v0.52.2`) which includes a fix for the `Simulate`/`Commit` IAVL data race ([celestiaorg/cosmos-sdk#726](https://github.com/celestiaorg/cosmos-sdk/pull/726))
- Also includes all changes from [v0.52.2](https://github.com/celestiaorg/cosmos-sdk/releases/tag/v0.52.2):
  - fix: protect lastCommitInfo race at baseapp level ([#715](https://github.com/celestiaorg/cosmos-sdk/pull/715))
  - fix: data race in x/tx signing Context.GetSigners ([#719](https://github.com/celestiaorg/cosmos-sdk/pull/719))
  - fix: increase LatestHeight timeout from 5s to 30s ([#722](https://github.com/celestiaorg/cosmos-sdk/pull/722))
  - chore: switch to CAT mempool in server and bump core to v0.39.25 ([#718](https://github.com/celestiaorg/cosmos-sdk/pull/718))

## Verification

Ran `go test -v -race -run TestV2SubmitMethods -count=3` — all 3 runs pass with **zero data races**:

```
--- PASS: TestV2SubmitMethods (7.77s)
--- PASS: TestV2SubmitMethods (7.67s)
--- PASS: TestV2SubmitMethods (7.64s)
PASS
```

For comparison, v0.52.2 (without [#726](https://github.com/celestiaorg/cosmos-sdk/pull/726)) still reproduced the race on the first run.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -v -race -run TestV2SubmitMethods -count=3` passes with zero data races
- [ ] CI

Closes #6776

🤖 Generated with [Claude Code](https://claude.com/claude-code)