### PR TITLE
perf(fibre): decrease encoding memory usage by 8x

### DIFF
--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -18,6 +18,8 @@ var (
 	ErrBlobTooLarge = errors.New("blob size exceeds maximum allowed size")
 	// ErrBlobCommitmentMismatch is returned when the reconstructed commitment doesn't match the expected one.
 	ErrBlobCommitmentMismatch = errors.New("commitment mismatch: reconstructed data doesn't match expected commitment")
+	// ErrBlobConsumed is returned when a blob is reused after being uploaded.
+	ErrBlobConsumed = errors.New("blob cannot be reused after upload")
 )
 
 // BlobConfig contains configuration parameters for blob encoding and decoding.
@@ -35,11 +37,26 @@ type BlobConfig struct {
 	MaxDataSize int
 	// CodingWorkers is the number of workers to use for encoding and decoding rsema1d.
 	CodingWorkers int
+
+	// Coder is a cached Reed-Solomon encoder/decoder for encoding blobs.
+	Coder *rsema1d.Coder
+	// Assembler builds pooled row layouts for encoding blobs.
+	Assembler *RowAssembler
 }
 
+// defaultBlobConfigV0 is the shared default config, created at init time.
+var defaultBlobConfigV0 = func() BlobConfig {
+	cfg, err := NewBlobConfigFromParams(0, DefaultProtocolParams)
+	if err != nil {
+		panic(fmt.Sprintf("creating default blob config v0: %v", err))
+	}
+	return cfg
+}()
+
 // DefaultBlobConfigV0 returns a [BlobConfig] with default values for version 0.
+// The config is created once at init and shared across all callers.
 func DefaultBlobConfigV0() BlobConfig {
-	return NewBlobConfigFromParams(0, DefaultProtocolParams)
+	return defaultBlobConfigV0
 }
 
 // BlobConfigForVersion returns the [BlobConfig] for the given blob version.
