### PR TITLE
fix: use hardcoded Viper env prefix for telemetry disable env var

### DIFF
--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -10,9 +10,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -59,12 +57,11 @@ func New(version string, compressedBinary []byte) (*Appd, error) {
 // telemetryDisableEnv returns environment variables that disable the
 // Prometheus telemetry sink in the child process. This prevents
 // "duplicate metrics collector registration attempted" errors.
+// The env var prefix must match the Viper env prefix used by the child
+// process (envPrefix = "CELESTIA_APP"), not the binary filename.
 func (a *Appd) telemetryDisableEnv() []string {
-	basename := path.Base(a.path)
-	replacer := strings.NewReplacer(".", "_", "-", "_")
-	prefix := strings.ToUpper(replacer.Replace(basename))
 	return []string{
-		prefix + "_TELEMETRY_PROMETHEUS_RETENTION_TIME=0",
+		envPrefix + "_TELEMETRY_PROMETHEUS_RETENTION_TIME=0",
 	}
 }
 

--- a/multiplexer/appd/telemetry_test.go
+++ b/multiplexer/appd/telemetry_test.go
@@ -18,17 +18,17 @@ func TestTelemetryDisableEnv(t *testing.T) {
 		{
 			name: "v3 binary",
 			path: "/tmp/bin/celestia-appd-v3",
-			want: []string{"CELESTIA_APPD_V3_TELEMETRY_PROMETHEUS_RETENTION_TIME=0"},
+			want: []string{"CELESTIA_APP_TELEMETRY_PROMETHEUS_RETENTION_TIME=0"},
 		},
 		{
 			name: "v6 binary",
 			path: "/usr/local/bin/celestia-appd-v6",
-			want: []string{"CELESTIA_APPD_V6_TELEMETRY_PROMETHEUS_RETENTION_TIME=0"},
+			want: []string{"CELESTIA_APP_TELEMETRY_PROMETHEUS_RETENTION_TIME=0"},
 		},
 		{
 			name: "binary with dots in version",
 			path: "/tmp/bin/celestia-appd-v3.10.0",
-			want: []string{"CELESTIA_APPD_V3_10_0_TELEMETRY_PROMETHEUS_RETENTION_TIME=0"},
+			want: []string{"CELESTIA_APP_TELEMETRY_PROMETHEUS_RETENTION_TIME=0"},
 		},
 	}
 
@@ -55,15 +55,15 @@ func TestGetEnv(t *testing.T) {
 				for _, e := range os.Environ() {
 					require.Contains(t, env, e)
 				}
-				require.Contains(t, env, "CELESTIA_APPD_V3_TELEMETRY_PROMETHEUS_RETENTION_TIME=0")
+				require.Contains(t, env, "CELESTIA_APP_TELEMETRY_PROMETHEUS_RETENTION_TIME=0")
 			},
 		},
 		{
 			name:   "overrides existing telemetry env var",
 			path:   "/tmp/bin/celestia-appd-v3",
-			setenv: map[string]string{"CELESTIA_APPD_V3_TELEMETRY_PROMETHEUS_RETENTION_TIME": "60"},
+			setenv: map[string]string{"CELESTIA_APP_TELEMETRY_PROMETHEUS_RETENTION_TIME": "60"},
 			assert: func(t *testing.T, a *Appd, env []string) {
-				envKey := "CELESTIA_APPD_V3_TELEMETRY_PROMETHEUS_RETENTION_TIME"
+				envKey := "CELESTIA_APP_TELEMETRY_PROMETHEUS_RETENTION_TIME"
 				var matches []string
 				for _, e := range env {
 					if strings.HasPrefix(e, envKey+"=") {


### PR DESCRIPTION
## Summary

Fixes a bug where `telemetryDisableEnv()` derived the env var prefix from the binary filename (e.g. `celestia-appd` → `CELESTIA_APPD`), but Viper in the child process uses the hardcoded prefix `CELESTIA_APP`. The extra `D` meant the env var `CELESTIA_APPD_TELEMETRY_PROMETHEUS_RETENTION_TIME=0` was never read, making the defense-in-depth mechanism non-functional.

Uses the hardcoded `envPrefix` constant (`CELESTIA_APP`) instead of deriving from the filename. Updates tests to assert the correct prefix.

Found by Claude code review on #6784.

## Test plan

- [x] `go test -v -run TestTelemetryDisableEnv ./multiplexer/appd/` passes
- [x] `go test -v -run TestGetEnv ./multiplexer/appd/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6787" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
