### PR TITLE
fix: use key from txclient in put

### DIFF
--- a/fibre/client_put.go
+++ b/fibre/client_put.go
@@ -35,7 +35,7 @@ type PutResult struct {
 // TODO(@Wondertan): This does not belong here. Fibre protocol in it's core doesn't need to know about transactions.
 // Furthermore, this function cannot be generalized for all the cases with fee grants, multiple key managements, etc.
 // And users are strongly advised to use [fibre.Upload] with custom TX submission logic instead, ideally batching multiple blobs in a single PFF.
-func Put(ctx context.Context, c *Client, txClient *user.TxClient, ns share.Namespace, data []byte, opts ...UploadOption) (result PutResult, err error) {
+func Put(ctx context.Context, c *Client, txClient *user.TxClient, ns share.Namespace, data []byte) (result PutResult, err error) {
 	ctx, span := c.tracer.Start(ctx, "fibre.Client.Put",
 		trace.WithAttributes(
 			attribute.String("namespace", ns.String()),
@@ -58,7 +58,7 @@ func Put(ctx context.Context, c *Client, txClient *user.TxClient, ns share.Names
 		attribute.Int("row_size", blob.RowSize()),
 	))
 
-	signedPromise, err := c.Upload(ctx, ns, blob, opts...)
+	signedPromise, err := c.Upload(ctx, ns, blob, WithKeyName(txClient.DefaultAccountName()))
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to upload blob")

--- a/tools/fibre-txsim/main.go
+++ b/tools/fibre-txsim/main.go
@@ -364,7 +364,7 @@ func submitBlob(ctx context.Context, w worker, blobSize int, st *stats, dlCh cha
 	}
 
 	t := time.Now()
-	result, err := fibre.Put(ctx, w.fibreClient, w.txClient, ns, data, fibre.WithKeyName(w.keyName))
+	result, err := fibre.Put(ctx, w.fibreClient, w.txClient, ns, data)
 	lat := time.Since(t)
 
 	st.totalSent.Add(1)


### PR DESCRIPTION
## Overview

Fixing a bug when payment promise could be signed with different key, if key name was different from one used in `txclient`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6944" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
