### PR TITLE
feat(fibre): `RowAssembler` for zero-allocation blob encoding

### DIFF
--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -18,6 +18,8 @@ var (
 	ErrBlobTooLarge = errors.New("blob size exceeds maximum allowed size")
 	// ErrBlobCommitmentMismatch is returned when the reconstructed commitment doesn't match the expected one.
 	ErrBlobCommitmentMismatch = errors.New("commitment mismatch: reconstructed data doesn't match expected commitment")
+	// ErrBlobConsumed is returned when a blob is reused after being uploaded.
+	ErrBlobConsumed = errors.New("blob cannot be reused after upload")
 )
 
 // BlobConfig contains configuration parameters for blob encoding and decoding.
@@ -35,11 +37,26 @@ type BlobConfig struct {
 	MaxDataSize int
 	// CodingWorkers is the number of workers to use for encoding and decoding rsema1d.
 	CodingWorkers int
+
+	// Coder is a cached Reed-Solomon encoder/decoder for encoding blobs.
+	Coder *rsema1d.Coder
+	// Assembler builds pooled row layouts for encoding blobs.
+	Assembler *RowAssembler
 }
 
+// defaultBlobConfigV0 is the shared default config, created at init time.
+var defaultBlobConfigV0 = func() BlobConfig {
+	cfg, err := NewBlobConfigFromParams(0, DefaultProtocolParams)
+	if err != nil {
+		panic(fmt.Sprintf("creating default blob config v0: %v", err))
+	}
+	return cfg
+}()
+
 // DefaultBlobConfigV0 returns a [BlobConfig] with default values for version 0.
+// The config is created once at init and shared across all callers.
 func DefaultBlobConfigV0() BlobConfig {
-	return NewBlobConfigFromParams(0, DefaultProtocolParams)
+	return defaultBlobConfigV0
 }
 
 // BlobConfigForVersion returns the [BlobConfig] for the given blob version.
