### PR TITLE
feat: set evidence max age num blocks in upgrade handler

### DIFF
--- a/app/upgrades.go
+++ b/app/upgrades.go
@@ -79,6 +79,10 @@ func (app App) RegisterUpgradeHandlers() {
 				return nil, fmt.Errorf("failed to set block max bytes: %w", err)
 			}
 
+			if err := app.SetEvidenceMaxAgeNumBlocks(ctx, appconsts.MaxAgeNumBlocks); err != nil {
+				return nil, fmt.Errorf("failed to set evidence max age num blocks: %w", err)
+			}
+
 			if err := app.SetMaxExpectedTimePerBlock(sdkCtx); err != nil {
 				sdkCtx.Logger().Error("failed to set MaxExpectedTimePerBlock", "error", err)
 				return nil, err
@@ -116,6 +120,24 @@ func (app App) SetBlockMaxBytes(ctx context.Context, maxBytes int64) error {
 	}
 	params.Block.MaxBytes = maxBytes
 	sdkCtx.Logger().Info("setting block max bytes", "maxBytes", maxBytes)
+	if err := app.ConsensusKeeper.ParamsStore.Set(ctx, params); err != nil {
+		sdkCtx.Logger().Error("failed to set consensus params", "err", err)
+		return err
+	}
+	return nil
+}
+
+// SetEvidenceMaxAgeNumBlocks updates the consensus parameter Evidence.MaxAgeNumBlocks.
+func (app App) SetEvidenceMaxAgeNumBlocks(ctx context.Context, maxAgeNumBlocks int64) error {
+	sdkCtx := sdk.UnwrapSDKContext(ctx)
+
+	params, err := app.ConsensusKeeper.ParamsStore.Get(ctx)
+	if err != nil {
+		sdkCtx.Logger().Error("failed to get consensus params", "err", err)
+		return err
+	}
+	params.Evidence.MaxAgeNumBlocks = maxAgeNumBlocks
+	sdkCtx.Logger().Info("setting evidence max age num blocks", "maxAgeNumBlocks", maxAgeNumBlocks)
 	if err := app.ConsensusKeeper.ParamsStore.Set(ctx, params); err != nil {
 		sdkCtx.Logger().Error("failed to set consensus params", "err", err)
 		return err

--- a/app/upgrades_test.go
+++ b/app/upgrades_test.go
@@ -86,6 +86,45 @@ func TestApplyUpgradeSetBlockMaxBytes(t *testing.T) {
 	})
 }
 
+func TestApplyUpgradeSetEvidenceMaxAgeNumBlocks(t *testing.T) {
+	t.Run("apply upgrade should set Evidence.MaxAgeNumBlocks to 559940", func(t *testing.T) {
+		consensusParams := app.DefaultConsensusParams()
+		testApp, _, _ := util.NewTestAppWithGenesisSet(consensusParams)
+		require.True(t, testApp.UpgradeKeeper.HasHandler("v9"))
+
+		ctx := testApp.NewContext(false)
+
+		// Manually set MaxAgeNumBlocks to the pre-v9 mainnet value (242,640)
+		// because NewTestAppWithGenesisSet uses DefaultConsensusParams which
+		// already has the v9 value.
+		oldMaxAgeNumBlocks := int64(242_640)
+		params, err := testApp.ConsensusKeeper.ParamsStore.Get(ctx)
+		require.NoError(t, err)
+		params.Evidence.MaxAgeNumBlocks = oldMaxAgeNumBlocks
+		err = testApp.ConsensusKeeper.ParamsStore.Set(ctx, params)
+		require.NoError(t, err)
+
+		// Verify the initial value is 242,640.
+		params, err = testApp.ConsensusKeeper.ParamsStore.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, oldMaxAgeNumBlocks, params.Evidence.MaxAgeNumBlocks)
+
+		// Apply the upgrade.
+		plan := upgradetypes.Plan{
+			Name:   "v9",
+			Height: 1,
+			Info:   "test",
+		}
+		err = testApp.UpgradeKeeper.ApplyUpgrade(ctx, plan)
+		require.NoError(t, err)
+
+		// Verify Evidence.MaxAgeNumBlocks was updated to 559,940.
+		params, err = testApp.ConsensusKeeper.ParamsStore.Get(ctx)
+		require.NoError(t, err)
+		require.Equal(t, int64(appconsts.MaxAgeNumBlocks), params.Evidence.MaxAgeNumBlocks)
+	})
+}
+
 // createValidatorWithCommission creates a validator with specific commission
 // rates for testing
 func createValidatorWithCommission(t *testing.T, testApp *app.App, ctx sdk.Context, rate string, maxRate string) stakingtypes.Validator {


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-1466/add-an-upgrade-handler-for-maxagenumblocks
