### PR TITLE
docs: document `RowInclusionProof`

### DIFF
--- a/pkg/rsema1d/README.md
+++ b/pkg/rsema1d/README.md
@@ -161,7 +161,7 @@ type Config struct {
 - **Field Arithmetic** (`field/`): GF(2^16) and GF(2^128) operations
 - **Encoding** (`encoding/`): Leopard Reed-Solomon codec wrapper
 - **Merkle Trees** (`merkle/`): Binary trees with RFC 6962-compatible formatting
-- **Proof System**: Dual verification paths for different use cases
+- **Proof System**: Triple verification paths for different use cases
 - **Commitment**: SHA-256 based with Fiat-Shamir coefficient derivation
 
 ### Security Properties
@@ -175,7 +175,7 @@ type Config struct {
 
 ### Proof Sizes
 
-- **Original rows (standalone)**: `rowSize + O(log(K+N) × 32)` bytes
+- **Original rows (standalone)**: `rowSize + O(log(K+N) × 32) + O(log(K) × 32)` bytes
 - **Original rows (with context)**: `rowSize + O(log(K+N) × 32)` bytes
 - **Extended rows (with context)**: `rowSize + O(log(K+N) × 32)` bytes
 - **Inclusion-only (any row)**: `rowSize + O(log(K+N) × 32) + 32` bytes

--- a/specs/src/fibre_client.md
+++ b/specs/src/fibre_client.md
@@ -139,7 +139,7 @@ Inputs: `seed = commitment`, `n = 16384`, validators `k = |valset@PP.creation_he
 4. `base = n // k`, `r = n % k`; first `r` in chosen validator order get `base+1`, others `base`.
 5. Walk permuted shares handing contiguous blocks to validators in that order.
 
-## 6) ValTracker
+## 5) ValTracker
 
 ### API
 
@@ -165,7 +165,7 @@ type Validator struct {
 * `ValTrackerModeLight`: use embedded light client to track headers/valsets.
 * `ValTrackerModeRPC`: use json-RPC to fetch headers/valsets from remote Light or Bridge node.
 
-## 5) Proof Types
+## 6) Proof Types
 
 The rsema1d codec provides three proof types used across Fibre flows. Each has different verification guarantees and trade-offs:
 
@@ -177,7 +177,7 @@ The rsema1d codec provides three proof types used across Fibre flows. Each has d
 
 > **Caveat**: `RowInclusionProof` only proves that a row is included in the commitment. It does not prove that the row data is correctly encoded via RLC. A dishonest server could serve a row that passes inclusion verification but contains incorrect data. Clients MUST verify RLC correctness after reconstructing the full blob from K rows. This is acceptable for the Get flow because reconstruction inherently validates data integrity — if any row contains incorrect data, the reconstructed blob will not match the commitment.
 
-## 6) Flows
+## 7) Flows
 
 ### Put()
 
@@ -200,15 +200,15 @@ The rsema1d codec provides three proof types used across Fibre flows. Each has d
 1. Get Valset: `vals, _ := vt.CurrentSet(ctx)`.
    * This could be a different validator set to the the validator set that actually has the shares. It probably won't be problematic because the validator sets will likely have a high degree of overlap and the erasure coding ensures enough redundancy
 2. Send `GetRowsRequest{commitment}` to FSPs in parallel (≤ `read_workers`).
-3. Collect `DownloadShardResponse{shard}` from each FSP in parallel. Each `BlobShard` contains `rows[]` and `rlc_root` (32 bytes). For each received row, construct a `RowInclusionProof` from the row data, its Merkle proof, and the `rlc_root`. Verify each `RowInclusionProof` against `commitment` (i.e., Merkle path to `rowRoot` + `commitment == SHA256(rowRoot || rlcRoot)`). Note: this does **not** verify RLC correctness — a malicious server could serve rows that pass inclusion verification but contain incorrect data. RLC correctness is verified after reconstruction in step 4.
+3. Collect `GetRowsResponse{rows[], rlc_root}` from each FSP in parallel. For each received row, construct a `RowInclusionProof` from the row data, its Merkle proof, and the `rlc_root` (32 bytes). Verify each `RowInclusionProof` against `commitment` (i.e., Merkle path to `rowRoot` + `commitment == SHA256(rowRoot || rlcRoot)`). Note: this does **not** verify RLC correctness — a malicious server could serve rows that pass inclusion verification but contain incorrect data. RLC correctness is verified after reconstruction in step 4.
 4. Decode data once amount of collected rows > `original_rows`; cancel remaining ongoing requests. recompute & verify **RLC**.
 5. Return `data` or error.
 
-## 7) Account Management API (client ↔ DFSP)
+## 8) Account Management API (client ↔ DFSP)
 
 The client exposes `Account()` which returns an `AccountClient` bound to the **Default FSP (DFSP)** and mapped 1:1 to the server's `FibreAccount` gRPC service. Protobuf request/response messages and on‑chain semantics are defined by the payments spec (`x/fibre`); the client must not diverge.
 
-### 7.1 Transport & Routing
+### 8.1 Transport & Routing
 
 * **Endpoint**: DFSP gRPC connection from client config. **Best‑effort** relay policy (no obligation for any given FSP to accept beyond availability).
 * **Fallback**: if DFSP is unavailable, client MAY connect to any other FSP from config (same API).
@@ -218,7 +218,7 @@ The client exposes `Account()` which returns an `AccountClient` bound to the **D
   * `QueryEscrowAccount` & `PendingWithdrawals` are read‑only.
   * `Deposit`/`Withdraw` are **not** idempotent by default; callers must ensure they don't replay the same request.
 
-### 7.2 Grpc Requests & Responses
+### 8.2 Grpc Requests & Responses
 
 Use the Protobuf messages from the payments spec:
 
@@ -229,11 +229,11 @@ Use the Protobuf messages from the payments spec:
 
 TODO: Consider to include optional proofs for escrow state queries so clients can verify DFSP responses (or specify an alternative proof format). If proofs are provided, define verification rules here.
 
-### 7.3 Errors
+### 8.3 Errors
 
 TODO: Map gRPC status codes to client errors
 
-## 8) Client Defaults & Metrics
+## 9) Client Defaults & Metrics
 
 * `send_workers = 20`, `read_workers = 20`.
 * Metrics: encode latency, chosen `row_size`, per‑FSP upload latency, signatures collected, quorum time, PFF submit/inclusion, balance cache age, insufficient‑proofs processed.

--- a/specs/src/fibre_server.md
+++ b/specs/src/fibre_server.md
@@ -203,7 +203,7 @@ SignBytes = SHA256(
 
     * Persists `(commitment, valset_height)` buckets with:
 
-        * Assigned rows + `rlc_orig`,
+        * Assigned rows + `rlc_root`,
     * TTL GC based on `retention_ttl` (24h).
     * **Badger layout (v1):**
 
@@ -257,7 +257,7 @@ SignBytes = SHA256(
   * `pp/unprocessed/b/<YYYYMMDDHHmm>/<promise_hash>` → TTL bucket index
 
 * **Commitment data**
-  * `d/<commitment>/<valset_height>` → rows blob, rlc\_orig
+  * `d/<commitment>/<valset_height>` → rows blob, rlc\_root
   * `b/<YYYYMMDDHHmm>/<commitment>/<valset_height>` → TTL bucket index
 
 **Note:** `promise_hash = SHA256( PaymentPromise (canonical bytes) )`.


### PR DESCRIPTION
## Summary

- Add a proof types comparison table to `fibre_client.md` documenting the three rsema1d proof types and their trade-offs
- Update the Get() flow in `fibre_client.md` to explicitly reference `RowInclusionProof` and `rlc_root`
- Update `GetRowsResponse` proto in `fibre_server.md` to use `rlc_root` (matching actual implementation's `BlobShard.root`)
- Add inclusion-only verification mode with code example and security caveat to `pkg/rsema1d/README.md`
- Add bulk download (Fibre Get) use case to `pkg/rsema1d/README.md`

Closes #6742
Closes CLA-301

## Test plan

- [ ] Verify spec changes are consistent with implementation in `pkg/rsema1d/types.go`, `pkg/rsema1d/proof.go`, `fibre/client_download.go`, and `fibre/blob.go`
- [ ] Review that caveat language accurately describes the security trade-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6848" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
