### PR TITLE
feat(talis): add dedicated encoder instances for fibre-txsim

### DIFF
--- a/tools/talis/add.go
+++ b/tools/talis/add.go
@@ -41,6 +41,17 @@ func addCmd() *cobra.Command {
 						return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud)", provider)
 					}
 				}
+			case "encoder":
+				for i := 0; i < count; i++ {
+					switch provider {
+					case "digitalocean":
+						cfg = cfg.WithDigitalOceanEncoder(region)
+					case "googlecloud":
+						cfg = cfg.WithGoogleCloudEncoder(region)
+					default:
+						return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud)", provider)
+					}
+				}
 			case "bridge":
 				log.Println("bridges are not yet supported")
 				return nil
@@ -58,7 +69,7 @@ func addCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&rootDir, "directory", "d", ".", "root directory in which to initialize")
 	cmd.Flags().IntVarP(&count, "count", "c", 0, "Number of nodes to deploy")
 	_ = cmd.MarkFlagRequired("count")
-	cmd.Flags().StringVarP(&nodeType, "type", "t", "", "Type of the node (validator, bridge, light)")
+	cmd.Flags().StringVarP(&nodeType, "type", "t", "", "Type of the node (validator, encoder, bridge, light)")
 	_ = cmd.MarkFlagRequired("type")
 	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "Provider for the node (digitalocean, googlecloud)")
 	cmd.Flags().StringVarP(&region, "region", "r", "random", "the region to deploy the instance in (random if blank)")

