### PR TITLE
ci: restore CodeQL workflow with pull_request trigger

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,60 @@
+# CodeQL security analysis.
+#
+# This workflow addresses celestiaorg/celestia-app#5864 (the prior workflow did
+# not run on PRs). It runs on:
+#   - pull_request to main            -> catches regressions before merge
+#   - push to main and v* branches    -> records results against protected refs
+#   - weekly schedule                 -> picks up new CodeQL rule releases
+#
+# Pinned to commit SHAs per repo convention. Version comments indicate the
+# human-readable tag each SHA corresponds to.
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main", "v*"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "24 20 * * 4"
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          languages: ${{ matrix.language }}
+
+      # Build the module explicitly instead of `make build`. `make build` runs
+      # the multiplexer and embeds legacy v3-v8 binaries, which is too slow for
+      # a security scan and unnecessary for CodeQL's Go extractor.
+      - name: Build Go packages
+        run: go build ./...
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

- Restores `.github/workflows/codeql.yml` (removed in #5865) with the fix that it now runs on `pull_request` as well as `push` — closing the original concern from #5864.
- Uses `go build ./...` instead of `make build` so the scan does not compile the multiplexer or embed legacy v3-v8 binaries.

## Verification (post-merge)

- Healthy CodeQL analysis recorded on `main`: `analysis_key=.github/workflows/codeql.yml:analyze`, `tool_version=2.25.1`, `rules_count=34`, no error (analysis id `1143577191`, 2026-04-13T15:28:13Z).
- The new scan surfaced 3 real findings on `main` (alerts #16/#17/#18 — `go/zipslip`, `go/clear-text-logging`, `go/insecure-hostkeycallback`) — exactly the kind of PR-time signal #5864 wanted.
- `code-scanning/default-setup` state remains `not-configured` (no duplication with the workflow).

## Cleanup follow-up

The stale 2025-09-30 default-setup analysis (id `701827006`, `rules_count: 0`, `tool_version: null`) that was the original source of the Code Scanning page's configuration error could not be deleted via the API — `DELETE .../code-scanning/analyses/701827006?confirm_delete=true` returned `400 "Analysis specified is not deletable"`. Analyses created by GitHub's default setup (rather than a workflow) are not API-deletable. This is non-blocking: GitHub's tool status surfaces the most recent analysis, which is now the healthy 2026-04-13 run, so the stale record is inert history.

Closes #5864
Closes PROTOCO-1489