### PR TITLE
revert: set goleveldb as default db backend (#6960)

### DIFF
--- a/app/default_overrides.go
+++ b/app/default_overrides.go
@@ -283,8 +283,6 @@ func DefaultConsensusConfig() *tmcfg.Config {
 	cfg.P2P.SendRate = 100 * mebibyte
 	cfg.P2P.RecvRate = 100 * mebibyte
 
-	cfg.DBBackend = appconsts.DefaultDBBackend
-
 	return cfg
 }
 

--- a/app/default_overrides_test.go
+++ b/app/default_overrides_test.go
@@ -99,10 +99,6 @@ func TestDefaultConsensusConfig(t *testing.T) {
 		assert.Equal(t, int64(100*mebibyte), got.P2P.SendRate)
 		assert.Equal(t, int64(100*mebibyte), got.P2P.RecvRate)
 	})
-
-	t.Run("db backend", func(t *testing.T) {
-		assert.Equal(t, "goleveldb", got.DBBackend)
-	})
 }
 
 func Test_icaDefaultGenesis(t *testing.T) {

--- a/pkg/appconsts/app_consts.go
+++ b/pkg/appconsts/app_consts.go
@@ -78,8 +78,6 @@ const (
 	// BlockMaxBytes is the governance-modifiable max number of bytes in a block.
 	// Set via the v8 upgrade handler.
 	BlockMaxBytes = 32 * mebibyte
-	// DefaultDBBackend is the default database backend for CometBFT.
-	DefaultDBBackend = "goleveldb"
 )
 
 // MinCommissionRate is 20%.


### PR DESCRIPTION
## Summary

- Reverts commit 84dd4599f0f6c5d009af8036550719fbf1a8df5a ("chore: set goleveldb as default db backend (#6960)") because pebbledb was fixed for v3 in 2a2771aa9fbc82ce6c76f1ac9d4c94c428af212c ("feat: add the pebbledb adapter for v3 (#6984)").

Closes https://github.com/celestiaorg/celestia-app/issues/6992 and PROTOCO-1449
## Test plan

- [ ] `make build` succeeds
- [ ] `make test-short` passes
- [x] Verify pebbledb works as default db backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/6990" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
