### PR TITLE
chore(talis): add support for downloading latency-monitor and txsim logs

### DIFF
--- a/tools/talis/download.go
+++ b/tools/talis/download.go
@@ -50,6 +50,10 @@ func downloadCmd() *cobra.Command {
 			switch table {
 			case "logs":
 				remotePaths = append(remotePaths, "/root/logs")
+			case "latency-monitor":
+				remotePaths = append(remotePaths, "/root/talis-latency-monitor.log")
+			case "txsim":
+				remotePaths = append(remotePaths, "/root/talis-txsim.log")
 			case "*", "":
 				path := filepath.Join(baseTracesRemotePath, "*")
 				remotePaths = append(remotePaths, path)
@@ -144,6 +148,10 @@ func compressAndDownload(table, localPath, user, host, sshKeyPath string) error 
 	switch table {
 	case "logs":
 		compressCmd = fmt.Sprintf("tar -cf - -C /root logs | xz -6 -T0 > %s", remoteArchive)
+	case "latency-monitor":
+		compressCmd = fmt.Sprintf("tar -cf - -C /root talis-latency-monitor.log | xz -6 -T0 > %s", remoteArchive)
+	case "txsim":
+		compressCmd = fmt.Sprintf("tar -cf - -C /root talis-txsim.log | xz -6 -T0 > %s", remoteArchive)
 	case "*", "":
 		compressCmd = fmt.Sprintf("tar -cf - -C %s . | xz -6 -T0 > %s", baseTracesRemotePath, remoteArchive)
 	default:


### PR DESCRIPTION
## Overview

I find it useful to get these logs as well in some cases
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7008" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
