### PR TITLE
fix: prevent uint32 overflow in blobSize * GasPerBlobByte calculation

### DIFF
--- a/x/fibre/keeper/calculate_payment_test.go
+++ b/x/fibre/keeper/calculate_payment_test.go
@@ -1,4 +1,4 @@
-package keeper_test
+package keeper
 
 import (
 	"math"
@@ -6,18 +6,29 @@ import (
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v8/pkg/appconsts"
-	"github.com/celestiaorg/celestia-app/v8/x/fibre/keeper"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCalculatePaymentAmount(t *testing.T) {
+func TestCalculatePaymentCoin(t *testing.T) {
 	tests := []struct {
 		name           string
 		blobSize       uint32
 		gasPerBlobByte uint32
 		want           sdk.Coin
 	}{
+		{
+			name:           "zero blob size",
+			blobSize:       0,
+			gasPerBlobByte: 8,
+			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(0)),
+		},
+		{
+			name:           "zero gas per blob byte",
+			blobSize:       1000,
+			gasPerBlobByte: 0,
+			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(0)),
+		},
 		{
 			name:           "normal case",
 			blobSize:       1000,
@@ -46,7 +57,7 @@ func TestCalculatePaymentAmount(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := keeper.CalculatePaymentAmount(tt.blobSize, tt.gasPerBlobByte)
+			got := calculatePaymentCoin(tt.blobSize, tt.gasPerBlobByte)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -360,7 +360,7 @@ func (k Keeper) validatePaymentPromiseStatefulInternal(ctx sdk.Context, promise 
 	// Check sufficient available balance
 	// TODO: This assumes 1 gas = 1 utia but the minimum gas price could be
 	// different.
-	requiredAmount := CalculatePaymentAmount(promise.BlobSize, params.GasPerBlobByte)
+	requiredAmount := calculatePaymentCoin(promise.BlobSize, params.GasPerBlobByte)
 
 	hasSufficientBalance := escrowAccount.AvailableBalance.IsGTE(requiredAmount)
 	if !hasSufficientBalance {

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -298,12 +298,12 @@ func (ms msgServer) UpdateFibreParams(goCtx context.Context, msg *types.MsgUpdat
 func (ms msgServer) calculatePaymentAmount(ctx sdk.Context, blobSize uint32) sdk.Coin {
 	params := ms.GetParams(ctx)
 	// TODO: this assumes 1 utia per gas which may not be correct.
-	return CalculatePaymentAmount(blobSize, params.GasPerBlobByte)
+	return calculatePaymentCoin(blobSize, params.GasPerBlobByte)
 }
 
-// CalculatePaymentAmount computes the payment coin from blobSize and gasPerBlobByte.
+// calculatePaymentCoin computes the payment coin from blobSize and gasPerBlobByte.
 // Both operands are widened to uint64 before multiplication to prevent uint32 overflow.
-func CalculatePaymentAmount(blobSize, gasPerBlobByte uint32) sdk.Coin {
+func calculatePaymentCoin(blobSize, gasPerBlobByte uint32) sdk.Coin {
 	result := uint64(blobSize) * uint64(gasPerBlobByte)
 	return sdk.NewCoin(appconsts.BondDenom, math.NewIntFromUint64(result))
 }


### PR DESCRIPTION
## Summary
- Widen both `uint32` operands to `uint64` before multiplying in `calculatePaymentAmount` to prevent silent overflow when the product exceeds `math.MaxUint32` (~4.2B).
- Use `math.NewIntFromUint64` instead of an `int64` cast to avoid a secondary overflow when the product exceeds `math.MaxInt64`.
- Extract a `calculatePaymentCoin` helper and reuse it in `validatePaymentPromiseStatefulInternal` to deduplicate the payment calculation and replace a hardcoded `"utia"` with `appconsts.BondDenom`.
- Add tests covering zero, normal, overflow, and large-value cases.

Closes #6715

## Test plan
- [x] `TestCalculatePaymentCoin/zero_blob_size` — verifies zero input produces a zero coin
- [x] `TestCalculatePaymentCoin/zero_gas_per_blob_byte` — verifies zero input produces a zero coin
- [x] `TestCalculatePaymentCoin/normal_case` — verifies correct result for small values
- [x] `TestCalculatePaymentCoin/overflow_case` — verifies `8_388_608 * 1000 = 8_388_608_000` (would overflow uint32)
- [x] `TestCalculatePaymentCoin/large_values_near_uint32_max` — verifies `MaxUint32 * 2`
- [x] `TestCalculatePaymentCoin/max_uint32_*_max_uint32_does_not_overflow` — verifies `MaxUint32 * MaxUint32` (would overflow int64)
- [x] All existing `x/fibre/keeper` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)