### PR TITLE
fix: add WaitForNextBlock to prevent flaky Test01RegisterValidator

### DIFF
--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -145,6 +145,8 @@ func (s *FibreE2ETestSuite) Test01RegisterValidator() {
 	require.Equal(t, uint32(0), txResp.Code)
 	t.Logf("RegisterValidator tx included at height %d, hash: %s", txResp.Height, txResp.TxHash)
 
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
 	// verify the host is now registered.
 	valAddrClient := valtypes.NewQueryClient(s.cctx.GRPCClient)
 


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/6837

## Summary
- Adds `s.cctx.WaitForNextBlock()` in `Test01RegisterValidator` after `SubmitTx` and before the gRPC query for `FibreProviderInfo`
- CometBFT reports a tx as committed before the app's multistore has finished committing state, so gRPC queries can see stale data
- This matches the pattern already used in `Test03Put` (line 242) and the documented race condition in `test/util/testnode/node_interaction_api.go:117-120`

## Test plan
- [x] Verified with `go test -count=10 -run TestFibreE2ETestSuite/Test01RegisterValidator ./fibre/internal/e2e/` — all 10 runs passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6838" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