@@ -55,21 +72,42 @@ func BlobConfigForVersion(version uint8) (BlobConfig, error) {
 
 // NewBlobConfigFromParams creates a [BlobConfig] with values derived from the given [ProtocolParams].
 // Use this when you need a config with non-default protocol parameters (e.g., for testing).
-func NewBlobConfigFromParams(blobVersion uint8, p ProtocolParams) BlobConfig {
+func NewBlobConfigFromParams(blobVersion uint8, params ProtocolParams) (BlobConfig, error) {
 	if blobVersion != 0 {
-		panic(fmt.Sprintf("unsupported blob version: %d", blobVersion))
+		return BlobConfig{}, fmt.Errorf("unsupported blob version: %d", blobVersion)
+	}
+
+	workers := runtime.GOMAXPROCS(0)
+	codecCfg := &rsema1d.Config{
+		K:           params.Rows,
+		N:           params.ParityRows(),
+		WorkerCount: workers,
+	}
+
+	coder, err := rsema1d.NewCoder(codecCfg)
+	if err != nil {
+		return BlobConfig{}, fmt.Errorf("creating rsema1d coder: %w", err)
+	}
+
+	allocCfg := DefaultRowAssemblerConfig()
+	allocCfg.MaxRowSize = params.MaxRowSize(blobVersion)
+	assembler, err := NewRowAssembler(codecCfg, allocCfg)
+	if err != nil {
+		return BlobConfig{}, fmt.Errorf("creating row assembler: %w", err)
 	}
 
 	return BlobConfig{
 		BlobVersion:  blobVersion,
-		OriginalRows: p.Rows,
-		ParityRows:   p.ParityRows(),
+		OriginalRows: params.Rows,
+		ParityRows:   params.ParityRows(),
 		RowSize: func(dataLen int) int {
-			return p.RowSize(blobVersion, dataLen+blobHeaderLen)
+			return params.RowSize(blobVersion, dataLen+blobHeaderLen)
 		},
-		MaxDataSize:   p.MaxBlobSize - blobHeaderLen, // subtract the header overhead
-		CodingWorkers: runtime.GOMAXPROCS(0),
-	}
+		MaxDataSize:   params.MaxBlobSize - blobHeaderLen,
+		CodingWorkers: workers,
+		Coder:         coder,
+		Assembler:     assembler,
+	}, nil
 }
 
 // TotalRows returns the total number of rows (OriginalRows + ParityRows).
@@ -93,7 +131,6 @@ type Blob struct {
 	extendedData *rsema1d.ExtendedData
 	id           BlobID
 	originalID   BlobID
-	rlcCoeffs    []field.GF128
 
 	// holds meta fields about the blob
 	header blobHeaderV0
@@ -102,13 +139,30 @@ type Blob struct {
 
 	// fields for reconstruction
 	rows [][]byte
+
+	consumed atomic.Bool
+
+	// mu guards Row access against concurrent release. Row takes a read lock;
+	// release takes a write lock to ensure all in-flight Row calls complete
+	// before pooled memory is returned.
+	mu       sync.RWMutex
+	released bool
+	// releaseFn returns pooled row buffers to the assembler.
+	// Set when the blob was created via NewBlob with a pooled assembler.
+	releaseFn func()
 }
 
 // NewBlob creates a new [Blob] instance by encoding the data.
-// It takes the data and a [BlobConfig].
+// It takes ownership of data and may reuse it directly as backing storage for
+// original rows. Callers must not modify data after calling NewBlob.
+//
 // The data is prefixed with a header containing the blob version and data size.
 // Returns [ErrBlobTooLarge] if the data size exceeds BlobConfig.MaxDataSize.
-func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
+//
+// The returned blob holds pooled row buffers from the [RowAssembler].
+// Pooled storage is released automatically when [Client.Upload] completes.
+// Data must not be modified after ownership is transferred to the blob.
+func NewBlob(data []byte, cfg BlobConfig) (*Blob, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
@@ -116,26 +170,20 @@ func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
 		return nil, fmt.Errorf("%w: data size %d exceeds maximum %d", ErrBlobTooLarge, len(data), cfg.MaxDataSize)
 	}
 
-	d = &Blob{
-		cfg:    cfg,
-		header: newBlobHeaderV0(len(data)),
-		data:   data,
-	}
-
-	rows := d.header.encodeToRows(data, cfg)
-	var rsemaCommitment rsema1d.Commitment
-	d.extendedData, rsemaCommitment, d.rlcCoeffs, err = rsema1d.Encode(rows, &rsema1d.Config{
-		K:           cfg.OriginalRows,
-		N:           cfg.ParityRows,
-		RowSize:     len(rows[0]),
-		WorkerCount: cfg.CodingWorkers,
-	})
+	header := newBlobHeaderV0(len(data))
+	extendedData, release, err := header.encode(data, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("encoding data: %w", err)
+		return nil, err
 	}
-	d.id = NewBlobID(cfg.BlobVersion, rsemaCommitment)
 
-	return d, nil
+	return &Blob{
+		cfg:          cfg,
+		extendedData: extendedData,
+		id:           NewBlobID(cfg.BlobVersion, extendedData.Commitment()),
+		header:       header,
+		data:         data,
+		releaseFn:    release,
+	}, nil
 }
 
 // NewEmptyBlob creates a new [Blob] instance for receiving and reconstructing data.
@@ -191,9 +239,12 @@ func (d *Blob) Config() BlobConfig {
 	return d.cfg
 }
 
-// RLCCoeffs returns RLC coefficients of the original data.
-func (d *Blob) RLCCoeffs() []field.GF128 {
-	return d.rlcCoeffs
+// RLC returns the computed random linear combination values for the original rows.
+func (d *Blob) RLC() []field.GF128 {
+	if d.extendedData == nil {
+		return nil
+	}
+	return d.extendedData.RLC()
 }
 
 // RowSize returns the size of each row in bytes.
@@ -222,6 +273,12 @@ func (d *Blob) Data() []byte {
 
 // Row returns the [rsema1d.RowInclusionProof] for the given index from the extended data.
 func (d *Blob) Row(index int) (*rsema1d.RowInclusionProof, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+
+	if d.released {
+		return nil, errors.New("blob row storage has been released")
+	}
 	if d.extendedData == nil {
 		return nil, fmt.Errorf("no extended data available")
 	}
@@ -389,7 +446,7 @@ func (d *Blob) Reconstruct(opts ...ReconstructOption) error {
 		RowSize:     len(d.rows[0]), // NOTE: successful reconstruct must fill all rows, so if this ever panics something is really wrong
 		WorkerCount: d.cfg.CodingWorkers,
 	}
-	extendedData, reconstructedCommitment, rlcCoeffs, err := rsema1d.EncodeParity(d.rows, config)
+	extendedData, reconstructedCommitment, _, err := rsema1d.EncodeParity(d.rows, config)
 	if err != nil {
 		return fmt.Errorf("encoding parity: %w", err)
 	}
@@ -408,12 +465,31 @@ func (d *Blob) Reconstruct(opts ...ReconstructOption) error {
 
 	d.data = originalData
 	d.extendedData = extendedData
-	d.rlcCoeffs = rlcCoeffs
 	if opt.skipCommitmentCheck {
 		d.originalID = d.id
 		d.id = NewBlobID(d.cfg.BlobVersion, Commitment(reconstructedCommitment))
 	}
 	return nil
+}
+
+// consume marks the blob as owned by an upload. Returns false if already consumed.
+func (d *Blob) consume() bool {
+	return d.consumed.CompareAndSwap(false, true)
+}
+
+// release returns pooled row buffers to the assembler.
+// Blocks until all in-flight Row calls complete.
+func (d *Blob) release() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.released {
+		return
+	}
+	d.released = true
+	if d.releaseFn != nil {
+		d.releaseFn()
+	}
 }
 
 const (
@@ -440,42 +516,20 @@ func newBlobHeaderV0(dataSize int) blobHeaderV0 {
 	}
 }
 
-// encodeToRows encodes the data into rows with version 0 header format.
-// Returns OriginalRows rows of calculated rowSize bytes each, padding with zeros as needed.
-// The first row contains the header followed by data.
-func (h blobHeaderV0) encodeToRows(data []byte, cfg BlobConfig) [][]byte {
+// encode assembles rows from data, writes the blob header, and produces the
+// commitment via the [rsema1d.Coder]. Returns the extended data and a release
+// function that returns pooled buffers to the assembler.
+func (h blobHeaderV0) encode(data []byte, cfg BlobConfig) (*rsema1d.ExtendedData, func(), error) {
 	rowSize := cfg.RowSize(len(data))
-	rows := make([][]byte, cfg.OriginalRows)
+	rows, release := cfg.Assembler.Assemble(data, rowSize, blobHeaderLen)
+	h.marshalTo(rows[0])
 
-	// First row: allocate and write header + beginning of data
-	rows[0] = make([]byte, rowSize)
-	h.encode(rows[0])
-
-	// Copy as much data as fits in the first row after the header
-	firstRowDataSize := min(rowSize-blobHeaderLen, len(data))
-	copy(rows[0][blobHeaderLen:], data[:firstRowDataSize])
-
-	// Remaining rows: use slices from data (offset by what we already used)
-	dataOffset := firstRowDataSize
-	for i := 1; i < cfg.OriginalRows; i++ {
-		start := dataOffset
-		end := start + rowSize
-		dataOffset += rowSize
-
-		if end <= len(data) {
-			// Full row available in data - use slice directly
-			rows[i] = data[start:end:end]
-			continue
-		}
-		// Some or no data left - allocate zero-filled padded row
-		rows[i] = make([]byte, rowSize)
-		if start < len(data) {
-			// Partial row - insert the remaining data into the row
-			copy(rows[i], data[start:])
-		}
+	extData, err := cfg.Coder.Encode(rows)
+	if err != nil {
+		release()
+		return nil, nil, fmt.Errorf("encoding data: %w", err)
 	}
-
-	return rows
+	return extData, release, nil
 }
 
 // decodeFromRows decodes the data from rows with version 0 header format.
@@ -491,7 +545,7 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	}
 
 	// decode header from first row
-	if err := h.decode(rows[0]); err != nil {
+	if err := h.unmarshalFrom(rows[0]); err != nil {
 		return nil, fmt.Errorf("decoding header: %w", err)
 	}
 
@@ -525,18 +579,18 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	return data, nil
 }
 
-// encode writes the version 0 blob header into the provided buffer.
+// marshalTo writes the version 0 blob header into the provided buffer.
 // The buffer must be at least blobHeaderLen bytes long.
 // Always writes version byte as 0.
-func (h blobHeaderV0) encode(buf []byte) {
+func (h blobHeaderV0) marshalTo(buf []byte) {
 	buf[0] = 0 // version 0
 	binary.BigEndian.PutUint32(buf[blobVersionLen:blobHeaderLen], h.dataSize)
 }
 
-// decode reads the blob header from the provided buffer.
+// unmarshalFrom reads the blob header from the provided buffer.
 // The buffer must be at least blobHeaderLen bytes long.
 // Returns an error if the version byte is not 0.
-func (h *blobHeaderV0) decode(buf []byte) error {
+func (h *blobHeaderV0) unmarshalFrom(buf []byte) error {
 	if buf[0] != 0 {
 		return fmt.Errorf("invalid blob version: expected 0, got %d", buf[0])
 	}

--- a/fibre/blob_test.go
+++ b/fibre/blob_test.go
@@ -7,7 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
+func TestBlobHeaderV0_MarshalRoundTrip(t *testing.T) {
+	sizes := []int{1, 10, 500, 5000, 1024, 1 << 20}
+
+	for _, size := range sizes {
+		h := newBlobHeaderV0(size)
+		buf := make([]byte, blobHeaderLen)
+		h.marshalTo(buf)
+
+		var got blobHeaderV0
+		require.NoError(t, got.unmarshalFrom(buf))
+		require.Equal(t, uint32(size), got.dataSize)
+	}
+}
+
+func TestNewBlob_EncodeDecodeRoundTrip(t *testing.T) {
 	cfg := DefaultBlobConfigV0()
 
 	tests := []struct {
@@ -15,60 +29,26 @@ func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
 		dataSize int
 	}{
 		{"single byte", 1},
-		{"small data", 10},
-		{"medium data", 500},
-		{"large data", 5000},
+		{"small", 10},
+		{"medium", 500},
+		{"large", 5000},
 		{"1 KiB", 1024},
-		{"1 MiB", 1024 * 1024},
+		{"1 MiB", 1 << 20},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test data with recognizable pattern
 			data := make([]byte, tt.dataSize)
 			for i := range data {
 				data[i] = byte(i % 256)
 			}
 
-			// Encode
-			header := newBlobHeaderV0(len(data))
-			rows := header.encodeToRows(data, cfg)
+			blob, err := NewBlob(data, cfg)
+			require.NoError(t, err)
+			defer blob.release()
 
-			// Verify correct number of rows
-			if len(rows) != cfg.OriginalRows {
-				t.Fatalf("encodeToRows() returned %d rows, want %d", len(rows), cfg.OriginalRows)
-			}
-
-			// Verify all rows have same size
-			expectedRowSize := cfg.RowSize(len(data))
-			for i, row := range rows {
-				if len(row) != expectedRowSize {
-					t.Errorf("row %d size = %d, want %d", i, len(row), expectedRowSize)
-				}
-			}
-
-			// Decode
-			var decodeHeader blobHeaderV0
-			decodedData, err := decodeHeader.decodeFromRows(rows, cfg)
-			if err != nil {
-				t.Fatalf("decodeFromRows() error = %v", err)
-			}
-
-			// Verify round-trip
-			if len(decodedData) != len(data) {
-				t.Errorf("decodeFromRows() data length mismatch, got %d bytes, want %d bytes", len(decodedData), len(data))
-			}
-			for i := range data {
-				if decodedData[i] != data[i] {
-					t.Errorf("decodeFromRows() data mismatch at index %d, got %d, want %d", i, decodedData[i], data[i])
-					break
-				}
-			}
-
-			// Verify header was decoded correctly
-			if decodeHeader.dataSize != uint32(tt.dataSize) {
-				t.Errorf("decodeFromRows() header.dataSize = %d, want %d", decodeHeader.dataSize, tt.dataSize)
-			}
+			require.Equal(t, tt.dataSize, blob.DataSize())
+			require.Equal(t, data, blob.Data())
 		})
 	}
 }
@@ -79,6 +59,7 @@ func TestBlob_Reconstruct(t *testing.T) {
 
 	blob, err := NewBlob(testData, cfg)
 	require.NoError(t, err)
+	defer blob.release()
 
 	totalRows := cfg.OriginalRows + cfg.ParityRows
 	allRows := make([]*rsema1d.RowInclusionProof, totalRows)
@@ -93,16 +74,12 @@ func TestBlob_Reconstruct(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, row := range rows {
-			err = reconstructBlob.VerifyRow(row)
-			require.NoError(t, err)
+			require.NoError(t, reconstructBlob.VerifyRow(row))
 			require.True(t, reconstructBlob.SetRow(row))
 		}
 
-		err = reconstructBlob.Reconstruct()
-		require.NoError(t, err)
-
-		reconstructedData := reconstructBlob.Data()
-		require.Equal(t, testData, reconstructedData)
+		require.NoError(t, reconstructBlob.Reconstruct())
+		require.Equal(t, testData, reconstructBlob.Data())
 	}
 
 	t.Run("FirstKRows", func(t *testing.T) {
@@ -123,4 +100,17 @@ func TestBlob_Reconstruct(t *testing.T) {
 		}
 		testReconstruct(t, mixedRows)
 	})
+}
+
+func TestBlob_RowAfterRelease(t *testing.T) {
+	blob, err := NewBlob([]byte("test"), DefaultBlobConfigV0())
+	require.NoError(t, err)
+
+	_, err = blob.Row(0)
+	require.NoError(t, err)
+
+	blob.release()
+
+	_, err = blob.Row(0)
+	require.Error(t, err)
 }

--- a/fibre/client_download_test.go
+++ b/fibre/client_download_test.go
@@ -529,7 +529,7 @@ func (d *downloadMockClient) DownloadShard(ctx context.Context, req *types.Downl
 	}
 
 	if req.WithRlc {
-		rlcCoeffs := blob.RLCCoeffs()
+		rlcCoeffs := blob.RLC()
 		coeffBytes := make([]byte, len(rlcCoeffs)*16)
 		for i, c := range rlcCoeffs {
 			b := field.ToBytes128(c)

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -87,18 +87,21 @@ func TestClientServerUploadDownload(t *testing.T) {
 						return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
 					}
 
-					blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
-					if err != nil {
-						return fmt.Errorf("creating blob %d: %w", blobIdx, err)
-					}
-
 					slotIdx := clientIdx*tt.blobsPerClient + blobIdx
 					allPromiseHashes[slotIdx] = make([][]byte, 0, tt.duplicate)
 
 					// upload blob (possibly multiple times at different heights)
+					// each upload requires a fresh blob since Upload takes ownership
 					for uploadIdx := range tt.duplicate {
 						if tt.duplicate > 1 {
 							env.SetHeight(uint64(100 + uploadIdx*100))
+						}
+						blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+						if err != nil {
+							return fmt.Errorf("creating blob %d (upload %d): %w", blobIdx, uploadIdx, err)
+						}
+						if uploadIdx == 0 {
+							allBlobIDs[slotIdx] = blob.ID()
 						}
 						signedPromise, err := client.Upload(ctx, testNamespace, blob)
 						if err != nil {
@@ -112,7 +115,6 @@ func TestClientServerUploadDownload(t *testing.T) {
 						allPromiseHashes[slotIdx] = append(allPromiseHashes[slotIdx], promiseHash)
 					}
 
-					allBlobIDs[slotIdx] = blob.ID()
 					allData[slotIdx] = data
 				}
 

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -39,8 +39,23 @@ func WithKeyName(keyName string) UploadOption {
 // It creates a [PaymentPromise], uploads the data to validators, and collects signatures confirming the upload.
 // Returns a [SignedPaymentPromise] containing the promise and validator signatures.
 // May keep uploading data in background after returning successfully.
+//
+// Upload takes ownership of the blob and releases its pooled storage when all
+// background uploads complete. The blob must not be reused after calling Upload;
+// create a new one with [NewBlob] for each upload.
+//
 // Returns [ErrClientClosed] if the client has been closed.
 func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opts ...UploadOption) (result SignedPaymentPromise, err error) {
+	if !blob.consume() {
+		return result, ErrBlobConsumed
+	}
+	defer func() {
+		// immediate release for errors
+		if err != nil {
+			blob.release()
+		}
+	}()
+
 	if !c.started.Load() {
 		return result, errors.New("fibre client is not started")
 	}
@@ -110,7 +125,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 		span.SetStatus(codes.Error, "failed to convert payment promise to proto")
 		return result, fmt.Errorf("converting payment promise to proto: %w", err)
 	}
-	requests := makeUploadRequests(shardMap, promiseProto, blob.RLCCoeffs())
+	requests := makeUploadRequests(shardMap, promiseProto, blob.RLC())
 	sigSet := valSet.NewSignatureSet(c.Config.SafetyThreshold, signBytes)
 
 	c.log.DebugContext(ctx, "initiating blob upload",
@@ -340,6 +355,8 @@ func (c *Client) uploadShards(
 				// increment responses and mark as completed if so
 				if int(responses.Add(1)) == len(requests) {
 					close(responsesExhaustedCh)
+					// release buffers on the blob
+					blob.release()
 				}
 
 				// unblock Close

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -32,6 +32,7 @@ func TestClientUpload(t *testing.T) {
 		{"InsufficientVotingPower", testClientUploadInsufficientVotingPower},
 		{"AllValidatorsReceiveData", testClientUploadAllValidatorsReceiveData},
 		{"ClosedClient", testClientUploadClosedClient},
+		{"BlobConsumed", testClientUploadBlobConsumed},
 	}
 
 	for _, tt := range tests {
@@ -158,6 +159,19 @@ func testClientUploadClosedClient(t *testing.T) {
 	// attempt to upload after closing
 	_, err := client.Upload(t.Context(), testNamespace, blob)
 	require.ErrorIs(t, err, fibre.ErrClientClosed, "expected ErrClientClosed when uploading to closed client")
+}
+
+func testClientUploadBlobConsumed(t *testing.T) {
+	client := makeTestUploadClient(t, 100, nil)
+	t.Cleanup(func() { require.NoError(t, client.Stop(t.Context())) })
+
+	blob := makeTestBlobV0(t, 256*1024)
+
+	_, err := client.Upload(t.Context(), testNamespace, blob)
+	require.NoError(t, err)
+
+	_, err = client.Upload(t.Context(), testNamespace, blob)
+	require.ErrorIs(t, err, fibre.ErrBlobConsumed)
 }
 
 // makeTestUploadClient creates an upload client for testing.

--- a/fibre/row_assembler.go
+++ b/fibre/row_assembler.go
@@ -1,0 +1,272 @@
+package fibre
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+	"github.com/klauspost/reedsolomon"
+)
+
+// RowAssembler assembles K+N row sets for encoding and pools backing storage
+// for parity rows: original rows are a hybrid view over the input
+// data (zero-copy where possible), parity rows come from pooled storage.
+//
+// Two pooling strategies are used. When rowSize == MaxRowSize, entire parity
+// batches are pooled (bounded by MaxRowPoolCap). For smaller rows, parity is
+// packed into fixed-size chunks via sync.Pool.
+//
+// RowAssembler is safe for concurrent use.
+type RowAssembler struct {
+	codec *rsema1d.Config
+	cfg   *RowAssemblerConfig
+
+	maxPool   *maxRowPool
+	chunkPool sync.Pool // []byte of PackedChunkSize
+	metaPool  sync.Pool // *meta
+
+	zeroRow []byte // read-only; shared across concurrent Assemble calls
+}
+
+// RowAssemblerConfig contains tuning knobs for RowAssembler.
+// K and N are taken from the [rsema1d.Config] passed to [NewRowAssembler].
+type RowAssemblerConfig struct {
+	// MaxRowSize is the largest row size the allocator must support.
+	MaxRowSize int
+
+	// PackedChunkSize is the backing chunk size used when rowSize < MaxRowSize.
+	// Smaller rows are packed into chunks. Larger values reduce pool.Get/Put
+	// traffic for small and medium rows, at the cost of larger retained objects
+	// and potential tail slack for row sizes that do not divide the chunk size evenly.
+	PackedChunkSize int
+
+	// MaxRowPoolCap is the maximum number of idle whole-batch allocations
+	// to retain for rowSize == MaxRowSize. This bounds idle retained memory for
+	// the largest-row path, but does not limit how many max-row batches may be
+	// checked out concurrently. A value of 0 disables idle retention for that path.
+	MaxRowPoolCap int
+}
+
+// DefaultRowAssemblerConfig returns a RowAssemblerConfig initialized to
+// conservative defaults suitable for typical celestia-app sizing.
+func DefaultRowAssemblerConfig() *RowAssemblerConfig {
+	return &RowAssemblerConfig{
+		MaxRowSize:      32832,
+		PackedChunkSize: 1 << 19, // 512 KiB is enough for parity-only chunking while keeping retained chunks smaller.
+		MaxRowPoolCap:   6,
+	}
+}
+
+// Validate checks RowAssemblerConfig constraints.
+func (c *RowAssemblerConfig) Validate() error {
+	if c.MaxRowSize < 64 {
+		return fmt.Errorf("MaxRowSize must be at least 64, got %d", c.MaxRowSize)
+	}
+	if c.MaxRowSize%64 != 0 {
+		return fmt.Errorf("MaxRowSize must be a multiple of 64, got %d", c.MaxRowSize)
+	}
+	if c.PackedChunkSize < 64 {
+		return fmt.Errorf("PackedChunkSize must be at least 64, got %d", c.PackedChunkSize)
+	}
+	if c.PackedChunkSize%64 != 0 {
+		return fmt.Errorf("PackedChunkSize must be a multiple of 64, got %d", c.PackedChunkSize)
+	}
+	if c.PackedChunkSize < 2*c.MaxRowSize {
+		return fmt.Errorf("PackedChunkSize (%d) must be >= 2*MaxRowSize (%d)", c.PackedChunkSize, 2*c.MaxRowSize)
+	}
+	if c.MaxRowPoolCap < 0 {
+		return fmt.Errorf("MaxRowPoolCap must be non-negative, got %d", c.MaxRowPoolCap)
+	}
+	return nil
+}
+
+// NewRowAssembler creates a RowAssembler. K and N are taken from the codec
+// [rsema1d.Config]; pooling behaviour is controlled by [RowAssemblerConfig].
+func NewRowAssembler(codec *rsema1d.Config, cfg *RowAssemblerConfig) (*RowAssembler, error) {
+	if err := codec.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid codec config: %w", err)
+	}
+	if err := cfg.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid row allocator config: %w", err)
+	}
+
+	totalRows := codec.K + codec.N
+	a := &RowAssembler{
+		codec: codec,
+		cfg:   cfg,
+		maxPool: &maxRowPool{
+			free: make([][][]byte, 0, cfg.MaxRowPoolCap),
+			cap:  cfg.MaxRowPoolCap,
+		},
+		zeroRow: reedsolomon.AllocAligned(1, cfg.MaxRowSize)[0],
+	}
+	a.chunkPool.New = func() any {
+		return reedsolomon.AllocAligned(1, cfg.PackedChunkSize)[0]
+	}
+	a.metaPool.New = func() any {
+		return &meta{
+			rows:   make([][]byte, totalRows),
+			chunks: make([][]byte, maxChunks(cfg, codec.N)),
+		}
+	}
+	return a, nil
+}
+
+// Assemble returns K+N rows for encoding data with the given rowSize.
+//
+// rows[:K] are original rows: row 0 reserves firstRowDataOffset bytes,
+// full middle rows alias data directly (zero-copy), a partial tail gets
+// a tail buffer, and empty trailing rows share one zeroed row.
+// rows[K:] are zeroed parity rows from pooled storage.
+//
+// Callers must not modify data after Assemble. The returned rows must also be
+// treated as immutable until release, because some rows may alias the input
+// data or shared zero-filled backing storage. Call release when done.
+func (a *RowAssembler) Assemble(data []byte, rowSize, firstRowDataOffset int) (rows [][]byte, release func()) {
+	m := a.metaPool.Get().(*meta)
+	rows = m.rows[:a.codec.K+a.codec.N]
+
+	if rowSize == a.cfg.MaxRowSize {
+		return a.assembleMax(m, rows, data, rowSize, firstRowDataOffset)
+	}
+
+	// packed path: parity rows + head/tail carved from pooled chunks.
+	head, tail := a.packParity(rows[a.codec.K:], m.chunks, rowSize)
+	a.fillData(rows[:a.codec.K], data, rowSize, firstRowDataOffset, head, tail)
+
+	release = func() {
+		for _, ch := range m.chunks {
+			if ch == nil {
+				break
+			}
+			a.chunkPool.Put(ch) //nolint:staticcheck // SA6002: []byte is intentional; wrapping adds complexity for no benefit on the release path
+		}
+		clear(m.rows)
+		clear(m.chunks)
+		a.metaPool.Put(m)
+	}
+	return rows, release
+}
+
+// assembleMax handles the MaxRowSize path where entire parity batches are
+// pooled as one unit instead of being packed into chunks. Head and tail
+// for fillOriginal are allocated as extra rows in the same batch.
+func (a *RowAssembler) assembleMax(m *meta, rows [][]byte, data []byte, rowSize, firstRowDataOffset int) ([][]byte, func()) {
+	batch := a.maxPool.Get(a.codec.N+extraRows, a.cfg.MaxRowSize)
+	copy(rows[a.codec.K:], batch[:a.codec.N])
+	for _, row := range rows[a.codec.K:] {
+		clear(row)
+	}
+	a.fillData(rows[:a.codec.K], data, rowSize, firstRowDataOffset, batch[a.codec.N], batch[a.codec.N+1])
+
+	release := func() {
+		a.maxPool.Put(batch)
+		clear(m.rows)
+		a.metaPool.Put(m)
+	}
+	return rows, release
+}
+
+// extraRows is the number of extra rows beyond parity (head + tail).
+const extraRows = 2
+
+// packParity packs zeroed parity rows into pooled chunks and returns head
+// and tail buffers carved from the last chunk's tail.
+func (a *RowAssembler) packParity(rows [][]byte, chunks [][]byte, rowSize int) (head, tail []byte) {
+	rowsPerChunk := a.cfg.PackedChunkSize / rowSize
+	numChunks := (len(rows) + extraRows + rowsPerChunk - 1) / rowsPerChunk
+	clear(chunks[numChunks:])
+
+	ri, end := 0, 0
+	for i := range numChunks {
+		chunk := a.chunkPool.Get().([]byte)
+		chunks[i] = chunk
+		end = 0
+		for j := 0; j < rowsPerChunk && ri < len(rows); j++ {
+			off := j * rowSize
+			rows[ri] = chunk[off : off+rowSize]
+			end = off + rowSize
+			ri++
+		}
+	}
+	for _, row := range rows {
+		clear(row)
+	}
+	return chunks[numChunks-1][end : end+rowSize], chunks[numChunks-1][end+rowSize : end+2*rowSize]
+}
+
+// fillData builds original rows as a hybrid view over data. Head is used for
+// rows[0] (prefix offset + start of data). Tail is placed at the partial
+// trailing row position if needed. Full middle rows alias data directly.
+// Empty trailing rows share a read-only zero row.
+func (a *RowAssembler) fillData(rows [][]byte, data []byte, rowSize, offset int, head, tail []byte) {
+	// head row: prefix offset + start of data.
+	rows[0] = head
+	clear(head)
+	n := min(rowSize-offset, len(data))
+	copy(head[offset:], data[:n])
+
+	// full middle rows alias data directly (zero-copy).
+	ri := 1
+	for ri < len(rows) && n+rowSize <= len(data) {
+		rows[ri] = data[n : n+rowSize]
+		n += rowSize
+		ri++
+	}
+
+	// partial tail row.
+	if ri < len(rows) && n < len(data) {
+		rows[ri] = tail
+		clear(tail)
+		copy(tail, data[n:])
+		ri++
+	}
+
+	// empty original rows share a read-only zero row.
+	if ri < len(rows) {
+		zero := a.zeroRow[:rowSize]
+		for i := ri; i < len(rows); i++ {
+			rows[i] = zero
+		}
+	}
+}
+
+// maxChunks returns the maximum number of packed chunks needed for any
+// row size that hits the packed path, including head and tail slots.
+func maxChunks(cfg *RowAssemblerConfig, parityRows int) int {
+	minRowsPerChunk := cfg.PackedChunkSize / cfg.MaxRowSize
+	return (parityRows + extraRows + minRowsPerChunk - 1) / minRowsPerChunk
+}
+
+type meta struct {
+	rows   [][]byte
+	chunks [][]byte
+}
+
+// maxRowPool bounds idle retention for the MaxRowSize batch path.
+type maxRowPool struct {
+	mu   sync.Mutex
+	free [][][]byte
+	cap  int
+}
+
+func (p *maxRowPool) Get(n, rowSize int) [][]byte {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.free) == 0 {
+		return reedsolomon.AllocAligned(n, rowSize)
+	}
+	last := len(p.free) - 1
+	rows := p.free[last]
+	p.free[last] = nil
+	p.free = p.free[:last]
+	return rows
+}
+
+func (p *maxRowPool) Put(rows [][]byte) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.free) < p.cap {
+		p.free = append(p.free, rows)
+	}
+}

--- a/fibre/row_assembler_bench_test.go
+++ b/fibre/row_assembler_bench_test.go
@@ -1,0 +1,100 @@
+package fibre
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+)
+
+func BenchmarkRowAssemblerAssembleRelease(b *testing.B) {
+	codecCfg := &rsema1d.Config{K: 4096, N: 12288, WorkerCount: 1}
+	cases := []struct {
+		name      string
+		rowSize   int
+		chunkSize int
+	}{
+		{"64/chunk_512KiB", 64, 1 << 19},
+		{"1024/chunk_512KiB", 1024, 1 << 19},
+		{"32832/chunk_512KiB", 32832, 1 << 19},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			allocCfg := DefaultRowAssemblerConfig()
+			allocCfg.PackedChunkSize = tc.chunkSize
+			alloc, err := NewRowAssembler(codecCfg, allocCfg)
+			if err != nil {
+				b.Fatal(err)
+			}
+			dataLen := max(1, tc.rowSize-5)
+			data := make([]byte, dataLen)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				rows, release := alloc.Assemble(data, tc.rowSize, 5)
+				rows[0][0]++
+				release()
+			}
+		})
+	}
+}
+
+func BenchmarkRowAssemblerEncode(b *testing.B) {
+	cases := []struct {
+		name     string
+		k, n     int
+		rowSize  int
+		allocCfg *RowAssemblerConfig
+	}{
+		{
+			"32x32x64", 32, 32, 64,
+			&RowAssemblerConfig{MaxRowSize: 256, PackedChunkSize: 1 << 19, MaxRowPoolCap: 6},
+		},
+		{
+			"256x256x1024", 256, 256, 1024,
+			&RowAssemblerConfig{MaxRowSize: 4096, PackedChunkSize: 1 << 19, MaxRowPoolCap: 6},
+		},
+		{
+			"256x256x4096", 256, 256, 4096,
+			&RowAssemblerConfig{MaxRowSize: 4096, PackedChunkSize: 1 << 19, MaxRowPoolCap: 6},
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			codecCfg := &rsema1d.Config{K: tc.k, N: tc.n, WorkerCount: 1}
+			coder, err := rsema1d.NewCoder(codecCfg)
+			if err != nil {
+				b.Fatal(err)
+			}
+			alloc, err := NewRowAssembler(codecCfg, tc.allocCfg)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			data := make([]byte, max(1, tc.k*tc.rowSize-5))
+			for i := range data {
+				data[i] = byte(i)
+			}
+
+			// warm up
+			rows, release := alloc.Assemble(data, tc.rowSize, 5)
+			if _, err := coder.Encode(rows); err != nil {
+				b.Fatal(err)
+			}
+			release()
+
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.k * tc.rowSize))
+			b.ResetTimer()
+			for b.Loop() {
+				rows, release := alloc.Assemble(data, tc.rowSize, 5)
+				if _, err := coder.Encode(rows); err != nil {
+					b.Fatal(err)
+				}
+				release()
+			}
+		})
+	}
+}

