### PR TITLE
chore: update CLAUDE.md with Hacken bug bounty PR guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,4 @@ All branches use forked cosmos-sdk and celestia-core:
 1. **Multi-module repo**: Copy `go.work.example` to `go.work` and run `go work sync`
 2. **Conventional commits**: PR titles must follow [conventionalcommits.org](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `chore:`, `feat!:` for breaking changes)
 3. **Validate inputs** in message handlers; be cautious with arithmetic overflow and gas consumption
+4. **Hacken bug bounty PRs**: When creating a PR that resolves a Hacken bug bounty report, do NOT include details about the bug in the PR description. Instead, link to a Linear issue that contains more details on the bug and the link to the Hacken bug bounty report.


### PR DESCRIPTION
## Summary
- Add guidance to CLAUDE.md instructing Claude to not include bug details in PR descriptions for Hacken bug bounty fixes. Instead, the PR description should link to a Linear issue with more details.

Closes https://linear.app/celestia/issue/PROTOCO-1445/update-claudemd

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6986" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
