### PR TITLE
fix: deduplicate signatures in SignatureSet.Add

### DIFF
--- a/fibre/validator/signature_set.go
+++ b/fibre/validator/signature_set.go
@@ -51,9 +51,16 @@ func (ss *SignatureSet) Add(val *core.Validator, signature []byte) (bool, error)
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
+	// if this validator already signed, treat as a no-op to avoid
+	// double-counting voting power.
+	addr := val.Address.String()
+	if _, ok := ss.signatures[addr]; ok {
+		return ss.votingPower >= ss.minRequiredVotingPower, nil
+	}
+
 	// add to collection
 	ss.votingPower += val.VotingPower
-	ss.signatures[val.Address.String()] = signature
+	ss.signatures[addr] = signature
 
 	// check if thresholds are met
 	return ss.votingPower >= ss.minRequiredVotingPower, nil

--- a/fibre/validator/signature_set_test.go
+++ b/fibre/validator/signature_set_test.go
@@ -174,6 +174,57 @@ func TestSignatureSet(t *testing.T) {
 		require.False(t, hasEnough)
 	})
 
+	t.Run("DuplicateSignatureNoOp", func(t *testing.T) {
+		s := setupSignatureSet(3, 10, half)
+
+		// Add a valid signature from validator 0
+		signature, err := s.privKeys[0].Sign(s.signBytes)
+		require.NoError(t, err)
+		hasEnough, err := s.sigSet.Add(s.validators[0], signature)
+		require.NoError(t, err)
+		require.False(t, hasEnough)
+
+		// Add the same validator's signature again — should be a no-op
+		hasEnough, err = s.sigSet.Add(s.validators[0], signature)
+		require.NoError(t, err)
+		require.False(t, hasEnough)
+
+		// Voting power should be 10 (not 20)
+		sigs, err := s.sigSet.Signatures()
+		require.Error(t, err)
+
+		var sigErr *validator.NotEnoughSignaturesError
+		require.ErrorAs(t, err, &sigErr)
+		require.Equal(t, int64(10), sigErr.CollectedPower)
+		require.Equal(t, int64(15), sigErr.RequiredPower)
+		require.Nil(t, sigs)
+	})
+
+	t.Run("DuplicateSignatureConcurrent", func(t *testing.T) {
+		s := setupSignatureSet(3, 10, half)
+
+		signature, err := s.privKeys[0].Sign(s.signBytes)
+		require.NoError(t, err)
+
+		// Add the same validator's signature concurrently from 10 goroutines
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Go(func() {
+				_, addErr := s.sigSet.Add(s.validators[0], signature)
+				require.NoError(t, addErr)
+			})
+		}
+		wg.Wait()
+
+		// Voting power should be 10 (not 100)
+		_, err = s.sigSet.Signatures()
+		require.Error(t, err)
+
+		var sigErr *validator.NotEnoughSignaturesError
+		require.ErrorAs(t, err, &sigErr)
+		require.Equal(t, int64(10), sigErr.CollectedPower)
+	})
+
 	t.Run("MixedMissAndValid", func(t *testing.T) {
 		s := setupSignatureSet(5, 10, half)
 


### PR DESCRIPTION
Closes https://linear.app/celestia/issue/DA-1153/add-tests-for-adding-a-signature-from-the-same-validator-twice
Closes #6714

## Summary

- Check for duplicate validator signatures in `SignatureSet.Add()` to prevent double-counting voting power
- Add tests for duplicate signature handling (sequential and concurrent)

## Test plan

- [x] `go test -v -run TestSignatureSet ./fibre/validator/` passes (including new `DuplicateSignatureNoOp` and `DuplicateSignatureConcurrent` subtests)
- [x] `go test -race ./fibre/validator/` passes
- [x] `golangci-lint run ./fibre/validator/...` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
