### PR TITLE
fix: wait for app multistore in TestGasConsumption

### DIFF
--- a/pkg/user/tx_client_test.go
+++ b/pkg/user/tx_client_test.go
@@ -603,6 +603,14 @@ func (suite *TxClientTestSuite) TestGasConsumption() {
 	require.NoError(t, err)
 
 	require.EqualValues(t, abci.CodeTypeOK, resp.Code)
+
+	// SubmitTx returns as soon as CometBFT reports the tx committed, but the
+	// app's multistore Commit() that makes the post-tx state visible over gRPC
+	// may still be in flight. Wait for the app to reach resp.Height so the
+	// balance query below reflects the tx.
+	_, err = suite.ctx.WaitForHeight(resp.Height)
+	require.NoError(t, err)
+
 	balanceAfter := suite.queryCurrentBalance(t)
 
 	// verify that the amount deducted depends on the fee set in the tx.


### PR DESCRIPTION
## Summary

- `TestTxClientTestSuite/TestGasConsumption` still flakes on `main` after #7095. That PR wrapped `ServiceClient.GetTx` with `GetTxWithRetry` to tolerate the async tx indexer, but the test also calls the bank gRPC `AllBalances` immediately after `SubmitTx`. CometBFT's `TxStatus` can report the tx as committed before the app's `cms.Commit()` runs (see the comment in `test/util/testnode/node_interaction_api.go` `WaitForHeightWithTimeout`), so the post-tx balance query can still return stale state.
- Wait for `suite.ctx.WaitForHeight(resp.Height)` after `SubmitTx`. `WaitForHeight` already checks `ABCIInfo().LastBlockHeight`, which guarantees the app's multistore has committed the tx's block before the balance query runs.

## Test plan

- [x] `go test -run TestTxClientTestSuite/TestGasConsumption -count=5 ./pkg/user/` (5/5 passed locally)
- [x] `go test -run TestTxClientTestSuite ./pkg/user/` (full suite passes)
- [ ] CI passes

Closes #7099
Closes https://linear.app/celestia/issue/PROTOCO-1522
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7100" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
