### PR TITLE
perf(rsema1d): reduce allocations in merkle proof and RLC computation

### DIFF
--- a/pkg/rsema1d/commitment.go
+++ b/pkg/rsema1d/commitment.go
@@ -30,11 +30,10 @@ func computeRLC(row []byte, coeffs []field.GF128) field.GF128 {
 
 	for c := range numChunks {
 		chunk := row[c*chunkSize : (c+1)*chunkSize]
-		symbols := extractSymbols(chunk)
-		for j, sym := range symbols {
-			// result += symbol * coefficient
-			symbolIndex := c*32 + j // Overall symbol index in the row
-			product := field.Mul128(sym, coeffs[symbolIndex])
+		coeffBase := c * 32
+		for j := range 32 {
+			sym := field.GF16(chunk[32+j])<<8 | field.GF16(chunk[j])
+			product := field.Mul128(sym, coeffs[coeffBase+j])
 			result = field.Add128(result, product)
 		}
 	}

--- a/pkg/rsema1d/merkle/merkle.go
+++ b/pkg/rsema1d/merkle/merkle.go
@@ -125,9 +125,9 @@ func hashLeaf(data []byte, dst *[32]byte) {
 
 // hashPair hashes two nodes with the inner prefix, writing result directly to dst
 func hashPair(left, right *[32]byte, dst *[32]byte) {
-	h := sha256.New()
-	h.Write(innerPrefix)
-	h.Write(left[:])
-	h.Write(right[:])
-	h.Sum(dst[:0])
+	var buf [65]byte // 1 byte prefix + 32 left + 32 right
+	buf[0] = innerPrefix[0]
+	copy(buf[1:33], left[:])
+	copy(buf[33:65], right[:])
+	*dst = sha256.Sum256(buf[:])
 }


### PR DESCRIPTION
## Summary
- Zero-alloc `hashPair` using `sha256.Sum256` with stack-allocated buffer instead of `sha256.New()` heap allocation
- Inline symbol extraction in `computeRLC` to eliminate per-chunk `make([]field.GF16, 32)` allocation

## Changes
- `pkg/rsema1d/merkle/merkle.go`: `hashPair` uses `[65]byte` stack buffer + `sha256.Sum256`
- `pkg/rsema1d/commitment.go`: `computeRLC` inlines the Leopard symbol extraction loop

## Benchmarks
- `BenchmarkComputeRootFromProof`: **0 allocs/op** across all tree depths (was allocating per hash)
- `BenchmarkVerifyRowWithContext/1MB`: 32 B/op, 1 alloc/op (per-chunk allocs eliminated)

## Test plan
- [x] `go test ./pkg/rsema1d/...` passes
- [x] `go test ./pkg/rsema1d/merkle/...` passes
- [x] Benchmarks show allocation reduction
- [ ] CI passes

Closes https://linear.app/celestia/issue/PROTOCO-1493/rsema1d-reduce-allocations-in-merkle-proof-and-rlc-computation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7060" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
