### PR TITLE
fix(talis): use presigned S3 URLs for payload distribution

### DIFF
--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -535,17 +535,28 @@ func uploadToS3(ctx context.Context, client *s3.Client, cfg S3Config, localPath 
 	filename := filepath.Base(localPath)
 	uploader := manager.NewUploader(client)
 
-	result, err := uploader.Upload(ctx, &s3.PutObjectInput{
+	if _, err := uploader.Upload(ctx, &s3.PutObjectInput{
 		Bucket: &cfg.BucketName,
 		Key:    &filename,
-		ACL:    "public-read",
 		Body:   file,
-	})
-	if err != nil {
+	}); err != nil {
 		return "", fmt.Errorf("failed to upload file: %w", err)
 	}
 
-	return result.Location, nil
+	// Return a presigned GET URL valid for an hour so remote hosts can curl
+	// the object without the bucket/object needing public-read ACLs. Works
+	// for real AWS S3 (where public access is blocked by default) and for
+	// S3-compatible providers like DigitalOcean Spaces.
+	presign := s3.NewPresignClient(client)
+	req, err := presign.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: &cfg.BucketName,
+		Key:    &filename,
+	}, s3.WithPresignExpires(time.Hour))
+	if err != nil {
+		return "", fmt.Errorf("failed to presign GET: %w", err)
+	}
+
+	return req.URL, nil
 }
 
 func downCmd() *cobra.Command {

--- a/tools/talis/s3.go
+++ b/tools/talis/s3.go
@@ -131,46 +131,38 @@ func downloadS3Directory(ctx context.Context, client *s3.Client, bucket, prefix,
 
 func createS3Client(ctx context.Context, cfg Config) (*s3.Client, error) {
 	s3cfg := cfg.S3Config
-	var awsCfg aws.Config
-	var err error
-	if cfg.S3Config.Endpoint != "" {
+
+	opts := []func(*config.LoadOptions) error{config.WithRegion(s3cfg.Region)}
+
+	// If static creds are provided in config (typical for DO Spaces), use
+	// them. Otherwise fall back to the SDK default credential chain — env
+	// vars, AWS_PROFILE in ~/.aws/credentials, IAM role, etc. — so the AWS
+	// compute path works with named profiles.
+	if s3cfg.AccessKeyID != "" && s3cfg.SecretAccessKey != "" {
+		opts = append(opts, config.WithCredentialsProvider(
+			aws.NewCredentialsCache(
+				credentials.NewStaticCredentialsProvider(
+					s3cfg.AccessKeyID,
+					s3cfg.SecretAccessKey,
+					"",
+				),
+			),
+		))
+	}
+
+	if s3cfg.Endpoint != "" {
 		customResolver := aws.EndpointResolverWithOptionsFunc(func(service, region string, options ...any) (aws.Endpoint, error) { //nolint:staticcheck
 			return aws.Endpoint{ //nolint:staticcheck
-				URL:           cfg.S3Config.Endpoint,
+				URL:           s3cfg.Endpoint,
 				SigningRegion: region,
 			}, nil
 		})
-
-		awsCfg, err = config.LoadDefaultConfig(ctx,
-			config.WithRegion(s3cfg.Region),
-			config.WithCredentialsProvider(
-				aws.NewCredentialsCache(
-					credentials.NewStaticCredentialsProvider(
-						s3cfg.AccessKeyID,
-						s3cfg.SecretAccessKey,
-						"",
-					),
-				),
-			),
-			config.WithEndpointResolverWithOptions(customResolver), //nolint:staticcheck
-		)
-	} else {
-		awsCfg, err = config.LoadDefaultConfig(ctx,
-			config.WithRegion(s3cfg.Region),
-			config.WithCredentialsProvider(
-				aws.NewCredentialsCache(
-					credentials.NewStaticCredentialsProvider(
-						s3cfg.AccessKeyID,
-						s3cfg.SecretAccessKey,
-						"",
-					),
-				),
-			),
-		)
+		opts = append(opts, config.WithEndpointResolverWithOptions(customResolver)) //nolint:staticcheck
 	}
+
+	awsCfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build AWS config: %w", err)
 	}
-
 	return s3.NewFromConfig(awsCfg), nil
 }


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1538/fixtalis-use-presigned-s3-urls-for-payload-distribution

## Summary

- `uploadToS3` currently sets `ACL: public-read` on every payload object and returns the bucket/object URL for nodes to `curl`. That works on DigitalOcean Spaces but fails on vanilla AWS S3 buckets, where account- and bucket-level Block Public Access is on by default — the PutObject call is rejected and the whole deploy aborts.
- Drop the public ACL and return a **presigned GET URL** valid for one hour. Remote nodes keep using the same `curl -L` — no init-script changes. Works identically on AWS S3 and S3-compatible backends (DO Spaces, MinIO, etc.).
- `createS3Client` also learns to fall back to the SDK default credential chain when `S3Config.AccessKeyID`/`SecretAccessKey` are empty. Today it hard-requires static creds in the config, which blocks `AWS_PROFILE=<name>`, IAM instance roles, and standard `AWS_*` env vars unless they're threaded into `S3Config` explicitly. Existing DO Spaces configs with static creds are unchanged — the static branch is preserved when creds are set.

## Test plan

- [x] `go build ./tools/talis/... && go vet ./tools/talis/... && go test ./tools/talis/...` all pass locally.
- [ ] Deploy to talis via DO Spaces and confirm the `curl`-and-extract path still works end-to-end.
- [ ] Deploy to talis via an AWS S3 bucket that has Block Public Access enabled (the default on new accounts) and confirm `talis deploy` completes without `403 AccessDenied`.
- [ ] Deploy using `AWS_PROFILE=<celestia>` with no `AWS_*` keys in `S3Config` and confirm the upload succeeds via shared-credentials fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7141" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
