### PR TITLE
feat(fibre): add ConstantValsetClient to cache validator set

### DIFF
--- a/fibre/state/constant_set_getter.go
+++ b/fibre/state/constant_set_getter.go
@@ -1,0 +1,64 @@
+package state
+
+import (
+	"context"
+	"sync"
+
+	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
+)
+
+// ConstantValsetClient wraps a [Client] and caches the validator set returned by
+// the first successful call to the underlying client's [validator.SetGetter].
+// All subsequent calls to [Head] and [GetByHeight] return the cached set,
+// ignoring the requested height. All other [Client] methods are forwarded
+// directly to the inner client.
+//
+// This wrapper MUST only be used for networks whose validator set is known to be
+// constant (e.g. a single-validator devnet or a frozen testnet). Using it on a
+// network where validators can change will silently return stale data and break
+// shard assignment, signature verification, and download scheduling.
+type ConstantValsetClient struct {
+	Client
+
+	once sync.Once
+	set  validator.Set
+	err  error
+}
+
+// NewConstantValsetClient returns a [ConstantValsetClient] that delegates to
+// inner for all operations, but caches the first validator set and returns it
+// for every subsequent [Head] and [GetByHeight] call.
+func NewConstantValsetClient(inner Client) *ConstantValsetClient {
+	return &ConstantValsetClient{Client: inner}
+}
+
+// WithConstantValset wraps a [Client] constructor function so that the returned
+// client caches the validator set after the first fetch. See
+// [ConstantValsetClient] for caveats.
+func WithConstantValset(fn func() (Client, error)) func() (Client, error) {
+	return func() (Client, error) {
+		inner, err := fn()
+		if err != nil {
+			return nil, err
+		}
+		return NewConstantValsetClient(inner), nil
+	}
+}
+
+// Head returns the cached validator set, fetching it from the underlying
+// [Client] on the first call.
+func (c *ConstantValsetClient) Head(ctx context.Context) (validator.Set, error) {
+	c.once.Do(func() {
+		c.set, c.err = c.Client.Head(ctx)
+	})
+	return c.set, c.err
+}
+
+// GetByHeight returns the cached validator set, ignoring the height parameter.
+// The set is fetched from the underlying [Client] on the first call to either
+// [Head] or [GetByHeight].
+func (c *ConstantValsetClient) GetByHeight(ctx context.Context, _ uint64) (validator.Set, error) {
+	return c.Head(ctx)
+}
+
+var _ Client = (*ConstantValsetClient)(nil)

--- a/fibre/state/constant_set_getter_test.go
+++ b/fibre/state/constant_set_getter_test.go
@@ -1,0 +1,102 @@
+package state_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/fibre/state"
+	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
+	core "github.com/cometbft/cometbft/types"
+)
+
+// countingClient tracks calls to the inner SetGetter methods.
+type countingClient struct {
+	headCalls atomic.Int64
+}
+
+func (c *countingClient) Head(context.Context) (validator.Set, error) {
+	c.headCalls.Add(1)
+	return validator.Set{ValidatorSet: &core.ValidatorSet{}, Height: 42}, nil
+}
+
+func (c *countingClient) GetByHeight(_ context.Context, h uint64) (validator.Set, error) {
+	c.headCalls.Add(1)
+	return validator.Set{ValidatorSet: &core.ValidatorSet{}, Height: h}, nil
+}
+
+func (c *countingClient) GetHost(_ context.Context, _ *core.Validator) (validator.Host, error) {
+	return "", nil
+}
+
+func (c *countingClient) ChainID() string { return "test" }
+
+func (c *countingClient) VerifyPromise(context.Context, *state.PaymentPromise) (state.VerifiedPromise, error) {
+	return state.VerifiedPromise{}, nil
+}
+
+func (c *countingClient) Start(context.Context) error { return nil }
+func (c *countingClient) Stop(context.Context) error  { return nil }
+
+func TestConstantValsetClient_CachesSet(t *testing.T) {
+	inner := &countingClient{}
+	var client state.Client = state.NewConstantValsetClient(inner)
+
+	ctx := context.Background()
+
+	// Multiple Head calls should only trigger one inner call.
+	for range 5 {
+		set, err := client.Head(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if set.Height != 42 {
+			t.Fatalf("expected height 42, got %d", set.Height)
+		}
+	}
+
+	// GetByHeight calls should also return the cached set.
+	for _, h := range []uint64{1, 100, 999} {
+		set, err := client.GetByHeight(ctx, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if set.Height != 42 {
+			t.Fatalf("GetByHeight(%d): expected cached height 42, got %d", h, set.Height)
+		}
+	}
+
+	if calls := inner.headCalls.Load(); calls != 1 {
+		t.Fatalf("expected 1 inner call, got %d", calls)
+	}
+}
+
+func TestConstantValsetClient_DelegatesOtherMethods(t *testing.T) {
+	inner := &countingClient{}
+	var client state.Client = state.NewConstantValsetClient(inner)
+
+	if client.ChainID() != "test" {
+		t.Fatalf("ChainID not forwarded, got %q", client.ChainID())
+	}
+}
+
+func TestWithConstantValset(t *testing.T) {
+	inner := &countingClient{}
+	fn := state.WithConstantValset(func() (state.Client, error) {
+		return inner, nil
+	})
+
+	client, err := fn()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	_, _ = client.Head(ctx)
+	_, _ = client.Head(ctx)
+	_, _ = client.GetByHeight(ctx, 10)
+
+	if calls := inner.headCalls.Load(); calls != 1 {
+		t.Fatalf("expected 1 inner call through WithConstantValset, got %d", calls)
+	}
+}

--- a/tools/fibre-txsim/main.go
+++ b/tools/fibre-txsim/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/app"
 	"github.com/celestiaorg/celestia-app/v9/app/encoding"
 	"github.com/celestiaorg/celestia-app/v9/fibre"
+	"github.com/celestiaorg/celestia-app/v9/fibre/state"
 	"github.com/celestiaorg/celestia-app/v9/pkg/user"
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
@@ -152,10 +153,18 @@ func run(cfg config) error {
 		defer cancel()
 	}
 
-	// Create a single shared fibre client
+	// Create a single shared fibre client.
+	// The txsim targets networks with a constant validator set, so we wrap the
+	// state client to cache the validator set and avoid redundant gRPC calls.
 	clientCfg := fibre.DefaultClientConfig()
 	clientCfg.StateAddress = cfg.grpcEndpoint
 	clientCfg.DefaultKeyName = fmt.Sprintf("%s-0", cfg.keyPrefix)
+	// Validate populates StateClientFn from StateAddress so we can wrap it.
+	// NewClient calls Validate again, which is idempotent for already-set fields.
+	if err := clientCfg.Validate(); err != nil {
+		return fmt.Errorf("invalid fibre client config: %w", err)
+	}
+	clientCfg.StateClientFn = state.WithConstantValset(clientCfg.StateClientFn)
 
 	sharedFibreClient, err := fibre.NewClient(kr, clientCfg)
 	if err != nil {


### PR DESCRIPTION
For networks with a constant validator set (e.g. single-validator devnets), every Head/GetByHeight call on the gRPC SetGetter is a redundant round-trip. ConstantValsetClient wraps a state.Client and caches the validator set after the first fetch via sync.Once, returning the cached value for all subsequent calls while forwarding everything else to the inner client.

Integrates the wrapper into fibre-txsim via the WithConstantValset helper.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7077" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
