### PR TITLE
WIP: add a cometbft-db compatibility layer for v3.x

### DIFF
--- a/app/ante/min_fee_test.go
+++ b/app/ante/min_fee_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app/ante"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v3/x/minfee"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -22,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	version "github.com/tendermint/tendermint/proto/tendermint/version"
-	tmdb "github.com/tendermint/tm-db"
 )
 
 func TestValidateTxFee(t *testing.T) {
@@ -164,7 +164,7 @@ func setUp(t *testing.T) (paramkeeper.Keeper, storetypes.CommitMultiStore) {
 	tStoreKey := storetypes.NewTransientStoreKey(paramtypes.TStoreKey)
 
 	// Create the state store
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	stateStore := store.NewCommitMultiStore(db)
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 	stateStore.MountStoreWithDB(tStoreKey, storetypes.StoreTypeTransient, nil)

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/test/util"
 	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v3/x/minfee"
@@ -21,12 +22,11 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
-	tmdb "github.com/tendermint/tm-db"
 )
 
 func TestNew(t *testing.T) {
 	logger := log.NewNopLogger()
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	traceStore := &NoopWriter{}
 	invCheckPeriod := uint(1)
 	encodingConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...)
@@ -63,7 +63,7 @@ func TestNew(t *testing.T) {
 
 func TestInitChain(t *testing.T) {
 	logger := log.NewNopLogger()
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	traceStore := &NoopWriter{}
 	invCheckPeriod := uint(1)
 	encodingConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...)
@@ -217,7 +217,7 @@ func TestEndBlock(t *testing.T) {
 }
 
 func createTestApp(t *testing.T) *app.App {
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	config := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	upgradeHeight := int64(3)
 	timeoutCommit := time.Second
@@ -226,7 +226,7 @@ func createTestApp(t *testing.T) *app.App {
 		err := os.RemoveAll(snapshotDir)
 		require.NoError(t, err)
 	})
-	snapshotDB, err := tmdb.NewDB("metadata", tmdb.GoLevelDBBackend, snapshotDir)
+	snapshotDB, err := dbcompat.NewDB("metadata", dbcompat.GoLevelDBBackend, snapshotDir)
 	t.Cleanup(func() {
 		err := snapshotDB.Close()
 		require.NoError(t, err)
@@ -243,7 +243,7 @@ func createTestApp(t *testing.T) *app.App {
 }
 
 func createTestAppWithInitChain(t *testing.T, upgradeHeight int64) *app.App {
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	config := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	timeoutCommit := time.Second
 	snapshotDir := filepath.Join(t.TempDir(), "data", "snapshots")
@@ -251,7 +251,7 @@ func createTestAppWithInitChain(t *testing.T, upgradeHeight int64) *app.App {
 		err := os.RemoveAll(snapshotDir)
 		require.NoError(t, err)
 	})
-	snapshotDB, err := tmdb.NewDB("metadata", tmdb.GoLevelDBBackend, snapshotDir)
+	snapshotDB, err := dbcompat.NewDB("metadata", dbcompat.GoLevelDBBackend, snapshotDir)
 	t.Cleanup(func() {
 		err := snapshotDB.Close()
 		require.NoError(t, err)

--- a/app/module/configurator_test.go
+++ b/app/module/configurator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/celestiaorg/celestia-app/v3/app/module"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/x/signal"
 	signaltypes "github.com/celestiaorg/celestia-app/v3/x/signal/types"
 	"github.com/cosmos/cosmos-sdk/store"
@@ -17,7 +18,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 func TestConfigurator(t *testing.T) {
@@ -32,7 +32,7 @@ func TestConfigurator(t *testing.T) {
 		configurator := module.NewConfigurator(config.Codec, mockServer, mockServer)
 		storeKey := sdk.NewKVStoreKey(signaltypes.StoreKey)
 
-		db := dbm.NewMemDB()
+		db := dbcompat.NewMemDB()
 		stateStore := store.NewCommitMultiStore(db)
 		stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 		require.NoError(t, stateStore.LoadLatestVersion())

--- a/app/test/upgrade_test.go
+++ b/app/test/upgrade_test.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
 	v3 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v3"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/pkg/user"
 	"github.com/celestiaorg/celestia-app/v3/test/util"
 	"github.com/celestiaorg/celestia-app/v3/test/util/genesis"
@@ -30,7 +31,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
-	dbm "github.com/tendermint/tm-db"
 )
 
 func TestAppUpgradeV3(t *testing.T) {
@@ -252,7 +252,7 @@ func TestBlobstreamRemovedInV2(t *testing.T) {
 func SetupTestAppWithUpgradeHeight(t *testing.T, upgradeHeightV2 int64) (*app.App, *genesis.Genesis) {
 	t.Helper()
 
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	testApp := app.New(log.NewNopLogger(), db, nil, 0, encCfg, upgradeHeightV2, 0, util.EmptyAppOptions{})
 	genesis := genesis.NewDefaultGenesis().

--- a/cmd/celestia-appd/cmd/start.go
+++ b/cmd/celestia-appd/cmd/start.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -709,7 +710,7 @@ If you need to bypass this check use the --force-no-bbr flag.
 
 func openDB(rootDir string, backendType dbm.BackendType) (dbm.DB, error) {
 	dataDir := filepath.Join(rootDir, "data")
-	return dbm.NewDB("application", backendType, dataDir)
+	return dbcompat.NewDB("application", backendType, dataDir)
 }
 
 func openTraceWriter(traceWriterFile string) (w io.Writer, err error) {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/celestiaorg/knuu v0.16.2
 	github.com/celestiaorg/nmt v0.23.0
 	github.com/celestiaorg/rsmt2d v0.14.0
-	github.com/cometbft/cometbft-db v1.0.3
+	github.com/cometbft/cometbft-db v1.0.4
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.46.16
 	github.com/cosmos/gogoproto v1.7.0
@@ -28,7 +28,7 @@ require (
 	github.com/rs/zerolog v1.33.0
 	github.com/spf13/cast v1.6.0
 	github.com/spf13/cobra v1.8.1
-	github.com/spf13/pflag v1.0.5
+	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
 	github.com/tendermint/tendermint v0.34.29
 	github.com/tendermint/tm-db v0.6.7
@@ -215,7 +215,7 @@ require (
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zondax/hid v0.9.2 // indirect
 	github.com/zondax/ledger-go v0.14.3 // indirect
-	go.etcd.io/bbolt v1.3.11 // indirect
+	go.etcd.io/bbolt v1.4.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/coinbase/rosetta-sdk-go v0.7.9 h1:lqllBjMnazTjIqYrOGv8h8jxjg9+hJazIGZ
 github.com/coinbase/rosetta-sdk-go v0.7.9/go.mod h1:0/knutI7XGVqXmmH4OQD8OckFrbQ8yMsUZTG7FXCR2M=
 github.com/cometbft/cometbft-db v1.0.3 h1:r14sw/ALiiT70btJ8dl1w5eWhPUOe6ZjMflUyuOJrPw=
 github.com/cometbft/cometbft-db v1.0.3/go.mod h1:mt5LIFwMQwioKxJ8+eZPyMscmAc7lbSoNMmW+xP1hvo=
+github.com/cometbft/cometbft-db v1.0.4 h1:cezb8yx/ZWcF124wqUtAFjAuDksS1y1yXedvtprUFxs=
+github.com/cometbft/cometbft-db v1.0.4/go.mod h1:M+BtHAGU2XLrpUxo3Nn1nOCcnVCiLM9yx5OuT0u5SCA=
 github.com/confio/ics23/go v0.9.1 h1:3MV46eeWwO3xCauKyAtuAdJYMyPnnchW4iLr2bTw6/U=
 github.com/confio/ics23/go v0.9.1/go.mod h1:4LPZ2NYqnYIVRklaozjNR1FScgDJ2s5Xrp+e/mYVRak=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
@@ -1234,6 +1236,8 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.15.0 h1:js3yy885G8xwJa6iOISGFwd+qlUo5AvyXb7CiihdtiU=
 github.com/spf13/viper v1.15.0/go.mod h1:fFcTBJxvhhzSJiZy8n+PeW6t8l+KeT/uTARa0jHOQLA=
@@ -1342,6 +1346,7 @@ gitlab.com/NebulousLabs/fastrand v0.0.0-20181126182046-603482d69e40/go.mod h1:rO
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.11 h1:yGEzV1wPz2yVCLsD8ZAiGHhHVlczyC9d1rP43/VCRJ0=
 go.etcd.io/bbolt v1.3.11/go.mod h1:dksAq7YMXoljX0xu6VF5DMZGbhYYoLUalEiSySYAS4I=
+go.etcd.io/bbolt v1.4.0/go.mod h1:AsD+OCi/qPN1giOX1aiLAha3o1U8rAz65bvN4j0sRuk=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.20.2/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=

--- a/pkg/dbcompat/dbcompat.go
+++ b/pkg/dbcompat/dbcompat.go
@@ -1,0 +1,184 @@
+package dbcompat
+
+import (
+	cdb "github.com/cometbft/cometbft-db"
+	tmdb "github.com/tendermint/tm-db"
+)
+
+type BackendType = tmdb.BackendType
+
+const (
+	GoLevelDBBackend BackendType = tmdb.GoLevelDBBackend
+	CLevelDBBackend  BackendType = tmdb.CLevelDBBackend
+	MemDBBackend     BackendType = tmdb.MemDBBackend
+	BoltDBBackend    BackendType = tmdb.BoltDBBackend
+	RocksDBBackend   BackendType = tmdb.RocksDBBackend
+	BadgerDBBackend  BackendType = tmdb.BadgerDBBackend
+)
+
+// Wrap exposes a cometbft-db database through the tm-db interfaces expected by
+// Celestia App v3.x and Cosmos SDK v0.46.
+func Wrap(db cdb.DB) tmdb.DB {
+	return &dbAdapter{db: db}
+}
+
+// NewDB constructs a cometbft-db backend and wraps it with tm-db-compatible
+// interfaces for the app layer.
+func NewDB(name string, backend tmdb.BackendType, dir string) (tmdb.DB, error) {
+	db, err := cdb.NewDB(name, cdb.BackendType(backend), dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return Wrap(db), nil
+}
+
+// NewGoLevelDB constructs a wrapped goleveldb database.
+func NewGoLevelDB(name string, dir string) (tmdb.DB, error) {
+	db, err := cdb.NewGoLevelDB(name, dir)
+	if err != nil {
+		return nil, err
+	}
+
+	return Wrap(db), nil
+}
+
+// NewMemDB constructs a wrapped in-memory database.
+func NewMemDB() tmdb.DB {
+	return Wrap(cdb.NewMemDB())
+}
+
+type dbAdapter struct {
+	db cdb.DB
+}
+
+var _ tmdb.DB = (*dbAdapter)(nil)
+
+func (d *dbAdapter) Get(key []byte) ([]byte, error) {
+	return d.db.Get(key)
+}
+
+func (d *dbAdapter) Has(key []byte) (bool, error) {
+	return d.db.Has(key)
+}
+
+func (d *dbAdapter) Set(key, value []byte) error {
+	return d.db.Set(key, value)
+}
+
+func (d *dbAdapter) SetSync(key, value []byte) error {
+	return d.db.SetSync(key, value)
+}
+
+func (d *dbAdapter) Delete(key []byte) error {
+	return d.db.Delete(key)
+}
+
+func (d *dbAdapter) DeleteSync(key []byte) error {
+	return d.db.DeleteSync(key)
+}
+
+func (d *dbAdapter) Close() error {
+	return d.db.Close()
+}
+
+func (d *dbAdapter) NewBatch() tmdb.Batch {
+	return &batchAdapter{batch: d.db.NewBatch()}
+}
+
+func (d *dbAdapter) Iterator(start, end []byte) (tmdb.Iterator, error) {
+	itr, err := d.db.Iterator(start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	return &iteratorAdapter{itr: itr}, nil
+}
+
+func (d *dbAdapter) ReverseIterator(start, end []byte) (tmdb.Iterator, error) {
+	itr, err := d.db.ReverseIterator(start, end)
+	if err != nil {
+		return nil, err
+	}
+
+	return &iteratorAdapter{itr: itr}, nil
+}
+
+func (d *dbAdapter) Print() error {
+	return d.db.Print()
+}
+
+func (d *dbAdapter) Stats() map[string]string {
+	return d.db.Stats()
+}
+
+type batchAdapter struct {
+	batch cdb.Batch
+}
+
+var _ tmdb.Batch = (*batchAdapter)(nil)
+
+func (b *batchAdapter) Set(key, value []byte) error {
+	return b.batch.Set(key, value)
+}
+
+func (b *batchAdapter) Delete(key []byte) error {
+	return b.batch.Delete(key)
+}
+
+func (b *batchAdapter) Write() error {
+	return b.batch.Write()
+}
+
+func (b *batchAdapter) WriteSync() error {
+	return b.batch.WriteSync()
+}
+
+func (b *batchAdapter) Close() error {
+	return b.batch.Close()
+}
+
+type iteratorAdapter struct {
+	itr cdb.Iterator
+}
+
+var _ tmdb.Iterator = (*iteratorAdapter)(nil)
+
+func (i *iteratorAdapter) Domain() (start []byte, end []byte) {
+	iterStart, iterEnd := i.itr.Domain()
+	return copyBytes(iterStart), copyBytes(iterEnd)
+}
+
+func (i *iteratorAdapter) Valid() bool {
+	return i.itr.Valid()
+}
+
+func (i *iteratorAdapter) Next() {
+	i.itr.Next()
+}
+
+func (i *iteratorAdapter) Key() []byte {
+	return copyBytes(i.itr.Key())
+}
+
+func (i *iteratorAdapter) Value() []byte {
+	return copyBytes(i.itr.Value())
+}
+
+func (i *iteratorAdapter) Error() error {
+	return i.itr.Error()
+}
+
+func (i *iteratorAdapter) Close() error {
+	return i.itr.Close()
+}
+
+func copyBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}

--- a/pkg/dbcompat/dbcompat_test.go
+++ b/pkg/dbcompat/dbcompat_test.go
@@ -1,0 +1,54 @@
+package dbcompat
+
+import (
+	"testing"
+
+	cdb "github.com/cometbft/cometbft-db"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIteratorCopiesKeyAndValue(t *testing.T) {
+	dir := t.TempDir()
+
+	db, err := cdb.NewDB("iterator-copy", cdb.PebbleDBBackend, dir)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, db.Close())
+	})
+
+	require.NoError(t, db.Set([]byte("a"), []byte("one")))
+	require.NoError(t, db.Set([]byte("b"), []byte("two")))
+
+	wrapped := Wrap(db)
+	itr, err := wrapped.Iterator(nil, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, itr.Close())
+	})
+
+	require.True(t, itr.Valid())
+	key := itr.Key()
+	value := itr.Value()
+
+	itr.Next()
+	require.True(t, itr.Valid())
+
+	require.Equal(t, []byte("a"), key)
+	require.Equal(t, []byte("one"), value)
+	require.Equal(t, []byte("b"), itr.Key())
+	require.Equal(t, []byte("two"), itr.Value())
+}
+
+func TestWrappedDBBehavesLikeTMDB(t *testing.T) {
+	db := NewMemDB()
+
+	require.NoError(t, db.Set([]byte("key"), []byte("value")))
+
+	got, err := db.Get([]byte("key"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), got)
+
+	has, err := db.Has([]byte("key"))
+	require.NoError(t, err)
+	require.True(t, has)
+}

--- a/test/pfm/setup.go
+++ b/test/pfm/setup.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -23,7 +24,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmprotoversion "github.com/tendermint/tendermint/proto/tendermint/version"
 	tmtypes "github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 )
 
 // NewTestChain initializes a new test chain with a default of 4 validators.
@@ -219,7 +219,7 @@ func SetupWithGenesisValSetAndConsensusParams(t *testing.T, consensusParams *abc
 }
 
 func SetupTestingApp() (ibctesting.TestingApp, map[string]json.RawMessage) {
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 	encCdc := simapp.MakeTestEncodingConfig()
 	app := NewSimApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, simapp.DefaultNodeHome, 5, encCdc, simapp.EmptyAppOptions{})
 	return app, simapp.NewDefaultGenesisState(encCdc.Marshaler)

--- a/test/tokenfilter/setup.go
+++ b/test/tokenfilter/setup.go
@@ -9,6 +9,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
 	"github.com/celestiaorg/celestia-app/v3/x/minfee"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -20,16 +21,14 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	ibctesting "github.com/cosmos/ibc-go/v6/testing"
+	"github.com/cosmos/ibc-go/v6/testing/mock"
+	"github.com/cosmos/ibc-go/v6/testing/simapp"
 	"github.com/stretchr/testify/require"
 	abci "github.com/tendermint/tendermint/abci/types"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 	tmtypes "github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
-
-	"github.com/cosmos/ibc-go/v6/testing/mock"
-	"github.com/cosmos/ibc-go/v6/testing/simapp"
 )
 
 // NewTestChainWithValSet initializes a new TestChain instance with the given validator set
@@ -143,7 +142,7 @@ func NewTestChain(t *testing.T, coord *ibctesting.Coordinator, chainID string) *
 // of one consensus engine unit (10^6) in the default token of the simapp from first genesis
 // account. A Nop logger is set in SimApp.
 func SetupWithGenesisValSet(t testing.TB, valSet *tmtypes.ValidatorSet, genAccs []authtypes.GenesisAccount, chainID string, powerReduction math.Int, balances ...banktypes.Balance) ibctesting.TestingApp {
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 	encCdc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	genesisState := app.NewDefaultGenesisState(encCdc.Codec)
 	app := app.New(log.NewNopLogger(), db, nil, 5, encCdc, 0, 0, simapp.EmptyAppOptions{})

--- a/test/util/common.go
+++ b/test/util/common.go
@@ -9,6 +9,7 @@ import (
 
 	cosmosmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v3/app"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/x/blobstream/keeper"
 	blobstreamtypes "github.com/celestiaorg/celestia-app/v3/x/blobstream/types"
 	"github.com/cosmos/cosmos-sdk/codec"
@@ -44,7 +45,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
-	dbm "github.com/tendermint/tm-db"
 )
 
 var (
@@ -191,7 +191,7 @@ func CreateTestEnvWithoutBlobstreamKeysInit(t *testing.T) TestInput {
 	keySlashing := sdk.NewKVStoreKey(slashingtypes.StoreKey)
 
 	// Initialize memory database and mount stores on it
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 	ms := store.NewCommitMultiStore(db)
 	ms.MountStoreWithDB(keyBlobstream, storetypes.StoreTypeIAVL, db)
 	ms.MountStoreWithDB(keyAuth, storetypes.StoreTypeIAVL, db)

--- a/test/util/test_app.go
+++ b/test/util/test_app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
 	v1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/test/util/genesis"
 	"github.com/celestiaorg/celestia-app/v3/test/util/testfactory"
 	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
@@ -36,7 +37,6 @@ import (
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
 	tmtypes "github.com/tendermint/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -98,7 +98,7 @@ func NewTestApp() *app.App {
 	// EmptyAppOptions is a stub implementing AppOptions
 	emptyOpts := EmptyAppOptions{}
 	// var anteOpt = func(bapp *baseapp.BaseApp) { bapp.SetAnteHandler(nil) }
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
@@ -465,7 +465,7 @@ func NewDefaultGenesisState(cdc codec.JSONCodec) app.GenesisState {
 func SetupTestAppWithUpgradeHeight(t *testing.T, upgradeHeight int64) (*app.App, keyring.Keyring) {
 	t.Helper()
 
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 	chainID := "test_chain"
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	testApp := app.New(log.NewNopLogger(), db, nil, 0, encCfg, upgradeHeight, 0, EmptyAppOptions{})

--- a/test/util/testnode/comet_node.go
+++ b/test/util/testnode/comet_node.go
@@ -3,13 +3,13 @@ package testnode
 import (
 	"path/filepath"
 
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	"github.com/tendermint/tendermint/node"
 	"github.com/tendermint/tendermint/p2p"
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/proxy"
-	tmdb "github.com/tendermint/tm-db"
 )
 
 // NewCometNode creates a ready to use comet node that operates a single
@@ -18,7 +18,7 @@ import (
 func NewCometNode(baseDir string, config *UniversalTestingConfig) (*node.Node, servertypes.Application, error) {
 	logger := NewLogger(config)
 	dbPath := filepath.Join(config.TmConfig.RootDir, "data")
-	db, err := tmdb.NewGoLevelDB("application", dbPath)
+	db, err := dbcompat.NewGoLevelDB("application", dbPath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/test/util/genesis"
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	srvconfig "github.com/cosmos/cosmos-sdk/server/config"
@@ -184,7 +185,7 @@ func DefaultAppCreator(opts ...AppCreationOptions) srvtypes.AppCreator {
 		encodingConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 		app := app.New(
 			log.NewNopLogger(),
-			tmdb.NewMemDB(),
+			dbcompat.NewMemDB(),
 			nil, // trace store
 			0,   // invCheckPerid
 			encodingConfig,
@@ -207,7 +208,7 @@ func CustomAppCreator(minGasPrice string) srvtypes.AppCreator {
 		encodingConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 		app := app.New(
 			log.NewNopLogger(),
-			tmdb.NewMemDB(),
+			dbcompat.NewMemDB(),
 			nil, // trace store
 			0,   // invCheckPerid
 			encodingConfig,

--- a/tools/chainbuilder/integration_test.go
+++ b/tools/chainbuilder/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/test/util"
 	"github.com/celestiaorg/celestia-app/v3/test/util/testnode"
 	"github.com/cosmos/cosmos-sdk/baseapp"
@@ -20,7 +21,6 @@ import (
 	"github.com/tendermint/tendermint/privval"
 	"github.com/tendermint/tendermint/proxy"
 	"github.com/tendermint/tendermint/rpc/client/local"
-	tmdbm "github.com/tendermint/tm-db"
 
 	"github.com/stretchr/testify/require"
 )
@@ -54,7 +54,7 @@ func TestRun(t *testing.T) {
 	tmCfg := testnode.DefaultTendermintConfig()
 	tmCfg.SetRoot(cfg.ExistingDir)
 
-	appDB, err := tmdbm.NewDB("application", tmdbm.GoLevelDBBackend, tmCfg.DBDir())
+	appDB, err := dbcompat.NewDB("application", dbcompat.GoLevelDBBackend, tmCfg.DBDir())
 	require.NoError(t, err)
 
 	encCfg := encoding.MakeConfig(app.ModuleBasics)

--- a/tools/chainbuilder/main.go
+++ b/tools/chainbuilder/main.go
@@ -24,12 +24,12 @@ import (
 	sm "github.com/tendermint/tendermint/state"
 	"github.com/tendermint/tendermint/store"
 	"github.com/tendermint/tendermint/types"
-	tmdbm "github.com/tendermint/tm-db"
 
 	"github.com/celestiaorg/celestia-app/v3/app"
 	"github.com/celestiaorg/celestia-app/v3/app/encoding"
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v3/pkg/da"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/pkg/user"
 	"github.com/celestiaorg/celestia-app/v3/test/util"
 	"github.com/celestiaorg/celestia-app/v3/test/util/genesis"
@@ -191,7 +191,7 @@ func Run(ctx context.Context, cfg BuilderConfig, dir string) error {
 		DiscardABCIResponses: true,
 	})
 
-	appDB, err := tmdbm.NewDB("application", tmdbm.GoLevelDBBackend, tmCfg.DBDir())
+	appDB, err := dbcompat.NewDB("application", dbcompat.GoLevelDBBackend, tmCfg.DBDir())
 	if err != nil {
 		return fmt.Errorf("failed to create application database: %w", err)
 	}

--- a/x/blob/keeper/keeper_test.go
+++ b/x/blob/keeper/keeper_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	testutil "github.com/celestiaorg/celestia-app/v3/test/util"
 	"github.com/celestiaorg/celestia-app/v3/x/blob/keeper"
 	"github.com/celestiaorg/celestia-app/v3/x/blob/types"
@@ -22,7 +23,6 @@ import (
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
-	tmdb "github.com/tendermint/tm-db"
 )
 
 // TestPayForBlobs verifies the attributes on the emitted event.
@@ -76,7 +76,7 @@ func CreateKeeper(t *testing.T, version uint64) (*keeper.Keeper, store.CommitMul
 	storeKey := sdk.NewKVStoreKey(paramtypes.StoreKey)
 	tStoreKey := storetypes.NewTransientStoreKey(paramtypes.TStoreKey)
 
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	stateStore := store.NewCommitMultiStore(db)
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 	stateStore.MountStoreWithDB(tStoreKey, storetypes.StoreTypeTransient, nil)

--- a/x/minfee/module_test.go
+++ b/x/minfee/module_test.go
@@ -3,6 +3,7 @@ package minfee_test
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/x/minfee"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
@@ -12,7 +13,6 @@ import (
 	paramkeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 	"github.com/stretchr/testify/require"
-	tmdb "github.com/tendermint/tm-db"
 )
 
 func TestNewModuleInitializesKeyTable(t *testing.T) {
@@ -20,7 +20,7 @@ func TestNewModuleInitializesKeyTable(t *testing.T) {
 	tStoreKey := storetypes.NewTransientStoreKey(paramtypes.TStoreKey)
 
 	// Create the state store
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	stateStore := store.NewCommitMultiStore(db)
 	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
 	stateStore.MountStoreWithDB(tStoreKey, storetypes.StoreTypeTransient, nil)

--- a/x/mint/module_test.go
+++ b/x/mint/module_test.go
@@ -3,12 +3,12 @@ package mint_test
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/stretchr/testify/require"
 	abcitypes "github.com/tendermint/tendermint/abci/types"
 	tmjson "github.com/tendermint/tendermint/libs/json"
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	dbm "github.com/tendermint/tm-db"
 
 	"github.com/celestiaorg/celestia-app/v3/x/mint/types"
 	"github.com/cosmos/cosmos-sdk/simapp"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestItCreatesModuleAccountOnInitBlock(t *testing.T) {
-	db := dbm.NewMemDB()
+	db := dbcompat.NewMemDB()
 	encCdc := simapp.MakeTestEncodingConfig()
 	app := simapp.NewSimApp(log.NewNopLogger(), db, nil, true, map[int64]bool{}, simapp.DefaultNodeHome, 5, encCdc, simapp.EmptyAppOptions{})
 

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v3/pkg/appconsts"
 	v1 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v1"
 	v2 "github.com/celestiaorg/celestia-app/v3/pkg/appconsts/v2"
+	"github.com/celestiaorg/celestia-app/v3/pkg/dbcompat"
 	"github.com/celestiaorg/celestia-app/v3/x/signal"
 	"github.com/celestiaorg/celestia-app/v3/x/signal/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
@@ -26,7 +27,6 @@ import (
 	"github.com/tendermint/tendermint/libs/log"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
 	tmversion "github.com/tendermint/tendermint/proto/tendermint/version"
-	tmdb "github.com/tendermint/tm-db"
 )
 
 func TestGetVotingPowerThreshold(t *testing.T) {
@@ -536,7 +536,7 @@ func TestTallyAfterTryUpgrade(t *testing.T) {
 
 func setup(t *testing.T) (signal.Keeper, sdk.Context, *mockStakingKeeper) {
 	signalStore := sdk.NewKVStoreKey(types.StoreKey)
-	db := tmdb.NewMemDB()
+	db := dbcompat.NewMemDB()
 	stateStore := store.NewCommitMultiStore(db)
 	stateStore.MountStoreWithDB(signalStore, storetypes.StoreTypeIAVL, nil)
 	require.NoError(t, stateStore.LoadLatestVersion())


### PR DESCRIPTION
## Summary
- bump  from  to 
- add a  wrapper that backs  interfaces with 
- preserve legacy  iterator semantics by copying iterator keys and values in the adapter
- switch local app DB construction sites and tests to use the compatibility layer instead of constructing  databases directly

## Why
 still depends on Cosmos SDK , so the app layer must continue to satisfy  interfaces. A direct swap to raw  would expose the iterator aliasing change and can break callers that reuse iterator-backed byte slices after advancing the iterator.

This keeps the branch compatible with the SDK surface while migrating local DB construction onto  and explicitly restoring the iterator copy behavior expected by older  callers.

## Verification
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 

## Notes
-  remains in the dependency graph because Cosmos SDK  still types its app/database interfaces against .
- This PR limits the migration to repo-local DB construction and compatibility behavior needed for .