### PR TITLE
feat: default min-retain-blocks to appconsts.MinRetainBlocks

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -305,5 +305,6 @@ func DefaultAppConfig() *serverconfig.Config {
 	cfg.MinGasPrices = ""
 	cfg.GRPC.MaxRecvMsgSize = appconsts.DefaultUpperBoundMaxBytes * 2
 	cfg.GRPC.MaxSendMsgSize = appconsts.DefaultUpperBoundMaxBytes * 2
+	cfg.MinRetainBlocks = appconsts.MinRetainBlocks
 	return cfg
 }

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -56,7 +56,7 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, "", cfg.MinGasPrices)
 
 	assert.Equal(t, appconsts.DefaultUpperBoundMaxBytes*2, cfg.GRPC.MaxRecvMsgSize)
-	assert.Equal(t, uint64(0), cfg.MinRetainBlocks)
+	assert.Equal(t, appconsts.MinRetainBlocks, cfg.MinRetainBlocks)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

- Default `min-retain-blocks` to `appconsts.MinRetainBlocks` (3000) instead of `0` in `DefaultAppConfig()`, so fresh nodes automatically prune the block store instead of retaining all blocks forever
- Without this, operators who don't change the default config end up with 1.2TB+ `blockstore.db` on mainnet

Closes #6947

## Test plan

- [x] `TestDefaultAppConfig` updated and passes
- [ ] Verify a fresh node generates `app.toml` with `min-retain-blocks = 3000`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6948" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
