### PR TITLE
fix!: add nil SignerKey guards to ToProto() and SignBytes()

### DIFF
--- a/fibre/client_put.go
+++ b/fibre/client_put.go
@@ -69,10 +69,14 @@ func Put(ctx context.Context, c *Client, txClient *user.TxClient, ns share.Names
 	))
 
 	// broadcast PayForFibre transaction
+	promiseProto, err := signedPromise.ToProto()
+	if err != nil {
+		return result, fmt.Errorf("converting payment promise to proto: %w", err)
+	}
 	signerAddr := txClient.DefaultAddress()
 	msg := &types.MsgPayForFibre{
 		Signer:              signerAddr.String(),
-		PaymentPromise:      *signedPromise.ToProto(),
+		PaymentPromise:      *promiseProto,
 		ValidatorSignatures: signedPromise.ValidatorSignatures,
 	}
 

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -80,7 +80,13 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 		return result, fmt.Errorf("preparing validator sign bytes: %w", err)
 	}
 
-	requests := makeUploadRequests(shardMap, promise.ToProto(), blob.RLCCoeffs())
+	promiseProto, err := promise.ToProto()
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "failed to convert payment promise to proto")
+		return result, fmt.Errorf("converting payment promise to proto: %w", err)
+	}
+	requests := makeUploadRequests(shardMap, promiseProto, blob.RLCCoeffs())
 	sigSet := valSet.NewSignatureSet(c.Config.SafetyThreshold, validatorSignBytes)
 
 	c.log.DebugContext(ctx, "initiating blob upload",

--- a/fibre/payment_promise.go
+++ b/fibre/payment_promise.go
@@ -56,7 +56,10 @@ type PaymentPromise struct {
 
 // MarshalBinary encodes the [PaymentPromise] using protobuf.
 func (p *PaymentPromise) MarshalBinary() ([]byte, error) {
-	pbMsg := p.ToProto()
+	pbMsg, err := p.ToProto()
+	if err != nil {
+		return nil, err
+	}
 	return gogoproto.Marshal(pbMsg)
 }
 
@@ -102,7 +105,10 @@ func (p *PaymentPromise) FromProto(pbMsg *types.PaymentPromise) error {
 }
 
 // ToProto converts the [PaymentPromise] to its protobuf representation.
-func (p *PaymentPromise) ToProto() *types.PaymentPromise {
+func (p *PaymentPromise) ToProto() (*types.PaymentPromise, error) {
+	if p.SignerKey == nil {
+		return nil, errors.New("signer key must not be nil")
+	}
 	return &types.PaymentPromise{
 		ChainId:           p.ChainID,
 		Height:            int64(p.Height),
@@ -113,7 +119,7 @@ func (p *PaymentPromise) ToProto() *types.PaymentPromise {
 		CreationTimestamp: p.CreationTimestamp,
 		SignerPublicKey:   *p.SignerKey,
 		Signature:         p.Signature,
-	}
+	}, nil
 }
 
 // Validate performs stateless validation on the [PaymentPromise].
@@ -203,6 +209,9 @@ const (
 // SignBytes caches the result of the computation for subsequent calls,
 // so its not allowed to change the promise after signing.
 func (p *PaymentPromise) SignBytes() ([]byte, error) {
+	if p.SignerKey == nil {
+		return nil, errors.New("signer key must not be nil")
+	}
 	p.signBytesOnce.Do(func() {
 		// use MarshalBinary for timestamp
 		timestampBytes, err := p.CreationTimestamp.UTC().MarshalBinary() // this must be UTC

--- a/fibre/payment_promise_test.go
+++ b/fibre/payment_promise_test.go
@@ -188,6 +188,34 @@ func TestPaymentPromise(t *testing.T) {
 	})
 }
 
+func TestNilSignerKey(t *testing.T) {
+	pp := &fibre.PaymentPromise{
+		ChainID:           "test-chain-1",
+		Height:            12345,
+		Namespace:         testNamespace,
+		UploadSize:        1024,
+		CreationTimestamp: time.Now().UTC().Truncate(time.Second),
+	}
+
+	t.Run("ToProto", func(t *testing.T) {
+		_, err := pp.ToProto()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer key must not be nil")
+	})
+
+	t.Run("MarshalBinary", func(t *testing.T) {
+		_, err := pp.MarshalBinary()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer key must not be nil")
+	})
+
+	t.Run("SignBytes", func(t *testing.T) {
+		_, err := pp.SignBytes()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "signer key must not be nil")
+	})
+}
+
 func TestValidatorSignPaymentPromise(t *testing.T) {
 	signerPrivKey := secp256k1.GenPrivKey()
 	pp := makePaymentPromise(t, signerPrivKey)

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -182,7 +182,8 @@ func makeTestRequest(
 		SignerKey:         pubKey.(*secp256k1.PubKey),
 	}
 
-	promisePb := promise.ToProto()
+	promisePb, err := promise.ToProto()
+	require.NoError(t, err)
 	signPromise(promisePb)
 
 	// get row assignment for server validator

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -136,7 +136,11 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 	}
 
 	// write payment promise
-	ppData, err := gogoproto.Marshal(promise.ToProto())
+	promiseProto, err := promise.ToProto()
+	if err != nil {
+		return fmt.Errorf("converting payment promise to proto: %w", err)
+	}
+	ppData, err := gogoproto.Marshal(promiseProto)
 	if err != nil {
 		return fmt.Errorf("marshaling payment promise: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Adds nil `SignerKey` guard to `ToProto()`, changing its return type to `(*types.PaymentPromise, error)` to prevent nil pointer dereference at `*p.SignerKey`
- Adds nil `SignerKey` guard to `SignBytes()` to prevent nil pointer dereference at `p.SignerKey.Bytes()`
- Updates all callers of `ToProto()` (`MarshalBinary`, `Store.Put`, `Client.Upload`, `Put`, and test helper) to handle the new error return

Closes #6832

## Test plan
- [x] Added `TestNilSignerKey` with subtests for `ToProto`, `MarshalBinary`, and `SignBytes` verifying they return errors instead of panicking
- [x] Existing tests pass (`TestPaymentPromise`, `TestValidatorSignPaymentPromise`)
- [x] Full `go build ./...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6833" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
