### PR TITLE
feat!: use the same sign bytes in fibre for signatures

### DIFF
--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -73,7 +73,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	shardMap := valSet.Assign(blob.ID().Commitment(), blob.Config().TotalRows(), blob.Config().OriginalRows, c.Config.MinRowsPerValidator, c.Config.LivenessThreshold)
 	span.AddEvent("shards_assigned")
 
-	validatorSignBytes, err := promise.SignBytesValidator()
+	signBytes, err := promise.SignBytes()
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to prepare validator sign bytes")
@@ -81,7 +81,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob) (re
 	}
 
 	requests := makeUploadRequests(shardMap, promise.ToProto(), blob.RLCCoeffs())
-	sigSet := valSet.NewSignatureSet(c.Config.SafetyThreshold, validatorSignBytes)
+	sigSet := valSet.NewSignatureSet(c.Config.SafetyThreshold, signBytes)
 
 	c.log.DebugContext(ctx, "initiating blob upload",
 		"promise_hash", hex.EncodeToString(promiseHash),

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -213,7 +213,7 @@ func (v *validatorMockClient) UploadShard(ctx context.Context, req *types.Upload
 		return nil, err
 	}
 
-	validatorSignBytes, err := pp.SignBytesValidator()
+	signBytes, err := pp.SignBytes()
 	if err != nil {
 		return nil, err
 	}
@@ -224,7 +224,7 @@ func (v *validatorMockClient) UploadShard(ctx context.Context, req *types.Upload
 	}
 
 	return &types.UploadShardResponse{
-		ValidatorSignature: ed25519.Sign(ed25519.PrivateKey(privKeyBytes), validatorSignBytes),
+		ValidatorSignature: ed25519.Sign(ed25519.PrivateKey(privKeyBytes), signBytes),
 	}, nil
 }
 

--- a/fibre/payment_promise.go
+++ b/fibre/payment_promise.go
@@ -46,12 +46,12 @@ type PaymentPromise struct {
 	Height uint64
 
 	// cached sign bytes and hash
-	signBytesOnce sync.Once
-	signBytes     []byte
-	signBytesErr  error
-	hashOnce      sync.Once
-	hash          [32]byte
-	hashErr       error
+	signBytesOnce   sync.Once
+	cachedSignBytes []byte
+	signBytesErr    error
+	hashOnce        sync.Once
+	hash            [32]byte
+	hashErr         error
 }
 
 // MarshalBinary encodes the [PaymentPromise] using protobuf.
@@ -190,16 +190,17 @@ const (
 	signatureSize = 64
 )
 
-// SignBytes returns the bytes that should be signed for this [PaymentPromise].
-// Actual signing must be done by the caller.
-// The sign bytes are computed once and cached for subsequent calls.
-// Format: prefix || chainID || signer_bytes || namespace || blob_size_bytes ||
+// strippedSignBytes returns the payload-only bytes for this [PaymentPromise],
+// without any prefix or chainID. These bytes are suitable for wrapping with
+// domain separation (e.g., via [core.RawBytesMessageSignBytes]).
 //
-//	commitment || blob_version_bytes || height_bytes || creation_timestamp_bytes
+// Format: signer_bytes || namespace || blob_size_bytes || commitment ||
 //
