### PR TITLE
fix(deps): bump tastora to v0.17.0 to pin hyperlane CLI

### DIFF
--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/celestiaorg/celestia-app/v8 v8.0.0-rc0
 	github.com/celestiaorg/go-square/v3 v3.0.2
 	github.com/celestiaorg/go-square/v4 v4.0.0-rc4
-	github.com/celestiaorg/tastora v0.15.0
+	github.com/celestiaorg/tastora v0.17.0
 	github.com/cometbft/cometbft v1.0.1
 	github.com/cosmos/cosmos-sdk v0.50.13
 	github.com/cosmos/gogoproto v1.7.2

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -804,8 +804,8 @@ github.com/celestiaorg/nmt v0.24.2 h1:LlpJSPOd6/Lw1Ig6HUhZuqiINHLka/ZSRTBzlNJpch
 github.com/celestiaorg/nmt v0.24.2/go.mod h1:vgLBpWBi8F5KLxTdXSwb7AU4NhiIQ1AQRGa+PzdcLEA=
 github.com/celestiaorg/rsmt2d v0.15.1 h1:NF4D0LX501oDjw00RoJrTUrMHrO+Kv0LewL0FKQU7hg=
 github.com/celestiaorg/rsmt2d v0.15.1/go.mod h1:WKkpXoD1foHn4qgFx6GNoz36Wm0fbCh29ze4rA7ZwCs=
-github.com/celestiaorg/tastora v0.15.0 h1:rpXX/y19BzZ6Qf3pCc2YxJid2uwIJbTFf+BgBruOD34=
-github.com/celestiaorg/tastora v0.15.0/go.mod h1:C867PBm6Ne6e/1JlmsRqcLeJ6RHAuMoMRCvwJzV/q8g=
+github.com/celestiaorg/tastora v0.17.0 h1:pqhAkR9lmaAG5OXI0cs2Al2LraAtXyT3Ku34tqamEvE=
+github.com/celestiaorg/tastora v0.17.0/go.mod h1:C867PBm6Ne6e/1JlmsRqcLeJ6RHAuMoMRCvwJzV/q8g=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/6912

## Summary
- Bumps tastora from v0.15.0 to v0.17.0 in `test/docker-e2e/go.mod`
- Tastora v0.17.0 pins the hyperlane-init Docker image to a specific SHA, preventing the Hyperlane CLI from auto-updating to incompatible versions (v28 → v29 broke the `warp deploy --config` argument)

## Test plan
- [ ] CI merge queue runs `TestHyperlaneTestSuite` e2e tests successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6945" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
