### PR TITLE
test: expected v8 post upgrade assertions

### DIFF
--- a/test/docker-e2e/e2e_upgrade_test.go
+++ b/test/docker-e2e/e2e_upgrade_test.go
@@ -210,7 +210,6 @@ func (s *CelestiaTestSuite) TestUpgradeLatest() {
 	s.ValidatePreUpgrade(ctx, chain, cfg)
 	s.UpgradeChain(ctx, chain, cfg, appconsts.Version)
 	s.ValidatePostUpgrade(ctx, chain, cfg)
-	s.validateZKISMQuery(ctx, chain.GetNodes()[0])
 }
 
 // TestUpgradeV6ToV8 performs a coordinated chain upgrade from app version v6 to v8.


### PR DESCRIPTION
## Overview

In e2e upgrade test:
- Add max and min commission assertions after upgrading to v8.
- Make sure ZK ISM key is not empty after upgrading to v8.

Fixes https://linear.app/celestia/issue/PROTOCO-1394/make-sure-v8-upgrade-tests-have-expected-post-upgrade-assertions

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6936" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
