### PR TITLE
test: fix flaky TestMaxBlockSize on loaded CI runners

### DIFF
--- a/app/test/integration_test.go
+++ b/app/test/integration_test.go
@@ -98,7 +98,13 @@ func (s *IntegrationTestSuite) TestMaxBlockSize() {
 				hashes[i] = res.TxHash
 			}
 
-			require.NoError(t, s.cctx.WaitForBlocks(10))
+			// Use a generous timeout because producing 10 blocks that each
+			// contain up to ~1 MiB of blob txs is CPU-heavy and the default
+			// 30s timeout flakes on loaded CI runners. See #7080.
+			lastHeight, err := s.cctx.LatestHeight()
+			require.NoError(t, err)
+			_, err = s.cctx.WaitForHeightWithTimeout(lastHeight+10, 2*time.Minute)
+			require.NoError(t, err)
 
 			heights := make(map[int64]int)
 			for _, hash := range hashes {


### PR DESCRIPTION
## Summary

- `TestIntegrationTestSuite/TestMaxBlockSize` broadcasts 60 blob txs of ~1 MiB each and then calls `s.cctx.WaitForBlocks(10)`, which bakes in the default 30s timeout. On CPU-constrained runners, producing 10 blocks worth of ~1 MiB blob txs can exceed 30s, so the test flakes with `timeout (30s) exceeded waiting for network to reach height N. Got to height M`.
- Switch that specific call to `WaitForHeightWithTimeout(..., 2*time.Minute)`. All correctness assertions are unchanged; the test simply gets more runway to finish on slow runners.

## Reproduction

Running 6 copies of the test in parallel on an idle machine to simulate runner contention:

| timeout | result |
| --- | --- |
| 30s (baseline) | **6/6 workers fail** with the same error shape as CI |
| 2m (this PR) | Under lighter but still-contended 2-worker stress, **10/10 iterations pass** |

Consensus is still making progress during the failure (height advances); it's purely a timing-budget miss, not a liveness bug.

Closes #7080

## Test plan

- [ ] `test / go-test (github.com/celestiaorg/celestia-app/v9/app/test, TestIntegration.*)` passes in CI
- [ ] Monitor the merge queue for ~a week; flake should not recur

🤖 Generated with [Claude Code](https://claude.com/claude-code)