### PR TITLE
fix(fibre): sanitize pprof labels before Pyroscope upload

### DIFF
--- a/fibre/cmd/profiling.go
+++ b/fibre/cmd/profiling.go
@@ -8,8 +8,10 @@ import (
 	httppprof "net/http/pprof"
 	"os"
 	"runtime"
+	"time"
 
 	"github.com/grafana/pyroscope-go"
+	"github.com/grafana/pyroscope-go/upstream/remote"
 	"github.com/spf13/cobra"
 )
 
@@ -105,23 +107,46 @@ func setupProfiling(cmd *cobra.Command) (func(), error) {
 	}
 
 	hostname, _ := os.Hostname()
-	profiler, err := pyroscope.Start(pyroscope.Config{
-		ApplicationName:   "fibre",
-		ServerAddress:     endpoint,
+	logger := &pyroscopeSlogAdapter{}
+
+	// We construct the pyroscope-go pieces manually (instead of calling
+	// pyroscope.Start) so we can wrap the Upstream and strip sample
+	// labels before upload. See pyroscope_labels.go for why this is
+	// needed. Everything below mirrors what pyroscope.Start does
+	// internally; the only difference is `Upstream: &stripLabelsUpstream{...}`.
+	uploader, err := remote.NewRemote(remote.Config{
+		Address:           endpoint,
 		BasicAuthUser:     basicAuthUser,
 		BasicAuthPassword: basicAuthPass,
-		Logger:            &pyroscopeSlogAdapter{},
-		Tags:              map[string]string{"version": version, "hostname": hostname},
+		Threads:           5, // matches pyroscope.Start's default
+		Timeout:           30 * time.Second,
+		Logger:            logger,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("starting Pyroscope profiler: %w", err)
+		return nil, fmt.Errorf("starting Pyroscope uploader: %w", err)
+	}
+	uploader.Start()
+
+	session, err := pyroscope.NewSession(pyroscope.SessionConfig{
+		Upstream:       &stripLabelsUpstream{inner: uploader},
+		Logger:         logger,
+		AppName:        "fibre",
+		Tags:           map[string]string{"version": version, "hostname": hostname},
+		ProfilingTypes: pyroscope.DefaultProfileTypes,
+	})
+	if err != nil {
+		uploader.Stop()
+		return nil, fmt.Errorf("starting Pyroscope session: %w", err)
+	}
+	if err := session.Start(); err != nil {
+		uploader.Stop()
+		return nil, fmt.Errorf("starting Pyroscope session: %w", err)
 	}
 	slog.Info("profiling enabled", "endpoint", endpoint)
 
 	return func() {
-		if err := profiler.Stop(); err != nil {
-			slog.Error("stopping Pyroscope profiler", "error", err)
-		}
+		session.Stop()
+		uploader.Stop()
 	}, nil
 }
 

--- a/fibre/cmd/pyroscope_labels.go
+++ b/fibre/cmd/pyroscope_labels.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bytes"
+
+	"github.com/google/pprof/profile"
+	"github.com/grafana/pyroscope-go/upstream"
+)
+
+// stripLabelsUpstream wraps a pyroscope-go Upstream and removes every
+// runtime/pprof sample label before upload.
+//
+// Why: Pyroscope's ingest API enforces the Prometheus label-name rule
+// `[a-zA-Z_][a-zA-Z0-9_]*` and rejects the entire profile (HTTP 422) if
+// any sample carries a label key that violates it. Pebble — which fibre
+// uses as its shard store — attaches pprof labels like
+// `output-level="L6"` and `pebble="compact"` to its background
+// goroutines via `pprof.Do()`. CPU profiles sample at 100 Hz and almost
+// always catch those goroutines in flight, so every fibre CPU profile
+// gets dropped. Memory / alloc profiles rarely sample under those
+// contexts and go through, which is why flamegraphs for the fibre
+// server show heap but not CPU.
+//
+// Stripping sample labels is the minimum fix. Pyroscope's flamegraph UI
+// attributes CPU samples by stack frames — the frames already identify
+// pebble flush/compact work. Labels attached via `pprof.Do` only show
+// up as a secondary filter dimension that nobody uses for this. The
+// service-level tags (hostname, version, app_name) come from
+// SessionConfig.Tags, not per-sample labels, so they survive intact.
+//
+// On any parse failure we forward the original bytes unchanged:
+// profiling must degrade gracefully, never take the service down.
+type stripLabelsUpstream struct {
+	inner upstream.Upstream
+}
+
+func (s *stripLabelsUpstream) Upload(job *upstream.UploadJob) {
+	p, err := profile.ParseData(job.Profile)
+	if err != nil {
+		s.inner.Upload(job)
+		return
+	}
+	dirty := false
+	for _, sam := range p.Sample {
+		if len(sam.Label) > 0 || len(sam.NumLabel) > 0 || len(sam.NumUnit) > 0 {
+			sam.Label = nil
+			sam.NumLabel = nil
+			sam.NumUnit = nil
+			dirty = true
+		}
+	}
+	if dirty {
+		var buf bytes.Buffer
+		if err := p.Write(&buf); err == nil {
+			job.Profile = buf.Bytes()
+		}
+	}
+	s.inner.Upload(job)
+}
+
+func (s *stripLabelsUpstream) Flush() { s.inner.Flush() }

--- a/fibre/cmd/pyroscope_labels_test.go
+++ b/fibre/cmd/pyroscope_labels_test.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/pprof/profile"
+	"github.com/grafana/pyroscope-go/upstream"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type captureUpstream struct {
+	last    *upstream.UploadJob
+	flushed int
+}
+
+func (c *captureUpstream) Upload(j *upstream.UploadJob) { c.last = j }
+func (c *captureUpstream) Flush()                       { c.flushed++ }
+
+func TestStripLabelsUpstream_RemovesAllSampleLabels(t *testing.T) {
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "cpu", Unit: "samples"}},
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:     1,
+		Sample: []*profile.Sample{{
+			Value: []int64{1},
+			Label: map[string][]string{
+				"output-level": {"L6"},
+				"pebble":       {"compact"},
+				"other_valid":  {"keep-me"},
+			},
+			NumLabel: map[string][]int64{"size": {42}},
+			NumUnit:  map[string][]string{"size": {"bytes"}},
+		}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, p.Write(&buf))
+
+	cap := &captureUpstream{}
+	s := &stripLabelsUpstream{inner: cap}
+	s.Upload(&upstream.UploadJob{Profile: buf.Bytes()})
+
+	require.NotNil(t, cap.last, "inner Upload must be invoked")
+	out, err := profile.ParseData(cap.last.Profile)
+	require.NoError(t, err)
+	require.Len(t, out.Sample, 1)
+	assert.Empty(t, out.Sample[0].Label, "all string labels must be stripped")
+	assert.Empty(t, out.Sample[0].NumLabel, "all numeric labels must be stripped")
+	assert.Empty(t, out.Sample[0].NumUnit, "all numeric label units must be stripped")
+}
+
+func TestStripLabelsUpstream_NoLabelsPassesThroughUnchanged(t *testing.T) {
+	p := &profile.Profile{
+		SampleType: []*profile.ValueType{{Type: "cpu", Unit: "samples"}},
+		PeriodType: &profile.ValueType{Type: "cpu", Unit: "nanoseconds"},
+		Period:     1,
+		Sample:     []*profile.Sample{{Value: []int64{1}}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, p.Write(&buf))
+	raw := buf.Bytes()
+
+	cap := &captureUpstream{}
+	s := &stripLabelsUpstream{inner: cap}
+	s.Upload(&upstream.UploadJob{Profile: raw})
+
+	require.NotNil(t, cap.last)
+	// When no labels need stripping we avoid re-encoding — the caller
+	// sees the exact bytes they passed in.
+	assert.Equal(t, raw, cap.last.Profile)
+}
+
+func TestStripLabelsUpstream_MalformedProfilePassesThrough(t *testing.T) {
+	raw := []byte("definitely not a pprof profile")
+	cap := &captureUpstream{}
+	s := &stripLabelsUpstream{inner: cap}
+	s.Upload(&upstream.UploadJob{Profile: raw})
+	require.NotNil(t, cap.last)
+	assert.Equal(t, raw, cap.last.Profile, "malformed profile must forward unchanged")
+}
+
+func TestStripLabelsUpstream_FlushForwards(t *testing.T) {
+	cap := &captureUpstream{}
+	s := &stripLabelsUpstream{inner: cap}
+	s.Flush()
+	s.Flush()
+	assert.Equal(t, 2, cap.flushed)
+}

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/gofrs/flock v0.13.0
 	github.com/golang/protobuf v1.5.4
+	github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6
 	github.com/grafana/otel-profiling-go v0.5.1
 	github.com/grafana/pyroscope-go v1.2.8
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
@@ -260,7 +261,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/orderedcode v0.0.1 // indirect
-	github.com/google/pprof v0.0.0-20250820193118-f64d9cf942d6 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.14 // indirect


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1537/fixfibre-sanitize-pprof-labels-before-pyroscope-upload

## Summary

- Pyroscope's ingest API enforces the Prometheus label-name rule (`[a-zA-Z_][a-zA-Z0-9_]*`) and rejects the whole profile (HTTP 422) if any sample carries a label key that violates it.
- Pebble — fibre's shard store — attaches pprof labels like `output-level="L6"` and `pebble="compact"` to its background goroutines via `pprof.Do()`. CPU profiles sample at 100 Hz and almost always catch those goroutines in flight, so **every fibre CPU profile gets dropped**. Memory / alloc profiles sample rarely under those contexts and go through — which is why flamegraphs for the `fibre` service show heap but not CPU today.
- Wrap the pyroscope-go SDK's `Upstream` interface with a small shim that parses the pprof profile, drops per-sample labels (`Label` / `NumLabel` / `NumUnit`), and re-encodes before upload. The service-level tags the flamegraph UI uses for filtering (hostname, version, app name) come from `SessionConfig.Tags`, not per-sample labels, and are unaffected.
- Graceful degradation: on any parse failure the bytes are forwarded unchanged so profiling can never take the service down.

## Why strip rather than rename

Pyroscope's flamegraph UI attributes CPU samples **by stack frames**, not by `pprof.Do` labels. Pebble's labels never surface as useful attribution for fibre's hot path — the stack already identifies `flush` vs `compact` work. Renaming would need collision-merge logic, NumUnit-key consistency tracking, and extra tests; stripping is a ~60-LOC helper.

## Changes

| File | Change |
|---|---|
| `fibre/cmd/pyroscope_labels.go` (new) | `stripLabelsUpstream` — ~30 LOC of logic + ~30 lines of docstring |
| `fibre/cmd/pyroscope_labels_test.go` (new) | 4 unit tests: strip, pass-through-when-no-labels, malformed-passthrough, flush-forward |
| `fibre/cmd/profiling.go` | Swap `pyroscope.Start(Config{...})` for a `remote.NewRemote` + `pyroscope.NewSession(SessionConfig{Upstream: &stripLabelsUpstream{...}, ...})` — same behaviour, now with the Upstream hook |
| `go.mod` | Promotes `google/pprof` from indirect to direct |

## Test plan

- [x] `go vet -tags fibre ./fibre/cmd/...` clean
- [x] `go test -tags fibre -run TestStripLabelsUpstream ./fibre/cmd/...` — 4/4 pass
- [x] `go build -tags fibre ./fibre/cmd` — clean
- [ ] Deploy fibre to talis and confirm CPU flamegraphs for the `fibre` service appear in Pyroscope alongside the existing `fibre-txsim` ones, and `docker logs docker-pyroscope-1` shows **no** 422s for `service_name=fibre`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)