### PR TITLE
chore: update CODEOWNERS to use protocol team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 
 # Everything goes through the protocol team by default. The team's review
 # assignment settings control how many reviewers are auto-assigned per PR.
-# See: https://github.com/orgs/celestiaorg/teams/protocol/settings/review_assignment
+# See: https://github.com/orgs/celestiaorg/teams/protocol/edit/review_assignment
 
 # global owners
 * @celestiaorg/protocol


### PR DESCRIPTION
Part of https://linear.app/celestia/issue/PROTOCO-1217/fix-codeowners-and-pr-reviews-for-protocol-maintained-repos

I want to test this on celestia-app before applying to all protocol repos

## Summary

- Replace `@celestiaorg/celestia-core` with `@celestiaorg/protocol` in CODEOWNERS
- This auto-assigns a reviewer from the protocol team on every PR (controlled by [team review assignment settings](https://github.com/orgs/celestiaorg/teams/protocol/edit/review_assignment))

## Test plan

- [ ] Verify exactly 1 protocol team member is auto-assigned as reviewer on this PR
- [ ] Verify the team review request is replaced by an individual assignment
- [ ] If verified, roll out to remaining protocol repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)