-// SignBytes caches the result of the computation for subsequent calls,
-// so its not allowed to change the promise after signing.
-func (p *PaymentPromise) SignBytes() ([]byte, error) {
+//	blob_version_bytes || height_bytes || creation_timestamp_bytes
+//
+// strippedSignBytes caches the result of the computation for subsequent calls,
+// so it's not allowed to change the promise after signing.
+func (p *PaymentPromise) strippedSignBytes() ([]byte, error) {
 	p.signBytesOnce.Do(func() {
 		// use MarshalBinary for timestamp
 		timestampBytes, err := p.CreationTimestamp.UTC().MarshalBinary() // this must be UTC
@@ -208,14 +209,8 @@ func (p *PaymentPromise) SignBytes() ([]byte, error) {
 			return
 		}
 
-		// calculate total size including the prefix
-		totalSize := len(signBytesPrefix) + len(p.ChainID) + signBytesFixedSize
-		buf := make([]byte, 0, totalSize)
+		buf := make([]byte, 0, signBytesFixedSize)
 
-		// prepend domain separation prefix
-		buf = append(buf, []byte(signBytesPrefix)...)
-		// append chainID
-		buf = append(buf, []byte(p.ChainID)...)
 		// append signer_bytes (33 bytes - compressed public key)
 		buf = append(buf, p.SignerKey.Bytes()...)
 		// append namespace (29 bytes)
@@ -231,13 +226,25 @@ func (p *PaymentPromise) SignBytes() ([]byte, error) {
 		// append timestamp bytes
 		buf = append(buf, timestampBytes...)
 
-		p.signBytes = buf
+		p.cachedSignBytes = buf
 	})
 
 	if p.signBytesErr != nil {
 		return nil, p.signBytesErr
 	}
-	return p.signBytes, nil
+	return p.cachedSignBytes, nil
+}
+
+// SignBytes returns the canonical bytes that should be signed for this [PaymentPromise].
+// Both keyring (client) and validator paths sign these same bytes.
+// The result is the stripped payload wrapped with CometBFT domain separation
+// via [core.RawBytesMessageSignBytes].
+func (p *PaymentPromise) SignBytes() ([]byte, error) {
+	stripped, err := p.strippedSignBytes()
+	if err != nil {
+		return nil, err
+	}
+	return core.RawBytesMessageSignBytes(p.ChainID, signBytesPrefix, stripped)
 }
 
 // Hash returns the SHA256 hash of the [PaymentPromise] including the signature.
@@ -269,27 +276,14 @@ func (p *PaymentPromise) Hash() ([]byte, error) {
 	return p.hash[:], nil
 }
 
-// SignBytesValidator returns the [PaymentPromise] bytes for validators to sign.
-// This wraps the [PaymentPromise.SignBytes] with domain separation using the chain ID and signBytesPrefix.
-//
-// NOTE: This method encapsulates Comet's quirk which enforces a particular signing domain separation format.
-// This goes on top of native [PaymentPromise] domain separation.
-func (p *PaymentPromise) SignBytesValidator() ([]byte, error) {
-	signBytes, err := p.SignBytes()
-	if err != nil {
-		return nil, fmt.Errorf("getting sign bytes: %w", err)
-	}
-	return core.RawBytesMessageSignBytes(p.ChainID, signBytesPrefix, signBytes)
-}
-
 // SignPaymentPromiseValidator signs the [PaymentPromise] using validator's private key behind [core.PrivValidator].
 func SignPaymentPromiseValidator(promise *PaymentPromise, privVal core.PrivValidator) ([]byte, error) {
-	signBytes, err := promise.SignBytes()
+	stripped, err := promise.strippedSignBytes()
 	if err != nil {
-		return nil, fmt.Errorf("getting sign bytes: %w", err)
+		return nil, fmt.Errorf("getting stripped sign bytes: %w", err)
 	}
 
-	signature, err := privVal.SignRawBytes(promise.ChainID, signBytesPrefix, signBytes)
+	signature, err := privVal.SignRawBytes(promise.ChainID, signBytesPrefix, stripped)
 	if err != nil {
 		return nil, fmt.Errorf("signing payment promise: %w", err)
 	}

--- a/fibre/payment_promise_test.go
+++ b/fibre/payment_promise_test.go
@@ -147,8 +147,5 @@ func TestValidatorSignPaymentPromise(t *testing.T) {
 	valSignature, err := fibre.SignPaymentPromiseValidator(pp, privVal)
 	require.NoError(t, err)
 	require.Len(t, valSignature, ed25519.SignatureSize)
-
-	validatorSignBytes, err := pp.SignBytesValidator()
-	require.NoError(t, err)
-	require.True(t, privVal.PrivKey.PubKey().VerifySignature(validatorSignBytes, valSignature))
+	require.True(t, privVal.PrivKey.PubKey().VerifySignature(signBytes, valSignature))
 }

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -142,12 +142,12 @@ func (ms msgServer) PayForFibre(goCtx context.Context, msg *types.MsgPayForFibre
 	}
 
 	// Validate validator signatures
-	validatorSignBytes, err := pp.SignBytesValidator()
+	signBytes, err := pp.SignBytes()
 	if err != nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "failed to get validator sign bytes: %s", err)
 	}
 
-	if err := ms.validateValidatorSignatures(ctx, validatorSignBytes, msg.PaymentPromise.Height, msg.ValidatorSignatures); err != nil {
+	if err := ms.validateValidatorSignatures(ctx, signBytes, msg.PaymentPromise.Height, msg.ValidatorSignatures); err != nil {
 		return nil, errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "validator signature validation failed: %s", err)
 	}
 
@@ -314,7 +314,7 @@ func calculatePaymentCoin(blobSize, gasPerBlobByte uint32) sdk.Coin {
 }
 
 // validateValidatorSignatures validates validator signatures using the existing SignatureSet infrastructure
-func (ms msgServer) validateValidatorSignatures(ctx sdk.Context, validatorSignBytes []byte, height int64, signatures [][]byte) error {
+func (ms msgServer) validateValidatorSignatures(ctx sdk.Context, signBytes []byte, height int64, signatures [][]byte) error {
 	// Get historical validator set at the height
 	historicalInfo, err := ms.stakingKeeper.GetHistoricalInfo(ctx, height)
 	if err != nil {
@@ -348,7 +348,7 @@ func (ms msgServer) validateValidatorSignatures(ctx sdk.Context, validatorSignBy
 
 	// Create signature set with 2/3+ thresholds
 	twoThirds := cmtmath.Fraction{Numerator: 2, Denominator: 3}
-	sigSet := valSet.NewSignatureSet(twoThirds, validatorSignBytes)
+	sigSet := valSet.NewSignatureSet(twoThirds, signBytes)
 
 	// Add all provided signatures to the signature set
 	for i, signature := range signatures {

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -734,7 +734,7 @@ func (suite *MsgServerTestSuite) generateValidatorSignatures(paymentPromise *typ
 	suite.NoError(err)
 
 	// Prepare validator sign bytes with domain separation (same as validation code)
-	validatorSignBytes, err := pp.SignBytesValidator()
+	signBytes, err := pp.SignBytes()
 	suite.NoError(err)
 
 	// Get validator key
@@ -743,7 +743,7 @@ func (suite *MsgServerTestSuite) generateValidatorSignatures(paymentPromise *typ
 		return [][]byte{}
 	}
 
-	signature, err := valPrivKey.Sign(validatorSignBytes)
+	signature, err := valPrivKey.Sign(signBytes)
 	suite.NoError(err)
 
 	return [][]byte{signature}


### PR DESCRIPTION
## Overview

Closes https://github.com/celestiaorg/celestia-app/issues/6710 and DA-1149

TLDR: Unified the sign bytes path so both client (keyring) and validator (privval) sign the same canonical bytes. Previously, SignBytes() produced prefix || chainID || payload and SignBytesValidator() wrapped that   
  again with CometBFT domain separation, causing chainID/prefix to appear twice in the validator path. Now:                                                                                                             
                                                                                                                                                                                                                          
  - strippedSignBytes() (private) returns payload-only bytes                                                                                                                                                              
  - SignBytes() wraps those with RawBytesMessageSignBytes — this is the single canonical format both paths use                                                                                                            
  - SignBytesValidator() is removed                                                                                                                                                                                       
  - SignPaymentPromiseValidator() passes stripped bytes to SignRawBytes, which internally applies the same wrapping      
  
<!-- devin-review-badge-begin -->
---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6836" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
