### PR TITLE
docs: add PebbleDB motivation to LevelDB deprecation section

### DIFF
--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -24,7 +24,7 @@ No manual action is required, but validators should be aware of this change.
 
 #### LevelDB Deprecation
 
-LevelDB (`goleveldb`) is deprecated starting in v7. Node operators should migrate to PebbleDB using the [`migrate-db` tool](../../tools/migrate-db/README.md). LevelDB support will be removed in v8.
+LevelDB (`goleveldb`) is deprecated starting in v7. PebbleDB provides faster performance when saving blocks and is required for Fibre. Node operators should migrate to PebbleDB using the [`migrate-db` tool](../../tools/migrate-db/README.md). LevelDB support will be removed in v8.
 
 #### Horcrux Deprecation
 


### PR DESCRIPTION
## Summary
- Adds context to the LevelDB Deprecation section in release notes explaining why PebbleDB is the replacement
- PebbleDB provides faster performance when saving blocks and is required for Fibre

## Test plan
- [ ] Verify the release notes render correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6794" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
