### PR TITLE
test: add E2E test upgrading to v8

### DIFF
--- a/test/docker-e2e/e2e_upgrade_test.go
+++ b/test/docker-e2e/e2e_upgrade_test.go
@@ -66,7 +66,7 @@ const (
 	MaxExpectedTimePerBlockV8Ns = uint64(15 * time.Second)
 
 	// Block params for v8
-	MaxBytesV8 = 32 * 1048576 // 32 MiB
+	MaxBytesV8 = 32 * 1024 * 1024 // 32 MiB
 )
 
 // TestAllUpgrades tests all app version upgrades using the signaling mechanism.


### PR DESCRIPTION
Closes #6835
Closes https://linear.app/celestia/issue/PROTOCO-1249/testing-add-e2e-test-upgrading-to-v8

## Summary

- Expand `TestUpgradeLatest` to validate v8-specific behavior after upgrading from v7
- After the upgrade, assert:
  - **CIP-048 consensus timeouts** via `ABCIInfo` → `TimeoutInfo` (`TimeoutPropose`, `DelayedPrecommitTimeout`, `TimeoutPrevote`, `TimeoutPrecommit`, etc.)
  - **CIP-048 evidence params**: `MaxAgeNumBlocks` doubled to 485,280
  - **CIP-048 IBC `MaxExpectedTimePerBlock`** corrected to 15s (via IBC connection gRPC)
  - **Block params**: `max_bytes` = 32 MiB
  - **Fibre module**: active with default params (via Fibre gRPC query)

Note: `TimeoutPrevote` and `TimeoutPrecommit` currently use the values from `appconsts` (3000ms). A TODO for @ninabarbakadze tracks reducing them to 1500ms per CIP-048.


## Test plan

- [x] `TestCelestiaTestSuite/TestUpgradeLatest` passes locally
- [x] `go build ./...` passes
- [x] `golangci-lint` introduces no new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6841" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
