### PR TITLE
feat(scripts): add single-node v6 -> v8 upgrade script

### DIFF
--- a/scripts/single-node-v6-to-v8.sh
+++ b/scripts/single-node-v6-to-v8.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+
+# This script starts a local single node testnet on app version 6 and then
+# upgrades directly to app version 8 by signalling v8 from the single
+# validator (100% voting power) and submitting MsgTryUpgrade.
+#
+# Prerequisites:
+# - Check out the v8.x branch.
+# - Run `make install` so celestia-appd embeds v3-v7 and runs v8 natively.
+
+set -o errexit # Stop script execution if an error is encountered
+set -o nounset # Stop script execution if an undefined variable is used
+
+if ! [ -x "$(command -v celestia-appd)" ]
+then
+    echo "celestia-appd could not be found. Please install the celestia-appd binary using 'make install' and make sure the PATH contains the directory where the binary exists. By default, go will install the binary under '~/go/bin'"
+    exit 1
+fi
+
+# Constants
+CHAIN_ID="test"
+KEY_NAME="validator"
+KEYRING_BACKEND="test"
+FEES="1000utia"
+BROADCAST_MODE="sync"
+FROM_VERSION="6"
+TO_VERSION="8"
+
+# Use argument as home directory if provided, else default to ~/.celestia-app
+if [ $# -ge 1 ]; then
+  APP_HOME="$1"
+else
+  APP_HOME="${HOME}/.celestia-app"
+fi
+
+VERSION=$(celestia-appd version 2>&1)
+GENESIS_FILE="${APP_HOME}/config/genesis.json"
+
+echo "celestia-app version: ${VERSION}"
+echo "celestia-app home: ${APP_HOME}"
+echo "celestia-app genesis file: ${GENESIS_FILE}"
+echo ""
+
+createGenesis() {
+    echo "Initializing validator and node config files..."
+    celestia-appd passthrough ${FROM_VERSION} init ${CHAIN_ID} \
+      --chain-id ${CHAIN_ID} \
+      --home "${APP_HOME}" \
+      > /dev/null 2>&1 # Hide output to reduce terminal noise
+
+    echo "Adding a new key to the keyring..."
+    celestia-appd keys add ${KEY_NAME} \
+      --keyring-backend=${KEYRING_BACKEND} \
+      --home "${APP_HOME}" \
+      > /dev/null 2>&1 # Hide output to reduce terminal noise
+
+    echo "Adding genesis account..."
+    celestia-appd passthrough ${FROM_VERSION} genesis add-genesis-account \
+      "$(celestia-appd keys show ${KEY_NAME} -a --keyring-backend=${KEYRING_BACKEND} --home "${APP_HOME}")" \
+      "1000000000000000utia" \
+      --home "${APP_HOME}"
+
+    echo "Creating a genesis tx..."
+    celestia-appd passthrough ${FROM_VERSION} genesis gentx ${KEY_NAME} 5000000000utia \
+      --fees ${FEES} \
+      --keyring-backend=${KEYRING_BACKEND} \
+      --chain-id ${CHAIN_ID} \
+      --home "${APP_HOME}" \
+      > /dev/null 2>&1 # Hide output to reduce terminal noise
+
+    echo "Collecting genesis txs..."
+    celestia-appd passthrough ${FROM_VERSION} genesis collect-gentxs \
+      --home "${APP_HOME}" \
+        > /dev/null 2>&1 # Hide output to reduce terminal noise
+
+    # Override the default RPC server listening address
+    sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' "${APP_HOME}"/config/config.toml
+
+    # Enable transaction indexing
+    sed -i'.bak' 's#"null"#"kv"#g' "${APP_HOME}"/config/config.toml
+
+    # Persist ABCI responses
+    sed -i'.bak' 's#discard_abci_responses = true#discard_abci_responses = false#g' "${APP_HOME}"/config/config.toml
+
+    # Override the VotingPeriod from 1 week to 1 minute
+    sed -i'.bak' 's#"604800s"#"60s"#g' "${APP_HOME}"/config/genesis.json
+
+    # Override the log level to reduce noisy logs
+    sed -i.bak 's#log_level = "info"#log_level = "*:error,p2p:info,state:info"#g' "${APP_HOME}"/config/config.toml
+}
+
+deleteCelestiaAppHome() {
+    echo "Deleting $APP_HOME..."
+    rm -r "$APP_HOME"
+}
+
+startCelestiaApp() {
+  echo "Starting celestia-app..."
+  celestia-appd start \
+    --home "${APP_HOME}" \
+    --api.enable \
+    --grpc.enable \
+    --grpc-web.enable \
+    --delayed-precommit-timeout 1s
+}
+
+upgrade() {
+    sleep 10
+    echo "Submitting signal for v${TO_VERSION}..."
+    celestia-appd tx signal signal ${TO_VERSION} \
+        --keyring-backend=${KEYRING_BACKEND} \
+        --home "${APP_HOME}" \
+        --from ${KEY_NAME} \
+        --fees ${FEES} \
+        --chain-id ${CHAIN_ID} \
+        --broadcast-mode ${BROADCAST_MODE} \
+        --yes
+
+    sleep 5
+    echo "Querying the tally for v${TO_VERSION}..."
+    celestia-appd query signal tally ${TO_VERSION}
+
+    echo "Submitting msg try upgrade..."
+    celestia-appd tx signal try-upgrade \
+        --keyring-backend=${KEYRING_BACKEND} \
+        --home "${APP_HOME}" \
+        --from ${KEY_NAME} \
+        --fees ${FEES} \
+        --chain-id ${CHAIN_ID} \
+        --broadcast-mode ${BROADCAST_MODE} \
+        --yes
+
+    sleep 2
+    echo "Querying for pending upgrade..."
+    celestia-appd query signal upgrade
+
+    echo "Waiting for the chain to activate app version ${TO_VERSION}..."
+    while true; do
+        current_version=$(celestia-appd status 2>/dev/null | jq -r '.node_info.protocol_version.app')
+        if [ "$current_version" = "${TO_VERSION}" ]; then
+            echo "Upgrade to version ${TO_VERSION} complete!"
+            break
+        fi
+        echo "Current version: ${current_version:-unknown}, waiting for version ${TO_VERSION}..."
+        sleep 2
+    done
+}
+
+if [ -f "$GENESIS_FILE" ]; then
+  echo "Do you want to delete existing ${APP_HOME} and start a new local testnet? [y/n]"
+  read -r response
+  if [ "$response" = "y" ]; then
+    deleteCelestiaAppHome
+    createGenesis
+  fi
+else
+  createGenesis
+fi
+
+upgrade & # Start the upgrade process to v8 in the background.
+startCelestiaApp # Start celestia-app in the foreground.


### PR DESCRIPTION
## Summary
- Adds `scripts/single-node-v6-to-v8.sh` for locally reproducing the mainnet v6 -> v8 upgrade path against the v8.x branch (where v8 is the native multiplexer binary and v3-v7 are embedded).
- Single validator signals v8 directly (100% voting power, immediate quorum), submits `MsgTryUpgrade`, and the script polls `celestia-appd status` until `protocol_version.app == 8`.

## Test plan
- [x] `sh -n scripts/single-node-v6-to-v8.sh` passes.
- [x] End-to-end: `./scripts/single-node-v6-to-v8.sh /tmp/celestia-app-v6-to-v8` — chain boots at v6, upgrade activates, script prints `Upgrade to version 8 complete!`, chain continues producing blocks under native v8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)