### PR TITLE
chore: add warning comment and test for SubtreeRootThreshold

### DIFF
--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -19,6 +19,14 @@ const (
 	// SubtreeRootThreshold.
 	//
 	// The rationale for this value is described in more detail in ADR-013.
+	//
+	// WARNING: DO NOT MODIFY this value without cross-team coordination.
+	// SubtreeRootThreshold is hard-coded in clients (e.g. Lumina). Changing this
+	// value is a breaking change for those clients. Client upgrades are difficult
+	// to coordinate because they are deployed across many environments. At a
+	// minimum, changing SubtreeRootThreshold requires a new client release and
+	// deployment before the change takes effect on the network.
+	// See: https://github.com/celestiaorg/celestia-app/issues/6831
 	SubtreeRootThreshold  int    = 64
 	TxSizeCostPerByte     uint64 = 10
 	GasPerBlobByte        uint32 = 8

--- a/pkg/appconsts/app_consts_test.go
+++ b/pkg/appconsts/app_consts_test.go
@@ -31,6 +31,15 @@ func TestMaxExpectedTimePerBlock(t *testing.T) {
 		MaxExpectedTimePerBlock, want, tolerance)
 }
 
+// TestSubtreeRootThreshold verifies that SubtreeRootThreshold has not changed
+// from 64. SubtreeRootThreshold is hard-coded in clients (e.g. Lumina) and
+// changing it is a breaking change that requires cross-team coordination. If
+// this test fails, you likely need to revert the change to SubtreeRootThreshold.
+// See https://github.com/celestiaorg/celestia-app/issues/6831
+func TestSubtreeRootThreshold(t *testing.T) {
+	require.Equal(t, 64, SubtreeRootThreshold)
+}
+
 func TestConsts(t *testing.T) {
 	t.Run("TestUpgradeHeightDelay should be 3", func(t *testing.T) {
 		require.Equal(t, int64(3), TestUpgradeHeightDelay)

--- a/pkg/appconsts/v5/app_consts.go
+++ b/pkg/appconsts/v5/app_consts.go
@@ -12,5 +12,7 @@ const (
 	// SubtreeRootThreshold.
 	//
 	// The rationale for this value is described in more detail in ADR-013.
+	//
+	// WARNING: DO NOT MODIFY. See pkg/appconsts/app_consts.go for details.
 	SubtreeRootThreshold int = 64
 )

--- a/pkg/appconsts/v7/app_consts.go
+++ b/pkg/appconsts/v7/app_consts.go
@@ -5,7 +5,8 @@ import "time"
 const (
 	Version              uint64 = 7
 	SquareSizeUpperBound int    = 512
-	SubtreeRootThreshold int    = 64
+	// WARNING: DO NOT MODIFY. See pkg/appconsts/app_consts.go for details.
+	SubtreeRootThreshold int = 64
 	// TimeoutPropose is the duration a proposer has to propose a block.
 	TimeoutPropose = time.Millisecond * 8500
 	// TimeoutProposeDelta is the increase in timeout propose per round.


### PR DESCRIPTION
## Summary
- Add a prominent `WARNING: DO NOT MODIFY` comment on `SubtreeRootThreshold` in `pkg/appconsts/app_consts.go` explaining it is hard-coded in clients (e.g. Lumina) and changing it requires cross-team coordination.
- Add shorter warning comments in versioned const files (`v5`, `v7`) pointing back to the main file.
- Add `TestSubtreeRootThreshold` unit test that asserts the value is `64` to prevent accidental modifications.

Closes #6831

## Test plan
- [x] `TestSubtreeRootThreshold` passes and will fail if anyone changes the value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6834" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
