### PR TITLE
feat(rsema1d): new `Coder` API

### DIFF
--- a/pkg/rsema1d/codec.go
+++ b/pkg/rsema1d/codec.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/encoding"
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
@@ -39,7 +40,7 @@ func Encode(data [][]byte, config *Config) (*ExtendedData, Commitment, []field.G
 	rowRoot := rowTree.Root()
 
 	// 4. Derive RLC coefficients
-	coeffs := deriveCoefficients(rowRoot, config)
+	coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 	// 5. Compute RLC results for original rows
 	rlcOrig := computeRLCOrig(data, coeffs, config)
@@ -97,7 +98,7 @@ func EncodeParity(extended [][]byte, config *Config) (*ExtendedData, Commitment,
 	rowRoot := rowTree.Root()
 
 	// 3. Derive RLC coefficients
-	coeffs := deriveCoefficients(rowRoot, config)
+	coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 	// 4. Compute RLC results for original rows (first K rows)
 	originalRows := extended[:config.K]
@@ -132,17 +133,35 @@ func EncodeParity(extended [][]byte, config *Config) (*ExtendedData, Commitment,
 func computeRLCOrig(rows [][]byte, coeffs []field.GF128, config *Config) []field.GF128 {
 	results := make([]field.GF128, len(rows))
 
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, config.WorkerCount)
+	workers := min(config.WorkerCount, len(rows))
+	if workers <= 1 {
+		for i, row := range rows {
+			results[i] = computeRLC(row, coeffs)
+		}
+		return results
+	}
 
-	for i, row := range rows {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(idx int, r []byte) {
+	var wg sync.WaitGroup
+	// use more chunks than workers so workers can pick up more work if a
+	// previous chunk runs slower, without falling back to per-row scheduling.
+	chunkCount := min(len(rows), workers*4)
+	chunkSize := (len(rows) + chunkCount - 1) / chunkCount
+	var next atomic.Int64
+	wg.Add(workers)
+	for range workers {
+		go func() {
 			defer wg.Done()
-			defer func() { <-sem }()
-			results[idx] = computeRLC(r, coeffs)
-		}(i, row)
+			for {
+				start := int(next.Add(int64(chunkSize)) - int64(chunkSize))
+				if start >= len(rows) {
+					return
+				}
+				end := min(start+chunkSize, len(rows))
+				for i, row := range rows[start:end] {
+					results[start+i] = computeRLC(row, coeffs)
+				}
+			}
+		}()
 	}
 	wg.Wait()
 

--- a/pkg/rsema1d/codec_bench_test.go
+++ b/pkg/rsema1d/codec_bench_test.go
@@ -206,6 +206,37 @@ func BenchmarkEncode(b *testing.B) {
 	}
 }
 
+// BenchmarkComputeRLCOrig isolates the RLC computation over original rows.
+func BenchmarkComputeRLCOrig(b *testing.B) {
+	configs := generateBenchmarkConfigs(true)
+
+	for _, cfg := range configs {
+		b.Run(configName(cfg), func(b *testing.B) {
+			codecConfig := &Config{
+				K:           cfg.k,
+				N:           cfg.n,
+				RowSize:     cfg.rowSize,
+				WorkerCount: cfg.workerCount,
+			}
+
+			rowRoot := [32]byte{1, 2, 3, 4}
+			coeffs := deriveCoefficients(rowRoot, cfg.rowSize)
+
+			setup := func() any {
+				return generateTestData(cfg.k, cfg.rowSize)
+			}
+
+			benchFunc := func(state any) error {
+				rows := state.([][]byte)
+				_ = computeRLCOrig(rows, coeffs, codecConfig)
+				return nil
+			}
+
+			runBenchmark(b, cfg, setup, benchFunc, true)
+		})
+	}
+}
+
 // BenchmarkReconstruct benchmarks the Reconstruct function
 func BenchmarkReconstruct(b *testing.B) {
 	// Reconstruct doesn't support worker parallelism directly
@@ -574,7 +605,7 @@ func BenchmarkDeriveCoefficients(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				deriveCoefficients(rowRoot, config)
+				deriveCoefficients(rowRoot, config.RowSize)
 			}
 		})
 	}

--- a/pkg/rsema1d/codec_tamper_test.go
+++ b/pkg/rsema1d/codec_tamper_test.go
@@ -41,7 +41,7 @@ func TestTamperedExtendedDataBeforeCommitment(t *testing.T) {
 			rowRoot := rowTree.Root()
 
 			// Step 3: Derive RLC coefficients
-			coeffs := deriveCoefficients(rowRoot, config)
+			coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 			// Step 4: Compute RLC results for original rows
 			rlcOrig := computeRLCOrig(data, coeffs, config)
@@ -129,7 +129,7 @@ func TestTamperedRLCBeforeCommitment(t *testing.T) {
 			rowRoot := rowTree.Root()
 
 			// Step 3: Derive RLC coefficients
-			coeffs := deriveCoefficients(rowRoot, config)
+			coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 			// Step 4: Compute RLC results for original rows
 			rlcOrig := computeRLCOrig(data, coeffs, config)
@@ -211,7 +211,7 @@ func TestTamperedOriginalRLCBeforeCommitment(t *testing.T) {
 			rowRoot := rowTree.Root()
 
 			// Step 3: Derive RLC coefficients
-			coeffs := deriveCoefficients(rowRoot, config)
+			coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 			// Step 4: Compute RLC results for original rows
 			rlcOrig := computeRLCOrig(data, coeffs, config)
@@ -317,7 +317,7 @@ func TestMultipleTamperedRows(t *testing.T) {
 			rowTree := buildPaddedRowTree(extended, config)
 			rowRoot := rowTree.Root()
 
-			coeffs := deriveCoefficients(rowRoot, config)
+			coeffs := deriveCoefficients(rowRoot, config.RowSize)
 			rlcOrig := computeRLCOrig(data, coeffs, config)
 
 			// Build padded RLC Merkle tree
@@ -403,7 +403,7 @@ func TestInvalidRowProofDepth(t *testing.T) {
 			rowTree := buildPaddedRowTree(extended, config)
 			rowRoot := rowTree.Root()
 
-			coeffs := deriveCoefficients(rowRoot, config)
+			coeffs := deriveCoefficients(rowRoot, config.RowSize)
 			rlcOrig := computeRLCOrig(data, coeffs, config)
 			if err != nil {
 				t.Fatalf("ExtendRLCResults failed: %v", err)
@@ -449,7 +449,7 @@ func TestInvalidRowProofDepth(t *testing.T) {
 			if err != nil {
 				t.Errorf("Failed to compute fake row root: %v", err)
 			}
-			fakeCoeffs := deriveCoefficients(fakeRowRoot, config)
+			fakeCoeffs := deriveCoefficients(fakeRowRoot, config.RowSize)
 			fakeRlcCommitment := computeRLC(maliciousProof.Row, fakeCoeffs)
 			ctx.rlcOrigRoot = rlcOrigRoot
 
@@ -494,7 +494,7 @@ func TestVerifyRowWithContextWithMultipleOpenings(t *testing.T) {
 	assert.NoError(t, err)
 	nodes, asNodes := buildAdversarialPaddedRowTree(extended)
 	rowRoot := nodes[0]
-	coeffs := deriveCoefficients([32]byte(rowRoot), config)
+	coeffs := deriveCoefficients([32]byte(rowRoot), config.RowSize)
 	rlcOrig := computeRLCOrig(data, coeffs, config)
 	rlcOrigTree := BuildPaddedRLCTree(rlcOrig, config)
 	rlcOrigRoot := rlcOrigTree.Root()

--- a/pkg/rsema1d/codec_test.go
+++ b/pkg/rsema1d/codec_test.go
@@ -269,7 +269,7 @@ func TestRLCCommutationProperty(t *testing.T) {
 				t.Fatalf("Encode() error: %v", err)
 			}
 
-			coeffs := deriveCoefficients(extData.rowRoot, config)
+			coeffs := deriveCoefficients(extData.rowRoot, config.RowSize)
 			extendedRLCs, err := encoding.ExtendRLCResults(extData.rlcOrig, tc.n)
 			if err != nil {
 				t.Fatalf("ExtendRLCResults() error: %v", err)

--- a/pkg/rsema1d/coder.go
+++ b/pkg/rsema1d/coder.go
@@ -1,0 +1,93 @@
+package rsema1d
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/klauspost/reedsolomon"
+)
+
+// Coder provides encoding and reconstruction operations with a cached Reed-Solomon encoder.
+// Use NewCoder to create an instance and reuse it for multiple operations with the same Config.
+type Coder struct {
+	config *Config
+	enc    reedsolomon.Encoder
+}
+
+// NewCoder creates a Coder with cached Reed-Solomon encoder.
+func NewCoder(cfg *Config) (*Coder, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
+	}
+
+	enc, err := reedsolomon.New(cfg.K, cfg.N, reedsolomon.WithLeopardGF16(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create encoder: %w", err)
+	}
+
+	return &Coder{config: cfg, enc: enc}, nil
+}
+
+// Encode creates parity and commitment for K+N rows.
+// rows must have length K+N. Original data goes in rows[:K], and parity rows
+// in rows[K:] must be allocated and zeroed before calling Encode.
+func (c *Coder) Encode(rows [][]byte) (*ExtendedData, error) {
+	if err := c.validateRows(rows); err != nil {
+		return nil, err
+	}
+	if err := c.enc.Encode(rows); err != nil {
+		return nil, fmt.Errorf("failed to encode: %w", err)
+	}
+	return c.commit(rows), nil
+}
+
+// Reconstruct fills any missing rows and then computes commitment material for
+// the full extended data set. rows must have length K+N. Missing rows may be nil.
+func (c *Coder) Reconstruct(rows [][]byte) (*ExtendedData, error) {
+	if err := c.validateRows(rows); err != nil {
+		return nil, err
+	}
+	if err := c.enc.Reconstruct(rows); err != nil {
+		return nil, fmt.Errorf("failed to reconstruct: %w", err)
+	}
+	return c.commit(rows), nil
+}
+
+func (c *Coder) validateRows(rows [][]byte) error {
+	if len(rows) != c.config.K+c.config.N {
+		return fmt.Errorf("expected %d rows, got %d", c.config.K+c.config.N, len(rows))
+	}
+	return nil
+}
+
+func (c *Coder) commit(extendedRows [][]byte) *ExtendedData {
+	// build padded Merkle tree for rows
+	rowTree := buildPaddedRowTree(extendedRows, c.config)
+	rowRoot := rowTree.Root()
+
+	// derive RLC coefficients and compute RLC results for original rows
+	coeffs := deriveCoefficients(rowRoot, len(extendedRows[0]))
+	rlcOrig := computeRLCOrig(extendedRows[:c.config.K], coeffs, c.config)
+
+	// build padded RLC Merkle tree
+	rlcOrigTree := BuildPaddedRLCTree(rlcOrig, c.config)
+	rlcOrigRoot := rlcOrigTree.Root()
+
+	// create commitment: SHA256(rowRoot || rlcOrigRoot)
+	h := sha256.New()
+	h.Write(rowRoot[:])
+	h.Write(rlcOrigRoot[:])
+	var commitment Commitment
+	h.Sum(commitment[:0])
+
+	return &ExtendedData{
+		config:      c.config,
+		rows:        extendedRows,
+		rowRoot:     rowRoot,
+		rlcOrig:     rlcOrig,
+		rowTree:     rowTree,
+		rlcOrigTree: rlcOrigTree,
+		rlcOrigRoot: rlcOrigRoot,
+		commitment:  commitment,
+	}
+}

--- a/pkg/rsema1d/coder_bench_test.go
+++ b/pkg/rsema1d/coder_bench_test.go
@@ -1,0 +1,108 @@
+package rsema1d
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+func BenchmarkCoderEncode(b *testing.B) {
+	sizes := []struct {
+		name    string
+		k, n    int
+		rowSize int
+	}{
+		{"4x4x64", 4, 4, 64},
+		{"64x64x512", 64, 64, 512},
+		{"1024x1024x1024", 1024, 1024, 1024},
+		{"4096x12288x8192", 4096, 12288, 8192},
+	}
+
+	for _, sz := range sizes {
+		b.Run(sz.name, func(b *testing.B) {
+			coder, err := NewCoder(&Config{K: sz.k, N: sz.n, WorkerCount: 1})
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			rows := make([][]byte, sz.k+sz.n)
+			for i := range sz.k {
+				rows[i] = make([]byte, sz.rowSize)
+				for j := range sz.rowSize {
+					rows[i][j] = byte(rand.IntN(256))
+				}
+			}
+			for i := sz.k; i < sz.k+sz.n; i++ {
+				rows[i] = make([]byte, sz.rowSize)
+			}
+
+			b.SetBytes(int64(sz.k * sz.rowSize))
+			b.ResetTimer()
+			for b.Loop() {
+				for i := sz.k; i < sz.k+sz.n; i++ {
+					clear(rows[i])
+				}
+				if _, err := coder.Encode(rows); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkCoderReconstruct(b *testing.B) {
+	sizes := []struct {
+		name    string
+		k, n    int
+		rowSize int
+	}{
+		{"4x4x64", 4, 4, 64},
+		{"64x64x512", 64, 64, 512},
+		{"1024x1024x1024", 1024, 1024, 1024},
+	}
+
+	for _, sz := range sizes {
+		b.Run(sz.name, func(b *testing.B) {
+			config := &Config{K: sz.k, N: sz.n, RowSize: sz.rowSize, WorkerCount: 1}
+			data := make([][]byte, sz.k)
+			for i := range sz.k {
+				data[i] = make([]byte, sz.rowSize)
+				for j := range sz.rowSize {
+					data[i][j] = byte(rand.IntN(256))
+				}
+			}
+
+			extData, _, _, err := Encode(data, config)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			// mixed indices: half original, half parity
+			indices := make([]int, sz.k)
+			halfK := sz.k / 2
+			for i := range halfK {
+				indices[i] = i
+			}
+			for i := range sz.k - halfK {
+				indices[halfK+i] = sz.k + i
+			}
+
+			rows := make([][]byte, sz.k)
+			for i, idx := range indices {
+				rows[i] = extData.rows[idx]
+			}
+
+			coder, _ := NewCoder(&Config{K: sz.k, N: sz.n, WorkerCount: 1})
+			b.SetBytes(int64(sz.k * sz.rowSize))
+			b.ResetTimer()
+			for b.Loop() {
+				reconRows := make([][]byte, sz.k+sz.n)
+				for i, idx := range indices {
+					reconRows[idx] = rows[i]
+				}
+				if _, err := coder.Reconstruct(reconRows); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/rsema1d/commitment.go
+++ b/pkg/rsema1d/commitment.go
@@ -8,9 +8,9 @@ import (
 )
 
 // deriveCoefficients generates RLC coefficients via Fiat-Shamir (internal)
-func deriveCoefficients(rowRoot [32]byte, config *Config) []field.GF128 {
+func deriveCoefficients(rowRoot [32]byte, rowSize int) []field.GF128 {
 	seed := sha256.Sum256(rowRoot[:])
-	numSymbols := config.RowSize / 2 // Each GF16 symbol is 2 bytes
+	numSymbols := rowSize / 2 // Each GF16 symbol is 2 bytes
 	coeffs := make([]field.GF128, numSymbols)
 
 	var input [32 + 4]byte

--- a/pkg/rsema1d/commitment_test.go
+++ b/pkg/rsema1d/commitment_test.go
@@ -33,8 +33,8 @@ func TestDeriveCoefficients(t *testing.T) {
 			rowRoot := sha256.Sum256([]byte("test root"))
 
 			// Derive coefficients
-			coeffs1 := deriveCoefficients(rowRoot, config)
-			coeffs2 := deriveCoefficients(rowRoot, config)
+			coeffs1 := deriveCoefficients(rowRoot, config.RowSize)
+			coeffs2 := deriveCoefficients(rowRoot, config.RowSize)
 
 			// Test determinism
 			if len(coeffs1) != len(coeffs2) {
@@ -55,7 +55,7 @@ func TestDeriveCoefficients(t *testing.T) {
 
 			// Test that different roots produce different coefficients
 			differentRoot := sha256.Sum256([]byte("different root"))
-			coeffs3 := deriveCoefficients(differentRoot, config)
+			coeffs3 := deriveCoefficients(differentRoot, config.RowSize)
 
 			allSame := true
 			for i := range coeffs1 {
@@ -98,7 +98,7 @@ func TestComputeRLC(t *testing.T) {
 
 			// Derive coefficients
 			rowRoot := sha256.Sum256([]byte("test"))
-			coeffs := deriveCoefficients(rowRoot, config)
+			coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 			// Compute RLC
 			rlc1 := computeRLC(row, coeffs)
@@ -190,7 +190,7 @@ func TestRLCLinearity(t *testing.T) {
 
 	// Derive coefficients
 	rowRoot := sha256.Sum256([]byte("test"))
-	coeffs := deriveCoefficients(rowRoot, config)
+	coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 	// Compute RLCs
 	rlcA := computeRLC(rowA, coeffs)
@@ -271,7 +271,7 @@ func TestCoefficientsConsistency(t *testing.T) {
 			WorkerCount: 1,
 		}
 
-		coeffs := deriveCoefficients(rowRoot, config)
+		coeffs := deriveCoefficients(rowRoot, config.RowSize)
 
 		// All configs with same rowSize should produce same coefficients
 		if i > 0 {

--- a/pkg/rsema1d/config.go
+++ b/pkg/rsema1d/config.go
@@ -39,8 +39,9 @@ func (c *Config) Validate() error {
 	if c.N <= 0 {
 		return errors.New("n must be positive")
 	}
-	if c.RowSize <= 0 {
-		return errors.New("RowSize must be positive")
+	// RowSize=0 is valid (means variable row size, determined at runtime)
+	if c.RowSize < 0 {
+		return errors.New("RowSize must be non-negative")
 	}
 
 	// Check K + N <= 65536 (GF(2^16) field size limit)
@@ -48,14 +49,17 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("k + n must be <= 65536, got %d", c.K+c.N)
 	}
 
-	// Check RowSize is multiple of 64 (Leopard constraint)
-	if c.RowSize%64 != 0 {
-		return fmt.Errorf("RowSize must be a multiple of 64, got %d", c.RowSize)
-	}
+	// When RowSize is specified (> 0), validate constraints
+	if c.RowSize > 0 {
+		// Check RowSize is multiple of 64 (Leopard constraint)
+		if c.RowSize%64 != 0 {
+			return fmt.Errorf("RowSize must be a multiple of 64, got %d", c.RowSize)
+		}
 
-	// Check RowSize is at least 64
-	if c.RowSize < 64 {
-		return fmt.Errorf("RowSize must be at least 64, got %d", c.RowSize)
+		// Check RowSize is at least 64
+		if c.RowSize < 64 {
+			return fmt.Errorf("RowSize must be at least 64, got %d", c.RowSize)
+		}
 	}
 
 	// WorkerCount must be at least 1

--- a/pkg/rsema1d/incorrect_encoding.go
+++ b/pkg/rsema1d/incorrect_encoding.go
@@ -59,7 +59,7 @@ func GenerateIncorrectEncoding(data [][]byte, config *Config, rowIndices []int, 
 	newRowRoot := newRowTree.Root()
 
 	// 4. Derive new coefficients from the new row root
-	newCoeffs := deriveCoefficients(newRowRoot, config)
+	newCoeffs := deriveCoefficients(newRowRoot, config.RowSize)
 
 	// 5. Compute RLC using non-tampered original rows: for any tampered original
 	// row, use the saved pre-tamper data so the RLC values stay correct for them.

--- a/pkg/rsema1d/incorrect_encoding_test.go
+++ b/pkg/rsema1d/incorrect_encoding_test.go
@@ -169,7 +169,7 @@ func TestIncorrectEncodingGenerator(t *testing.T) {
 			// Verify the RLC commutation property directly for all rows:
 			// For unmodified rows, RLC(row, coeffs) == extendedRLC[i]
 			// For modified rows, RLC(row, coeffs) != extendedRLC[i]
-			coeffs := deriveCoefficients(fake.ExtendedData.rowRoot, config)
+			coeffs := deriveCoefficients(fake.ExtendedData.rowRoot, config.RowSize)
 			rlcExtended, err := encoding.ExtendRLCResults(fake.RLCOrig, config.N)
 			if err != nil {
 				t.Fatalf("ExtendRLCResults() error: %v", err)

--- a/pkg/rsema1d/padding.go
+++ b/pkg/rsema1d/padding.go
@@ -7,7 +7,7 @@ import (
 
 // buildPaddedRowTree creates a padded Merkle tree from extended rows
 func buildPaddedRowTree(extended [][]byte, config *Config) *merkle.Tree {
-	zeroRow := make([]byte, config.RowSize)
+	zeroRow := make([]byte, len(extended[0]))
 	paddedRows := make([][]byte, config.totalPadded)
 
 	// Fill padded array: [original | padding | extended | padding]

--- a/pkg/rsema1d/proof.go
+++ b/pkg/rsema1d/proof.go
@@ -52,8 +52,8 @@ func VerifyRowWithContext(proof *RowProof, commitment Commitment, context *Verif
 		return fmt.Errorf("index %d out of range [0, %d)", proof.Index, context.config.K+context.config.N)
 	}
 
-	// The row size must match the config
-	if len(proof.Row) != context.config.RowSize {
+	// When RowSize is specified, validate it matches
+	if context.config.RowSize > 0 && len(proof.Row) != context.config.RowSize {
 		return fmt.Errorf("row size mismatch: expected %d, got %d", context.config.RowSize, len(proof.Row))
 	}
 
@@ -74,8 +74,11 @@ func VerifyRowWithContext(proof *RowProof, commitment Commitment, context *Verif
 
 	// 2. Derive coefficients once and compute RLC for the row
 	context.coeffsOnce.Do(func() {
-		context.coeffs = deriveCoefficients(rowRoot, context.config)
+		context.coeffs = deriveCoefficients(rowRoot, len(proof.Row))
 	})
+	if len(context.coeffs) != len(proof.Row)/2 {
+		return fmt.Errorf("row size mismatch: cached coefficients for %d bytes, got %d", len(context.coeffs)*2, len(proof.Row))
+	}
 	computedRLC := computeRLC(proof.Row, context.coeffs)
 
 	// 3. Verify RLC matches the extended value at this index
@@ -118,8 +121,8 @@ func VerifyStandaloneProof(proof *StandaloneProof, commitment Commitment, config
 		return errors.New("standalone verification only supports original rows")
 	}
 
-	// The row size must match the config
-	if len(proof.Row) != config.RowSize {
+	// When RowSize is specified, validate it matches
+	if config.RowSize > 0 && len(proof.Row) != config.RowSize {
 		return fmt.Errorf("row size mismatch: expected %d, got %d", config.RowSize, len(proof.Row))
 	}
 
@@ -144,7 +147,7 @@ func VerifyStandaloneProof(proof *StandaloneProof, commitment Commitment, config
 	}
 
 	// 2. Compute RLC for the row
-	coeffs := deriveCoefficients(rowRoot, config)
+	coeffs := deriveCoefficients(rowRoot, len(proof.Row))
 	computedRLC := computeRLC(proof.Row, coeffs)
 
 	// 3. Compute RLC root from proof

--- a/pkg/rsema1d/types.go
+++ b/pkg/rsema1d/types.go
@@ -22,6 +22,17 @@ type ExtendedData struct {
 	rowTree     *merkle.Tree  // Cached row Merkle tree
 	rlcOrigTree *merkle.Tree  // Cached RLC Merkle tree
 	rlcOrigRoot [32]byte      // Cached RLC root
+	commitment  Commitment    // SHA256(rowRoot || rlcOrigRoot)
+}
+
+// Commitment returns the cryptographic commitment for this extended data.
+func (ed *ExtendedData) Commitment() Commitment {
+	return ed.commitment
+}
+
+// RLC returns the computed random linear combination values for the original rows.
+func (ed *ExtendedData) RLC() []field.GF128 {
+	return ed.rlcOrig
 }
 
 // VerificationContext holds precomputed RLC data for efficient batch verification


### PR DESCRIPTION
Unlike the standalone Encode function, which creates a new RS encoder per call, Coder caches it across operations. Its Encode and Reconstruct methods also accept pre-allocated K+N row slices, enabling zero-allocation encoding.

The Coder aims to replace the old Encode and EncodeParity API together with the `encoding` subpkg in rsema1d. However, the old API has not been removed yet, as it's still used by the downloading, which will be optimized in a further PR. This PR starts a series of PR optimizing fibre/rsema encoding, bringing runtime allocations to the minimal possible ground.


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7068" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
