### PR TITLE
feat: implement gas estimation for fibre blobs

### DIFF
--- a/pkg/appconsts/fibre_gas_consts.go
+++ b/pkg/appconsts/fibre_gas_consts.go
@@ -1,0 +1,16 @@
+package appconsts
+
+// These constants are in a separate file from fibre_consts.go because they are
+// referenced by packages that are compiled without the fibre build tag.
+// fibre_consts.go is gated behind //go:build fibre && !benchmarks, so any
+// constants there are unavailable in non-fibre builds and in CI lint checks.
+const (
+	// PFBFibreGasFixedCost is the fixed gas cost per blob in a PayForFibre transaction.
+	PFBFibreGasFixedCost uint64 = 650_000
+
+	// PFBFibreGasPerChunk is the gas cost per 256 KiB chunk in a PayForFibre transaction.
+	PFBFibreGasPerChunk uint64 = 45_000
+
+	// PFBFibreChunkSize is the chunk size (256 KiB) used for gas calculation in PayForFibre.
+	PFBFibreChunkSize uint32 = 262_144
+)

--- a/x/fibre/keeper/calculate_payment_test.go
+++ b/x/fibre/keeper/calculate_payment_test.go
@@ -1,7 +1,6 @@
 package keeper
 
 import (
-	"math"
 	"testing"
 
 	sdkmath "cosmossdk.io/math"
@@ -10,54 +9,89 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCalculatePaymentCoin(t *testing.T) {
+func TestEstimateGasForPayForFibre(t *testing.T) {
 	tests := []struct {
-		name           string
-		blobSize       uint32
-		gasPerBlobByte uint32
-		want           sdk.Coin
+		name     string
+		blobSize uint32
+		want     uint64
 	}{
 		{
-			name:           "zero blob size",
-			blobSize:       0,
-			gasPerBlobByte: 8,
-			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(0)),
+			name:     "zero blob size returns fixed cost only",
+			blobSize: 0,
+			want:     650_000,
 		},
 		{
-			name:           "zero gas per blob byte",
-			blobSize:       1000,
-			gasPerBlobByte: 0,
-			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(0)),
+			name:     "1 byte = 1 chunk",
+			blobSize: 1,
+			want:     650_000 + 45_000,
 		},
 		{
-			name:           "normal case",
-			blobSize:       1000,
-			gasPerBlobByte: 8,
-			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(8000)),
+			name:     "exactly 256 KiB = 1 chunk",
+			blobSize: 262_144,
+			want:     650_000 + 45_000,
 		},
 		{
-			name:           "overflow case: product exceeds uint32 max",
-			blobSize:       8_388_608, // 8 MiB
-			gasPerBlobByte: 1000,
-			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(8_388_608_000)),
+			name:     "256 KiB + 1 byte = 2 chunks",
+			blobSize: 262_145,
+			want:     650_000 + 2*45_000,
 		},
 		{
-			name:           "large values near uint32 max",
-			blobSize:       math.MaxUint32,
-			gasPerBlobByte: 2,
-			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(2*uint64(math.MaxUint32))),
+			name:     "exactly 512 KiB = 2 chunks",
+			blobSize: 524_288,
+			want:     650_000 + 2*45_000,
 		},
 		{
-			name:           "max uint32 * max uint32 does not overflow",
-			blobSize:       math.MaxUint32,
-			gasPerBlobByte: math.MaxUint32,
-			want:           sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(uint64(math.MaxUint32)*uint64(math.MaxUint32))),
+			name:     "1 MiB = 4 chunks",
+			blobSize: 1_048_576,
+			want:     650_000 + 4*45_000,
+		},
+		{
+			name:     "8 MiB = 32 chunks",
+			blobSize: 8_388_608,
+			want:     650_000 + 32*45_000,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := calculatePaymentCoin(tt.blobSize, tt.gasPerBlobByte)
+			got := EstimateGasForPayForFibre(tt.blobSize)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestCalculatePaymentAmount(t *testing.T) {
+	tests := []struct {
+		name     string
+		blobSize uint32
+		want     sdk.Coin
+	}{
+		{
+			name:     "zero blob size",
+			blobSize: 0,
+			want:     sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(650_000)),
+		},
+		{
+			name:     "1 byte blob",
+			blobSize: 1,
+			want:     sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(695_000)),
+		},
+		{
+			name:     "exactly 256 KiB",
+			blobSize: 262_144,
+			want:     sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(695_000)),
+		},
+		{
+			name:     "8 MiB blob",
+			blobSize: 8_388_608,
+			want:     sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(2_090_000)),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gas := EstimateGasForPayForFibre(tt.blobSize)
+			got := sdk.NewCoin(appconsts.BondDenom, sdkmath.NewIntFromUint64(gas))
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/math"
 	storetypes "cosmossdk.io/store/types"
 	"github.com/celestiaorg/celestia-app/v9/fibre"
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v9/x/fibre/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -361,7 +362,8 @@ func (k Keeper) validatePaymentPromiseStatefulInternal(ctx sdk.Context, promise 
 	// Check sufficient balance (includes funds locked in pending withdrawals)
 	// TODO: This assumes 1 gas = 1 utia but the minimum gas price could be
 	// different.
-	requiredAmount := calculatePaymentCoin(promise.BlobSize, params.GasPerBlobByte)
+	gas := EstimateGasForPayForFibre(promise.BlobSize)
+	requiredAmount := sdk.NewCoin(appconsts.BondDenom, math.NewIntFromUint64(gas))
 
 	hasSufficientBalance := escrowAccount.Balance.IsGTE(requiredAmount)
 	if !hasSufficientBalance {

--- a/x/fibre/keeper/keeper_test.go
+++ b/x/fibre/keeper/keeper_test.go
@@ -562,8 +562,7 @@ func (suite *KeeperTestSuite) TestValidatePaymentPromiseInternal() {
 		signerAddrStr := signerAddr.String()
 
 		// Create escrow account with insufficient balance
-		params := suite.keeper.GetParams(suite.ctx)
-		gasRequired := uint64(paymentPromise.BlobSize) * uint64(params.GasPerBlobByte)
+		gasRequired := keeper.EstimateGasForPayForFibre(paymentPromise.BlobSize)
 		requiredAmount := sdk.NewInt64Coin("utia", int64(gasRequired))
 		insufficientBalance := sdk.NewInt64Coin("utia", int64(gasRequired)-1) // Less than required
 
@@ -728,8 +727,7 @@ func (suite *KeeperTestSuite) createEscrowAccount(paymentPromise types.PaymentPr
 	signerAddrStr := signerAddr.String()
 	extraBalance := int64(1000)
 
-	params := suite.keeper.GetParams(suite.ctx)
-	gasRequired := uint64(paymentPromise.BlobSize) * uint64(params.GasPerBlobByte)
+	gasRequired := keeper.EstimateGasForPayForFibre(paymentPromise.BlobSize)
 	availableBalance := sdk.NewInt64Coin("utia", int64(gasRequired)+extraBalance)
 
 	escrowAccount := types.EscrowAccount{

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -313,18 +313,28 @@ func (ms msgServer) deductPaymentFromEscrow(ctx sdk.Context, escrowAccount *type
 	return nil
 }
 
-// calculatePaymentAmount calculates the payment amount for a fibre blob based on its size and gas parameters
-func (ms msgServer) calculatePaymentAmount(ctx sdk.Context, blobSize uint32) sdk.Coin {
-	params := ms.GetParams(ctx)
-	// TODO: this assumes 1 utia per gas which may not be correct.
-	return calculatePaymentCoin(blobSize, params.GasPerBlobByte)
+// calculatePaymentAmount calculates the payment amount for a fibre blob based on its size.
+// TODO: this assumes 1 utia per gas which may not be correct.
+func (ms msgServer) calculatePaymentAmount(_ sdk.Context, blobSize uint32) sdk.Coin {
+	gas := EstimateGasForPayForFibre(blobSize)
+	return sdk.NewCoin(appconsts.BondDenom, math.NewIntFromUint64(gas))
 }
 
-// calculatePaymentCoin computes the payment coin from blobSize and gasPerBlobByte.
-// Both operands are widened to uint64 before multiplication to prevent uint32 overflow.
-func calculatePaymentCoin(blobSize, gasPerBlobByte uint32) sdk.Coin {
-	result := uint64(blobSize) * uint64(gasPerBlobByte)
-	return sdk.NewCoin(appconsts.BondDenom, math.NewIntFromUint64(result))
+// EstimateGasForPayForFibre estimates the gas required for a PayForFibre message.
+// The formula is: GasFibre = B + A × n
+// where:
+//
+//	B = 650,000 — fixed cost per blob
+//	A = 45,000 — per-chunk cost
+//	n = ⌈blobSize / 262,144⌉ — number of 256 KiB chunks
+//
+// This formula is standalone and not dependent on GasPerBlobByte or GasPerCelestiaByte.
+func EstimateGasForPayForFibre(blobSize uint32) uint64 {
+	if blobSize == 0 {
+		return appconsts.PFBFibreGasFixedCost
+	}
+	chunks := (uint64(blobSize) + uint64(appconsts.PFBFibreChunkSize) - 1) / uint64(appconsts.PFBFibreChunkSize)
+	return appconsts.PFBFibreGasFixedCost + appconsts.PFBFibreGasPerChunk*chunks
 }
 
 // validateValidatorSignatures validates validator signatures using the existing SignatureSet infrastructure

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -265,8 +265,7 @@ func (suite *MsgServerTestSuite) TestPayForFibre() {
 	paymentPromise := suite.createPaymentPromise(signerPubKey, privKey)
 
 	// Calculate required balance
-	params := suite.keeper.GetParams(suite.ctx)
-	gasRequired := uint64(paymentPromise.BlobSize) * uint64(params.GasPerBlobByte)
+	gasRequired := keeper.EstimateGasForPayForFibre(paymentPromise.BlobSize)
 	requiredAmount := sdk.NewInt64Coin(appconsts.BondDenom, int64(gasRequired)+1000)
 
 	// Setup: Create escrow account with sufficient balance
@@ -403,7 +402,7 @@ func (suite *MsgServerTestSuite) TestPaymentPromiseTimeout() {
 	paymentPromise := suite.createPaymentPromiseWithTime(signerPubKey, privKey, oldTime)
 
 	// Calculate required balance
-	gasRequired := uint64(paymentPromise.BlobSize) * uint64(params.GasPerBlobByte)
+	gasRequired := keeper.EstimateGasForPayForFibre(paymentPromise.BlobSize)
 	requiredAmount := sdk.NewInt64Coin(appconsts.BondDenom, int64(gasRequired)+1000)
 
 	// Setup: Create escrow account with sufficient balance
@@ -664,7 +663,7 @@ func (suite *MsgServerTestSuite) TestPayForFibreWithPendingWithdrawals() {
 	suite.T().Run("payment succeeds when full withdrawal exists", func(t *testing.T) {
 		signerPubKey, privKey, signer := suite.newSigner()
 		paymentPromise := suite.createPaymentPromise(signerPubKey, privKey)
-		gasRequired := uint64(paymentPromise.BlobSize) * uint64(params.GasPerBlobByte)
+		gasRequired := keeper.EstimateGasForPayForFibre(paymentPromise.BlobSize)
 		depositAmount := sdk.NewInt64Coin(appconsts.BondDenom, int64(gasRequired)+1000)
 
 		// Create escrow account with deposit

--- a/x/fibre/types/params.go
+++ b/x/fibre/types/params.go
@@ -18,6 +18,8 @@ var (
 	KeyPaymentPromiseHeightWindow    = []byte("PaymentPromiseHeightWindow")
 
 	// DefaultGasPerBlobByte is the initial value of the gas per blob byte parameter.
+	// TODO: should this param be removed? The PFF gas formula is now standalone
+	// (EstimateGasForPayForFibre) and does not depend on GasPerBlobByte.
 	DefaultGasPerBlobByte uint32 = 1
 	// DefaultWithdrawalDelay is the initial value of the withdrawal delay parameter.
 	DefaultWithdrawalDelay = 24 * time.Hour


### PR DESCRIPTION
  ## Summary                                                                                                                                               
                                                                                                                                                         
  - Replaced the simple `blobSize × gasPerBlobByte` payment calculation for `MsgPayForFibre` with a new chunk-based gas formula: `GasFibre = B + A × n`    
    - B = 650,000 — fixed cost per blob                                                                                                                  
    - A = 45,000 — per-chunk cost                                                                                                                          
    - n = ⌈blobSize / 262,144⌉ — number of 256 KiB chunks                                                                                                  
  - Added constants `PFBFibreGasFixedCost`, `PFBFibreGasPerChunk`, and `PFBFibreChunkSize` to `pkg/appconsts/fibre_consts.go`                              
  - Added exported `EstimateGasForPayForFibre()` function in `x/fibre/keeper/`                                                                             
  - Updated both call sites: `calculatePaymentAmount` (msg_server.go) and `ValidatePaymentPromiseStatefulForTimeout` (keeper.go)                           
  - Updated all tests in `msg_server_test.go` and `keeper_test.go` to use the new formula                                                                  
  - Added TODO questioning whether `GasPerBlobByte` governance param should be removed since the formula is now standalone                                 
                                                                                                                                                          


Resolves https://linear.app/celestia/issue/PROTOCO-1402/update-and-implement-new-gas-cost-calculation-for-fibre
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7066" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