--- a/fibre/row_assembler_test.go
+++ b/fibre/row_assembler_test.go
@@ -1,0 +1,186 @@
+package fibre
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+)
+
+func TestRowAssembler_Assemble(t *testing.T) {
+	codecCfg := &rsema1d.Config{K: 4, N: 2, WorkerCount: 1}
+	allocCfg := DefaultRowAssemblerConfig()
+	allocCfg.MaxRowSize = 256
+	allocCfg.PackedChunkSize = 4096
+
+	alloc, err := NewRowAssembler(codecCfg, allocCfg)
+	if err != nil {
+		t.Fatalf("NewRowAssembler: %v", err)
+	}
+
+	rowSize := 64
+	offset := 5
+	// data spans: partial first row + 1 full row + 3 bytes into a third row
+	data := make([]byte, rowSize-offset+rowSize+3)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	rows, release := alloc.Assemble(data, rowSize, offset)
+	defer release()
+
+	if len(rows) != codecCfg.K+codecCfg.N {
+		t.Fatalf("got %d rows, want %d", len(rows), codecCfg.K+codecCfg.N)
+	}
+	for i, row := range rows {
+		if len(row) != rowSize {
+			t.Fatalf("row %d: len %d, want %d", i, len(row), rowSize)
+		}
+	}
+
+	// full middle row aliases input data
+	fullRowStart := rowSize - offset
+	rows[1][0] ^= 0xFF
+	if rows[1][0] != data[fullRowStart] {
+		t.Fatal("full middle row does not alias input data")
+	}
+
+	// partial tail row is a copy, not an alias
+	tailStart := fullRowStart + rowSize
+	rows[2][0] ^= 0xFF
+	if rows[2][0] == data[tailStart] {
+		t.Fatal("partial tail row unexpectedly aliases input data")
+	}
+
+	// empty original rows share a single backing array
+	for i := 3; i < codecCfg.K; i++ {
+		if &rows[3][0] != &rows[i][0] {
+			t.Fatal("empty original rows do not share the zero row")
+		}
+	}
+
+	// parity rows are zeroed
+	for i := codecCfg.K; i < codecCfg.K+codecCfg.N; i++ {
+		for j, b := range rows[i] {
+			if b != 0 {
+				t.Fatalf("parity row %d byte %d = %d, want 0", i, j, b)
+			}
+		}
+	}
+}
+
+func TestRowAssembler_Assemble_AllRowSizes(t *testing.T) {
+	k, n := 64, 64
+	maxRowSize := 4096
+
+	codecCfg := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
+	allocCfg := DefaultRowAssemblerConfig()
+	allocCfg.MaxRowSize = maxRowSize
+	alloc, err := NewRowAssembler(codecCfg, allocCfg)
+	if err != nil {
+		t.Fatalf("NewRowAssembler: %v", err)
+	}
+
+	for rowSize := 64; rowSize <= maxRowSize; rowSize += 64 {
+		data := make([]byte, max(1, k*rowSize-5))
+		rows, release := alloc.Assemble(data, rowSize, 5)
+
+		if len(rows) != k+n {
+			t.Fatalf("rowSize %d: got %d rows, want %d", rowSize, len(rows), k+n)
+		}
+		for i, row := range rows {
+			if len(row) != rowSize {
+				t.Fatalf("rowSize %d: row %d len %d", rowSize, i, len(row))
+			}
+		}
+
+		release()
+	}
+}
+
+func TestRowAssembler_InvalidConfig(t *testing.T) {
+	codecCfg := &rsema1d.Config{K: 32, N: 32, WorkerCount: 1}
+	_, err := NewRowAssembler(codecCfg, &RowAssemblerConfig{
+		MaxRowSize:      256,
+		PackedChunkSize: 0,
+		MaxRowPoolCap:   1,
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid config")
+	}
+}
+
+func TestRowAssembler_ReuseDirty(t *testing.T) {
+	k, n := 4, 4
+	tests := []struct {
+		name       string
+		rowSize    int
+		maxRowSize int
+	}{
+		{"packed", 64, 256},
+		{"max", 256, 256},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			codecCfg := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
+			coder, _ := rsema1d.NewCoder(codecCfg)
+			allocCfg := DefaultRowAssemblerConfig()
+			allocCfg.MaxRowSize = tc.maxRowSize
+			alloc, _ := NewRowAssembler(codecCfg, allocCfg)
+
+			// first encode
+			data1 := make([]byte, k*tc.rowSize-7)
+			for i := range data1 {
+				data1[i] = byte(i + 1)
+			}
+			rows1, release1 := alloc.Assemble(data1, tc.rowSize, 7)
+			if _, err := coder.Encode(rows1); err != nil {
+				t.Fatalf("first Encode: %v", err)
+			}
+			release1()
+
+			// second encode — parity must be clean
+			data2 := make([]byte, k*tc.rowSize-7)
+			for i := range data2 {
+				data2[i] = byte(i*3 + 7)
+			}
+			rows2, release2 := alloc.Assemble(data2, tc.rowSize, 7)
+			defer release2()
+
+			for i := k; i < k+n; i++ {
+				for j, b := range rows2[i] {
+					if b != 0 {
+						t.Fatalf("parity row %d byte %d = %d, want 0", i, j, b)
+					}
+				}
+			}
+
+			// pooled encode must match fresh encode
+			extPool, err := coder.Encode(rows2)
+			if err != nil {
+				t.Fatalf("pooled Encode: %v", err)
+			}
+
+			fresh := make([][]byte, k+n)
+			for i := range fresh {
+				fresh[i] = make([]byte, tc.rowSize)
+			}
+			n0 := min(tc.rowSize-7, len(data2))
+			copy(fresh[0][7:], data2[:n0])
+			off := n0
+			for i := 1; i < k && off < len(data2); i++ {
+				end := min(off+tc.rowSize, len(data2))
+				copy(fresh[i], data2[off:end])
+				off += tc.rowSize
+			}
+			extFresh, err := coder.Encode(fresh)
+			if err != nil {
+				t.Fatalf("fresh Encode: %v", err)
+			}
+
+			if extPool.Commitment() != extFresh.Commitment() {
+				t.Fatal("pooled and fresh commitments differ")
+			}
+		})
+	}
+}

