### PR TITLE
fix(test): fix flaky TestSortAndExtractGasPrice

### DIFF
--- a/app/test/gas_estimation_test.go
+++ b/app/test/gas_estimation_test.go
@@ -76,7 +76,7 @@ func TestSortAndExtractGasPrice(t *testing.T) {
 		gasPrice float64
 		size     int
 	}
-	var allTxInfos []txInfo
+	allTxInfos := make([]txInfo, 0, len(txs))
 	for _, rawTx := range txs {
 		sdkTx, err := testApp.GetTxConfig().TxDecoder()(rawTx)
 		require.NoError(t, err)

--- a/app/test/gas_estimation_test.go
+++ b/app/test/gas_estimation_test.go
@@ -91,8 +91,8 @@ func TestSortAndExtractGasPrice(t *testing.T) {
 	require.Greater(t, len(gasPrices), 0)
 
 	// Verify gas prices are sorted ascending.
-	for i := 1; i < len(gasPrices); i++ {
-		assert.GreaterOrEqual(t, gasPrices[i], gasPrices[i-1])
+	for i, gp := range gasPrices[1:] {
+		assert.GreaterOrEqual(t, gp, gasPrices[i]) // i is offset by 1 due to [1:] slice
 	}
 
 	// Verify total size of included txs does not exceed maxBytes.

--- a/app/test/gas_estimation_test.go
+++ b/app/test/gas_estimation_test.go
@@ -39,18 +39,18 @@ func TestSortAndExtractGasPrice(t *testing.T) {
 
 	txGas := uint64(100000)
 	txs := make([]coretypes.Tx, 0, len(accounts)*2)
-	txGasToSizeMap := make(map[float64]int)
+	// Use a seeded random to make the test deterministic.
+	rng := rand.New(rand.NewSource(42))
 	for i, acc := range accounts {
 		signer, err := user.NewSigner(kr, enc, testutil.ChainID, user.NewAccount(acc, infos[i].AccountNum, infos[i].Sequence))
 		require.NoError(t, err)
-		bTxFee := rand.Uint64() % 10000
+		bTxFee := rng.Uint64() % 10000
 		bTx, _, err := signer.CreatePayForBlobs(acc, blobs[i],
 			user.SetFee(bTxFee),
 			user.SetGasLimit(txGas))
 		require.NoError(t, err)
-		bTxGasPrice := float64(bTxFee) / float64(txGas)
 
-		sTxFee := rand.Uint64() % 10000
+		sTxFee := rng.Uint64() % 10000
 		sendTx := testutil.SendTxWithManualSequence(
 			t,
 			enc,
@@ -64,13 +64,25 @@ func TestSortAndExtractGasPrice(t *testing.T) {
 			user.SetFee(sTxFee),
 			user.SetGasLimit(txGas),
 		)
-		sTxGasPrice := float64(sTxFee) / float64(txGas)
 
 		txs = append(txs, sendTx)
 		txs = append(txs, bTx)
+	}
 
-		txGasToSizeMap[bTxGasPrice] = len(bTx)
-		txGasToSizeMap[sTxGasPrice] = len(sendTx)
+	// Build a gas price → size map from all txs using the same decoding
+	// as SortAndExtractGasPrices. Use a slice instead of a map to handle
+	// duplicate gas prices correctly.
+	type txInfo struct {
+		gasPrice float64
+		size     int
+	}
+	var allTxInfos []txInfo
+	for _, rawTx := range txs {
+		sdkTx, err := testApp.GetTxConfig().TxDecoder()(rawTx)
+		require.NoError(t, err)
+		feeTx := sdkTx.(sdk.FeeTx)
+		gp := float64(feeTx.GetFee().AmountOf(appconsts.BondDenom).Uint64()) / float64(feeTx.GetGas())
+		allTxInfos = append(allTxInfos, txInfo{gasPrice: gp, size: len(rawTx)})
 	}
 
 	maxBytes := 3000
@@ -78,13 +90,25 @@ func TestSortAndExtractGasPrice(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(gasPrices), 0)
 
-	currentGasPrice := gasPrices[0]
-	currentSize := txGasToSizeMap[currentGasPrice]
-	for _, gasPrice := range gasPrices[1:] {
-		assert.GreaterOrEqual(t, gasPrice, currentGasPrice)
-		currentSize += txGasToSizeMap[gasPrice]
+	// Verify gas prices are sorted ascending.
+	for i := 1; i < len(gasPrices); i++ {
+		assert.GreaterOrEqual(t, gasPrices[i], gasPrices[i-1])
 	}
-	assert.LessOrEqual(t, currentSize, maxBytes)
+
+	// Verify total size of included txs does not exceed maxBytes.
+	// Match returned gas prices back to tx sizes (accounting for duplicates).
+	used := make([]bool, len(allTxInfos))
+	totalSize := 0
+	for _, gp := range gasPrices {
+		for j, info := range allTxInfos {
+			if !used[j] && info.gasPrice == gp {
+				totalSize += info.size
+				used[j] = true
+				break
+			}
+		}
+	}
+	assert.LessOrEqual(t, totalSize, maxBytes)
 }
 
 func TestEstimateGasPrice(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes intermittent CI failures in `TestSortAndExtractGasPrice` (e.g. "gas estimation value 3422 exceeded expected max 3000").

## Root cause

Two issues:

1. **Gas price map collisions**: The test used a `map[float64]int` keyed by gas price to look up tx sizes. Random fees could produce duplicate gas prices, causing one entry to overwrite another. The size accumulation then used wrong values, sometimes exceeding `maxBytes` even though `SortAndExtractGasPrices` was correct.

2. **Non-deterministic randomness**: `rand` without a seed made failures hard to reproduce.

## Fix

- Seeded random source for deterministic test runs
- Match returned gas prices back to original txs using a slice with used-flags instead of a map, correctly handling duplicate gas prices

Verified: 10/10 passes locally.

Closes https://linear.app/celestia/issue/PROTOCO-1503/fix-flaky-testsortandextractgasprice