### PR TITLE
feat: increase default min-retain-blocks to 100_000

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -305,6 +305,6 @@ func DefaultAppConfig() *serverconfig.Config {
 	cfg.MinGasPrices = ""
 	cfg.GRPC.MaxRecvMsgSize = appconsts.DefaultUpperBoundMaxBytes * 2
 	cfg.GRPC.MaxSendMsgSize = appconsts.DefaultUpperBoundMaxBytes * 2
-	cfg.MinRetainBlocks = appconsts.MinRetainBlocks
+	cfg.MinRetainBlocks = appconsts.DefaultMinRetainBlocks
 	return cfg
 }

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -56,7 +56,7 @@ func TestDefaultAppConfig(t *testing.T) {
 	assert.Equal(t, "", cfg.MinGasPrices)
 
 	assert.Equal(t, appconsts.DefaultUpperBoundMaxBytes*2, cfg.GRPC.MaxRecvMsgSize)
-	assert.Equal(t, appconsts.MinRetainBlocks, cfg.MinRetainBlocks)
+	assert.Equal(t, appconsts.DefaultMinRetainBlocks, cfg.MinRetainBlocks)
 }
 
 func TestDefaultConsensusConfig(t *testing.T) {

--- a/pkg/appconsts/initial_consts.go
+++ b/pkg/appconsts/initial_consts.go
@@ -29,4 +29,9 @@ const (
 	// This ensures all blocks in the snapshot window (SnapshotInterval × SnapshotKeepRecent)
 	// are retained so other nodes can sync from snapshots.
 	MinRetainBlocks uint64 = 3000
+
+	// DefaultMinRetainBlocks is the default number of blocks to retain in the
+	// block store. This value is large enough for bridge nodes to sync while
+	// still bounding block store growth for operators who don't change the default.
+	DefaultMinRetainBlocks uint64 = 100_000
 )


### PR DESCRIPTION
## Summary

- Add `DefaultMinRetainBlocks = 100_000` const to `appconsts` and use it as the default in `DefaultAppConfig()`

Closes #6947

## Test plan

- [x] `TestDefaultAppConfig` updated and passes
- [ ] Verify bridge node can sync from a consensus node retaining 100k blocks

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6949" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