--- a/tools/talis/add.go
+++ b/tools/talis/add.go
@@ -31,7 +31,7 @@ func addCmd() *cobra.Command {
 
 			switch nodeType {
 			case "validator":
-				for i := 0; i < count; i++ {
+				for range count {
 					switch provider {
 					case "digitalocean":
 						cfg = cfg.WithDigitalOceanValidator(region)
@@ -42,7 +42,7 @@ func addCmd() *cobra.Command {
 					}
 				}
 			case "encoder":
-				for i := 0; i < count; i++ {
+				for range count {
 					switch provider {
 					case "digitalocean":
 						cfg = cfg.WithDigitalOceanEncoder(region)

--- a/tools/talis/client.go
+++ b/tools/talis/client.go
@@ -77,7 +77,8 @@ func NewDOClient(cfg Config) (*DOClient, error) {
 
 func (c *DOClient) Up(ctx context.Context, workers int) error {
 	insts := make([]Instance, 0)
-	for _, v := range append(c.cfg.Validators, c.cfg.Observability...) {
+	allInstances := append(append(c.cfg.Validators, c.cfg.Observability...), c.cfg.Encoders...)
+	for _, v := range allInstances {
 		if v.Provider != DigitalOcean {
 			log.Println("unexpectedly skipping instance since only DO is supported", v.Name, "in region", v.Region)
 			continue
@@ -149,7 +150,8 @@ func (c *DOClient) countRunningDroplets(ctx context.Context) (int, error) {
 
 func (c *DOClient) Down(ctx context.Context, workers int) error {
 	insts := make([]Instance, 0)
-	for _, v := range append(c.cfg.Validators, c.cfg.Observability...) {
+	allInstances := append(append(c.cfg.Validators, c.cfg.Observability...), c.cfg.Encoders...)
+	for _, v := range allInstances {
 		if v.Provider != DigitalOcean {
 			log.Println("unexpectedly skipping instance since only DO is supported", v.Name, "in region", v.Region)
 			continue

--- a/tools/talis/config.go
+++ b/tools/talis/config.go
@@ -21,6 +21,8 @@ const (
 	Light NodeType = "light"
 	// Observability represents a observability monitoring node for Prometheus/Grafana.
 	Observability NodeType = "observability"
+	// Encoder represents a dedicated fibre-txsim encoder node.
+	Encoder NodeType = "encoder"
 )
 
 var (
@@ -28,6 +30,7 @@ var (
 	nodeCount          = atomic.Uint32{}
 	lightCount         = atomic.Uint32{}
 	observabilityCount = atomic.Uint32{}
+	encoderCount       = atomic.Uint32{}
 )
 
 // NodeName returns the name of the node based on its type and index. The
@@ -44,6 +47,8 @@ func NodeName(nodeType NodeType) string {
 		index = int(lightCount.Add(1)) - 1
 	case Observability:
 		index = int(observabilityCount.Add(1)) - 1
+	case Encoder:
+		index = int(encoderCount.Add(1)) - 1
 	default:
 		panic(fmt.Sprintf("unknown node type: %s", nodeType))
 	}
@@ -120,7 +125,7 @@ func ExperimentTag(nodeType NodeType, index int, experimentID, chainID string) s
 
 func GetExperimentTag(tags []string) string {
 	for _, tag := range tags {
-		if strings.HasPrefix(tag, "validator-") || strings.HasPrefix(tag, "bridge-") || strings.HasPrefix(tag, "light-") || strings.HasPrefix(tag, "observability-") {
+		if strings.HasPrefix(tag, "validator-") || strings.HasPrefix(tag, "bridge-") || strings.HasPrefix(tag, "light-") || strings.HasPrefix(tag, "observability-") || strings.HasPrefix(tag, "encoder-") {
 			return tag
 		}
 	}
@@ -133,6 +138,7 @@ type Config struct {
 	Bridges       []Instance `json:"bridges,omitempty"`
 	Lights        []Instance `json:"lights,omitempty"`
 	Observability []Instance `json:"observability,omitempty"`
+	Encoders      []Instance `json:"encoders,omitempty"`
 
 	// ChainID is the chain ID of the network. This is used to identify the
 	// network and is also used as the chain ID of the network. It is
@@ -164,6 +170,7 @@ func NewConfig(experiment, chainID string) Config {
 		Bridges:       []Instance{},
 		Lights:        []Instance{},
 		Observability: []Instance{},
+		Encoders:      []Instance{},
 		Experiment:    experiment,
 		ChainID:       TalisChainID(chainID),
 		S3Config: S3Config{
@@ -227,6 +234,18 @@ func (cfg Config) WithGoogleCloudValidator(region string) Config {
 func (cfg Config) WithGoogleCloudObservability(region string) Config {
 	i := NewGoogleCloudObservability(region).WithExperiment(cfg.Experiment, cfg.ChainID)
 	cfg.Observability = append(cfg.Observability, i)
+	return cfg
+}
+
+func (cfg Config) WithDigitalOceanEncoder(region string) Config {
+	i := NewDigitalOceanEncoder(region).WithExperiment(cfg.Experiment, cfg.ChainID)
+	cfg.Encoders = append(cfg.Encoders, i)
+	return cfg
+}
+
+func (cfg Config) WithGoogleCloudEncoder(region string) Config {
+	i := NewGoogleCloudEncoder(region).WithExperiment(cfg.Experiment, cfg.ChainID)
+	cfg.Encoders = append(cfg.Encoders, i)
 	return cfg
 }
 
@@ -303,6 +322,13 @@ func (cfg Config) UpdateInstance(name, publicIP, privateIP string) (Config, erro
 		if cfg.Observability[i].Name == name {
 			cfg.Observability[i].PublicIP = publicIP
 			cfg.Observability[i].PrivateIP = privateIP
+			return cfg, nil
+		}
+	}
+	for i := range cfg.Encoders {
+		if cfg.Encoders[i].Name == name {
+			cfg.Encoders[i].PublicIP = publicIP
+			cfg.Encoders[i].PrivateIP = privateIP
 			return cfg, nil
 		}
 	}

--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -130,7 +130,7 @@ func deployCmd() *cobra.Command {
 				if err := deployObservabilityIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload); err != nil {
 					return err
 				}
-				return deployEncodersIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, workers)
+				return deployEncodersIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload, workers)
 			}
 			if err := deployPayloadViaS3(cmd.Context(), rootDir, cfg.Validators, tarPath, SSHKeyPath, "/root", "payload/validator_init.sh", 7*time.Minute, cfg.S3Config, workers); err != nil {
 				if !ignoreFailed {
@@ -141,7 +141,7 @@ func deployCmd() *cobra.Command {
 			if err := deployObservabilityIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload); err != nil {
 				return err
 			}
-			return deployEncodersIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, workers)
+			return deployEncodersIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload, workers)
 		},
 	}
 
@@ -192,8 +192,8 @@ func deployObservabilityIfConfigured(ctx context.Context, cfg Config, rootDir, s
 }
 
 // deployEncodersIfConfigured creates a lightweight encoder-payload tar and deploys
-// it to all configured encoder instances via S3.
-func deployEncodersIfConfigured(ctx context.Context, cfg Config, rootDir, sshKeyPath string, workers int) error {
+// it to all configured encoder instances.
+func deployEncodersIfConfigured(ctx context.Context, cfg Config, rootDir, sshKeyPath string, directUpload bool, workers int) error {
 	if len(cfg.Encoders) == 0 {
 		return nil
 	}
@@ -212,8 +212,14 @@ func deployEncodersIfConfigured(ctx context.Context, cfg Config, rootDir, sshKey
 	}
 	log.Printf("Sending encoder payload to %d encoder(s)...\n", len(cfg.Encoders))
 
-	if err := deployPayloadViaS3(ctx, rootDir, cfg.Encoders, encoderTarPath, sshKeyPath, "/root", "encoder-payload/encoder_init.sh", 7*time.Minute, cfg.S3Config, workers); err != nil {
-		return fmt.Errorf("encoder deployment: %w", err)
+	if directUpload {
+		if err := deployPayloadDirect(cfg.Encoders, encoderTarPath, sshKeyPath, "/root", "encoder-payload/encoder_init.sh", 7*time.Minute, workers); err != nil {
+			return fmt.Errorf("encoder deployment: %w", err)
+		}
+	} else {
+		if err := deployPayloadViaS3(ctx, rootDir, cfg.Encoders, encoderTarPath, sshKeyPath, "/root", "encoder-payload/encoder_init.sh", 7*time.Minute, cfg.S3Config, workers); err != nil {
+			return fmt.Errorf("encoder deployment: %w", err)
+		}
 	}
 
 	log.Printf("Encoder deployment complete\n")

--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -127,7 +127,10 @@ func deployCmd() *cobra.Command {
 					}
 					log.Printf("continuing despite validator deployment errors: %v", err)
 				}
-				return deployObservabilityIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload)
+				if err := deployObservabilityIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload); err != nil {
+					return err
+				}
+				return deployEncodersIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, workers)
 			}
 			if err := deployPayloadViaS3(cmd.Context(), rootDir, cfg.Validators, tarPath, SSHKeyPath, "/root", "payload/validator_init.sh", 7*time.Minute, cfg.S3Config, workers); err != nil {
 				if !ignoreFailed {
@@ -135,7 +138,10 @@ func deployCmd() *cobra.Command {
 				}
 				log.Printf("continuing despite validator deployment errors: %v", err)
 			}
-			return deployObservabilityIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload)
+			if err := deployObservabilityIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, directUpload); err != nil {
+				return err
+			}
+			return deployEncodersIfConfigured(cmd.Context(), cfg, rootDir, SSHKeyPath, workers)
 		},
 	}
 
@@ -182,6 +188,35 @@ func deployObservabilityIfConfigured(ctx context.Context, cfg Config, rootDir, s
 	}
 
 	printGrafanaInfo(observabilityNode, rootDir)
+	return nil
+}
+
+// deployEncodersIfConfigured creates a lightweight encoder-payload tar and deploys
+// it to all configured encoder instances via S3.
+func deployEncodersIfConfigured(ctx context.Context, cfg Config, rootDir, sshKeyPath string, workers int) error {
+	if len(cfg.Encoders) == 0 {
+		return nil
+	}
+
+	encoderPayloadDir := filepath.Join(rootDir, "encoder-payload")
+	if _, err := os.Stat(encoderPayloadDir); os.IsNotExist(err) {
+		return fmt.Errorf("encoder-payload directory not found — run 'talis genesis' first")
+	}
+
+	encoderTarPath := filepath.Join(rootDir, "encoder-payload.tar.gz")
+	log.Printf("Compressing encoder payload to %s\n", encoderTarPath)
+	tarCmd := exec.Command("tar", "-czf", encoderTarPath, "-C", rootDir, "encoder-payload")
+	tarCmd.Env = append(os.Environ(), "COPYFILE_DISABLE=1")
+	if output, err := tarCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("failed to compress encoder payload: %w, output: %s", err, string(output))
+	}
+	log.Printf("Sending encoder payload to %d encoder(s)...\n", len(cfg.Encoders))
+
+	if err := deployPayloadViaS3(ctx, rootDir, cfg.Encoders, encoderTarPath, sshKeyPath, "/root", "encoder-payload/encoder_init.sh", 7*time.Minute, cfg.S3Config, workers); err != nil {
+		return fmt.Errorf("encoder deployment: %w", err)
+	}
+
+	log.Printf("Encoder deployment complete\n")
 	return nil
 }
 

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -123,8 +123,6 @@ func GetDOSSHKeyMeta(ctx context.Context, client *godo.Client, publicKey string)
 // CreateDroplets launches all droplets in parallel, waits for their IPs, and
 // returns the filled-out []Instance slice.
 func CreateDroplets(ctx context.Context, client *godo.Client, insts []Instance, key godo.Key, workers int) ([]Instance, error) {
-	total := len(insts)
-
 	type result struct {
 		inst         Instance
 		err          error
@@ -143,6 +141,7 @@ func CreateDroplets(ctx context.Context, client *godo.Client, insts []Instance, 
 		}
 	}
 
+	total := len(insts)
 	results := make(chan result, total)
 	workerChan := make(chan struct{}, workers)
 	var wg sync.WaitGroup

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	DODefaultValidatorSlug     = "c2-16vcpu-32gb"
+	DODefaultEncoderSlug       = "c2-8vcpu-16gb"
 	DODefaultObservabilitySlug = "s-2vcpu-4gb"
 	DODefaultImage             = "ubuntu-22-04-x64"
 	RandomRegion               = "random"
@@ -46,6 +47,17 @@ func NewDigitalOceanValidator(region string) Instance {
 	i := NewBaseInstance(Validator)
 	i.Provider = DigitalOcean
 	i.Slug = DODefaultValidatorSlug
+	i.Region = region
+	return i
+}
+
+func NewDigitalOceanEncoder(region string) Instance {
+	if region == "" || region == RandomRegion {
+		region = RandomDORegion()
+	}
+	i := NewBaseInstance(Encoder)
+	i.Provider = DigitalOcean
+	i.Slug = DODefaultEncoderSlug
 	i.Region = region
 	return i
 }
@@ -473,7 +485,7 @@ func checkForRunningDOExperiments(ctx context.Context, client *godo.Client, expe
 
 func hasExperimentTag(tags []string, experimentID, chainID string) bool {
 	for _, tag := range tags {
-		if (strings.HasPrefix(tag, "validator-") || strings.HasPrefix(tag, "bridge-") || strings.HasPrefix(tag, "light-")) &&
+		if (strings.HasPrefix(tag, "validator-") || strings.HasPrefix(tag, "bridge-") || strings.HasPrefix(tag, "light-") || strings.HasPrefix(tag, "encoder-")) &&
 			strings.Contains(tag, experimentID) && strings.Contains(tag, chainID) {
 			return true
 		}

--- a/tools/talis/fibre_setup.go
+++ b/tools/talis/fibre_setup.go
@@ -116,7 +116,7 @@ func setupFibreCmd() *cobra.Command {
 					nAccounts := encoderFibreAccounts
 
 					var sb strings.Builder
-					for i := 0; i < nAccounts; i++ {
+					for i := range nAccounts {
 						keyName := fmt.Sprintf("%s-%d", keyPrefix, i)
 						sb.WriteString(fmt.Sprintf(
 							"celestia-appd tx fibre deposit-to-escrow %s "+

--- a/tools/talis/fibre_setup.go
+++ b/tools/talis/fibre_setup.go
@@ -14,13 +14,14 @@ const SetupFibreSessionName = "setup-fibre"
 
 func setupFibreCmd() *cobra.Command {
 	var (
-		rootDir       string
-		SSHKeyPath    string
-		escrowAmount  string
-		fibrePort     int
-		fees          string
-		workers       int
-		fibreAccounts int
+		rootDir              string
+		SSHKeyPath           string
+		escrowAmount         string
+		fibrePort            int
+		fees                 string
+		workers              int
+		fibreAccounts        int
+		encoderFibreAccounts int
 	)
 
 	cmd := &cobra.Command{
@@ -100,7 +101,47 @@ func setupFibreCmd() *cobra.Command {
 			if err := waitForTmuxSessions(cfg.Validators, resolvedSSHKeyPath, SetupFibreSessionName, 10*time.Minute); err != nil {
 				return fmt.Errorf("waiting for setup-fibre sessions: %w", err)
 			}
-			fmt.Println("Done!")
+			fmt.Println("Validator setup done!")
+
+			// Deposit escrow for encoder accounts.
+			// Each encoder runs deposit-to-escrow from its own machine using its
+			// own keyring, broadcasting via the first validator's RPC endpoint.
+			if len(cfg.Encoders) > 0 && len(cfg.Validators) > 0 {
+				rpcNode := fmt.Sprintf("tcp://%s:26657", cfg.Validators[0].PublicIP)
+				fmt.Printf("Setting up escrow for %d encoder(s) via %s...\n", len(cfg.Encoders), rpcNode)
+
+				for _, enc := range cfg.Encoders {
+					encIndex := extractIndexFromName(enc.Name)
+					keyPrefix := fmt.Sprintf("enc%d", encIndex)
+					nAccounts := encoderFibreAccounts
+
+					var sb strings.Builder
+					for i := 0; i < nAccounts; i++ {
+						keyName := fmt.Sprintf("%s-%d", keyPrefix, i)
+						sb.WriteString(fmt.Sprintf(
+							"celestia-appd tx fibre deposit-to-escrow %s "+
+								"--from %s --keyring-backend=test --home .celestia-app "+
+								"--chain-id %s --fees %s --node %s --yes\n",
+							escrowAmount,
+							keyName,
+							cfg.ChainID, fees, rpcNode,
+						))
+					}
+
+					script := sb.String()
+					fmt.Printf("Running escrow deposits on encoder %s (%s) — %d accounts\n", enc.Name, enc.PublicIP, nAccounts)
+					if err := runScriptInTMux([]Instance{enc}, resolvedSSHKeyPath, script, SetupFibreSessionName, 30*time.Minute); err != nil {
+						return fmt.Errorf("encoder %s escrow setup: %w", enc.Name, err)
+					}
+				}
+
+				fmt.Printf("Waiting for encoder escrow deposits to complete...\n")
+				if err := waitForTmuxSessions(cfg.Encoders, resolvedSSHKeyPath, SetupFibreSessionName, 15*time.Minute); err != nil {
+					return fmt.Errorf("waiting for encoder setup-fibre sessions: %w", err)
+				}
+				fmt.Println("Encoder escrow setup done!")
+			}
+
 			return nil
 		},
 	}
@@ -112,6 +153,7 @@ func setupFibreCmd() *cobra.Command {
 	cmd.Flags().StringVar(&fees, "fees", "5000utia", "transaction fees")
 	cmd.Flags().IntVarP(&workers, "workers", "w", 10, "number of validators to set up in parallel")
 	cmd.Flags().IntVar(&fibreAccounts, "fibre-accounts", 100, "number of fibre worker accounts to deposit escrow for")
+	cmd.Flags().IntVar(&encoderFibreAccounts, "encoder-fibre-accounts", 100, "number of fibre worker accounts per encoder instance")
 
 	return cmd
 }

--- a/tools/talis/fibre_setup.go
+++ b/tools/talis/fibre_setup.go
@@ -62,7 +62,7 @@ func setupFibreCmd() *cobra.Command {
 				sb.WriteString("sleep 10\n")
 
 				// 2. Deposit escrow for each fibre worker account
-				for i := 0; i < fibreAccounts; i++ {
+				for i := range fibreAccounts {
 					keyName := fmt.Sprintf("fibre-%d", i)
 					sb.WriteString(fmt.Sprintf(
 						"celestia-appd tx fibre deposit-to-escrow %s "+

--- a/tools/talis/fibre_txsim.go
+++ b/tools/talis/fibre_txsim.go
@@ -23,12 +23,13 @@ func fibreTxsimCmd() *cobra.Command {
 		download          bool
 		uploadOnly        bool
 		pyroscopeEndpoint string
+		onEncoders        bool
 	)
 
 	cmd := &cobra.Command{
 		Use:   "fibre-txsim",
-		Short: "Start fibre-txsim on remote validators via SSH + tmux",
-		Long:  "Starts fibre-txsim tmux sessions on remote validators. The fibre-txsim binary must already be deployed via 'talis deploy' (built by 'make build-talis-bins').",
+		Short: "Start fibre-txsim on remote validators or encoder instances via SSH + tmux",
+		Long:  "Starts fibre-txsim tmux sessions on remote validators or dedicated encoder instances. The fibre-txsim binary must already be deployed via 'talis deploy' (built by 'make build-talis-bins').",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cfg, err := LoadConfig(rootDir)
 			if err != nil {
@@ -40,7 +41,11 @@ func fibreTxsimCmd() *cobra.Command {
 
 			resolvedSSHKeyPath := resolveValue(SSHKeyPath, EnvVarSSHKeyPath, strings.ReplaceAll(cfg.SSHPubKeyPath, ".pub", ""))
 
-			// Select first N validators
+			if onEncoders {
+				return startFibreTxsimOnEncoders(cfg, resolvedSSHKeyPath, instances, concurrency, blobSize, interval, duration, download, uploadOnly, pyroscopeEndpoint)
+			}
+
+			// Legacy mode: run fibre-txsim on validators themselves
 			n := min(instances, len(cfg.Validators))
 			validators := cfg.Validators[:n]
 
@@ -75,26 +80,14 @@ func fibreTxsimCmd() *cobra.Command {
 				return fmt.Errorf("failed to start remote sessions: %w", err)
 			}
 
-			// Print summary
-			fmt.Println()
-			fmt.Println("=== fibre-txsim sessions started ===")
-			fmt.Printf("  tmux session: %s\n", FibreTxSimSessionName)
-			fmt.Printf("  log file:     /root/talis-%s.log\n", FibreTxSimSessionName)
-			fmt.Println("  validators:")
-			for _, val := range validators {
-				fmt.Printf("    - %s (%s)\n", val.Name, val.PublicIP)
-			}
-			fmt.Println()
-			fmt.Printf("  To kill all:  talis kill-session -s %s\n", FibreTxSimSessionName)
-			fmt.Printf("  To view logs: ssh root@<ip> 'cat /root/talis-%s.log'\n", FibreTxSimSessionName)
-
+			printFibreTxsimSummary(validators)
 			return nil
 		},
 	}
 
 	cmd.Flags().StringVarP(&rootDir, "directory", "d", ".", "root directory (for config.json)")
 	cmd.Flags().StringVarP(&SSHKeyPath, "ssh-key-path", "k", "", "path to SSH private key (overrides env/default)")
-	cmd.Flags().IntVar(&instances, "instances", 1, "number of validators to start fibre-txsim on")
+	cmd.Flags().IntVar(&instances, "instances", 1, "number of instances to start fibre-txsim on")
 	cmd.Flags().IntVar(&concurrency, "concurrency", 1, "number of concurrent blob submissions per instance")
 	cmd.Flags().IntVar(&blobSize, "blob-size", 1000000, "size of each blob in bytes")
 	cmd.Flags().DurationVar(&interval, "interval", 0, "delay between blob submissions (0 = no delay)")
@@ -103,6 +96,77 @@ func fibreTxsimCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&download, "download", false, "enable download verification after each successful upload (downloads blob back and compares with original data)")
 	cmd.Flags().BoolVar(&uploadOnly, "upload-only", false, "skip PFF transaction — only upload shards to validators without on-chain confirmation")
 	cmd.Flags().StringVar(&pyroscopeEndpoint, "pyroscope-endpoint", "", "Pyroscope endpoint for continuous profiling (default: auto-detected from observability config, e.g. http://host:4040)")
+	cmd.Flags().BoolVar(&onEncoders, "on-encoders", false, "run fibre-txsim on dedicated encoder instances instead of validators")
 
 	return cmd
+}
+
+// startFibreTxsimOnEncoders launches fibre-txsim on each encoder instance.
+// Each encoder is mapped to a validator (round-robin) and uses a unique key
+// prefix (enc0, enc1, ...) so that their escrow accounts are independent.
+func startFibreTxsimOnEncoders(cfg Config, sshKeyPath string, instances, concurrency, blobSize int, interval, duration time.Duration, download, uploadOnly bool, pyroscopeEndpoint string) error {
+	if len(cfg.Encoders) == 0 {
+		return fmt.Errorf("no encoder instances found in config — add encoders via 'talis add -t encoder'")
+	}
+
+	n := min(instances, len(cfg.Encoders))
+	encoders := cfg.Encoders[:n]
+
+	fmt.Printf("Starting fibre-txsim on %d encoder(s)...\n", len(encoders))
+
+	for _, enc := range encoders {
+		encIndex := extractIndexFromName(enc.Name)
+		// Round-robin map encoder → validator for gRPC endpoint
+		valIndex := encIndex % len(cfg.Validators)
+		grpcEndpoint := fmt.Sprintf("%s:9091", cfg.Validators[valIndex].PublicIP)
+		encKeyPrefix := fmt.Sprintf("enc%d", encIndex)
+
+		remoteCmd := fmt.Sprintf(
+			"OTEL_METRICS_EXEMPLAR_FILTER=always_on fibre-txsim --chain-id %s --grpc-endpoint %s --keyring-dir .celestia-app --key-prefix %s --blob-size %d --concurrency %d --interval %s --duration %s --download=%t --upload-only=%t",
+			cfg.ChainID,
+			grpcEndpoint,
+			encKeyPrefix,
+			blobSize,
+			concurrency,
+			interval,
+			duration,
+			download,
+			uploadOnly,
+		)
+
+		// Auto-wire observability endpoints
+		if len(cfg.Observability) > 0 {
+			remoteCmd += fmt.Sprintf(" --otel-endpoint http://%s:4318", cfg.Observability[0].PublicIP)
+			if pyroscopeEndpoint == "" {
+				remoteCmd += fmt.Sprintf(" --pyroscope-endpoint http://%s:4040", cfg.Observability[0].PublicIP)
+			}
+		}
+		if pyroscopeEndpoint != "" {
+			remoteCmd += fmt.Sprintf(" --pyroscope-endpoint %s", pyroscopeEndpoint)
+		}
+
+		fmt.Printf("  encoder %s → validator %s (grpc=%s, keys=%s-*)\n",
+			enc.Name, cfg.Validators[valIndex].Name, grpcEndpoint, encKeyPrefix)
+
+		if err := runScriptInTMux([]Instance{enc}, sshKeyPath, remoteCmd, FibreTxSimSessionName, 5*time.Minute); err != nil {
+			return fmt.Errorf("failed to start fibre-txsim on encoder %s: %w", enc.Name, err)
+		}
+	}
+
+	printFibreTxsimSummary(encoders)
+	return nil
+}
+
+func printFibreTxsimSummary(instances []Instance) {
+	fmt.Println()
+	fmt.Println("=== fibre-txsim sessions started ===")
+	fmt.Printf("  tmux session: %s\n", FibreTxSimSessionName)
+	fmt.Printf("  log file:     /root/talis-%s.log\n", FibreTxSimSessionName)
+	fmt.Println("  instances:")
+	for _, inst := range instances {
+		fmt.Printf("    - %s (%s)\n", inst.Name, inst.PublicIP)
+	}
+	fmt.Println()
+	fmt.Printf("  To kill all:  talis kill-session -s %s\n", FibreTxSimSessionName)
+	fmt.Printf("  To view logs: ssh root@<ip> 'cat /root/talis-%s.log'\n", FibreTxSimSessionName)
 }

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -53,6 +53,9 @@ func generateCmd() *cobra.Command {
 			if err := os.RemoveAll(payloadDir); err != nil {
 				return fmt.Errorf("failed to remove old payload directory: %w", err)
 			}
+			if err := os.RemoveAll(filepath.Join(rootDir, "encoder-payload")); err != nil {
+				return fmt.Errorf("failed to remove old encoder-payload directory: %w", err)
+			}
 
 			err = createPayload(cfg.Validators, cfg.Encoders, cfg.ChainID, payloadDir, squareSize, useMainnetStakingDistribution, fibreAccounts, encoderFibreAccounts)
 			if err != nil {

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -32,6 +32,7 @@ func generateCmd() *cobra.Command {
 		observabilityDirPath          string
 		useMainnetStakingDistribution bool
 		fibreAccounts                 int
+		encoderFibreAccounts          int
 	)
 	cmd := &cobra.Command{
 		Use:   "genesis",
@@ -53,7 +54,7 @@ func generateCmd() *cobra.Command {
 				return fmt.Errorf("failed to remove old payload directory: %w", err)
 			}
 
-			err = createPayload(cfg.Validators, cfg.ChainID, payloadDir, squareSize, useMainnetStakingDistribution, fibreAccounts)
+			err = createPayload(cfg.Validators, cfg.Encoders, cfg.ChainID, payloadDir, squareSize, useMainnetStakingDistribution, fibreAccounts, encoderFibreAccounts)
 			if err != nil {
 				log.Fatalf("Failed to create payload: %v", err)
 			}
@@ -125,6 +126,14 @@ func generateCmd() *cobra.Command {
 				return fmt.Errorf("failed to stage observability payload: %w", err)
 			}
 
+			// Stage encoder payload: copy binaries, genesis, and vars to the
+			// encoder-payload directory so deploy can create a lightweight tar.
+			if len(cfg.Encoders) > 0 {
+				if err := stageEncoderPayload(rootDir, payloadDir, appBinaryPath, fibreTxsimBinaryPath, buildDirPath); err != nil {
+					return fmt.Errorf("failed to stage encoder payload: %w", err)
+				}
+			}
+
 			return cfg.Save(rootDir)
 		},
 	}
@@ -152,13 +161,14 @@ func generateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&observabilityDirPath, "observability-dir", "", "path to observability directory containing docker-compose, Prometheus config, and scripts (required if observability nodes are configured)")
 	cmd.Flags().BoolVarP(&useMainnetStakingDistribution, "mainnet-staking-distribution", "m", false, "replace the default uniform staking distribution with the actual mainnet distribution")
 	cmd.Flags().IntVar(&fibreAccounts, "fibre-accounts", 100, "number of pre-funded fibre accounts to create per validator")
+	cmd.Flags().IntVar(&encoderFibreAccounts, "encoder-fibre-accounts", 100, "number of pre-funded fibre accounts to create per encoder instance")
 
 	return cmd
 }
 
 // createPayload takes ips created by pulumi and the path to the payload directory
 // to create the payload required for the experiment.
-func createPayload(ips []Instance, chainID, ppath string, squareSize int, useMainnetDistribution bool, fibreAccounts int, mods ...genesis.Modifier) error {
+func createPayload(ips, encoders []Instance, chainID, ppath string, squareSize int, useMainnetDistribution bool, fibreAccounts, encoderFibreAccounts int, mods ...genesis.Modifier) error {
 	n, err := NewNetwork(chainID, squareSize, mods...)
 	if err != nil {
 		return err
@@ -179,6 +189,21 @@ func createPayload(ips []Instance, chainID, ppath string, squareSize int, useMai
 		)
 		if err != nil {
 			return err
+		}
+	}
+
+	// Create encoder-payload directory and keyrings for each encoder.
+	// Encoder keyrings are stored in <ppath>/../encoder-payload/<encoder-name>/
+	// so that a separate, lighter tar can be built during deploy.
+	encoderPayloadDir := filepath.Join(filepath.Dir(ppath), "encoder-payload")
+	if len(encoders) > 0 {
+		if err := os.MkdirAll(encoderPayloadDir, 0o755); err != nil {
+			return fmt.Errorf("failed to create encoder-payload dir: %w", err)
+		}
+	}
+	for _, enc := range encoders {
+		if err := n.AddEncoder(enc.Name, encoderPayloadDir, encoderFibreAccounts); err != nil {
+			return fmt.Errorf("failed to add encoder %s: %w", enc.Name, err)
 		}
 	}
 
@@ -225,6 +250,88 @@ func getMainnetStake(index int) int64 {
 		return int64(mainnetVotingPowers[len(mainnetVotingPowers)-1])
 	}
 	return int64(mainnetVotingPowers[index])
+}
+
+// stageEncoderPayload copies the binaries (celestia-appd, fibre-txsim), genesis,
+// vars.sh, and an encoder_init.sh script into the encoder-payload directory so
+// that the deploy step can create a lightweight tar for encoder instances.
+func stageEncoderPayload(rootDir, payloadDir, appBinaryPath, fibreTxsimBinaryPath, buildDirPath string) error {
+	encPayload := filepath.Join(rootDir, "encoder-payload")
+
+	// Build directory with only the two binaries an encoder needs
+	encBuild := filepath.Join(encPayload, "build")
+	if err := os.MkdirAll(encBuild, 0o755); err != nil {
+		return err
+	}
+
+	if buildDirPath != "" {
+		for _, name := range []string{"celestia-appd", "fibre-txsim"} {
+			src := filepath.Join(buildDirPath, name)
+			if err := copyFile(src, filepath.Join(encBuild, name), 0o755); err != nil {
+				return fmt.Errorf("copy %s from build dir: %w", name, err)
+			}
+		}
+	} else {
+		if err := copyFile(appBinaryPath, filepath.Join(encBuild, "celestia-appd"), 0o755); err != nil {
+			return fmt.Errorf("copy celestia-appd: %w", err)
+		}
+		if err := copyFile(fibreTxsimBinaryPath, filepath.Join(encBuild, "fibre-txsim"), 0o755); err != nil {
+			return fmt.Errorf("copy fibre-txsim: %w", err)
+		}
+	}
+
+	// Copy genesis and vars.sh
+	if err := copyFile(filepath.Join(payloadDir, "genesis.json"), filepath.Join(encPayload, "genesis.json"), 0o644); err != nil {
+		return fmt.Errorf("copy genesis.json: %w", err)
+	}
+	if err := copyFile(filepath.Join(payloadDir, "vars.sh"), filepath.Join(encPayload, "vars.sh"), 0o755); err != nil {
+		return fmt.Errorf("copy vars.sh: %w", err)
+	}
+
+	// Write the encoder init script
+	return writeEncoderInitScript(filepath.Join(encPayload, "encoder_init.sh"))
+}
+
+// writeEncoderInitScript creates a minimal init script for encoder instances.
+// Encoders only need the fibre-txsim binary, celestia-appd (for escrow deposits),
+// a keyring, and genesis.
+func writeEncoderInitScript(path string) error {
+	script := `#!/bin/bash
+set -euo pipefail
+
+CELES_HOME="$HOME/.celestia-app"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+apt-get install curl jq chrony --yes -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold"
+
+systemctl enable chrony
+systemctl start chrony
+
+# TCP BBR
+modprobe tcp_bbr || true
+sysctl -w net.core.default_qdisc=fq
+sysctl -w net.ipv4.tcp_congestion_control=bbr
+
+# Install binaries
+cp encoder-payload/build/celestia-appd /bin/celestia-appd
+cp encoder-payload/build/fibre-txsim /bin/fibre-txsim
+
+source encoder-payload/vars.sh
+
+# Determine this encoder's directory from hostname (e.g. "encoder-0")
+hostname=$(hostname)
+parsed_hostname=$(echo "$hostname" | awk -F'-' '{print $1 "-" $2}')
+
+# Set up celestia-app home with keyring + genesis
+rm -rf "$CELES_HOME"
+mkdir -p "$CELES_HOME/config"
+cp encoder-payload/genesis.json "$CELES_HOME/config/genesis.json"
+cp -r "encoder-payload/$parsed_hostname/keyring-test" "$CELES_HOME/"
+
+echo "Encoder $parsed_hostname initialized"
+`
+	return os.WriteFile(path, []byte(script), 0o755)
 }
 
 func writeAWSEnv(varsPath string, cfg Config) error {

--- a/tools/talis/google_cloud.go
+++ b/tools/talis/google_cloud.go
@@ -664,7 +664,7 @@ func checkForRunningGCExperiments(ctx context.Context, project string, opts []op
 }
 
 func hasGCExperimentLabel(label, experimentID, chainID string) bool {
-	if !strings.HasPrefix(label, "validator_") && !strings.HasPrefix(label, "bridge_") && !strings.HasPrefix(label, "light_") {
+	if !strings.HasPrefix(label, "validator_") && !strings.HasPrefix(label, "bridge_") && !strings.HasPrefix(label, "light_") && !strings.HasPrefix(label, "encoder_") {
 		return false
 	}
 	experimentIDLabel := strings.ReplaceAll(experimentID, "-", "_")

--- a/tools/talis/google_cloud.go
+++ b/tools/talis/google_cloud.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	GCDefaultValidatorMachineType     = "c3d-highcpu-16"
+	GCDefaultEncoderMachineType       = "c3d-highcpu-8"
 	GCDefaultObservabilityMachineType = "e2-medium"
 	GCDefaultImage                    = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
 	GCDefaultDiskSizeGB               = 400
@@ -73,7 +74,8 @@ func NewGCClient(cfg Config) (*GCClient, error) {
 
 func (c *GCClient) Up(ctx context.Context, workers int) error {
 	insts := make([]Instance, 0)
-	for _, v := range append(c.cfg.Validators, c.cfg.Observability...) {
+	allInstances := append(append(c.cfg.Validators, c.cfg.Observability...), c.cfg.Encoders...)
+	for _, v := range allInstances {
 		if v.Provider != GoogleCloud {
 			continue
 		}
@@ -112,7 +114,8 @@ func (c *GCClient) Up(ctx context.Context, workers int) error {
 
 func (c *GCClient) Down(ctx context.Context, workers int) error {
 	insts := make([]Instance, 0)
-	for _, v := range append(c.cfg.Validators, c.cfg.Observability...) {
+	allInstances := append(append(c.cfg.Validators, c.cfg.Observability...), c.cfg.Encoders...)
+	for _, v := range allInstances {
 		if v.Provider != GoogleCloud {
 			continue
 		}
@@ -218,6 +221,17 @@ func NewGoogleCloudValidator(region string) Instance {
 	i := NewBaseInstance(Validator)
 	i.Provider = GoogleCloud
 	i.Slug = GCDefaultValidatorMachineType
+	i.Region = region
+	return i
+}
+
+func NewGoogleCloudEncoder(region string) Instance {
+	if region == "" || region == RandomRegion {
+		region = RandomGCRegion()
+	}
+	i := NewBaseInstance(Encoder)
+	i.Provider = GoogleCloud
+	i.Slug = GCDefaultEncoderMachineType
 	i.Region = region
 	return i
 }

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -138,6 +138,29 @@ func (n *Network) AddValidator(name, ip, payLoadRoot, region string, stake int64
 	return nil
 }
 
+// AddEncoder creates a keyring for a dedicated encoder instance with uniquely
+// prefixed fibre accounts (enc0-0, enc0-1, ...) so that multiple encoders can
+// each fund their own escrow without blocking one another.
+func (n *Network) AddEncoder(name, payLoadRoot string, fibreAccounts int) error {
+	kr, err := keyring.New(app.Name, keyring.BackendTest,
+		filepath.Join(payLoadRoot, name), nil, n.ecfg.Codec)
+	if err != nil {
+		return err
+	}
+
+	index := extractIndexFromName(name)
+	keyPrefix := fmt.Sprintf("enc%d", index)
+
+	fmt.Printf("creating %d fibre accounts for encoder %s (prefix=%s)\n", fibreAccounts, name, keyPrefix)
+	for i := range fibreAccounts {
+		if err := addFundedAccount(kr, n.genesis, fmt.Sprintf("%s-%d", keyPrefix, i)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // addFundedAccount creates a new key in the local keyring and registers it as a
 // funded account in genesis. The key lives in the validator's keyring so the
 // binary (txsim, fibre-txsim) can sign transactions at runtime.

--- a/tools/talis/reset.go
+++ b/tools/talis/reset.go
@@ -80,6 +80,7 @@ func resetCmd() *cobra.Command {
 			// Clean up encoder instances.
 			if len(cfg.Encoders) > 0 {
 				encoderCleanup := `
+					tmux kill-session -t app 2>/dev/null || true
 					tmux kill-session -t fibre-txsim 2>/dev/null || true
 					tmux kill-session -t setup-fibre 2>/dev/null || true
 					rm -rf .celestia-app encoder-payload encoder-payload.tar.gz /bin/celestia* /bin/fibre-txsim

--- a/tools/talis/reset.go
+++ b/tools/talis/reset.go
@@ -77,6 +77,30 @@ func resetCmd() *cobra.Command {
 			}
 			wg.Wait()
 
+			// Clean up encoder instances.
+			if len(cfg.Encoders) > 0 {
+				encoderCleanup := `
+					tmux kill-session -t fibre-txsim 2>/dev/null || true
+					tmux kill-session -t setup-fibre 2>/dev/null || true
+					rm -rf .celestia-app encoder-payload encoder-payload.tar.gz /bin/celestia* /bin/fibre-txsim
+				`
+				var encWG sync.WaitGroup
+				encWorkerChan := make(chan struct{}, workers)
+				for _, enc := range cfg.Encoders {
+					encWG.Add(1)
+					go func(e Instance) {
+						defer encWG.Done()
+						encWorkerChan <- struct{}{}
+						defer func() { <-encWorkerChan }()
+						fmt.Printf("Resetting encoder %s...\n", e.Name)
+						if err := runScriptInTMux([]Instance{e}, resolvedKey, encoderCleanup, "cleanup", time.Minute*5); err != nil {
+							fmt.Printf("Warning: error while cleaning up %s: %v\n", e.Name, err)
+						}
+					}(enc)
+				}
+				encWG.Wait()
+			}
+
 			// Clean up observability stack (Grafana/Prometheus/Loki) if configured.
 			if len(cfg.Observability) > 0 {
 				observabilityCleanup := `

--- a/tools/talis/txsim.go
+++ b/tools/talis/txsim.go
@@ -120,8 +120,12 @@ func killTmuxSessionCmd() *cobra.Command {
 				session,
 			)
 
+			// Target all instance types: validators + encoders
+			targets := append([]Instance{}, cfg.Validators...)
+			targets = append(targets, cfg.Encoders...)
+
 			// Run the kill script in its own tmux on each host
-			return runScriptInTMux(cfg.Validators, resolvedKey, killScript, "kill", timeout)
+			return runScriptInTMux(targets, resolvedKey, killScript, "kill", timeout)
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Adds `encoder` node type to talis for running fibre-txsim on dedicated instances separate from validators
- Each encoder gets its own keyring with unique key prefixes (`enc0-*`, `enc1-*`, ...) and independent escrow accounts
- Encoders are round-robin mapped to validators for gRPC and upload shards to all validators
- Frees ~2.5 GB RAM per validator by moving encoding off-box

## Changes
- `config.go`: `Encoder` NodeType, `Encoders []Instance`, builder methods
- `add.go`: `--type encoder` support
- `client.go`, `google_cloud.go`: encoders in Up/Down
- `deployment.go`: `deployEncodersIfConfigured` via S3
- `genesis.go`: encoder payload creation with init script
- `network.go`: `AddEncoder` with unique key prefixes
- `fibre_setup.go`: encoder escrow deposits
- `fibre_txsim.go`: `--on-encoders` flag, round-robin validator mapping
- `reset.go`, `txsim.go`: encoder cleanup

## Test plan
- [ ] `go build ./tools/talis/` compiles
- [ ] `talis add -t encoder -c 3` adds encoder instances to config
- [ ] `talis up` + `talis deploy` creates and deploys to encoder instances
- [ ] `talis fibre-txsim --on-encoders` runs fibre-txsim on encoders
- [ ] `talis kill-session -s fibre-txsim` kills sessions on both validators and encoders
- [ ] `talis reset` cleans up encoder instances

Closes https://linear.app/celestia/issue/PROTOCO-1492/talis-add-dedicated-encoder-instances-for-fibre-txsim

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7059" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
