### PR TITLE
chore: update CODEOWNERS to use protocol team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,11 +1,8 @@
 # CODEOWNERS: <https://help.github.com/articles/about-codeowners/>
 
-# Everything goes through the following "global owners" by default. Unless a later
-# match takes precedence, the "global owners" will be requested for review when
-# someone opens a PR. Note that the last matching pattern takes precedence, so
-# global owners are only requested if there isn't a more specific codeowner
-# specified below. For this reason, the global owners are often repeated in
-# directory-level definitions.
+# Everything goes through the protocol team by default. The team's review
+# assignment settings control how many reviewers are auto-assigned per PR.
+# See: https://github.com/orgs/celestiaorg/teams/protocol/edit/review_assignment
 
 # global owners
-* @evan-forbes @rootulp @rach-id @ninabarbakadze @cmwaters
+* @celestiaorg/protocol


### PR DESCRIPTION
## Summary

- Replace individual user CODEOWNERS with `@celestiaorg/protocol` team on the v7.x branch, matching what was done on main in #6873.

Closes https://github.com/celestiaorg/celestia-app/pull/6873 (backport)

## Test plan

- [ ] Verify the CODEOWNERS file is valid by checking that the protocol team is auto-assigned on PRs targeting v7.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
