### PR TITLE
chore: bump embedded v3 binary from v3.10.6 to v3.11.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,10 +9,10 @@ before:
     - go mod tidy
     # These hooks get run once. We want to explicitly download every embedded binary so we can build the multiplexer
     # for every architecture. These versions must be updated at the same time as the version in the Makefile.
-    - ./scripts/download_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.10.6
-    - ./scripts/download_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.10.6
-    - ./scripts/download_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.10.6
-    - ./scripts/download_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.10.6
+    - ./scripts/download_binary.sh celestia-app_Darwin_arm64.tar.gz celestia-app_darwin_v3_arm64.tar.gz v3.11.0
+    - ./scripts/download_binary.sh celestia-app_Linux_arm64.tar.gz celestia-app_linux_v3_arm64.tar.gz v3.11.0
+    - ./scripts/download_binary.sh celestia-app_Darwin_x86_64.tar.gz celestia-app_darwin_v3_amd64.tar.gz v3.11.0
+    - ./scripts/download_binary.sh celestia-app_Linux_x86_64.tar.gz celestia-app_linux_v3_amd64.tar.gz v3.11.0
     - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v4_arm64.tar.gz v4.1.0
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v4_arm64.tar.gz v4.1.0
     - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v4_amd64.tar.gz v4.1.0

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_M
 # .goreleaser.yaml
 # docker/multiplexer.Dockerfile
 # dockerchain/config.go
-CELESTIA_V3_VERSION := v3.10.6
+CELESTIA_V3_VERSION := v3.11.0
 CELESTIA_V4_VERSION := v4.1.0
 CELESTIA_V5_VERSION := v5.0.12
 CELESTIA_V6_VERSION := v6.4.4

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -18,7 +18,7 @@ ARG UPGRADE_HEIGHT_DELAY
 ARG CELESTIA_APP_REPOSITORY=ghcr.io/celestiaorg/celestia-app-standalone
 # NOTE: This version must be updated at the same time as the version in the
 # Makefile.
-ARG CELESTIA_VERSION_V3="v3.10.6"
+ARG CELESTIA_VERSION_V3="v3.11.0"
 ARG CELESTIA_VERSION_V4="v4.1.0"
 ARG CELESTIA_VERSION_V5="v5.0.12"
 ARG CELESTIA_VERSION_V6="v6.4.4"

--- a/test/docker-e2e/e2e_block_sync_v2_upgrade_test.go
+++ b/test/docker-e2e/e2e_block_sync_v2_upgrade_test.go
@@ -38,7 +38,7 @@ func (s *CelestiaTestSuite) TestBlockSyncV2Upgrade() {
 	// Use v3.x standalone image for initial chain build
 	cfg := dockerchain.DefaultConfig(s.client, s.network).
 		WithImage("ghcr.io/celestiaorg/celestia-app-standalone").
-		WithTag("v3.10.6")
+		WithTag("v3.11.0")
 
 	// Set genesis to start at app version 1
 	cfg.Genesis = cfg.Genesis.WithAppVersion(1)


### PR DESCRIPTION
## Summary
- Bump the embedded v3 binary version from v3.10.6 to v3.11.0 across Makefile, .goreleaser.yaml, multiplexer Dockerfile, and e2e tests.

Closes https://github.com/celestiaorg/celestia-app/issues/6870
PROTOCO-1281

## Test plan
- [ ] CI passes (build, lint, tests)
- [ ] Multiplexer build succeeds with the new v3.11.0 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6987" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
