### PR TITLE
fix: validate fibre params before updating them

### DIFF
--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -282,6 +282,11 @@ func (ms msgServer) UpdateFibreParams(goCtx context.Context, msg *types.MsgUpdat
 		return nil, errorsmod.Wrapf(sdkerrors.ErrUnauthorized, "invalid authority; expected %s, got %s", ms.GetAuthority(), msg.Authority)
 	}
 
+	// Validate parameters before setting them
+	if err := msg.Params.Validate(); err != nil {
+		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "invalid parameters: %s", err)
+	}
+
 	// Set the new parameters
 	ms.SetParams(ctx, msg.Params)
 

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -596,6 +596,61 @@ func (suite *MsgServerTestSuite) TestUpdateFibreParams() {
 		suite.Nil(resp)
 		suite.Contains(err.Error(), "invalid authority")
 	})
+
+	suite.T().Run("invalid params zero GasPerBlobByte", func(t *testing.T) {
+		msg := &types.MsgUpdateFibreParams{
+			Authority: suite.authority,
+			Params:    types.NewParams(0, 24*time.Hour, time.Hour, 24*time.Hour, 1000),
+		}
+		resp, err := suite.msgServer.UpdateFibreParams(suite.ctx, msg)
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "invalid parameters")
+	})
+
+	suite.T().Run("invalid params zero WithdrawalDelay", func(t *testing.T) {
+		msg := &types.MsgUpdateFibreParams{
+			Authority: suite.authority,
+			Params:    types.NewParams(1, 0, time.Hour, 24*time.Hour, 1000),
+		}
+		resp, err := suite.msgServer.UpdateFibreParams(suite.ctx, msg)
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "invalid parameters")
+	})
+
+	suite.T().Run("invalid params zero PaymentPromiseTimeout", func(t *testing.T) {
+		msg := &types.MsgUpdateFibreParams{
+			Authority: suite.authority,
+			Params:    types.NewParams(1, 24*time.Hour, 0, 24*time.Hour, 1000),
+		}
+		resp, err := suite.msgServer.UpdateFibreParams(suite.ctx, msg)
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "invalid parameters")
+	})
+
+	suite.T().Run("invalid params zero PaymentPromiseRetentionWindow", func(t *testing.T) {
+		msg := &types.MsgUpdateFibreParams{
+			Authority: suite.authority,
+			Params:    types.NewParams(1, 24*time.Hour, time.Hour, 0, 1000),
+		}
+		resp, err := suite.msgServer.UpdateFibreParams(suite.ctx, msg)
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "invalid parameters")
+	})
+
+	suite.T().Run("invalid params zero PaymentPromiseHeightWindow", func(t *testing.T) {
+		msg := &types.MsgUpdateFibreParams{
+			Authority: suite.authority,
+			Params:    types.NewParams(1, 24*time.Hour, time.Hour, 24*time.Hour, 0),
+		}
+		resp, err := suite.msgServer.UpdateFibreParams(suite.ctx, msg)
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "invalid parameters")
+	})
 }
 
 // Helper functions


### PR DESCRIPTION
## Summary
- Validate fibre module params before setting them in `UpdateFibreParams` msg server handler
- Add test cases for each invalid param (zero `GasPerBlobByte`, zero `WithdrawalDelay`, zero `PaymentPromiseTimeout`, zero `PaymentPromiseRetentionWindow`, zero `PaymentPromiseHeightWindow`)

Closes https://github.com/celestiaorg/celestia-app/issues/6716

## Test plan
- [x] Added test cases that submit invalid params and assert they are rejected with `invalid parameters` error
- [x] Verified existing tests still pass
- [x] `make build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6780" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
