### PR TITLE
fix: make TestTxClientTestSuite wait for tx indexer after SubmitTx

### DIFF
--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -65,7 +65,7 @@ func (suite *TxClientTestSuite) TestSubmitPayForBlob() {
 	t.Run("submit blob without provided fee and gas limit", func(t *testing.T) {
 		resp, err := suite.txClient.SubmitPayForBlob(subCtx, blobs)
 		require.NoError(t, err)
-		getTxResp, err := suite.serviceClient.GetTx(subCtx, &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, err := utils.GetTxWithRetry(subCtx, suite.serviceClient, resp.TxHash)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, resp.Code)
 		require.Greater(t, getTxResp.TxResponse.GasWanted, int64(0))
@@ -76,7 +76,7 @@ func (suite *TxClientTestSuite) TestSubmitPayForBlob() {
 		gas := user.SetGasLimit(1e6)
 		resp, err := suite.txClient.SubmitPayForBlob(subCtx, blobs, fee, gas)
 		require.NoError(t, err)
-		getTxResp, err := suite.serviceClient.GetTx(subCtx, &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, err := utils.GetTxWithRetry(subCtx, suite.serviceClient, resp.TxHash)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, resp.Code)
 		require.EqualValues(t, getTxResp.TxResponse.GasWanted, 1e6)
@@ -98,7 +98,7 @@ func (suite *TxClientTestSuite) TestSubmitPayForBlob() {
 		require.NotEmpty(t, accountName, "could not find a non-default account")
 		resp, err := suite.txClient.SubmitPayForBlobWithAccount(subCtx, accountName, blobs, user.SetFee(1e6), user.SetGasLimit(1e6))
 		require.NoError(t, err)
-		getTxResp, err := suite.serviceClient.GetTx(subCtx, &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, err := utils.GetTxWithRetry(subCtx, suite.serviceClient, resp.TxHash)
 		require.NoError(t, err)
 		require.EqualValues(t, 0, resp.Code)
 		require.EqualValues(t, getTxResp.TxResponse.GasWanted, 1e6)
@@ -146,7 +146,7 @@ func TestSubmitPayForBlobWithEstimatorService(t *testing.T) {
 	require.Equal(t, abci.CodeTypeOK, resp.Code)
 
 	serviceClient := sdktx.NewServiceClient(ctx.GRPCClient)
-	getTxResp, err := serviceClient.GetTx(ctx.GoContext(), &sdktx.GetTxRequest{Hash: resp.TxHash})
+	getTxResp, err := utils.GetTxWithRetry(ctx.GoContext(), serviceClient, resp.TxHash)
 	require.NoError(t, err)
 
 	require.Equal(t, int64(70000), getTxResp.TxResponse.GasWanted)
@@ -178,7 +178,7 @@ func (suite *TxClientTestSuite) TestSubmitTx() {
 		resp, err := suite.txClient.SubmitTx(suite.ctx.GoContext(), []sdk.Msg{msg})
 		require.NoError(t, err)
 		require.Equal(t, abci.CodeTypeOK, resp.Code)
-		getTxResp, err := suite.serviceClient.GetTx(suite.ctx.GoContext(), &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, err := utils.GetTxWithRetry(suite.ctx.GoContext(), suite.serviceClient, resp.TxHash)
 		require.NoError(t, err)
 		require.Greater(t, getTxResp.TxResponse.GasWanted, int64(0))
 	})
@@ -191,7 +191,7 @@ func (suite *TxClientTestSuite) TestSubmitTx() {
 		resp, err := suite.txClient.SubmitTx(suite.ctx.GoContext(), []sdk.Msg{msg}, gasLimitOption)
 		require.NoError(t, err)
 		require.Equal(t, abci.CodeTypeOK, resp.Code)
-		getTxResp, err := suite.serviceClient.GetTx(suite.ctx.GoContext(), &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, err := utils.GetTxWithRetry(suite.ctx.GoContext(), suite.serviceClient, resp.TxHash)
 		require.NoError(t, err)
 		require.EqualValues(t, int64(gasLimit), getTxResp.TxResponse.GasWanted)
 	})
@@ -206,7 +206,7 @@ func (suite *TxClientTestSuite) TestSubmitTx() {
 		resp, err := suite.txClient.SubmitTx(suite.ctx.GoContext(), []sdk.Msg{msg}, feeOption, gasLimitOption)
 		require.NoError(t, err)
 		require.Equal(t, abci.CodeTypeOK, resp.Code)
-		getTxResp, err := suite.serviceClient.GetTx(suite.ctx.GoContext(), &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, err := utils.GetTxWithRetry(suite.ctx.GoContext(), suite.serviceClient, resp.TxHash)
 		require.NoError(t, err)
 		require.EqualValues(t, int64(gasLimit), getTxResp.TxResponse.GasWanted)
 	})
@@ -334,7 +334,7 @@ func (suite *TxClientTestSuite) TestConfirmTx() {
 		require.Equal(t, resp.TxHash, err.(*user.ExecutionError).TxHash)
 
 		// Compare it to the getTx response
-		getTxResp, getTxErr := suite.serviceClient.GetTx(suite.ctx.GoContext(), &sdktx.GetTxRequest{Hash: resp.TxHash})
+		getTxResp, getTxErr := utils.GetTxWithRetry(suite.ctx.GoContext(), suite.serviceClient, resp.TxHash)
 		require.NoError(t, getTxErr)
 		// This is a workaround because they are different types
 		require.Contains(t, err.(*user.ExecutionError).ErrorLog, getTxResp.TxResponse.RawLog)
@@ -609,7 +609,7 @@ func (suite *TxClientTestSuite) TestGasConsumption() {
 	amountDeducted := balanceBefore - balanceAfter - utiaToSend
 	require.Equal(t, int64(fee), amountDeducted)
 
-	res, err := suite.serviceClient.GetTx(suite.ctx.GoContext(), &sdktx.GetTxRequest{Hash: resp.TxHash})
+	res, err := utils.GetTxWithRetry(suite.ctx.GoContext(), suite.serviceClient, resp.TxHash)
 	require.NoError(t, err)
 
 	// verify that the amount deducted does not depend on the actual gas used.

--- a/pkg/user/utils/txclient_utils.go
+++ b/pkg/user/utils/txclient_utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -15,7 +16,13 @@ import (
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	sdktx "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// indexerWaitTimeout bounds how long GetTxWithRetry waits for the tx indexer
+// to index a committed tx before giving up.
+const indexerWaitTimeout = 10 * time.Second
 
 func SetupTxClient(
 	t *testing.T,
@@ -53,6 +60,36 @@ func SetupTxClientWithDefaultParams(t *testing.T, opts ...user.Option) (encoding
 	return SetupTxClient(t, 0, 128, 8388608, opts...) // no ttl and 8MiB block size
 }
 
+// GetTxWithRetry polls ServiceClient.GetTx until the tx is indexed or
+// indexerWaitTimeout elapses. The CometBFT TxStatus RPC (used by
+// TxClient.ConfirmTx) and the Cosmos SDK tx indexer (used by
+// ServiceClient.GetTx) are updated asynchronously after a block is
+// committed, so GetTx can return NotFound for a tx that ConfirmTx has just
+// reported as committed. Tests should prefer this helper whenever they need
+// to look up a tx by hash immediately after submitting it.
+func GetTxWithRetry(ctx context.Context, serviceClient sdktx.ServiceClient, txHash string) (*sdktx.GetTxResponse, error) {
+	ctx, cancel := context.WithTimeout(ctx, indexerWaitTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		resp, err := serviceClient.GetTx(ctx, &sdktx.GetTxRequest{Hash: txHash})
+		if err == nil {
+			return resp, nil
+		}
+		if status.Code(err) != codes.NotFound {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("waiting for tx %s to be indexed: %w", txHash, ctx.Err())
+		case <-ticker.C:
+		}
+	}
+}
+
 func VerifyTxResponse(
 	t *testing.T,
 	ctx context.Context,
@@ -77,7 +114,7 @@ func VerifyTxResponse(
 		require.FailNowf(t, "unexpected type", "unsupported confirmTxResp type: %T", confirmTxResp)
 	}
 
-	getTxResp, err := serviceClient.GetTx(ctx, &sdktx.GetTxRequest{Hash: expTxHash})
+	getTxResp, err := GetTxWithRetry(ctx, serviceClient, expTxHash)
 	require.NoError(t, err)
 
 	txResp := getTxResp.TxResponse


### PR DESCRIPTION
## Summary

- `TxClient.ConfirmTx` returns as soon as CometBFT's `TxStatus` RPC reports the tx as committed, but the Cosmos SDK tx indexer used by `ServiceClient.GetTx` is updated asynchronously. Tests that called `GetTx` immediately after `SubmitTx`/`ConfirmTx` hit `NotFound` when the indexer lagged (see the failing run in #7092).
- Add a `GetTxWithRetry` helper in `pkg/user/utils` that polls `GetTx` on `NotFound` until the tx is indexed or a 10s timeout elapses.
- Use it at every `pkg/user/tx_client_test.go` call site that looked up a tx by hash immediately after submitting it, and in `VerifyTxResponse`.

## Test plan

- [x] `go test -run TestTxClientTestSuite ./pkg/user/` (3x in a row, all green locally)
- [ ] CI passes

Closes #7092
Closes https://linear.app/celestia/issue/PROTOCO-1519
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7095" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
