### PR TITLE
chore: properly close the dbs and batches in the migrate-db script

### DIFF
--- a/tools/migrate-db/main.go
+++ b/tools/migrate-db/main.go
@@ -589,6 +589,7 @@ func copyAllKeys(ctx context.Context, dbName string, destDB db.DB, srcIter db.It
 	}
 	err := srcIter.Close()
 	if err != nil {
+		_ = batch.Close()
 		return 0, 0, fmt.Errorf("failed to close source iterator: %w", err)
 	}
 
@@ -678,10 +679,12 @@ func copyAndDeleteKeys(ctx context.Context, dbName string, sourceDB, destDB db.D
 			lastKey := make([]byte, len(key))
 			copy(lastKey, key)
 			if err := srcIter.Close(); err != nil {
+				_ = batch.Close()
 				return 0, 0, fmt.Errorf("failed to close source iterator: %w", err)
 			}
 
 			if err := deleteSourceKeys(sourceDB, deleteKeys); err != nil {
+				_ = batch.Close()
 				return 0, 0, fmt.Errorf("failed to delete source keys: %w", err)
 			}
 			deleteKeys = deleteKeys[:0]
@@ -691,6 +694,7 @@ func copyAndDeleteKeys(ctx context.Context, dbName string, sourceDB, destDB db.D
 			var err error
 			srcIter, err = sourceDB.Iterator(lastKey, nil)
 			if err != nil {
+				_ = batch.Close()
 				return 0, 0, fmt.Errorf("failed to reopen source iterator: %w", err)
 			}
 			// Skip lastKey if it still exists (might have been deleted above)
@@ -709,6 +713,7 @@ func copyAndDeleteKeys(ctx context.Context, dbName string, sourceDB, destDB db.D
 		return 0, 0, fmt.Errorf("iterator error: %w", err)
 	}
 	if err := srcIter.Close(); err != nil {
+		_ = batch.Close()
 		return 0, 0, fmt.Errorf("failed to close source iterator: %w", err)
 	}
 


### PR DESCRIPTION
## Overview

Closes https://github.com/celestiaorg/celestia-app/issues/6866 and PROTOCO-1271

After this and the other fixes PRs are merged, will ask Queblabs to re-run the tool again. 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6894" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
