### PR TITLE
fix: increase testnode network retries and add backoff

### DIFF
--- a/test/util/testnode/network.go
+++ b/test/util/testnode/network.go
@@ -20,7 +20,7 @@ import (
 // addresses. Configured genesis options will be applied after all accounts have
 // been initialized.
 func NewNetwork(t testing.TB, config *Config) (cctx Context, rpcAddr, grpcAddr string) {
-	return NewNetworkWithRetry(t, config, 3)
+	return NewNetworkWithRetry(t, config, 5)
 }
 
 // NewNetworkWithRetry creates a testnode network with port retry logic
@@ -34,7 +34,8 @@ func NewNetworkWithRetry(t testing.TB, config *Config, maxRetries int) (cctx Con
 				cleanup()
 			}
 			if isPortBindingError(err) {
-				time.Sleep(time.Second)
+				t.Logf("port binding error on attempt %d/%d, retrying after %ds: %v", attempt+1, maxRetries, attempt+1, err)
+				time.Sleep(time.Duration(attempt+1) * time.Second)
 				config.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
 				config.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
 				config.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())


### PR DESCRIPTION
## Summary
- Increase `NewNetwork` max retries from 3 to 5 to give CI runners more chances to find free ports
- Replace fixed 1s sleep with linear backoff (1s, 2s, 3s, 4s, 5s) between retries
- Add a log line on each retry attempt for better CI debuggability

Addresses flaky CI failure in `TestTxClientTestSuite/TestMultiConnBroadcast` where port binding errors exhausted all retry attempts: https://github.com/celestiaorg/celestia-app/actions/runs/24018301319/job/70041920378

## Test plan
- [x] `go build ./test/util/testnode/...` compiles successfully
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6968" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
