### PR TITLE
fix: bump cosmos-sdk to v0.52.3 to fix data races

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ HTTPS_GIT := https://github.com/celestiaorg/celestia-app.git
 PACKAGE_NAME := github.com/celestiaorg/celestia-app/v8
 # Before upgrading the GOLANG_CROSS_VERSION, please verify that a Docker image exists with the new tag.
 # See https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross
-GOLANG_CROSS_VERSION  ?= v1.25.7
+GOLANG_CROSS_VERSION  ?= v1.25.8
 # Set this to override v2 upgrade height for the v3 embedded binaries
 V2_UPGRADE_HEIGHT ?= 0
 

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -4,7 +4,7 @@
 #
 # Separating the builder and runtime image allows the runtime image to be
 # considerably smaller because it doesn't need to have Golang installed.
-ARG BUILDER_IMAGE=docker.io/golang:1.25.7-alpine
+ARG BUILDER_IMAGE=docker.io/golang:1.25.8-alpine
 ARG RUNTIME_IMAGE=docker.io/alpine:3.22
 ARG TARGETOS
 ARG TARGETARCH

--- a/docker/standalone.Dockerfile
+++ b/docker/standalone.Dockerfile
@@ -4,7 +4,7 @@
 #
 # Separating the builder and runtime image allows the runtime image to be
 # considerably smaller because it doesn't need to have Golang installed.
-ARG BUILDER_IMAGE=docker.io/golang:1.25.7-alpine
+ARG BUILDER_IMAGE=docker.io/golang:1.25.8-alpine
 ARG RUNTIME_IMAGE=docker.io/alpine:3.22
 ARG TARGETOS
 ARG TARGETARCH

--- a/docker/txsim/Dockerfile
+++ b/docker/txsim/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: generate txsim binary
-FROM --platform=$BUILDPLATFORM docker.io/golang:1.25.7-alpine AS builder
+FROM --platform=$BUILDPLATFORM docker.io/golang:1.25.8-alpine AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/celestiaorg/celestia-app/v8
 
-go 1.25.7
+go 1.25.8
 
 require (
 	cloud.google.com/go/compute v1.54.0
@@ -441,7 +441,7 @@ replace (
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.27
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.1
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.3
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/go.sum
+++ b/go.sum
@@ -862,8 +862,8 @@ github.com/celestiaorg/celestia-core v0.39.27 h1:gsXdVc6zip/MubpYfXC+ATChVQi/ZFD
 github.com/celestiaorg/celestia-core v0.39.27/go.mod h1:JF+hVOBTBuV5OtdT5wgcE9h2ymzVCAqYdORtH2Rly7k=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v0.52.1 h1:sH49jz9Vo/RkJz24fjr0jo7pd9stvxoXQ1G2n3nG3Xc=
-github.com/celestiaorg/cosmos-sdk v0.52.1/go.mod h1:r2LYq9wdoYUiNITEGrIq635ZXf2xhAPmMzimq3uITRI=
+github.com/celestiaorg/cosmos-sdk v0.52.3 h1:YPMFCycTw77P7tn+HQHTmmdBwXWNMDOrZ6/xVPK9nvM=
+github.com/celestiaorg/cosmos-sdk v0.52.3/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -1,6 +1,6 @@
 module celestiaorg/celestia-app/test/docker-e2e
 
-go 1.25.7
+go 1.25.8
 
 require (
 	cosmossdk.io/math v1.5.3


### PR DESCRIPTION
## Summary

- Bump `celestiaorg/cosmos-sdk` from v0.52.1 to v0.52.3 to fix two data races that cause flaky `test-race` failures
- [celestiaorg/cosmos-sdk#715](https://github.com/celestiaorg/cosmos-sdk/pull/715): fixes `lastCommitInfo` race between `Commit()` and `CreateQueryContext()` by widening `checkStateMu` to cover `cms.Commit()`
- [celestiaorg/cosmos-sdk#726](https://github.com/celestiaorg/cosmos-sdk/pull/726): fixes IAVL tree race between `Commit()` and `Simulate()` by holding `checkStateMu.RLock` for the duration of `Simulate()`
- Bump Go version from 1.25.7 to 1.25.8 (required by cosmos-sdk v0.52.3) in go.mod, Dockerfiles, and Makefile

Closes https://github.com/celestiaorg/celestia-app/issues/6614
Closes https://github.com/celestiaorg/celestia-app/issues/6776

## Test plan

- [x] `make build` succeeds
- [x] `go test -race -count=3 -v -run TestV2SubmitMethods ./pkg/user/v2/` passes with no data races (previously flaky)
- [ ] CI `test-race` job passes
- [ ] CI `build-e2e-image` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7037" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