@@ -55,21 +72,40 @@ func BlobConfigForVersion(version uint8) (BlobConfig, error) {
 
 // NewBlobConfigFromParams creates a [BlobConfig] with values derived from the given [ProtocolParams].
 // Use this when you need a config with non-default protocol parameters (e.g., for testing).
-func NewBlobConfigFromParams(blobVersion uint8, p ProtocolParams) BlobConfig {
+func NewBlobConfigFromParams(blobVersion uint8, params ProtocolParams) (BlobConfig, error) {
 	if blobVersion != 0 {
-		panic(fmt.Sprintf("unsupported blob version: %d", blobVersion))
+		return BlobConfig{}, fmt.Errorf("unsupported blob version: %d", blobVersion)
+	}
+
+	workers := runtime.GOMAXPROCS(0)
+	codecCfg := &rsema1d.Config{
+		K:           params.Rows,
+		N:           params.ParityRows(),
+		WorkerCount: workers,
+	}
+
+	assembler, err := NewRowAssembler(codecCfg, params.MaxRowSize(blobVersion))
+	if err != nil {
+		return BlobConfig{}, fmt.Errorf("creating row assembler: %w", err)
+	}
+
+	coder, err := rsema1d.NewCoder(codecCfg, reedsolomon.WithWorkAllocator(assembler.WorkAllocator()))
+	if err != nil {
+		return BlobConfig{}, fmt.Errorf("creating rsema1d coder: %w", err)
 	}
 
 	return BlobConfig{
 		BlobVersion:  blobVersion,
-		OriginalRows: p.Rows,
-		ParityRows:   p.ParityRows(),
+		OriginalRows: params.Rows,
+		ParityRows:   params.ParityRows(),
 		RowSize: func(dataLen int) int {
-			return p.RowSize(blobVersion, dataLen+blobHeaderLen)
+			return params.RowSize(blobVersion, dataLen+blobHeaderLen)
 		},
-		MaxDataSize:   p.MaxBlobSize - blobHeaderLen, // subtract the header overhead
-		CodingWorkers: runtime.GOMAXPROCS(0),
-	}
+		MaxDataSize:   params.MaxBlobSize - blobHeaderLen,
+		CodingWorkers: workers,
+		Coder:         coder,
+		Assembler:     assembler,
+	}, nil
 }
 
 // TotalRows returns the total number of rows (OriginalRows + ParityRows).
@@ -93,7 +129,6 @@ type Blob struct {
 	extendedData *rsema1d.ExtendedData
 	id           BlobID
 	originalID   BlobID
-	rlcCoeffs    []field.GF128
 
 	// holds meta fields about the blob
 	header blobHeaderV0
@@ -102,13 +137,25 @@ type Blob struct {
 
 	// fields for reconstruction
 	rows [][]byte
+
+	consumed atomic.Bool
+
+	// asm owns pooled row storage from the assembler and supports per-validator
+	// release of parity slots. Nil for reconstructed blobs.
+	asm *Assembly
 }
 
 // NewBlob creates a new [Blob] instance by encoding the data.
-// It takes the data and a [BlobConfig].
+// It takes ownership of data and may reuse it directly as backing storage for
+// original rows. Callers must not modify data after calling NewBlob.
+//
 // The data is prefixed with a header containing the blob version and data size.
 // Returns [ErrBlobTooLarge] if the data size exceeds BlobConfig.MaxDataSize.
-func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
+//
+// The returned blob holds pooled row buffers from the [RowAssembler].
+// Pooled storage is released automatically when [Client.Upload] completes.
+// Data must not be modified after ownership is transferred to the blob.
+func NewBlob(data []byte, cfg BlobConfig) (*Blob, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
@@ -116,26 +163,20 @@ func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
 		return nil, fmt.Errorf("%w: data size %d exceeds maximum %d", ErrBlobTooLarge, len(data), cfg.MaxDataSize)
 	}
 
-	d = &Blob{
-		cfg:    cfg,
-		header: newBlobHeaderV0(len(data)),
-		data:   data,
-	}
-
-	rows := d.header.encodeToRows(data, cfg)
-	var rsemaCommitment rsema1d.Commitment
-	d.extendedData, rsemaCommitment, d.rlcCoeffs, err = rsema1d.Encode(rows, &rsema1d.Config{
-		K:           cfg.OriginalRows,
-		N:           cfg.ParityRows,
-		RowSize:     len(rows[0]),
-		WorkerCount: cfg.CodingWorkers,
-	})
+	header := newBlobHeaderV0(len(data))
+	extendedData, asm, err := header.encode(data, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("encoding data: %w", err)
+		return nil, err
 	}
-	d.id = NewBlobID(cfg.BlobVersion, rsemaCommitment)
 
-	return d, nil
+	return &Blob{
+		cfg:          cfg,
+		extendedData: extendedData,
+		id:           NewBlobID(cfg.BlobVersion, extendedData.Commitment()),
+		header:       header,
+		data:         data,
+		asm:          asm,
+	}, nil
 }
 
 // NewEmptyBlob creates a new [Blob] instance for receiving and reconstructing data.
@@ -191,9 +232,12 @@ func (d *Blob) Config() BlobConfig {
 	return d.cfg
 }
 
-// RLCCoeffs returns RLC coefficients of the original data.
-func (d *Blob) RLCCoeffs() []field.GF128 {
-	return d.rlcCoeffs
+// RLC returns the computed random linear combination values for the original rows.
+func (d *Blob) RLC() []field.GF128 {
+	if d.extendedData == nil {
+		return nil
+	}
+	return d.extendedData.RLC()
 }
 
 // RowSize returns the size of each row in bytes.
@@ -220,12 +264,17 @@ func (d *Blob) Data() []byte {
 	return d.data
 }
 
-// Row returns the [rsema1d.RowInclusionProof] for the given index from the extended data.
+// Row returns the [rsema1d.RowInclusionProof] for the given index. Live parity
+// rows are served even after other validators have released theirs; only the
+// specific released rows return an error. After terminal release, all calls
+// return an error.
 func (d *Blob) Row(index int) (*rsema1d.RowInclusionProof, error) {
 	if d.extendedData == nil {
 		return nil, fmt.Errorf("no extended data available")
 	}
-
+	if d.asm.Freed(index) {
+		return nil, fmt.Errorf("row %d: storage has been released", index)
+	}
 	return d.extendedData.GenerateRowInclusionProof(index)
 }
 
@@ -389,7 +438,7 @@ func (d *Blob) Reconstruct(opts ...ReconstructOption) error {
 		RowSize:     len(d.rows[0]), // NOTE: successful reconstruct must fill all rows, so if this ever panics something is really wrong
 		WorkerCount: d.cfg.CodingWorkers,
 	}
-	extendedData, reconstructedCommitment, rlcCoeffs, err := rsema1d.EncodeParity(d.rows, config)
+	extendedData, reconstructedCommitment, _, err := rsema1d.EncodeParity(d.rows, config)
 	if err != nil {
 		return fmt.Errorf("encoding parity: %w", err)
 	}
@@ -408,12 +457,16 @@ func (d *Blob) Reconstruct(opts ...ReconstructOption) error {
 
 	d.data = originalData
 	d.extendedData = extendedData
-	d.rlcCoeffs = rlcCoeffs
 	if opt.skipCommitmentCheck {
 		d.originalID = d.id
 		d.id = NewBlobID(d.cfg.BlobVersion, Commitment(reconstructedCommitment))
 	}
 	return nil
+}
+
+// consume marks the blob as owned by an upload. Returns false if already consumed.
+func (d *Blob) consume() bool {
+	return d.consumed.CompareAndSwap(false, true)
 }
 
 const (
@@ -440,42 +493,20 @@ func newBlobHeaderV0(dataSize int) blobHeaderV0 {
 	}
 }
 
-// encodeToRows encodes the data into rows with version 0 header format.
-// Returns OriginalRows rows of calculated rowSize bytes each, padding with zeros as needed.
-// The first row contains the header followed by data.
-func (h blobHeaderV0) encodeToRows(data []byte, cfg BlobConfig) [][]byte {
+// encode assembles rows from data, writes the blob header, and produces the
+// commitment via the [rsema1d.Coder]. Returns the extended data and an
+// [Assembly] that owns the pooled row storage for the blob's lifetime.
+func (h blobHeaderV0) encode(data []byte, cfg BlobConfig) (*rsema1d.ExtendedData, *Assembly, error) {
 	rowSize := cfg.RowSize(len(data))
-	rows := make([][]byte, cfg.OriginalRows)
+	rows, asm := cfg.Assembler.Assemble(data, rowSize, blobHeaderLen)
+	h.marshalTo(rows[0])
 
-	// First row: allocate and write header + beginning of data
-	rows[0] = make([]byte, rowSize)
-	h.encode(rows[0])
-
-	// Copy as much data as fits in the first row after the header
-	firstRowDataSize := min(rowSize-blobHeaderLen, len(data))
-	copy(rows[0][blobHeaderLen:], data[:firstRowDataSize])
-
-	// Remaining rows: use slices from data (offset by what we already used)
-	dataOffset := firstRowDataSize
-	for i := 1; i < cfg.OriginalRows; i++ {
-		start := dataOffset
-		end := start + rowSize
-		dataOffset += rowSize
-
-		if end <= len(data) {
-			// Full row available in data - use slice directly
-			rows[i] = data[start:end:end]
-			continue
-		}
-		// Some or no data left - allocate zero-filled padded row
-		rows[i] = make([]byte, rowSize)
-		if start < len(data) {
-			// Partial row - insert the remaining data into the row
-			copy(rows[i], data[start:])
-		}
+	extData, err := cfg.Coder.Encode(rows)
+	if err != nil {
+		asm.Free(nil)
+		return nil, nil, fmt.Errorf("encoding data: %w", err)
 	}
-
-	return rows
+	return extData, asm, nil
 }
 
 // decodeFromRows decodes the data from rows with version 0 header format.
@@ -491,7 +522,7 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	}
 
 	// decode header from first row
-	if err := h.decode(rows[0]); err != nil {
+	if err := h.unmarshalFrom(rows[0]); err != nil {
 		return nil, fmt.Errorf("decoding header: %w", err)
 	}
 
@@ -525,18 +556,18 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	return data, nil
 }
 
-// encode writes the version 0 blob header into the provided buffer.
+// marshalTo writes the version 0 blob header into the provided buffer.
 // The buffer must be at least blobHeaderLen bytes long.
 // Always writes version byte as 0.
-func (h blobHeaderV0) encode(buf []byte) {
+func (h blobHeaderV0) marshalTo(buf []byte) {
 	buf[0] = 0 // version 0
 	binary.BigEndian.PutUint32(buf[blobVersionLen:blobHeaderLen], h.dataSize)
 }
 
-// decode reads the blob header from the provided buffer.
+// unmarshalFrom reads the blob header from the provided buffer.
 // The buffer must be at least blobHeaderLen bytes long.
 // Returns an error if the version byte is not 0.
-func (h *blobHeaderV0) decode(buf []byte) error {
+func (h *blobHeaderV0) unmarshalFrom(buf []byte) error {
 	if buf[0] != 0 {
 		return fmt.Errorf("invalid blob version: expected 0, got %d", buf[0])
 	}

--- a/fibre/blob_test.go
+++ b/fibre/blob_test.go
@@ -7,7 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
+func TestBlobHeaderV0_MarshalRoundTrip(t *testing.T) {
+	sizes := []int{1, 10, 500, 5000, 1024, 1 << 20}
+
+	for _, size := range sizes {
+		h := newBlobHeaderV0(size)
+		buf := make([]byte, blobHeaderLen)
+		h.marshalTo(buf)
+
+		var got blobHeaderV0
+		require.NoError(t, got.unmarshalFrom(buf))
+		require.Equal(t, uint32(size), got.dataSize)
+	}
+}
+
+func TestNewBlob_EncodeDecodeRoundTrip(t *testing.T) {
 	cfg := DefaultBlobConfigV0()
 
 	tests := []struct {
@@ -15,60 +29,26 @@ func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
 		dataSize int
 	}{
 		{"single byte", 1},
-		{"small data", 10},
-		{"medium data", 500},
-		{"large data", 5000},
+		{"small", 10},
+		{"medium", 500},
+		{"large", 5000},
 		{"1 KiB", 1024},
-		{"1 MiB", 1024 * 1024},
+		{"1 MiB", 1 << 20},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test data with recognizable pattern
 			data := make([]byte, tt.dataSize)
 			for i := range data {
 				data[i] = byte(i % 256)
 			}
 
-			// Encode
-			header := newBlobHeaderV0(len(data))
-			rows := header.encodeToRows(data, cfg)
+			blob, err := NewBlob(data, cfg)
+			require.NoError(t, err)
+			defer blob.asm.Free(nil)
 
-			// Verify correct number of rows
-			if len(rows) != cfg.OriginalRows {
-				t.Fatalf("encodeToRows() returned %d rows, want %d", len(rows), cfg.OriginalRows)
-			}
-
-			// Verify all rows have same size
-			expectedRowSize := cfg.RowSize(len(data))
-			for i, row := range rows {
-				if len(row) != expectedRowSize {
-					t.Errorf("row %d size = %d, want %d", i, len(row), expectedRowSize)
-				}
-			}
-
-			// Decode
-			var decodeHeader blobHeaderV0
-			decodedData, err := decodeHeader.decodeFromRows(rows, cfg)
-			if err != nil {
-				t.Fatalf("decodeFromRows() error = %v", err)
-			}
-
-			// Verify round-trip
-			if len(decodedData) != len(data) {
-				t.Errorf("decodeFromRows() data length mismatch, got %d bytes, want %d bytes", len(decodedData), len(data))
-			}
-			for i := range data {
-				if decodedData[i] != data[i] {
-					t.Errorf("decodeFromRows() data mismatch at index %d, got %d, want %d", i, decodedData[i], data[i])
-					break
-				}
-			}
-
-			// Verify header was decoded correctly
-			if decodeHeader.dataSize != uint32(tt.dataSize) {
-				t.Errorf("decodeFromRows() header.dataSize = %d, want %d", decodeHeader.dataSize, tt.dataSize)
-			}
+			require.Equal(t, tt.dataSize, blob.DataSize())
+			require.Equal(t, data, blob.Data())
 		})
 	}
 }
@@ -79,6 +59,7 @@ func TestBlob_Reconstruct(t *testing.T) {
 
 	blob, err := NewBlob(testData, cfg)
 	require.NoError(t, err)
+	defer blob.asm.Free(nil)
 
 	totalRows := cfg.OriginalRows + cfg.ParityRows
 	allRows := make([]*rsema1d.RowInclusionProof, totalRows)
@@ -93,16 +74,12 @@ func TestBlob_Reconstruct(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, row := range rows {
-			err = reconstructBlob.VerifyRow(row)
-			require.NoError(t, err)
+			require.NoError(t, reconstructBlob.VerifyRow(row))
 			require.True(t, reconstructBlob.SetRow(row))
 		}
 
-		err = reconstructBlob.Reconstruct()
-		require.NoError(t, err)
-
-		reconstructedData := reconstructBlob.Data()
-		require.Equal(t, testData, reconstructedData)
+		require.NoError(t, reconstructBlob.Reconstruct())
+		require.Equal(t, testData, reconstructBlob.Data())
 	}
 
 	t.Run("FirstKRows", func(t *testing.T) {
@@ -123,4 +100,37 @@ func TestBlob_Reconstruct(t *testing.T) {
 		}
 		testReconstruct(t, mixedRows)
 	})
+}
+
+func TestBlob_RowAfterRelease(t *testing.T) {
+	blob, err := NewBlob([]byte("test"), DefaultBlobConfigV0())
+	require.NoError(t, err)
+
+	_, err = blob.Row(0)
+	require.NoError(t, err)
+
+	blob.asm.Free(nil)
+
+	_, err = blob.Row(0)
+	require.Error(t, err)
+}
+
+func TestBlob_RowAfterPartialRelease(t *testing.T) {
+	cfg := DefaultBlobConfigV0()
+	blob, err := NewBlob([]byte("test"), cfg)
+	require.NoError(t, err)
+	defer blob.asm.Free(nil)
+
+	// Release a single parity row; other rows must remain available.
+	released := cfg.OriginalRows + 1
+	blob.asm.Free([]int{released})
+
+	_, err = blob.Row(released)
+	require.Error(t, err, "released parity row should error")
+
+	_, err = blob.Row(cfg.OriginalRows)
+	require.NoError(t, err, "untouched parity row should succeed")
+
+	_, err = blob.Row(0)
+	require.NoError(t, err, "original rows should always succeed")
 }

--- a/fibre/client_download_test.go
+++ b/fibre/client_download_test.go
@@ -529,7 +529,7 @@ func (d *downloadMockClient) DownloadShard(ctx context.Context, req *types.Downl
 	}
 
 	if req.WithRlc {
-		rlcCoeffs := blob.RLCCoeffs()
+		rlcCoeffs := blob.RLC()
 		coeffBytes := make([]byte, len(rlcCoeffs)*16)
 		for i, c := range rlcCoeffs {
 			b := field.ToBytes128(c)

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -87,18 +87,21 @@ func TestClientServerUploadDownload(t *testing.T) {
 						return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
 					}
 
-					blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
-					if err != nil {
-						return fmt.Errorf("creating blob %d: %w", blobIdx, err)
-					}
-
 					slotIdx := clientIdx*tt.blobsPerClient + blobIdx
 					allPromiseHashes[slotIdx] = make([][]byte, 0, tt.duplicate)
 
 					// upload blob (possibly multiple times at different heights)
+					// each upload requires a fresh blob since Upload takes ownership
 					for uploadIdx := range tt.duplicate {
 						if tt.duplicate > 1 {
 							env.SetHeight(uint64(100 + uploadIdx*100))
+						}
+						blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+						if err != nil {
+							return fmt.Errorf("creating blob %d (upload %d): %w", blobIdx, uploadIdx, err)
+						}
+						if uploadIdx == 0 {
+							allBlobIDs[slotIdx] = blob.ID()
 						}
 						signedPromise, err := client.Upload(ctx, testNamespace, blob)
 						if err != nil {
@@ -112,7 +115,6 @@ func TestClientServerUploadDownload(t *testing.T) {
 						allPromiseHashes[slotIdx] = append(allPromiseHashes[slotIdx], promiseHash)
 					}
 
-					allBlobIDs[slotIdx] = blob.ID()
 					allData[slotIdx] = data
 				}
 

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -49,8 +49,22 @@ func WithAwaitAllSignatures() UploadOption {
 // It creates a [PaymentPromise], uploads the data to validators, and collects signatures confirming the upload.
 // Returns a [SignedPaymentPromise] containing the promise and validator signatures.
 // May keep uploading data in background after returning successfully.
+//
+// Upload takes ownership of the blob and releases its pooled storage when all
+// background uploads complete. The blob must not be reused after calling Upload;
+// create a new one with [NewBlob] for each upload.
+//
 // Returns [ErrClientClosed] if the client has been closed.
 func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opts ...UploadOption) (result SignedPaymentPromise, err error) {
+	if !blob.consume() {
+		return result, ErrBlobConsumed
+	}
+	defer func() {
+		if err != nil {
+			blob.asm.Free(nil)
+		}
+	}()
+
 	if !c.started.Load() {
 		return result, errors.New("fibre client is not started")
 	}
@@ -120,7 +134,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 		span.SetStatus(codes.Error, "failed to convert payment promise to proto")
 		return result, fmt.Errorf("converting payment promise to proto: %w", err)
 	}
-	requests := makeUploadRequests(shardMap, promiseProto, blob.RLCCoeffs())
+	requests := makeUploadRequests(shardMap, promiseProto, blob.RLC())
 	threshold := c.Config.SafetyThreshold
 	if opt.awaitAll {
 		threshold = cmtmath.Fraction{Numerator: 1, Denominator: 1}
@@ -233,6 +247,10 @@ func (c *Client) uploadTo(
 	blob *Blob,
 	sigSet *validator.SignatureSet,
 ) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
 	ctx, cancel := context.WithCancel(ctx) // GRPC calls require context cancelling upon completion
 	defer cancel()
 
@@ -337,26 +355,32 @@ func (c *Client) uploadShards(
 		sigsCollectedCh   = make(chan struct{}) // closes when enough signatures are collected
 	)
 
+	// spawn unconditionally even under ctx cancellation: each goroutine exits
+	// fast via uploadTo(ctx) and runs its defer, so the "last one frees" path
+	// fires naturally without a separate drain step.
 	for val, req := range requests {
-		// acquire semaphore before spawning goroutine
-		select {
-		case c.uploadSem <- struct{}{}:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		c.uploadSem <- struct{}{}
 
 		c.closeWg.Add(1)
 		go func(val *core.Validator, req *types.UploadShardRequest) {
 			defer func() {
-				// release semaphore
 				<-c.uploadSem
 
-				// increment responses and mark as completed if so
 				if int(responses.Add(1)) == len(requests) {
+					// last goroutine: terminal release covers this validator's
+					// parity rows plus head/tail and any unassigned parity slots.
 					close(responsesExhaustedCh)
+					blob.asm.Free(nil)
+				} else {
+					// release just this validator's parity row slots so the
+					// next blob can reuse them.
+					rowIndices := make([]int, len(req.Shard.Rows))
+					for i, r := range req.Shard.Rows {
+						rowIndices[i] = int(r.Index)
+					}
+					blob.asm.Free(rowIndices)
 				}
 
-				// unblock Close
 				c.closeWg.Done()
 			}()
 
@@ -368,13 +392,11 @@ func (c *Client) uploadShards(
 	}
 
 	select {
-	case <-responsesExhaustedCh: // no more responses to wait for
-	case <-sigsCollectedCh: // enough signatures collected
-	case <-ctx.Done():
+	case <-responsesExhaustedCh: // every goroutine finished; terminal Free already fired
 		return ctx.Err()
+	case <-sigsCollectedCh: // detach: remaining goroutines finish in background
+		return nil
 	}
-
-	return nil
 }
 
 // makeUploadRequests constructs the requests map for all validators.

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -33,6 +33,7 @@ func TestClientUpload(t *testing.T) {
 		{"AllValidatorsReceiveData", testClientUploadAllValidatorsReceiveData},
 		{"AwaitAllSignatures", testClientUploadAwaitAllSignatures},
 		{"ClosedClient", testClientUploadClosedClient},
+		{"BlobConsumed", testClientUploadBlobConsumed},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +185,19 @@ func testClientUploadClosedClient(t *testing.T) {
 	// attempt to upload after closing
 	_, err := client.Upload(t.Context(), testNamespace, blob)
 	require.ErrorIs(t, err, fibre.ErrClientClosed, "expected ErrClientClosed when uploading to closed client")
+}
+
+func testClientUploadBlobConsumed(t *testing.T) {
+	client := makeTestUploadClient(t, 100, nil)
+	t.Cleanup(func() { require.NoError(t, client.Stop(t.Context())) })
+
+	blob := makeTestBlobV0(t, 256*1024)
+
+	_, err := client.Upload(t.Context(), testNamespace, blob)
+	require.NoError(t, err)
+
+	_, err = client.Upload(t.Context(), testNamespace, blob)
+	require.ErrorIs(t, err, fibre.ErrBlobConsumed)
 }
 
 // makeTestUploadClient creates an upload client for testing.

--- a/fibre/internal/slab/DESIGN.md
+++ b/fibre/internal/slab/DESIGN.md
@@ -1,0 +1,258 @@
+# Slab Pool Design
+
+`slab.Pool` is a growable byte-region allocator used in the fibre blob
+encoding pipeline. `RowAssembler` currently uses two independent pools built
+from the same allocator:
+
+- a parity pool for parity rows
+- a work pool for large Reed-Solomon FFT scratch buffers
+
+## Problem
+
+Go's `sync.Pool` drops all entries every GC cycle. The leopard RS encoder
+allocates ~1 GiB work buffers per encode, which triggers GC frequently enough
+that the pool never retains — every encode allocates fresh, inflating RSS from
+~1.5 GiB (theoretical) to 8+ GiB through accumulated MADV_FREE pages.
+
+## Properties
+
+### GC-proof retention
+
+Slabs are held in a regular slice (a GC root), not `sync.Pool`. They survive
+garbage collection indefinitely and are only released when [Pool.Shrink]
+drops them — retention is driven by observed demand, not by GC pressure.
+
+### Demand-driven growth
+
+No upfront sizing or pre-allocation. The pool starts empty and each `Get`
+tries existing slabs first; when a request can't be satisfied, a new slab
+is grown sized to exactly the unsatisfied deficit. One miss therefore
+doesn't inflate off the total live set — concurrent large blobs each add
+just the bytes they need, not triangular overprovisioning. The pool adapts
+to whatever mix of blob sizes the caller submits.
+
+### Dynamic row sizes
+
+The slab tracks byte regions via a free-list, not fixed-size slots. A 1 MiB
+blob's parity (12290 × 320 bytes = 3.8 MiB) and a 128 MiB blob's parity
+(12290 × 32 KiB = 384 MiB) both allocate from the same pool proportionally.
+Many small blobs pack efficiently into a slab sized for one large blob.
+
+### Contiguous-first allocation
+
+`allocMany` tries to satisfy the full request from a single contiguous region
+before falling back to scattered allocation from individual free regions.
+This preserves cache/TLB locality for RS FFT work buffers (which access
+`work[i]` and `work[i+dist]` in butterfly patterns) while still allowing
+parity rows to reuse scattered freed regions after per-validator release.
+
+### Per-validator release
+
+Individual row buffers can be freed back to the pool independently via `Put`.
+When a validator's upload completes, its parity rows are returned to the slab
+immediately — the next blob's `Get` can reuse those regions without waiting
+for all validators to finish. The free-list coalesces adjacent frees
+automatically.
+
+The last validator to finish calls terminal `Assembly.Free(nil)` which frees
+any remaining rows (head, tail, unassigned parity) and triggers `Shrink`.
+Non-terminal validators call `Assembly.Free(rowIndices)` for partial release.
+
+### Shrink when idle
+
+`Shrink()` is called only at blob lifecycle boundaries (terminal
+`Assembly.Free`), not on every `Put`. This prevents hot slabs (like the work
+buffer slab) from being destroyed and recreated between encode cycles.
+
+Shrink drops the **smallest** fully-free slabs first, so bootstrap-sized
+slabs are trimmed before well-adapted warm capacity.
+
+Eviction applies a grace period while the pool is still active. When at
+least one slab has outstanding allocations, each fully-free slab may survive
+up to `freeSlabShrinkGrace` shrink cycles before becoming evictable. A
+successful `alloc` resets the counter, so a slab that briefly becomes free
+and is then reused stays warm indefinitely. Once every slab is free (pool
+fully idle) the grace period is ignored and all slabs are dropped
+immediately — there's no active workload to preserve capacity for. The
+pool carries no permanent retention floor; its memory footprint tracks
+demand.
+
+This absorbs the common overlap pattern: blob A's terminal release fires
+while blob B's encode is mid-flight, briefly leaving a slab free. Without
+the grace period, that slab would be evicted and reallocated for B; with
+it, the same slab carries over.
+
+### SIMD alignment
+
+All row sizes are protocol-constrained to multiples of 64 bytes, so every
+carved offset within a slab is naturally SIMD-aligned. Small slabs (< 1 MiB)
+are allocated via `reedsolomon.AllocAligned` on the Go heap; large slabs use
+`mmap` which returns page-aligned memory (see below).
+
+### Off-heap allocation via mmap
+
+Slabs at or above 1 MiB go through `mmap(MAP_PRIVATE|MAP_ANONYMOUS)` rather
+than the Go heap. Large slabs stay invisible to the GC so GOGC's heap-
+doubling target doesn't stack multi-GiB slab allocations on top of each
+other (which OOMs memory-constrained nodes). `Shrink` calls `munmap`
+directly, returning pages to the OS without waiting for GC or MADV_FREE.
+Slabs below the threshold stay on the Go heap where allocation is cheap
+and GC overhead is negligible.
+
+## Free-path optimizations
+
+Per-validator shards of parity rows arrive at `Put` as a shuffled subset
+of offsets (validators are assigned rows through a ChaCha8 permutation in
+`Set.Assign`). A naive free-list that inserts each freed region one-by-one
+degrades to O(N·R) under this pattern: each insertion scans the regions
+list linearly, and R grows with every non-adjacent free until the next
+merge chain forms. Three composed optimizations keep the free path close
+to O(N) for typical workloads.
+
+### Sort by pointer at the entry of Put
+
+`Put` sorts its input buffers by data-pointer before acquiring `Pool.mu`.
+After the sort, buffers within one slab appear in ascending-offset order
+and adjacent-in-memory buffers end up contiguous in the sorted sequence.
+The sort is on the caller's slice and runs outside the lock.
+
+### Run merging in `freeBatch`
+
+Once Put has grouped consecutive same-slab buffers, `slab.freeBatch`
+walks the run and collapses adjacent-in-memory buffers into a single
+region before handing it to the coalesce step. Terminal `Assembly.Free(nil)`
+of a fast-path group — every slot adjacent — reduces to one region
+insertion regardless of the slot count.
+
+### Monotonic coalesce hint
+
+`coalesceAt(r, hint)` takes a starting index for the insertion scan and
+returns the final position (after any left-merge). For a sorted sequence
+of regions, the caller threads the returned index back in as the next
+`hint` so each insertion resumes from where the previous one landed.
+Amortized cost per insertion drops from O(R) to O(1) for monotonic batches.
+
+The three compose: sort makes the input sequence monotonic; run merging
+reduces insertion count by coalescing adjacencies up front; the hint keeps
+each remaining insertion O(1). Result: a sorted-batch Put is effectively
+linear in the number of freed bytes.
+
+## Integration
+
+The allocator is exposed through two separate pools:
+
+- **work pool / `reedsolomon.WorkAllocator`** — the RS encoder calls `Get`/`Put`
+  for its temporary FFT work buffers. Injected at encoder construction time
+  via `reedsolomon.WithWorkAllocator`.
+
+- **parity pool / `Assembly`** — `RowAssembler.Assemble` draws parity rows plus
+  head/tail buffers from a dedicated pool. `Assembly` owns that pooled storage
+  for a single blob, supports partial release via `Free(rowIndices)`, and
+  terminal release via `Free(nil)`. The `Assembly.Freed(index)` query lets
+  `Blob.Row()` reject reads on released rows.
+
+This split is intentional. A single shared pool was benchmarked and rejected:
+large contiguous work slabs and partially-freed parity slabs fragmented each
+other, causing steady-state multi-GiB/min slab churn even though total free
+capacity was ample. Separating the pools restored homogeneous allocation
+shapes, eliminated work-pool churn after warmup, and left only minor residual
+fragmentation inside the parity pool.
+
+## Allocation Lifecycle
+
+```text
+Encode blob A:
+  parityPool.Get(12290, rowSize) → parity A from slab (contiguous fast path)
+  workPool.Get(32768, rowSize)   → work from slab (contiguous, or new slab via growth)
+  [RS encode]
+  workPool.Put(work)              → work freed back to work pool
+
+Upload blob A (concurrent with encode blob B):
+  validator 1 done → asm.Free([rows]) → parity rows freed to parity pool
+  validator 2 done → asm.Free([rows])
+  ...
+
+Encode blob B (while blob A still uploading):
+  parityPool.Get(12290, rowSize) → parity B from freed regions (contiguous or scattered)
+  workPool.Get(32768, rowSize)   → work from warm work slab (contiguous fast path)
+  [RS encode]
+  workPool.Put(work)
+
+Last validator done for blob A:
+  asm.Free(nil)                  → remaining rows freed
+                                → parityPool.Shrink()
+                                → workPool.Shrink()
+```
+
+## Memory Footprint
+
+For max-size blobs the pool reaches the theoretical lower bound: per
+concurrent blob it reserves exactly 4×D work + 3×D parity + 1×D original
+= 8×D (D = data size). Nothing is allocated above that floor except a
+thin Go heap.
+
+Measured on a 16 GiB node with `--await-all`, 128 MiB blobs:
+
+- **c=1**: ~1.4 GiB steady RSS (1.36 GiB mmap slabs + ~50 MiB Go heap
+  under `GOMEMLIMIT=512MiB`).
+- **c=10**: 13 GiB floor, ~15 GiB peak. Ten concurrent encodes cleanly
+  fit the 16 GiB budget.
+
+Slab-allocation churn in steady state is ~1.5 MiB/min (Pyroscope
+`alloc_space`, c=3, 2-min window): the two pools grow to the concurrency
+high-water mark and stay warm.
+
+Smaller blobs scale down proportionally. For 1 MiB blobs (rowSize=320)
+a single concurrent encode needs ~10 MiB work + ~3.8 MiB parity.
+
+## Limitations
+
+- **Parity-pool fragmentation under mixed blob sizes**: split pools removed the
+  dominant work/parity cross-fragmentation, but the parity pool still serves a
+  range of row sizes and supports partial release. Mixed small/medium/large
+  blobs can therefore still leave scattered holes that force the parity path
+  onto the slower gather/scatter allocation path or trigger a new slab for a
+  relatively small deficit. This is now the main remaining fragmentation risk:
+  pool segregation fixed cross-class contamination, but it does not eliminate
+  variable-size fragmentation within one allocation class.
+
+- **Cold-start regrowth after full idle**: once both pools go fully idle,
+  all slabs are dropped. A subsequent burst has to pay the mmap + zeroing
+  cost for every slab it rebuilds. This is the tradeoff for carrying no
+  permanent retention floor — idle memory stays bounded, but the first
+  post-idle blob is slower than subsequent ones.
+
+## Future Improvements
+
+- **Independent retention policies per pool**: work and parity have very
+  different churn characteristics, so they may deserve different grace
+  periods or eviction heuristics. Work is throughput-sensitive and
+  homogeneous; parity is more fragmentation-sensitive and memory-sensitive.
+  Parity naturally shrinks at blob lifecycle boundaries
+  (`Assembly.Free(nil)`); work may be a better fit for an encode-idle
+  policy such as "pool fully free for T" rather than aging only through
+  later terminal frees.
+
+- **Size segmentation inside the parity pool**: if mixed blob sizes become
+  a meaningful source of churn, the next step is to segment parity
+  allocations further by size class or row-size bands. For example:
+  dedicated small/medium/large parity pools, or a special path for
+  oversized parity slabs.
+
+- **Demand-aware retention**: retention today is purely reactive (grace
+  period + smallest-first eviction, no floor). If the cold-start-after-idle
+  cost shows up under real workloads, `Shrink` could learn a warm-capacity
+  target from recent demand with decay, effectively acting as an adaptive
+  floor that shrinks after prolonged idle and grows back after bursts.
+
+- **Statically preallocated configurable slabs**: for deployments with
+  known-stable workload shape (blob size, concurrency, validator count),
+  pay the mmap cost once at `New()` and skip first-burst regrowth entirely.
+  The caller supplies a fixed inventory — e.g. `slab.NewWith(slab.Config{
+  Preallocate: []slab.SlabSpec{{Size: 1<<30, Count: 2}, {Size: 256<<20, Count: 4}}})`
+  — and those slabs are pinned: immune to `Shrink`, warm from the first
+  `Get`. Demand beyond the preallocated inventory still grows/shrinks
+  normally. Trades configurability + RSS cost for predictable steady-state
+  latency and no cold-start penalty; useful for validator/sequencer nodes
+  with a deterministic workload profile that currently pays the first-blob
+  tax on every cold start.

--- a/fibre/internal/slab/mmap.go
+++ b/fibre/internal/slab/mmap.go
@@ -1,0 +1,46 @@
+package slab
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"syscall"
+)
+
+// disableMmap routes all slabs through the Go heap when FIBRE_SLAB_NO_MMAP
+// is set. Useful for pprof alloc_space sampling, which doesn't see mmap'd
+// pages and would otherwise miss large-slab churn.
+var disableMmap = os.Getenv("FIBRE_SLAB_NO_MMAP") != ""
+
+// mmapAlloc allocates size bytes via mmap, invisible to Go's GC.
+// The returned slice is page-aligned (and therefore SIMD-aligned).
+// caller must call mmapFree when done.
+func mmapAlloc(size int) ([]byte, error) {
+	pageSize := syscall.Getpagesize()
+	size = (size + pageSize - 1) &^ (pageSize - 1)
+
+	data, err := syscall.Mmap(-1, 0, size,
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_PRIVATE|syscall.MAP_ANONYMOUS)
+	if err != nil {
+		return nil, fmt.Errorf("mmap(%d): %w", size, err)
+	}
+	if runtime.GOOS == "linux" {
+		// exclude large scratch buffers from core dumps; failure is non-fatal.
+		_ = syscall.Madvise(data, linuxMadvDontDumpCode)
+		// TODO: measure whether MADV_HUGEPAGE improves RS work-buffer throughput
+		// without unacceptable RSS/latency regressions before enabling it.
+		// _ = syscall.Madvise(data, linuxMadvHugePage)
+	}
+	return data, nil
+}
+
+// mmapFree releases mmap'd memory back to the OS.
+func mmapFree(data []byte) error {
+	return syscall.Munmap(data)
+}
+
+const (
+	linuxMadvHugePageCode = 14
+	linuxMadvDontDumpCode = 16
+)

--- a/fibre/internal/slab/slab.go
+++ b/fibre/internal/slab/slab.go
@@ -1,0 +1,372 @@
+// Package slab provides a growable byte-region allocator backed by
+// SIMD-aligned slabs.
+//
+// It is used by fibre to replace sync.Pool for multi-hundred-MiB Reed-Solomon
+// work and parity buffers, which sync.Pool drops aggressively under GC pressure.
+//
+// Contract: buffers returned by [Pool.Get] must be passed back to [Pool.Put]
+// exactly as received — callers must not re-slice. The allocator applies
+// cheap pointer-in-slab + overshoot bounds checks but does not verify exact
+// allocation boundaries, so a re-sliced Put would corrupt the free list.
+// All internal callers comply; do not expose this package to untrusted code.
+package slab
+
+import (
+	"cmp"
+	"slices"
+	"sync"
+	"unsafe"
+
+	"github.com/klauspost/reedsolomon"
+)
+
+// freeSlabShrinkGrace is the number of terminal Shrink calls a fully-free
+// slab may survive while the pool is still active. This adds hysteresis for
+// overlap-driven slab churn without pinning burst capacity after the pool
+// goes fully idle.
+const freeSlabShrinkGrace = 2
+
+// Pool is a growable allocator of SIMD-aligned byte regions. Slabs are
+// grown on demand, sized to the unsatisfied tail of each request, and
+// dropped by [Pool.Shrink] once they've been idle long enough. Retention
+// is purely demand-driven: hot slabs stay alive via the grace-period
+// counter (reset on each alloc); cold ones get evicted once the pool
+// goes fully idle. Implements [reedsolomon.WorkAllocator]. Safe for
+// concurrent use.
+type Pool struct {
+	mu    sync.Mutex
+	slabs []*slab
+
+	// lifetime counters, under mu
+	allocs int64 // number of times Get grew a new slab
+	evicts int64 // number of times Shrink dropped a slab
+}
+
+// New creates an empty Pool.
+func New() *Pool {
+	return &Pool{slabs: make([]*slab, 0)}
+}
+
+// Get returns n buffers of size bytes each, drawn from free regions across
+// existing slabs. Grows new slabs as needed to satisfy the request.
+//
+// Implements [reedsolomon.WorkAllocator].
+func (p *Pool) Get(n, size int) [][]byte {
+	if n == 0 {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	bufs := make([][]byte, 0, n)
+	for _, s := range p.slabs {
+		bufs = s.allocMany(bufs, n-len(bufs), size)
+		if len(bufs) == n {
+			return bufs
+		}
+	}
+
+	// grow by the remaining deficit after reusing whatever existing slabs
+	// could already satisfy.
+	remaining := n - len(bufs)
+	s := newSlab(remaining * size)
+	p.slabs = append(p.slabs, s)
+	p.allocs++
+	return s.allocMany(bufs, remaining, size)
+}
+
+// Put frees each buffer back to its owning slab. Put does NOT shrink the
+// pool — slabs are retained for reuse. Call [Pool.Shrink] explicitly at
+// lifecycle boundaries (e.g., after a blob upload completes).
+//
+// Implements [reedsolomon.WorkAllocator].
+func (p *Pool) Put(buffers [][]byte) {
+	if len(buffers) == 0 {
+		return
+	}
+	// sort by data pointer: within one slab buffers land in ascending
+	// offset order, letting freeBatch use a monotonic coalesce hint and
+	// merge adjacent-in-memory buffers into single region insertions.
+	slices.SortFunc(buffers, func(a, b []byte) int {
+		return cmp.Compare(
+			uintptr(unsafe.Pointer(unsafe.SliceData(a))),
+			uintptr(unsafe.Pointer(unsafe.SliceData(b))),
+		)
+	})
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// walk sorted buffers, grouping consecutive same-slab runs; freeBatch
+	// then merges adjacent-in-memory regions within each run before coalescing.
+	for i := 0; i < len(buffers); {
+		var owner *slab
+		for _, s := range p.slabs {
+			if s.contains(buffers[i]) {
+				owner = s
+				break
+			}
+		}
+		if owner == nil {
+			i++
+			continue
+		}
+		j := i + 1
+		for j < len(buffers) && owner.contains(buffers[j]) {
+			j++
+		}
+		owner.freeBatch(buffers[i:j])
+		i = j
+	}
+}
+
+// Shrink releases fully-free slabs smallest-first. While the pool is
+// still active, a fully-free slab survives up to [freeSlabShrinkGrace]
+// shrink cycles before becoming evictable — this absorbs brief free/reuse
+// gaps during overlapping uploads. Once the pool goes fully idle all free
+// slabs are dropped immediately.
+func (p *Pool) Shrink() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// single pass: bump the idle counter on every free slab and note whether
+	// any slab is still in use.
+	fullyIdle := true
+	for _, s := range p.slabs {
+		if s.isFree() {
+			s.idleShrinks++
+		} else {
+			fullyIdle = false
+		}
+	}
+
+	for {
+		smallest := -1
+		for i, s := range p.slabs {
+			if !s.isFree() {
+				continue
+			}
+			if !fullyIdle && s.idleShrinks < freeSlabShrinkGrace {
+				continue // still within grace period
+			}
+			if smallest == -1 || s.size < p.slabs[smallest].size {
+				smallest = i
+			}
+		}
+		if smallest == -1 {
+			return
+		}
+		if p.slabs[smallest].mmapped {
+			_ = mmapFree(p.slabs[smallest].data)
+		}
+		p.slabs = slices.Delete(p.slabs, smallest, smallest+1)
+		p.evicts++
+	}
+}
+
+// Slabs returns the current number of slabs. Intended for observability.
+func (p *Pool) Slabs() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.slabs)
+}
+
+// Stats is a snapshot of pool capacity, fragmentation, and lifetime counters.
+type Stats struct {
+	Slabs          int   // number of slabs currently held
+	TotalBytes     int64 // sum of slab sizes (reserved capacity)
+	FreeBytes      int64 // sum of free regions across all slabs
+	LargestFreeRun int64 // largest contiguous free region in any single slab
+	Allocs         int64 // lifetime count of new-slab allocations
+	Evictions      int64 // lifetime count of slabs evicted by Shrink
+}
+
+// Stats returns a snapshot of pool capacity, fragmentation, and lifetime
+// counters. Intended for metrics/observability; takes the pool lock, so avoid
+// calling it on the hot path.
+func (p *Pool) Stats() Stats {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	st := Stats{
+		Slabs:     len(p.slabs),
+		Allocs:    p.allocs,
+		Evictions: p.evicts,
+	}
+	for _, s := range p.slabs {
+		free, maxRegion := s.stats()
+		st.TotalBytes += int64(s.size)
+		st.FreeBytes += int64(free)
+		if int64(maxRegion) > st.LargestFreeRun {
+			st.LargestFreeRun = int64(maxRegion)
+		}
+	}
+	return st
+}
+
+// slab is a contiguous SIMD-aligned byte region with a first-fit free-list.
+type slab struct {
+	data    []byte
+	size    int
+	mmapped bool // true if data was allocated via mmap (not Go heap)
+	regions []region
+
+	// idleShrinks counts consecutive Shrink calls this slab has been fully
+	// free. Reset to 0 on every successful alloc. Used by Shrink to apply a
+	// grace period before evicting burst-era slabs; see freeSlabShrinkGrace.
+	idleShrinks int
+}
+
+type region struct {
+	off, size int
+}
+
+// mmapThreshold is the minimum slab size for mmap. Smaller slabs use the
+// Go heap; larger ones use mmap so they stay invisible to GOGC's heap
+// doubling.
+const mmapThreshold = 1 << 20 // 1 MiB
+
+func newSlab(size int) *slab {
+	data, mmapped := allocBacking(size)
+	return &slab{
+		data:    data,
+		size:    len(data),
+		mmapped: mmapped,
+		regions: []region{{0, len(data)}},
+	}
+}
+
+// allocBacking returns an aligned byte slab of at least `size` bytes. Large
+// requests go through mmap (off-heap) when not disabled; everything else
+// goes through the SIMD-aligned Go-heap allocator.
+func allocBacking(size int) (data []byte, mmapped bool) {
+	if !disableMmap && size >= mmapThreshold {
+		if d, err := mmapAlloc(size); err == nil {
+			return d, true
+		}
+	}
+	return reedsolomon.AllocAligned(1, size)[0], false
+}
+
+// allocMany appends up to n buffers of size bytes to dst. Caller must hold
+// Pool.mu. Fast path: one contiguous region for best cache/TLB locality
+// (critical for RS FFT work buffers). Slow path: gathers scattered buffers
+// from individual free regions when no single region is large enough.
+func (s *slab) allocMany(dst [][]byte, n, size int) [][]byte {
+	if n == 0 {
+		return dst
+	}
+	if flat, ok := s.alloc(n * size); ok {
+		for i := range n {
+			// full-slice expression keeps sub-buffers from appending into neighbors.
+			dst = append(dst, flat[i*size:(i+1)*size:(i+1)*size])
+		}
+		return dst
+	}
+	for range n {
+		buf, ok := s.alloc(size)
+		if !ok {
+			break
+		}
+		dst = append(dst, buf)
+	}
+	return dst
+}
+
+func (s *slab) alloc(size int) ([]byte, bool) {
+	for i, r := range s.regions {
+		if r.size < size {
+			continue
+		}
+		// full-slice expression caps the buffer so a caller can't append
+		// past its length into adjacent regions.
+		buf := s.data[r.off : r.off+size : r.off+size]
+		if r.size == size {
+			s.regions = slices.Delete(s.regions, i, i+1)
+		} else {
+			s.regions[i] = region{r.off + size, r.size - size}
+		}
+		s.idleShrinks = 0
+		return buf, true
+	}
+	return nil, false
+}
+
+// stats returns total free bytes and the size of the largest contiguous free
+// region. Caller must hold Pool.mu. Used by [Pool.Stats].
+func (s *slab) stats() (free, maxRegion int) {
+	for _, r := range s.regions {
+		free += r.size
+		if r.size > maxRegion {
+			maxRegion = r.size
+		}
+	}
+	return free, maxRegion
+}
+
+func (s *slab) contains(buf []byte) bool {
+	if len(buf) == 0 {
+		return false
+	}
+	p := uintptr(unsafe.Pointer(unsafe.SliceData(buf)))
+	base := uintptr(unsafe.Pointer(unsafe.SliceData(s.data)))
+	return p >= base && p < base+uintptr(s.size)
+}
+
+// freeBatch coalesces a sorted-by-offset run of same-slab buffers: adjacent
+// ones merge into one region insertion, and a monotonic hint through
+// coalesceAt keeps each insertion amortized O(1).
+func (s *slab) freeBatch(bufs [][]byte) {
+	var hint int
+	base := uintptr(unsafe.Pointer(unsafe.SliceData(s.data)))
+	var run region // zero size means "no pending run"
+
+	flush := func() {
+		if run.size == 0 {
+			return
+		}
+		hint = s.coalesceAt(run, hint)
+		run = region{}
+	}
+
+	for _, buf := range bufs {
+		if len(buf) == 0 {
+			continue
+		}
+		off := int(uintptr(unsafe.Pointer(unsafe.SliceData(buf))) - base)
+		if off < 0 || len(buf) > s.size-off {
+			continue // defense against overshoot / misaligned sub-slice
+		}
+		if run.off+run.size == off && run.size > 0 {
+			run.size += len(buf)
+			continue
+		}
+		flush()
+		run = region{off, len(buf)}
+	}
+	flush()
+}
+
+func (s *slab) isFree() bool {
+	return len(s.regions) == 1 && s.regions[0].off == 0 && s.regions[0].size == s.size
+}
+
+// coalesceAt inserts r into the sorted regions list, merging with adjacent
+// regions. Scan starts at hint; returns r's final index so callers doing a
+// monotonic sequence of inserts can resume from there for amortized O(1).
+func (s *slab) coalesceAt(r region, hint int) int {
+	i := min(hint, len(s.regions))
+	for i < len(s.regions) && s.regions[i].off < r.off {
+		i++
+	}
+	s.regions = slices.Insert(s.regions, i, r)
+
+	if i+1 < len(s.regions) && s.regions[i].off+s.regions[i].size == s.regions[i+1].off {
+		s.regions[i].size += s.regions[i+1].size
+		s.regions = slices.Delete(s.regions, i+1, i+2)
+	}
+	if i > 0 && s.regions[i-1].off+s.regions[i-1].size == s.regions[i].off {
+		s.regions[i-1].size += s.regions[i].size
+		s.regions = slices.Delete(s.regions, i, i+1)
+		i--
+	}
+	return i
+}

--- a/fibre/internal/slab/slab_bench_test.go
+++ b/fibre/internal/slab/slab_bench_test.go
@@ -1,0 +1,227 @@
+package slab
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"testing"
+)
+
+// BenchmarkAllocContiguous measures the fast path: clean slab, contiguous allocation.
+func BenchmarkAllocContiguous(b *testing.B) {
+	cases := []struct {
+		name string
+		n    int
+		size int
+	}{
+		{"work/max_blob", 32768, 32832},
+		{"work/1MiB_blob", 32768, 320},
+		{"parity/max_blob", 12290, 32832},
+		{"parity/1MiB_blob", 12290, 320},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			p := New()
+			// warm up: first Get creates the slab.
+			w := p.Get(tc.n, tc.size)
+			p.Put(w)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				bufs := p.Get(tc.n, tc.size)
+				p.Put(bufs)
+			}
+		})
+	}
+}
+
+// BenchmarkAllocFragmented measures the slow path: slab fragmented by partial
+// frees, forcing scattered allocation.
+func BenchmarkAllocFragmented(b *testing.B) {
+	cases := []struct {
+		name string
+		n    int
+		size int
+	}{
+		{"parity/max_blob", 12290, 32832},
+		{"parity/1MiB_blob", 12290, 320},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			p := New()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				b.StopTimer()
+				// create fragmentation: allocate, free every other buffer.
+				bufs := p.Get(tc.n, tc.size)
+				odd := make([][]byte, 0, tc.n/2)
+				even := make([][]byte, 0, tc.n/2)
+				for i, buf := range bufs {
+					if i%2 == 0 {
+						even = append(even, buf)
+					} else {
+						odd = append(odd, buf)
+					}
+				}
+				p.Put(odd) // free half, creating fragmentation
+				b.StartTimer()
+
+				// allocate into the fragmented slab — measures scattered path.
+				more := p.Get(tc.n/2, tc.size)
+				p.Put(more)
+
+				b.StopTimer()
+				p.Put(even) // clean up
+				b.StartTimer()
+			}
+		})
+	}
+}
+
+// BenchmarkReuseAfterPartial models the production release→reuse pattern:
+// blob A allocates a group, one validator shard is released (shuffled
+// offsets, matching Set.Assign), then a follow-up Get of varying size
+// measures whether the freed holes get reused or a new slab grows.
+// Sizes model a small-medium blob to keep memory reasonable.
+func BenchmarkReuseAfterPartial(b *testing.B) {
+	const (
+		parityN = 514 // N+2 for a small-medium blob
+		rowSize = 512
+		shardN  = 64 // ~one validator's worth out of ~8
+	)
+	cases := []struct {
+		name  string
+		nextN int
+	}{
+		{"small", 32},      // fits entirely inside the freed holes
+		{"same-size", 514}, // forces a grow; measures grow + re-allocation
+	}
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			var totalSlabs, iters int
+
+			b.ReportAllocs()
+			for b.Loop() {
+				b.StopTimer()
+				p := New()
+				bufsA := p.Get(parityN, rowSize)
+				rng := rand.New(rand.NewPCG(42, 42))
+				perm := rng.Perm(parityN)[:shardN]
+				shard := make([][]byte, shardN)
+				for i, idx := range perm {
+					shard[i] = bufsA[idx]
+				}
+				p.Put(shard)
+				b.StartTimer()
+
+				_ = p.Get(tc.nextN, rowSize)
+
+				totalSlabs += p.Slabs()
+				iters++
+				_ = bufsA
+			}
+			if iters > 0 {
+				b.ReportMetric(float64(totalSlabs)/float64(iters), "slabs/op")
+			}
+		})
+	}
+}
+
+// BenchmarkAdaptiveGrow measures the grow path under simulated concurrent
+// demand: Gets stack up before any Puts, forcing successive slab grows sized
+// only to each request's remaining deficit.
+func BenchmarkAdaptiveGrow(b *testing.B) {
+	cases := []struct {
+		name       string
+		concurrent int // outstanding Gets at peak
+		n          int
+		size       int
+	}{
+		{"2x/parity", 2, 12290, 32832},
+		{"4x/parity", 4, 12290, 32832},
+		{"2x/small", 2, 4096, 320},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				p := New()
+				outstanding := make([][][]byte, 0, tc.concurrent)
+				for range tc.concurrent {
+					outstanding = append(outstanding, p.Get(tc.n, tc.size))
+				}
+				for _, bufs := range outstanding {
+					p.Put(bufs)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkPutPartial measures per-validator release. The "contiguous"
+// variant frees each validator's aligned chunk (cheap — coalesce merges
+// left). The "shuffled" variant mirrors Set.Assign's ChaCha8 shuffle with
+// validators releasing uniformly-random row subsets — the production
+// release pattern. Two validator counts cover the cases that matter: v=1
+// (one big Put) and v=10 (many small shuffled Puts). v=5 runs within 5%
+// of v=10 on all measured workloads.
+func BenchmarkPutPartial(b *testing.B) {
+	const n, size = 12290, 32832
+	validators := []int{1, 10}
+
+	for _, nval := range validators {
+		b.Run(fmt.Sprintf("contiguous/v=%d", nval), func(b *testing.B) {
+			p := New()
+			rowsPerVal := n / nval
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				bufs := p.Get(n, size)
+				for v := range nval {
+					start, end := v*rowsPerVal, (v+1)*rowsPerVal
+					if v == nval-1 {
+						end = n
+					}
+					p.Put(bufs[start:end])
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("shuffled/v=%d", nval), func(b *testing.B) {
+			p := New()
+			// precompute shuffled shards so the cost shows up in the measured
+			// Put path, not the shuffle setup.
+			rng := rand.New(rand.NewPCG(42, 42))
+			perm := rng.Perm(n)
+			per := n / nval
+			shards := make([][]int, nval)
+			for v := range nval {
+				start, end := v*per, (v+1)*per
+				if v == nval-1 {
+					end = n
+				}
+				shards[v] = perm[start:end]
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				bufs := p.Get(n, size)
+				shard := make([][]byte, 0, per+1)
+				for _, idxs := range shards {
+					shard = shard[:0]
+					for _, i := range idxs {
+						shard = append(shard, bufs[i])
+					}
+					p.Put(shard)
+				}
+			}
+		})
+	}
+}

--- a/fibre/internal/slab/slab_fuzz_test.go
+++ b/fibre/internal/slab/slab_fuzz_test.go
@@ -1,0 +1,108 @@
+package slab
+
+import (
+	"fmt"
+	"testing"
+)
+
+// FuzzPool exercises random Get/Put/Shrink sequences against the pool.
+// Each byte of the fuzz input drives one operation (high nibble = op code,
+// low nibble = parameter). After each op and at end-of-sequence the fuzzer
+// verifies structural invariants: regions are sorted, disjoint, in-bounds,
+// and fully coalesced.
+func FuzzPool(f *testing.F) {
+	f.Add([]byte{0x01, 0x02, 0x13, 0x21, 0x04, 0x30})
+	f.Add([]byte{0x05, 0x05, 0x05, 0x11, 0x11, 0x20})
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, ops []byte) {
+		p := New()
+		var outstanding [][][]byte
+
+		for _, op := range ops {
+			code := op >> 4
+			arg := int(op & 0x0F)
+
+			switch code & 0x03 {
+			case 0: // Get: n in [1,8], size in {64, 128}
+				n := (arg & 0x07) + 1
+				size := 64 << (arg >> 3 & 0x01) // 64 or 128
+				bufs := p.Get(n, size)
+				if len(bufs) != n {
+					t.Fatalf("Get(%d, %d) returned %d bufs", n, size, len(bufs))
+				}
+				// smoke-write so race detector would notice aliasing.
+				for i, buf := range bufs {
+					if len(buf) != size {
+						t.Fatalf("buf[%d] len=%d, want %d", i, len(buf), size)
+					}
+					buf[0] = byte(i)
+				}
+				outstanding = append(outstanding, bufs)
+
+			case 1: // Put: release the oldest outstanding Get
+				if len(outstanding) > 0 {
+					p.Put(outstanding[0])
+					outstanding = outstanding[1:]
+				}
+
+			case 2: // Put subset: release first half of the most recent Get
+				if len(outstanding) > 0 {
+					last := outstanding[len(outstanding)-1]
+					half := len(last) / 2
+					if half > 0 {
+						p.Put(last[:half])
+						outstanding[len(outstanding)-1] = last[half:]
+					}
+				}
+
+			case 3: // Shrink
+				p.Shrink()
+			}
+			assertSlabInvariants(t, p)
+		}
+
+		// drain any remaining outstanding and re-check end-state invariants.
+		for _, bufs := range outstanding {
+			p.Put(bufs)
+		}
+		assertSlabInvariants(t, p)
+		p.Shrink()
+		if slabs := p.Slabs(); slabs != 0 {
+			t.Fatalf("Slabs=%d after drain+Shrink, want 0", slabs)
+		}
+	})
+}
+
+// assertSlabInvariants checks that every slab's regions list is sorted,
+// disjoint, within bounds, and fully coalesced (no adjacent regions that
+// should have merged). Test-only; accesses internal fields directly.
+func assertSlabInvariants(t *testing.T, p *Pool) {
+	t.Helper()
+	for si, s := range p.slabs {
+		for i, r := range s.regions {
+			if err := regionError(s, i, r); err != "" {
+				t.Fatalf("slab[%d]: %s", si, err)
+			}
+		}
+	}
+}
+
+func regionError(s *slab, i int, r region) string {
+	if r.size <= 0 {
+		return fmt.Sprintf("region[%d] non-positive size %d", i, r.size)
+	}
+	if r.off < 0 || r.off+r.size > s.size {
+		return fmt.Sprintf("region[%d] out of bounds off=%d size=%d slab=%d", i, r.off, r.size, s.size)
+	}
+	if i > 0 {
+		prev := s.regions[i-1]
+		if r.off < prev.off+prev.size {
+			return fmt.Sprintf("region[%d] overlaps region[%d]: %+v vs %+v", i-1, i, prev, r)
+		}
+		if r.off == prev.off+prev.size {
+			return fmt.Sprintf("region[%d] adjacent to region[%d] (coalesce miss): %+v, %+v", i-1, i, prev, r)
+		}
+	}
+	return ""
+}

--- a/fibre/internal/slab/slab_test.go
+++ b/fibre/internal/slab/slab_test.go
@@ -1,0 +1,222 @@
+package slab
+
+import (
+	"bytes"
+	"sync"
+	"testing"
+)
+
+func TestPool_GetPut(t *testing.T) {
+	p := New()
+
+	bufs := p.Get(4, 32)
+	if len(bufs) != 4 {
+		t.Fatalf("Get returned %d bufs, want 4", len(bufs))
+	}
+	for i, b := range bufs {
+		if len(b) != 32 {
+			t.Fatalf("bufs[%d] len=%d, want 32", i, len(b))
+		}
+	}
+
+	// writes to separate buffers must not alias
+	for i, b := range bufs {
+		for j := range b {
+			b[j] = byte(i + 1)
+		}
+	}
+	for i, b := range bufs {
+		if !bytes.Equal(b, bytes.Repeat([]byte{byte(i + 1)}, 32)) {
+			t.Fatalf("bufs[%d] corrupted by neighbor write", i)
+		}
+	}
+
+	p.Put(bufs)
+}
+
+func TestPool_GrowsAndShrinks(t *testing.T) {
+	p := New()
+
+	a := p.Get(4, 64) // creates first slab (256 bytes)
+	b := p.Get(4, 64) // first slab full, grows second
+	if p.Slabs() != 2 {
+		t.Fatalf("Slabs()=%d after growth, want 2", p.Slabs())
+	}
+
+	p.Put(a)
+	p.Put(b)
+	// put does not shrink — slabs retained for reuse.
+	if p.Slabs() != 2 {
+		t.Fatalf("Slabs()=%d after Put, want 2 (no shrink)", p.Slabs())
+	}
+	// explicit Shrink releases fully-free slabs once the pool goes idle.
+	p.Shrink()
+	if p.Slabs() != 0 {
+		t.Fatalf("Slabs()=%d after idle Shrink, want 0", p.Slabs())
+	}
+}
+
+func TestPool_GrowUsesOnlyDeficit(t *testing.T) {
+	p := New()
+
+	a := p.Get(2, 64) // slab1 = 128
+	b := p.Get(4, 64) // slab2 should match the unsatisfied deficit: 256
+	if got := p.Slabs(); got != 2 {
+		t.Fatalf("Slabs()=%d, want 2", got)
+	}
+	if got := p.slabs[1].size; got != 256 {
+		t.Fatalf("slab2 size=%d, want 256", got)
+	}
+
+	p.Put(a)
+	p.Put(b)
+}
+
+func TestPool_ScatteredGet(t *testing.T) {
+	p := New()
+
+	// create a slab with a hole in the middle
+	a := p.Get(1, 64) // [0..64)
+	b := p.Get(1, 64) // [64..128)
+	c := p.Get(1, 64) // [128..192)
+
+	// free the middle one, creating a hole
+	p.Put(b)
+
+	// get 2 buffers — should gather from the hole + grow or use remaining space
+	d := p.Get(2, 64)
+	if len(d) != 2 {
+		t.Fatalf("scattered Get returned %d, want 2", len(d))
+	}
+
+	// verify no aliasing
+	for j := range d[0] {
+		d[0][j] = 0xAA
+	}
+	for j := range d[1] {
+		d[1][j] = 0xBB
+	}
+	if d[0][0] == d[1][0] {
+		t.Fatal("scattered buffers alias")
+	}
+
+	p.Put(a)
+	p.Put(c)
+	p.Put(d)
+}
+
+func TestPool_SmallBlobsPack(t *testing.T) {
+	p := New()
+
+	// first Get creates a slab of 640 bytes; Put doesn't shrink so it stays.
+	first := p.Get(10, 64)
+	p.Put(first)
+
+	// 10 individual Gets should reuse the retained slab.
+	handles := make([][]byte, 0, 10)
+	for range 10 {
+		bufs := p.Get(1, 64)
+		handles = append(handles, bufs...)
+	}
+	if p.Slabs() != 1 {
+		t.Fatalf("Slabs()=%d, want 1 (all should fit)", p.Slabs())
+	}
+	for _, b := range handles {
+		p.Put([][]byte{b})
+	}
+}
+
+func TestPool_MixedSizes(t *testing.T) {
+	p := New()
+
+	large := p.Get(1, 512)
+	small1 := p.Get(1, 128)
+	small2 := p.Get(1, 128)
+
+	// free the large region, allocate something else in the gap
+	p.Put(large)
+	medium := p.Get(1, 256) // fits in the freed 512-byte gap
+	if len(medium) != 1 {
+		t.Fatal("medium alloc failed")
+	}
+
+	p.Put(small1)
+	p.Put(small2)
+	p.Put(medium)
+}
+
+func TestPool_PartialFree(t *testing.T) {
+	p := New()
+
+	bufs := p.Get(8, 64) // 512 bytes in one slab
+
+	// free odd-indexed buffers, leaving 4 scattered holes.
+	p.Put([][]byte{bufs[1], bufs[3], bufs[5], bufs[7]})
+
+	// a smaller follow-up Get should weave into the freed holes without
+	// needing a second slab.
+	more := p.Get(4, 64)
+	if len(more) != 4 {
+		t.Fatalf("got %d, want 4", len(more))
+	}
+	if p.Slabs() != 1 {
+		t.Fatalf("Slabs()=%d, want 1 (freed slots should be reused)", p.Slabs())
+	}
+
+	p.Put([][]byte{bufs[0], bufs[2], bufs[4], bufs[6]})
+	p.Put(more)
+}
+
+func TestPool_ShrinkGraceWhileActive(t *testing.T) {
+	p := New()
+
+	a := p.Get(2, 64) // slab1 = 128, stays live
+	b := p.Get(4, 64) // slab2 = 256, becomes the free candidate
+	if p.Slabs() != 2 {
+		t.Fatalf("Slabs()=%d, want 2", p.Slabs())
+	}
+	p.Put(b)
+
+	// first terminal boundary while another slab is still live: the grace
+	// period keeps the free slab warm rather than evicting it immediately.
+	p.Shrink()
+	if p.Slabs() != 2 {
+		t.Fatalf("Slabs()=%d after first active Shrink, want 2", p.Slabs())
+	}
+	if got := p.slabs[1].idleShrinks; got != 1 {
+		t.Fatalf("idleShrinks=%d after first active Shrink, want 1", got)
+	}
+
+	// second terminal boundary with the same active/free split ages the free
+	// slab past the grace period, so it becomes evictable.
+	p.Shrink()
+	if p.Slabs() != 1 {
+		t.Fatalf("Slabs()=%d after second active Shrink, want 1", p.Slabs())
+	}
+
+	p.Put(a)
+}
+
+func TestPool_Concurrent(t *testing.T) {
+	p := New()
+
+	const goroutines = 16
+	const iters = 200
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for range iters {
+				bufs := p.Get(4, 32)
+				for _, b := range bufs {
+					for i := range b {
+						b[i] = byte(id)
+					}
+				}
+				p.Put(bufs)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/fibre/row_assembler.go
+++ b/fibre/row_assembler.go
@@ -1,0 +1,271 @@
+package fibre
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/celestiaorg/celestia-app/v9/fibre/internal/slab"
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+	"github.com/klauspost/reedsolomon"
+)
+
+// RowAssembler assembles K+N row sets for Reed-Solomon encoding.
+//
+// Original rows are a hybrid view over the input data (zero-copy where
+// possible); parity rows come from a dedicated slab-backed parity pool, while
+// the RS encoder draws its large scratch buffers from a separate work pool via
+// [RowAssembler.WorkAllocator]. The pools are intentionally split: sharing one
+// free-list across these two allocation classes caused severe external
+// fragmentation and slab churn under concurrent uploads.
+//
+// The pools grow on demand when concurrent encodings exceed the initial
+// capacity and shrink back when excess slabs become fully free.
+//
+// RowAssembler is safe for concurrent use.
+type RowAssembler struct {
+	codec *rsema1d.Config
+
+	// parityPool backs Assemble (parity rows + head + tail). Slabs here are
+	// sized around N*rowSize; keeping them in a dedicated pool prevents the
+	// much larger work requests from fragmenting them.
+	parityPool *slab.Pool
+
+	// workPool backs [RowAssembler.WorkAllocator]. The RS encoder asks for
+	// one large contiguous scratch region per encode; keeping work in its
+	// own pool means parity allocations never carve holes in a work slab.
+	workPool *slab.Pool
+
+	zeroRow []byte
+}
+
+// NewRowAssembler creates a RowAssembler backed by slab pools with rows
+// up to maxRowSize bytes.
+//
+// The returned assembler's work pool also provides buffers for the RS
+// encoder via [RowAssembler.WorkAllocator].
+//
+// Large slabs are allocated off-heap via mmap and are only released when they
+// become fully free and [Pool.Shrink] drops them. There is currently no
+// explicit Close/Destroy API, so callers should treat RowAssembler as a
+// long-lived object and reuse it rather than constructing one per blob.
+func NewRowAssembler(codec *rsema1d.Config, maxRowSize int) (*RowAssembler, error) {
+	if err := codec.Validate(); err != nil {
+		return nil, fmt.Errorf("invalid codec config: %w", err)
+	}
+	if maxRowSize < 64 || maxRowSize%64 != 0 {
+		return nil, fmt.Errorf("maxRowSize must be a positive multiple of 64, got %d", maxRowSize)
+	}
+
+	return &RowAssembler{
+		codec:      codec,
+		parityPool: slab.New(),
+		workPool:   slab.New(),
+		zeroRow:    reedsolomon.AllocAligned(1, maxRowSize)[0],
+	}, nil
+}
+
+// WorkAllocator returns a [reedsolomon.WorkAllocator] backed by the
+// assembler's work pool. Pass it to [reedsolomon.WithWorkAllocator] when
+// constructing the RS encoder.
+func (a *RowAssembler) WorkAllocator() reedsolomon.WorkAllocator {
+	return a.workPool
+}
+
+// Assemble returns K+N rows for encoding data with the given rowSize.
+//
+// rows[:K] are original rows: row 0 reserves firstRowOffset bytes for a
+// header, full middle rows alias data directly (zero-copy), a partial tail
+// row is copied to a pooled buffer, and empty trailing rows share one
+// zeroed row.
+// rows[K:] are zeroed parity rows from pooled storage.
+//
+// The caller must not modify data or rows until [Assembly.Free] is called.
+// Rows that alias data or the shared zero row are immutable.
+func (a *RowAssembler) Assemble(data []byte, rowSize, firstRowOffset int) (rows [][]byte, asm *Assembly) {
+	rows = make([][]byte, a.codec.K+a.codec.N)
+
+	// n parity rows + head + tail, all from one slab.
+	pooled := a.parityPool.Get(a.codec.N+extraRows, rowSize)
+	for i := range a.codec.N {
+		rows[a.codec.K+i] = pooled[i]
+		clear(pooled[i])
+	}
+	head, tail := pooled[a.codec.N], pooled[a.codec.N+1]
+	a.fillOriginal(rows[:a.codec.K], data, rowSize, firstRowOffset, head, tail)
+
+	return rows, &Assembly{
+		pool:     a.parityPool,
+		workPool: a.workPool,
+		slots:    pooled,
+		rows:     rows,
+		k:        a.codec.K,
+	}
+}
+
+// fillOriginal populates original rows as a hybrid view over data.
+// head hosts row 0 (prefix offset + data start); tail hosts any partial
+// trailing row; full middle rows alias data directly; empty rows share a
+// read-only zero row.
+func (a *RowAssembler) fillOriginal(rows [][]byte, data []byte, rowSize, offset int, head, tail []byte) {
+	rows[0] = head
+	clear(head)
+	n := min(rowSize-offset, len(data))
+	copy(head[offset:], data[:n])
+
+	i := 1
+	for i < len(rows) && n+rowSize <= len(data) {
+		rows[i] = data[n : n+rowSize]
+		n += rowSize
+		i++
+	}
+
+	if i < len(rows) && n < len(data) {
+		rows[i] = tail
+		clear(tail)
+		copy(tail, data[n:])
+		i++
+	}
+
+	if i < len(rows) {
+		zero := a.zeroRow[:rowSize]
+		for j := i; j < len(rows); j++ {
+			rows[j] = zero
+		}
+	}
+}
+
+// extraRows is the pooled slot count beyond parity: head + tail.
+const extraRows = 2
+
+// Assembly owns the pooled row storage produced by a single
+// [RowAssembler.Assemble] call. Callers incrementally release parity rows via
+// [Assembly.Free] with global blob indices, and finalize with a nil argument
+// to return any remaining rows to the parity pool.
+//
+// Assembly is safe for concurrent use. The internal lock is a RWMutex so
+// that the hot read path (Blob.Row → Freed) can proceed in parallel across
+// validator goroutines; Free takes the exclusive side briefly to mutate
+// slots/rows.
+type Assembly struct {
+	mu       sync.RWMutex
+	pool     *slab.Pool // parity pool; owns slots
+	workPool *slab.Pool // work pool; shrunk alongside parity on terminal release
+	slots    [][]byte   // [N parity..., head, tail]; nil entries mean freed
+	rows     [][]byte   // K+N assembled view; nil'd per-row on partial Free, whole slice on terminal Free
+	k        int        // K; translates global blob indices to parity offsets
+}
+
+// Rows returns the K+N assembled row view. Returns nil after terminal Free.
+// Entries for rows released via partial Free are set to nil — the view
+// always reflects currently-live row data without exposing stale pool memory.
+//
+// The returned slice shares its backing array with the Assembly; callers
+// must not use it concurrently with Free, which mutates entries. In practice
+// Rows is intended for the encode phase before any Free has been issued.
+func (a *Assembly) Rows() [][]byte {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.rows
+}
+
+// Freed reports whether the pooled slot for the given global blob row index
+// has been freed. Terminally-freed Assemblies (after Free(nil)) report true
+// for every index.
+//
+// Original rows (rowIndex < K) only become freed on terminal release, since
+// partial frees only affect parity slots. Parity rows (>= K) are freed
+// individually.
+//
+// Synchronized internally; safe to call concurrently with Free.
+func (a *Assembly) Freed(rowIndex int) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	if a.slots == nil {
+		return true
+	}
+	parity := len(a.slots) - extraRows
+	off := rowIndex - a.k
+	if off < 0 || off >= parity {
+		return false
+	}
+	return a.slots[off] == nil
+}
+
+// Free releases pooled row storage.
+//
+// When rowIndices is non-nil, parity rows at the given global blob indices
+// (>= K) are freed back to the slab pool for immediate reuse; indices < K
+// and already-freed entries are ignored. The Assembly stays alive for
+// further calls and [Freed] reflects the updated state.
+//
+// When rowIndices is nil, all remaining rows (including head and tail) are
+// freed and the row-header slice is returned to the assembler's cache;
+// subsequent calls are no-ops.
+//
+// Safe to call concurrently.
+func (a *Assembly) Free(rowIndices []int) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.slots == nil {
+		return
+	}
+	if rowIndices == nil {
+		a.freeAll()
+	} else {
+		a.freeSubset(rowIndices)
+	}
+}
+
+// freeAll returns every remaining pooled buffer to the slab pool and
+// triggers a lifecycle-boundary Shrink on both pools. Caller must hold
+// a.mu and have verified a.slots != nil.
+func (a *Assembly) freeAll() {
+	toFree := make([][]byte, 0, len(a.slots))
+	for _, b := range a.slots {
+		if b != nil {
+			toFree = append(toFree, b)
+		}
+	}
+	if len(toFree) > 0 {
+		a.pool.Put(toFree)
+	}
+	// shrink at blob lifecycle boundary: release excess slabs that
+	// accumulated during concurrent uploads. Work slabs already came back
+	// to workPool when RS encoding finished, so shrinking it here picks up
+	// any burst-era slabs that are no longer needed.
+	a.pool.Shrink()
+	a.workPool.Shrink()
+	a.slots = nil
+	a.rows = nil
+}
+
+// freeSubset returns parity rows at the given global blob indices (>= K)
+// to the slab pool and nils out their entries in the header slice so
+// Rows() never hands out stale pool memory. Indices < K and already-freed
+// entries are ignored. Caller must hold a.mu and have verified
+// a.slots != nil.
+func (a *Assembly) freeSubset(rowIndices []int) {
+	parity := len(a.slots) - extraRows
+	toFree := make([][]byte, 0, len(rowIndices))
+	for _, idx := range rowIndices {
+		off := idx - a.k
+		if off >= 0 && off < parity && a.slots[off] != nil {
+			toFree = append(toFree, a.slots[off])
+			a.slots[off] = nil
+			a.rows[idx] = nil
+		}
+	}
+	if len(toFree) > 0 {
+		a.pool.Put(toFree)
+	}
+}

--- a/fibre/row_assembler_bench_test.go
+++ b/fibre/row_assembler_bench_test.go
@@ -1,0 +1,129 @@
+package fibre
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+)
+
+// BenchmarkAssemblyFreed measures the Assembly.Freed hot path. During
+// upload each per-validator goroutine calls Blob.Row → Assembly.Freed
+// once per assigned row — thousands of calls total, hundreds of
+// goroutines concurrent. The lock on Assembly is the bottleneck here.
+// The parallel variant is the one that exposes reader-vs-reader contention.
+func BenchmarkAssemblyFreed(b *testing.B) {
+	codec := &rsema1d.Config{K: 4096, N: 12288, WorkerCount: 1}
+	a, err := NewRowAssembler(codec, 32832)
+	if err != nil {
+		b.Fatal(err)
+	}
+	// Tiny data — we only care about Freed latency, not encoding cost.
+	data := []byte("x")
+	_, asm := a.Assemble(data, 64, 0)
+	defer asm.Free(nil)
+
+	totalRows := codec.K + codec.N
+
+	b.Run("serial", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		i := 0
+		for b.Loop() {
+			_ = asm.Freed(i % totalRows)
+			i++
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			i := 0
+			for pb.Next() {
+				_ = asm.Freed(i % totalRows)
+				i++
+			}
+		})
+	})
+}
+
+func BenchmarkRowAssemblerAssembleRelease(b *testing.B) {
+	codec := &rsema1d.Config{K: 4096, N: 12288, WorkerCount: 1}
+	cases := []struct {
+		name    string
+		rowSize int
+	}{
+		{"64", 64},
+		{"1024", 1024},
+		{"32832", 32832},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			a, err := NewRowAssembler(codec, 32832)
+			if err != nil {
+				b.Fatal(err)
+			}
+			dataLen := max(1, tc.rowSize-5)
+			data := make([]byte, dataLen)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				rows, rel := a.Assemble(data, tc.rowSize, 5)
+				rows[0][0]++
+				rel.Free(nil)
+			}
+		})
+	}
+}
+
+func BenchmarkRowAssemblerEncode(b *testing.B) {
+	cases := []struct {
+		name       string
+		k, n       int
+		rowSize    int
+		maxRowSize int
+	}{
+		{"32x32x64", 32, 32, 64, 256},
+		{"256x256x1024", 256, 256, 1024, 4096},
+		{"256x256x4096", 256, 256, 4096, 4096},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			codec := &rsema1d.Config{K: tc.k, N: tc.n, WorkerCount: 1}
+			coder, err := rsema1d.NewCoder(codec)
+			if err != nil {
+				b.Fatal(err)
+			}
+			a, err := NewRowAssembler(codec, tc.maxRowSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			data := make([]byte, max(1, tc.k*tc.rowSize-5))
+			for i := range data {
+				data[i] = byte(i)
+			}
+
+			// warm up
+			rows, rel := a.Assemble(data, tc.rowSize, 5)
+			if _, err := coder.Encode(rows); err != nil {
+				b.Fatal(err)
+			}
+			rel.Free(nil)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.k * tc.rowSize))
+			b.ResetTimer()
+			for b.Loop() {
+				rows, rel := a.Assemble(data, tc.rowSize, 5)
+				if _, err := coder.Encode(rows); err != nil {
+					b.Fatal(err)
+				}
+				rel.Free(nil)
+			}
+		})
+	}
+}

