### PR TITLE
chore(talis): upgrade default OS image to Ubuntu 24.04 LTS

### DIFF
--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -18,7 +18,7 @@ const (
 	DODefaultValidatorSlug     = "c2-16vcpu-32gb"
 	DODefaultEncoderSlug       = "c2-8vcpu-16gb"
 	DODefaultObservabilitySlug = "s-2vcpu-4gb"
-	DODefaultImage             = "ubuntu-22-04-x64"
+	DODefaultImage             = "ubuntu-24-04-x64"
 	RandomRegion               = "random"
 )
 

--- a/tools/talis/digital_ocean.go
+++ b/tools/talis/digital_ocean.go
@@ -163,7 +163,7 @@ func CreateDroplets(ctx context.Context, client *godo.Client, insts []Instance, 
 				Region: v.Region,
 				Size:   v.Slug,
 				Image: godo.DropletCreateImage{
-					Slug: "ubuntu-22-04-x64",
+					Slug: DODefaultImage,
 				},
 				SSHKeys: []godo.DropletCreateSSHKey{{ID: key.ID, Fingerprint: key.Fingerprint}},
 				Tags:    v.Tags,

--- a/tools/talis/google_cloud.go
+++ b/tools/talis/google_cloud.go
@@ -20,7 +20,7 @@ const (
 	GCDefaultValidatorMachineType     = "c3d-highcpu-16"
 	GCDefaultEncoderMachineType       = "c3d-highcpu-8"
 	GCDefaultObservabilityMachineType = "e2-medium"
-	GCDefaultImage                    = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2204-lts"
+	GCDefaultImage                    = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
 	GCDefaultDiskSizeGB               = 400
 )
 


### PR DESCRIPTION
## Summary
- Bump default Ubuntu image from 22.04 (Jammy) to 24.04 (Noble) across cloud providers
- GCP: `ubuntu-2204-lts` → `ubuntu-2404-lts-amd64`
- DigitalOcean: `ubuntu-22-04-x64` → `ubuntu-24-04-x64`
- AWS constant updated in the unmerged AWS branch (`aws.go`)

Ubuntu 24.04 ships with kernel 6.8, newer glibc, and security updates through 2029.

## Test plan
- [ ] Deploy a talis experiment on GCP and verify instances come up with Ubuntu 24.04
- [ ] Deploy a talis experiment on DO and verify instances come up with Ubuntu 24.04
- [ ] Verify install scripts (Docker, metrics, promtail) work on 24.04

Closes: https://linear.app/celestia/issue/PROTOCO-1531/choretalis-upgrade-default-os-image-to-ubuntu-2404-lts

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7136" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
