### PR TITLE
docs: add v7.x and v8.x to dependency forks table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,9 @@ All branches use forked cosmos-sdk and celestia-core:
 
 | celestia-app | celestia-core      | cosmos-sdk                 |
 |--------------|--------------------|----------------------------|
-| `main`       | `main`             | `release/v0.51.x-celestia` |
+| `main`       | `main`             | `release/v0.52.x-celestia` |
+| `v8.x`       | `v0.39.x-celestia` | `release/v0.52.x-celestia` |
+| `v7.x`       | `v0.39.x-celestia` | `release/v0.52.x-celestia` |
 | `v6.x`       | `v0.39.x-celestia` | `release/v0.51.x-celestia` |
 | `v5.x`       | `v0.38.x-celestia` | `release/v0.50.x-celestia` |
 | `v4.x`       | `v0.38.x-celestia` | `release/v0.50.x-celestia` |

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ The source of truth for dependencies is the `go.mod` file but the table below de
 | celestia-app | celestia-core      | cosmos-sdk                 |
 |--------------|--------------------|----------------------------|
 | `main`       | `main`             | `release/v0.52.x-celestia` |
+| `v8.x`       | `v0.39.x-celestia` | `release/v0.52.x-celestia` |
+| `v7.x`       | `v0.39.x-celestia` | `release/v0.52.x-celestia` |
 | `v6.x`       | `v0.39.x-celestia` | `release/v0.51.x-celestia` |
 | `v5.x`       | `v0.38.x-celestia` | `release/v0.50.x-celestia` |
 | `v4.x`       | `v0.38.x-celestia` | `release/v0.50.x-celestia` |


### PR DESCRIPTION
## Summary

- Add `v7.x` and `v8.x` rows to the dependency forks table in `README.md` and `CLAUDE.md`. Both pin celestia-core `v0.39.x-celestia` (v0.39.25 and v0.39.27 respectively) and cosmos-sdk `release/v0.52.x-celestia` (v0.52.1 and v0.52.3 respectively) per their `go.mod` files.
- Fix `CLAUDE.md` main row from `release/v0.51.x-celestia` to `release/v0.52.x-celestia` to match `go.mod` (which pins `github.com/celestiaorg/cosmos-sdk v0.52.3`) and the README.

## Test plan

- [x] `git diff` shows only the table additions and the `main` row correction
- [ ] Tables render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7094" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
