### PR TITLE
perf(rsema1d): reduce computeRLCOrig scheduling overhead

### DIFF
--- a/pkg/rsema1d/codec.go
+++ b/pkg/rsema1d/codec.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/encoding"
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
@@ -132,17 +133,35 @@ func EncodeParity(extended [][]byte, config *Config) (*ExtendedData, Commitment,
 func computeRLCOrig(rows [][]byte, coeffs []field.GF128, config *Config) []field.GF128 {
 	results := make([]field.GF128, len(rows))
 
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, config.WorkerCount)
+	workers := min(config.WorkerCount, len(rows))
+	if workers <= 1 {
+		for i, row := range rows {
+			results[i] = computeRLC(row, coeffs)
+		}
+		return results
+	}
 
-	for i, row := range rows {
-		wg.Add(1)
-		sem <- struct{}{}
-		go func(idx int, r []byte) {
+	var wg sync.WaitGroup
+	// use more chunks than workers so workers can pick up more work if a
+	// previous chunk runs slower, without falling back to per-row scheduling.
+	chunkCount := min(len(rows), workers*4)
+	chunkSize := (len(rows) + chunkCount - 1) / chunkCount
+	var next atomic.Int64
+	wg.Add(workers)
+	for range workers {
+		go func() {
 			defer wg.Done()
-			defer func() { <-sem }()
-			results[idx] = computeRLC(r, coeffs)
-		}(i, row)
+			for {
+				start := int(next.Add(int64(chunkSize)) - int64(chunkSize))
+				if start >= len(rows) {
+					return
+				}
+				end := min(start+chunkSize, len(rows))
+				for i, row := range rows[start:end] {
+					results[start+i] = computeRLC(row, coeffs)
+				}
+			}
+		}()
 	}
 	wg.Wait()
 

--- a/pkg/rsema1d/codec_bench_test.go
+++ b/pkg/rsema1d/codec_bench_test.go
@@ -206,6 +206,37 @@ func BenchmarkEncode(b *testing.B) {
 	}
 }
 
+// BenchmarkComputeRLCOrig isolates the RLC computation over original rows.
+func BenchmarkComputeRLCOrig(b *testing.B) {
+	configs := generateBenchmarkConfigs(true)
+
+	for _, cfg := range configs {
+		b.Run(configName(cfg), func(b *testing.B) {
+			codecConfig := &Config{
+				K:           cfg.k,
+				N:           cfg.n,
+				RowSize:     cfg.rowSize,
+				WorkerCount: cfg.workerCount,
+			}
+
+			rowRoot := [32]byte{1, 2, 3, 4}
+			coeffs := deriveCoefficients(rowRoot, cfg.rowSize)
+
+			setup := func() any {
+				return generateTestData(cfg.k, cfg.rowSize)
+			}
+
+			benchFunc := func(state any) error {
+				rows := state.([][]byte)
+				_ = computeRLCOrig(rows, coeffs, codecConfig)
+				return nil
+			}
+
+			runBenchmark(b, cfg, setup, benchFunc, true)
+		})
+	}
+}
+
 // BenchmarkReconstruct benchmarks the Reconstruct function
 func BenchmarkReconstruct(b *testing.B) {
 	// Reconstruct doesn't support worker parallelism directly


### PR DESCRIPTION
Replace the per-row goroutine and semaphore scheduling in computeRLCOrig with a fixed worker set that claims row chunks via an atomic cursor. This keeps parallelism bounded to WorkerCount while avoiding one goroutine and one semaphore round-trip per row.

Representative workers=16 results from the single-run sample:
- size=128KB/k=1024/n=1024: 681us -> 396us, 144KiB -> 18.0KiB, 2051 -> 19 allocs/op
- size=1MB/k=4096/n=4096: 4.08ms -> 2.73ms, 576KiB -> 65.9KiB, 8195 -> 19 allocs/op
- size=1MB/k=16384/n=16384: 11.61ms -> 2.74ms, 2305KiB -> 257.8KiB, 32773 -> 19 allocs/op

In this sample, larger 64MB cases were roughly flat in time, while allocs/op still dropped from 2051/8195/32771 to 19/19/20.

Based on https://github.com/celestiaorg/celestia-app/pull/7068

<!-- devin-review-badge-begin -->
---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7075" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