--- a/fibre/row_assembler_test.go
+++ b/fibre/row_assembler_test.go
@@ -1,0 +1,173 @@
+package fibre
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+)
+
+func TestRowAssembler_Assemble(t *testing.T) {
+	codec := &rsema1d.Config{K: 4, N: 2, WorkerCount: 1}
+	a, err := NewRowAssembler(codec, 256)
+	if err != nil {
+		t.Fatalf("NewRowAssembler: %v", err)
+	}
+
+	rowSize := 64
+	offset := 5
+	// data spans: partial first row + 1 full row + 3 bytes into a third row
+	data := make([]byte, rowSize-offset+rowSize+3)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	rows, rel := a.Assemble(data, rowSize, offset)
+	defer rel.Free(nil)
+
+	if len(rows) != codec.K+codec.N {
+		t.Fatalf("got %d rows, want %d", len(rows), codec.K+codec.N)
+	}
+	for i, row := range rows {
+		if len(row) != rowSize {
+			t.Fatalf("row %d: len %d, want %d", i, len(row), rowSize)
+		}
+	}
+
+	// full middle row aliases input data
+	fullRowStart := rowSize - offset
+	rows[1][0] ^= 0xFF
+	if rows[1][0] != data[fullRowStart] {
+		t.Fatal("full middle row does not alias input data")
+	}
+
+	// partial tail row is a copy, not an alias
+	tailStart := fullRowStart + rowSize
+	rows[2][0] ^= 0xFF
+	if rows[2][0] == data[tailStart] {
+		t.Fatal("partial tail row unexpectedly aliases input data")
+	}
+
+	// empty original rows share a single backing array
+	for i := 3; i < codec.K; i++ {
+		if &rows[3][0] != &rows[i][0] {
+			t.Fatal("empty original rows do not share the zero row")
+		}
+	}
+
+	// parity rows are zeroed
+	for i := codec.K; i < codec.K+codec.N; i++ {
+		for j, b := range rows[i] {
+			if b != 0 {
+				t.Fatalf("parity row %d byte %d = %d, want 0", i, j, b)
+			}
+		}
+	}
+}
+
+func TestRowAssembler_InvalidConfig(t *testing.T) {
+	codec := &rsema1d.Config{K: 32, N: 32, WorkerCount: 1}
+	if _, err := NewRowAssembler(codec, 63); err == nil {
+		t.Fatal("expected error for non-multiple-of-64 maxRowSize")
+	}
+}
+
+// TestRowAssembler_ReuseDirty verifies that reusing the assembler does not
+// leak state between encodes: parity rows are zeroed on reallocation and the
+// pooled encoding matches a fresh from-scratch encoding of the same data.
+func TestRowAssembler_ReuseDirty(t *testing.T) {
+	const k, n, rowSize, offset = 4, 4, 64, 7
+	codec := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
+	coder, _ := rsema1d.NewCoder(codec)
+	a, _ := NewRowAssembler(codec, 256)
+
+	// first encode dirties parity slots in the pool
+	data1 := make([]byte, k*rowSize-offset)
+	for i := range data1 {
+		data1[i] = byte(i + 1)
+	}
+	rows1, rel1 := a.Assemble(data1, rowSize, offset)
+	if _, err := coder.Encode(rows1); err != nil {
+		t.Fatalf("first Encode: %v", err)
+	}
+	rel1.Free(nil)
+
+	// second encode — parity must be clean on reuse
+	data2 := make([]byte, k*rowSize-offset)
+	for i := range data2 {
+		data2[i] = byte(i*3 + 7)
+	}
+	rows2, rel2 := a.Assemble(data2, rowSize, offset)
+	defer rel2.Free(nil)
+
+	for i := k; i < k+n; i++ {
+		for j, b := range rows2[i] {
+			if b != 0 {
+				t.Fatalf("parity row %d byte %d = %d, want 0", i, j, b)
+			}
+		}
+	}
+
+	// pooled commitment must match a fresh from-scratch encoding
+	extPool, err := coder.Encode(rows2)
+	if err != nil {
+		t.Fatalf("pooled Encode: %v", err)
+	}
+	extFresh, err := coder.Encode(freshRows(data2, k+n, rowSize, offset))
+	if err != nil {
+		t.Fatalf("fresh Encode: %v", err)
+	}
+	if extPool.Commitment() != extFresh.Commitment() {
+		t.Fatal("pooled and fresh commitments differ")
+	}
+}
+
+// freshRows rebuilds the K+N row layout that Assemble produces, using fresh
+// allocations instead of pooled storage. Used by ReuseDirty to cross-check.
+func freshRows(data []byte, total, rowSize, offset int) [][]byte {
+	rows := make([][]byte, total)
+	for i := range rows {
+		rows[i] = make([]byte, rowSize)
+	}
+	head := min(rowSize-offset, len(data))
+	copy(rows[0][offset:], data[:head])
+	for i, off := 1, head; i < total && off < len(data); i++ {
+		n := copy(rows[i], data[off:])
+		off += n
+	}
+	return rows
+}
+
+// TestAssembly_Free covers partial + terminal release semantics with the
+// observable checks (Rows() reflects partial frees, Freed() reports per-row
+// state, repeated/out-of-range calls are no-ops).
+func TestAssembly_Free(t *testing.T) {
+	codec := &rsema1d.Config{K: 4, N: 4, WorkerCount: 1}
+	a, _ := NewRowAssembler(codec, 256)
+
+	data := make([]byte, 4*64-3)
+	_, asm := a.Assemble(data, 64, 3)
+
+	// partial: K=4, so parity indices 5 and 7 map to parity offsets 1 and 3.
+	asm.Free([]int{5, 7})
+	// indices < K (original rows) are ignored; duplicate release is a no-op.
+	asm.Free([]int{0, 1, 2, 3, 5})
+
+	rows := asm.Rows()
+	for _, i := range []int{5, 7} {
+		if rows[i] != nil || !asm.Freed(i) {
+			t.Fatalf("row %d should be freed", i)
+		}
+	}
+	for _, i := range []int{0, 4, 6} { // head, first parity, non-freed parity
+		if rows[i] == nil || asm.Freed(i) {
+			t.Fatalf("row %d should still be live", i)
+		}
+	}
+
+	// terminal: frees remaining rows + header, idempotent.
+	asm.Free(nil)
+	asm.Free(nil)
+	if asm.Rows() != nil {
+		t.Fatal("Rows() should be nil after terminal Free")
+	}
+}

