### PR TITLE
fix: avoid panic in ABCIClientVersion.String for unknown values

### DIFF
--- a/multiplexer/abci/abci.go
+++ b/multiplexer/abci/abci.go
@@ -15,10 +15,14 @@ const (
 )
 
 func (v ABCIClientVersion) String() string {
-	return []string{
-		"ABCIClientVersion1",
-		"ABCIClientVersion2",
-	}[v]
+	switch v {
+	case ABCIClientVersion1:
+		return "ABCIClientVersion1"
+	case ABCIClientVersion2:
+		return "ABCIClientVersion2"
+	default:
+		return fmt.Sprintf("ABCIClientVersion(%d)", v)
+	}
 }
 
 var _ abci.Application = (*Multiplexer)(nil)


### PR DESCRIPTION
Prevent panic in ABCIClientVersion.String() for unknown enum values.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6916" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
