### PR TITLE
chore: gitignore .claude directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ tools/talis/talis
 .cache
 .gomodcache
 # Claude Code local settings
-.claude/*.local.json
+.claude/*


### PR DESCRIPTION
Because we don't have any team-wide skills in this directory and it is easy to accidentally include .claude worktrees, settings, or skills in here that shouldn't be committed to version control (at least for now)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