--- a/fibre/server_download_test.go
+++ b/fibre/server_download_test.go
@@ -156,7 +156,7 @@ func storeTestShard(t *testing.T, server *fibre.Server, blob *fibre.Blob) {
 	}
 
 	// flatten RLC coefficients for storage
-	rlcCoeffs := blob.RLCCoeffs()
+	rlcCoeffs := blob.RLC()
 	coeffBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, c := range rlcCoeffs {
 		b := field.ToBytes128(c)

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -206,8 +206,8 @@ func makeTestRequest(
 		}
 	}
 
-	// flatten RLC coefficients
-	rlcCoeffs := blob.RLCCoeffs()
+	// flatten RLC values
+	rlcCoeffs := blob.RLC()
 	rlcCoeffsBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, coeff := range rlcCoeffs {
 		b := field.ToBytes128(coeff)

--- a/fibre/store_bench_test.go
+++ b/fibre/store_bench_test.go
@@ -200,7 +200,8 @@ func BenchmarkStoreWriteRowsConcurrent(b *testing.B) {
 }
 
 func benchmarkStoreWriteRows(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -306,7 +307,8 @@ func benchmarkStoreWriteRows(b *testing.B, params fibre.ProtocolParams, validato
 }
 
 func benchmarkStoreWriteRowsConcurrent(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int, concurrency int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -527,7 +529,8 @@ func BenchmarkStoreReadRowsConcurrent(b *testing.B) {
 }
 
 func benchmarkStoreReadRows(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -615,7 +618,8 @@ func benchmarkStoreReadRows(b *testing.B, params fibre.ProtocolParams, validator
 }
 
 func benchmarkStoreReadRowsConcurrent(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int, concurrency int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -331,7 +331,7 @@ func makeShardWithRLC(t *testing.T, blob *fibre.Blob, indices ...int) *types.Blo
 	t.Helper()
 	shard := makeShardFrom(t, blob, indices...)
 
-	rlcCoeffs := blob.RLCCoeffs()
+	rlcCoeffs := blob.RLC()
 	coeffBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, c := range rlcCoeffs {
 		b := field.ToBytes128(c)

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-metrics v0.5.4
 	github.com/joho/godotenv v1.5.1
-	github.com/klauspost/reedsolomon v1.13.3
+	github.com/klauspost/reedsolomon v1.13.4-0.20260417105544-abb0a41f06dd
 	github.com/pelletier/go-toml/v2 v2.3.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -849,8 +849,8 @@ github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBF
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/klauspost/reedsolomon v1.13.3 h1:01GwnO2xoCSaM0ShP4qwl+FsHg3csFShC6Tu/RS1ji0=
-github.com/klauspost/reedsolomon v1.13.3/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
+github.com/klauspost/reedsolomon v1.13.4-0.20260417105544-abb0a41f06dd h1:vPOAxcsoDSz9n2Ye1aMDkPYoUrgAXrGMJ87WZUkNA5Q=
+github.com/klauspost/reedsolomon v1.13.4-0.20260417105544-abb0a41f06dd/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/pkg/rsema1d/coder.go
+++ b/pkg/rsema1d/coder.go
@@ -15,12 +15,15 @@ type Coder struct {
 }
 
 // NewCoder creates a Coder with cached Reed-Solomon encoder.
-func NewCoder(cfg *Config) (*Coder, error) {
+// Optional reedsolomon.Option values are forwarded to the underlying encoder
+// (e.g., reedsolomon.WithWorkAllocator to control work buffer allocation).
+func NewCoder(cfg *Config, opts ...reedsolomon.Option) (*Coder, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	enc, err := reedsolomon.New(cfg.K, cfg.N, reedsolomon.WithLeopardGF16(true))
+	rsOpts := append([]reedsolomon.Option{reedsolomon.WithLeopardGF16(true)}, opts...)
+	enc, err := reedsolomon.New(cfg.K, cfg.N, rsOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encoder: %w", err)
 	}

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -193,7 +193,7 @@ require (
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.5 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/klauspost/reedsolomon v1.13.3 // indirect
+	github.com/klauspost/reedsolomon v1.13.4-0.20260417105544-abb0a41f06dd // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.12.3 // indirect

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -651,8 +651,8 @@ github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBF
 github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/klauspost/reedsolomon v1.13.3 h1:01GwnO2xoCSaM0ShP4qwl+FsHg3csFShC6Tu/RS1ji0=
-github.com/klauspost/reedsolomon v1.13.3/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
+github.com/klauspost/reedsolomon v1.13.4-0.20260417105544-abb0a41f06dd h1:vPOAxcsoDSz9n2Ye1aMDkPYoUrgAXrGMJ87WZUkNA5Q=
+github.com/klauspost/reedsolomon v1.13.4-0.20260417105544-abb0a41f06dd/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
> [!IMPORTANT]
> Please read the summary carefully to understand the motivation behind such a change

## Summary
Fibre's Reed-Solomon encoding is memory-hungry by nature: every in-flight encode keeps roughly 8× the blob size resident: one copy of the original data, three copies for parity rows, and four copies of FFT scratch space. With 128 MiB blobs and a dozen concurrent uploads(throughput agentic payments targets), that's more than ten gigabytes of large, short-lived buffers churning through the heap. On modestly-sized validator nodes, this is genuinely hard to fit.

The first attempt (#7069) assumed Go's `sync.Pool` would absorb the churn. It doesn't. `sync.Pool` is tied to the garbage collector, and buffers this large trigger collections frequently enough that the pool never actually retains anything. Every encode ends up allocating fresh, and freed pages linger long enough that resident memory grows to several times the live working set. Meanwhile, the GC's heap-doubling behavior stacks successive allocations on top of each other, pushing memory-constrained nodes into OOMs before the pool has a chance to help. Essentially, the Go runtime is not suitable for this type of encoding workflow, especially if the encoding fibre client is intended to be embedded by other processes. 

However, the workload is a good fit for explicit memory management (and I would argue even requires it): allocations are large, predictable, and bound to a clear lifecycle event (the end of a blob's upload) rather than to GC timing. That's an unusual shape for a Go program, but it's the same shape embedded databases like pebble and badger deal with, and they reach for the same solution. This PR introduces a small slab allocator that owns fibre's encoding buffers directly, grows only when real demand appears, hands regions back to the OS when they stop being used, and is otherwise invisible to the GC.

The encoder retrieves these buffers via the new `WorkAllocator` interface added upstream in [klauspost/reedsolomon#331](https://github.com/klauspost/reedsolomon/pull/331), enabling full control over allocations for the work buffers during the encoding.

The allocator, its tradeoffs, and the reasoning behind each design choice are documented in [`fibre/internal/slab/DESIGN.md`](fibre/internal/slab/DESIGN.md). It felt necessary to make a design document, given the complexity this may bring to the codebase.

## Commits
The total number of changes is rather large, so they are split into two commits, and those commits should be reviewed independently. Most of those changes are auxiliary, like tests, benchmarks, and fuzzing, so hopefully the actual code review won't be that big of an issue. If changes are perceived as large, I can spend time sharding them further.

1. **`perf(fibre): slab-backed pool allocator for RS work + parity buffers`** — the allocator itself, with tests, benchmarks, a fuzzer, and the design doc.
2. **`feat(fibre): add RowAssembler for zero-allocation blob encoding`** — integration through `RowAssembler` / `Assembly`, which owns pooled storage across an encode and releases it incrementally as validators finish.

## Result
On a 16 GiB node, memory usage sits at the *theoretical floor*: around 1.4 GiB for a single in-flight encode, and roughly 13–15 GiB for ten concurrent ones, comfortably within the box. Steady-state slab churn drops to a few MiB per minute as both pools warm up to the concurrency high-water mark and stay there.

Most of the stress testing focused on the largest blob size because that's where memory pressure actually shows up. However, the allocator is size-agnostic by design, and slabs grow to whatever deficit a request leaves behind and pack smaller rows into the same space, so small and medium blobs should benefit from the same retention and reuse properties without any special-casing. That said, the mixed-size path has seen less direct measurement than the homogeneous large-blob case, and fragmentation behavior under varied workloads is noted as a known area to keep an eye on in the design doc.

Closes #7085