### PR TITLE
feat(fibre): add WithAwaitAllSignatures upload option

### DIFF
--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -12,6 +12,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
 	"github.com/celestiaorg/celestia-app/v9/x/fibre/types"
 	"github.com/celestiaorg/go-square/v4/share"
+	cmtmath "github.com/cometbft/cometbft/libs/math"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	txsigning "github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -24,7 +25,8 @@ import (
 type UploadOption func(*uploadOptions)
 
 type uploadOptions struct {
-	keyName string
+	keyName  string
+	awaitAll bool
 }
 
 // WithKeyName sets the key name used for signing the payment promise.
@@ -32,6 +34,14 @@ type uploadOptions struct {
 func WithKeyName(keyName string) UploadOption {
 	return func(o *uploadOptions) {
 		o.keyName = keyName
+	}
+}
+
+// WithAwaitAllSignatures makes [Client.Upload] wait for all validators to respond
+// instead of returning as soon as the safety threshold (2/3) of signatures is collected.
+func WithAwaitAllSignatures() UploadOption {
+	return func(o *uploadOptions) {
+		o.awaitAll = true
 	}
 }
 
@@ -111,7 +121,11 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 		return result, fmt.Errorf("converting payment promise to proto: %w", err)
 	}
 	requests := makeUploadRequests(shardMap, promiseProto, blob.RLCCoeffs())
-	sigSet := valSet.NewSignatureSet(c.Config.SafetyThreshold, signBytes)
+	threshold := c.Config.SafetyThreshold
+	if opt.awaitAll {
+		threshold = cmtmath.Fraction{Numerator: 1, Denominator: 1}
+	}
+	sigSet := valSet.NewSignatureSet(threshold, signBytes)
 
 	c.log.DebugContext(ctx, "initiating blob upload",
 		"promise_hash", hex.EncodeToString(promiseHash),

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -31,6 +31,7 @@ func TestClientUpload(t *testing.T) {
 		{"SucceedsWith1/3Failures_HighConcurrency", testClientUploadSucceedsWithOneThirdFailuresHighConcurrency},
 		{"InsufficientVotingPower", testClientUploadInsufficientVotingPower},
 		{"AllValidatorsReceiveData", testClientUploadAllValidatorsReceiveData},
+		{"AwaitAllSignatures", testClientUploadAwaitAllSignatures},
 		{"ClosedClient", testClientUploadClosedClient},
 	}
 
@@ -143,6 +144,31 @@ func testClientUploadAllValidatorsReceiveData(t *testing.T) {
 
 	// verify all validators received data
 	require.Equal(t, numValidators, int(counter.Load()), "not all validators received data")
+}
+
+func testClientUploadAwaitAllSignatures(t *testing.T) {
+	const numValidators = 100
+
+	var counter *atomic.Int64
+	client := makeTestUploadClient(t, numValidators, func(cfg *fibre.ClientConfig) {
+		cfg.NewClientFn, counter = countingClientFn(cfg.NewClientFn)
+	})
+	t.Cleanup(func() { require.NoError(t, client.Stop(t.Context())) })
+
+	blob := makeTestBlobV0(t, 256*1024)
+	result, err := client.Upload(t.Context(), testNamespace, blob, fibre.WithAwaitAllSignatures())
+	require.NoError(t, err)
+
+	// WithAwaitAllSignatures waits for all responses, so all validators
+	// must have been contacted by the time Upload returns — without needing Stop.
+	require.Equal(t, numValidators, int(counter.Load()), "all validators should have been contacted before Upload returned")
+	var nonNilSigs int
+	for _, sig := range result.ValidatorSignatures {
+		if sig != nil {
+			nonNilSigs++
+		}
+	}
+	require.Equal(t, numValidators, nonNilSigs, "should have non-nil signatures from all validators")
 }
 
 func testClientUploadClosedClient(t *testing.T) {


### PR DESCRIPTION
Allow callers to wait for all validators to respond instead of returning at the 2/3 safety threshold, useful when maximum signature coverage is needed.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7088" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