--- a/fibre/server_download_test.go
+++ b/fibre/server_download_test.go
@@ -156,7 +156,7 @@ func storeTestShard(t *testing.T, server *fibre.Server, blob *fibre.Blob) {
 	}
 
 	// flatten RLC coefficients for storage
-	rlcCoeffs := blob.RLCCoeffs()
+	rlcCoeffs := blob.RLC()
 	coeffBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, c := range rlcCoeffs {
 		b := field.ToBytes128(c)

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -206,8 +206,8 @@ func makeTestRequest(
 		}
 	}
 
-	// flatten RLC coefficients
-	rlcCoeffs := blob.RLCCoeffs()
+	// flatten RLC values
+	rlcCoeffs := blob.RLC()
 	rlcCoeffsBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, coeff := range rlcCoeffs {
 		b := field.ToBytes128(coeff)

--- a/fibre/store_bench_test.go
+++ b/fibre/store_bench_test.go
@@ -200,7 +200,8 @@ func BenchmarkStoreWriteRowsConcurrent(b *testing.B) {
 }
 
 func benchmarkStoreWriteRows(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -306,7 +307,8 @@ func benchmarkStoreWriteRows(b *testing.B, params fibre.ProtocolParams, validato
 }
 
 func benchmarkStoreWriteRowsConcurrent(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int, concurrency int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -527,7 +529,8 @@ func BenchmarkStoreReadRowsConcurrent(b *testing.B) {
 }
 
 func benchmarkStoreReadRows(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -615,7 +618,8 @@ func benchmarkStoreReadRows(b *testing.B, params fibre.ProtocolParams, validator
 }
 
 func benchmarkStoreReadRowsConcurrent(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int, concurrency int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -331,7 +331,7 @@ func makeShardWithRLC(t *testing.T, blob *fibre.Blob, indices ...int) *types.Blo
 	t.Helper()
 	shard := makeShardFrom(t, blob, indices...)
 
-	rlcCoeffs := blob.RLCCoeffs()
+	rlcCoeffs := blob.RLC()
 	coeffBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, c := range rlcCoeffs {
 		b := field.ToBytes128(c)


### PR DESCRIPTION
RowAssembler pools backing storage for parity rows and assembles K+N row sets for encoding. Original rows are built as a hybrid view over the input data (zero-copy where possible), while parity rows come from pooled chunks. Combined with the new rsema1d.Coder, NewBlob performs zero heap allocations for row backing memory on the hot path.

Two pooling strategies: when rowSize == MaxRowSize, entire parity batches are pooled with bounded idle retention. For smaller rows, parity is packed into fixed-size chunks via sync.Pool, with head and tail scratch carved from the last chunk.

Besides, the semantics of Upload have changed. Now, Upload takes ownership of a given blob and manages the release of the blob's rows back to the pool until the blob is fully submitted. As a result, blob instances cannot be reused across multiple upload calls. 

Based on #7068 

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7069" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
