### PR TITLE
test: verify fibre modules are not loaded without fibre build tag

### DIFF
--- a/app/fibre_disabled_test.go
+++ b/app/fibre_disabled_test.go
@@ -1,0 +1,33 @@
+//go:build !fibre
+
+package app_test
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v8/app"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestFibreModulesNotLoaded verifies that the fibre and valaddr modules are not
+// loaded in the app when the fibre build tag is not set.
+func TestFibreModulesNotLoaded(t *testing.T) {
+	testApp := getTestApp()
+
+	t.Run("module manager does not contain fibre or valaddr modules", func(t *testing.T) {
+		assert.NotContains(t, testApp.ModuleManager.Modules, "fibre")
+		assert.NotContains(t, testApp.ModuleManager.Modules, "valaddr")
+	})
+
+	t.Run("store keys do not contain fibre or valaddr", func(t *testing.T) {
+		assert.Nil(t, testApp.GetKey("fibre"))
+		assert.Nil(t, testApp.GetKey("valaddr"))
+	})
+
+	t.Run("encoding registers do not contain fibre or valaddr", func(t *testing.T) {
+		for _, register := range app.ModuleEncodingRegisters {
+			assert.NotEqual(t, "fibre", register.Name())
+			assert.NotEqual(t, "valaddr", register.Name())
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds a unit test gated with `//go:build !fibre` that verifies fibre and valaddr modules are not loaded in the state machine when the `fibre` build tag is not set
- Checks module manager, store keys, and encoding registers

Closes #6996
Closes PROTOCO-1452

## Test plan
- [x] `go test -v -run TestFibreModulesNotLoaded ./app/` passes without fibre tag
- [x] Test is correctly excluded when running with `-tags fibre`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7004" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
