### PR TITLE
chore: enable mergify backports for v8.x branch

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -55,6 +55,14 @@ pull_request_rules:
       backport:
         branches:
           - v7.x
+  - name: backport patches to v8.x branch
+    conditions:
+      - base=main
+      - label=backport:v8.x
+    actions:
+      backport:
+        branches:
+          - v8.x
   - name: forward-port patches to main branch
     conditions:
       - label=forwardport:main


### PR DESCRIPTION
## Overview

Enable backports for the label
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6917" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
