### PR TITLE
fix: add WaitForNextBlock to prevent flaky fibre tests

### DIFF
--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -207,6 +207,8 @@ func (s *FibreE2ETestSuite) Test02FundEscrowAccount() {
 	require.Equal(t, uint32(0), txResp.Code)
 	t.Logf("First deposit tx at height %d", txResp.Height)
 
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
 	// verify escrow balance matches deposit.
 	escrowResp, err = fibreQueryClient.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{
 		Signer: addr.String(),
@@ -225,6 +227,8 @@ func (s *FibreE2ETestSuite) Test02FundEscrowAccount() {
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), txResp.Code)
 	t.Logf("Second deposit tx at height %d", txResp.Height)
+
+	require.NoError(t, s.cctx.WaitForNextBlock())
 
 	// verify cumulative balance is 75 TIA.
 	escrowResp, err = fibreQueryClient.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{

--- a/fibre/internal/grpc/host_registry_e2e_test.go
+++ b/fibre/internal/grpc/host_registry_e2e_test.go
@@ -128,6 +128,8 @@ func (s *IntegrationTestSuite) TestGetHostWithRegistration() {
 	require.Equal(t, uint32(0), txResp.Code, "transaction failed with code %d", txResp.Code)
 	t.Logf("Transaction submitted successfully. TxHash: %s, Height: %d", txResp.TxHash, txResp.Height)
 
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
 	host, err := s.hostRegistry.GetHost(s.cctx.GoContext(), s.validator)
 	require.NoError(t, err, "GetHost should now succeed")
 	require.NotEmpty(t, host.String())
@@ -144,6 +146,8 @@ func (s *IntegrationTestSuite) TestGetHostWithRegistration() {
 	require.NoError(t, err, "failed to submit transaction")
 	require.Equal(t, uint32(0), txResp.Code, "transaction failed with code %d", txResp.Code)
 	t.Logf("Transaction submitted successfully. TxHash: %s, Height: %d", txResp.TxHash, txResp.Height)
+
+	require.NoError(t, s.cctx.WaitForNextBlock())
 
 	host, err = s.hostRegistry.GetHost(s.cctx.GoContext(), s.validator)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Add `WaitForNextBlock()` after `SubmitTx` calls in `Test02FundEscrowAccount` and `TestGetHostWithRegistration` to prevent the SubmitTx-then-gRPC-query race condition where CometBFT reports a tx as committed before the app's multistore finishes committing state.
- Matches the pattern already used in `Test01RegisterValidator` (#6838) and `Test03Put`.

Closes #6839

## Test plan
- [ ] CI passes for `fibre/internal/e2e` and `fibre/internal/grpc` test packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
