### PR TITLE
feat(talis): add AWS (EC2) as a compute provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.21.1
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.99.1
 	github.com/bcp-innovations/hyperlane-cosmos v1.1.0
 	github.com/celestiaorg/go-square/v2 v2.3.3

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23 h1:FPXsW9+gMuIeKmz7j6ENWcWtBGTe1kH8r9thNt5Uxx4=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.23/go.mod h1:7J8iGMdRKk6lw2C+cMIphgAnT8uTwBwNOsGkyOCm80U=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1 h1:9nfacm+uWgbdPaOplvJjxN50qgthexb7GOR/97ygc5o=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.297.1/go.mod h1:E1pnYwWFZ8N3REmeN9Fe/Zipbpps4HJj8DQGNnLUMYc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8 h1:HtOTYcbVcGABLOVuPYaIihj6IlkqubBwFj10K5fxRek=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.8/go.mod h1:VsK9abqQeGlzPgUr+isNWzPlK2vKe9INMLWnY65f5Xs=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.14 h1:xnvDEnw+pnj5mctWiYuFbigrEzSm35x7k4KS/ZkCANg=

--- a/tools/talis/add.go
+++ b/tools/talis/add.go
@@ -14,6 +14,7 @@ func addCmd() *cobra.Command {
 		nodeType string
 		provider string
 		region   string
+		slug     string
 	)
 	cmd := &cobra.Command{
 		Use:     "add",
@@ -31,27 +32,35 @@ func addCmd() *cobra.Command {
 
 			switch nodeType {
 			case "validator":
+				start := len(cfg.Validators)
 				for range count {
 					switch provider {
 					case "digitalocean":
 						cfg = cfg.WithDigitalOceanValidator(region)
 					case "googlecloud":
 						cfg = cfg.WithGoogleCloudValidator(region)
+					case "aws":
+						cfg = cfg.WithAWSValidator(region)
 					default:
-						return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud)", provider)
+						return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud, aws)", provider)
 					}
 				}
+				applySlug(cfg.Validators, start, slug)
 			case "encoder":
+				start := len(cfg.Encoders)
 				for range count {
 					switch provider {
 					case "digitalocean":
 						cfg = cfg.WithDigitalOceanEncoder(region)
 					case "googlecloud":
 						cfg = cfg.WithGoogleCloudEncoder(region)
+					case "aws":
+						cfg = cfg.WithAWSEncoder(region)
 					default:
-						return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud)", provider)
+						return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud, aws)", provider)
 					}
 				}
+				applySlug(cfg.Encoders, start, slug)
 			case "bridge":
 				log.Println("bridges are not yet supported")
 				return nil
@@ -71,8 +80,21 @@ func addCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("count")
 	cmd.Flags().StringVarP(&nodeType, "type", "t", "", "Type of the node (validator, encoder, bridge, light)")
 	_ = cmd.MarkFlagRequired("type")
-	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "Provider for the node (digitalocean, googlecloud)")
+	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "Provider for the node (digitalocean, googlecloud, aws)")
 	cmd.Flags().StringVarP(&region, "region", "r", "random", "the region to deploy the instance in (random if blank)")
+	cmd.Flags().StringVar(&slug, "slug", "", "provider-specific instance type override (e.g. c6in.4xlarge). Empty = provider default for the node type.")
 
 	return cmd
+}
+
+// applySlug overrides the Slug field on the just-added instances in the
+// slice. It only touches entries at index [start, len(instances)) so a
+// second `add` with a different `--slug` does not re-stamp earlier ones.
+func applySlug(instances []Instance, start int, slug string) {
+	if slug == "" {
+		return
+	}
+	for i := start; i < len(instances); i++ {
+		instances[i].Slug = slug
+	}
 }

--- a/tools/talis/aws.go
+++ b/tools/talis/aws.go
@@ -1,0 +1,983 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+const (
+	// c6in.4xlarge: 16 vCPU / 32 GiB / 25 Gbps baseline network with ENA
+	// Express (SRD). The "n" suffix marks network-enhanced variants, which
+	// is what talis fibre experiments care about — they're networking-bound.
+	AWSDefaultValidatorInstanceType = "c6in.4xlarge"
+	// c6in.2xlarge: 8 vCPU / 16 GiB — encoders submit blobs via gRPC and
+	// don't need the full validator footprint.
+	AWSDefaultEncoderInstanceType       = "c6in.2xlarge"
+	AWSDefaultObservabilityInstanceType = "t3.medium"
+	AWSDefaultRootVolumeGB              = int32(400)
+
+	// AWSSecurityGroupName is the name of the security group used by every
+	// talis instance. It is created per-region on demand and permits all
+	// inbound traffic — same posture as the GCP firewall rule.
+	AWSSecurityGroupName = "talis-allow-all"
+	// AWSPlacementGroupName is the name of the cluster placement group used
+	// by every talis instance in a region. Cluster strategy gives the lowest
+	// inter-instance latency within an AZ — critical for fibre/p2p.
+	AWSPlacementGroupName = "talis-cluster"
+
+	// AWSCanonicalOwnerID is Canonical's AWS account ID. It owns the
+	// official Ubuntu AMIs we filter against.
+	AWSCanonicalOwnerID = "099720109477"
+	// AWSUbuntuImageNamePattern matches Ubuntu 24.04 LTS amd64 EBS SSD
+	// images (matches talis' default OS image for DO / GCP).
+	AWSUbuntuImageNamePattern = "ubuntu/images/hvm-ssd*/ubuntu-noble-24.04-amd64-server-*"
+
+	// AWSDefaultZone is the AZ used for launches when Config.AWSZone is
+	// unset. Single-AZ launches keep all cross-instance traffic intra-AZ
+	// (free) and enable a cluster placement group for minimum latency.
+	AWSDefaultZone = "us-east-1a"
+)
+
+// AWSRegions is the pool used when "random" is selected for an AWS
+// instance. We ship a single region by default: cross-region traffic on
+// AWS is billed at $0.09/GB (~9× DO), so running networking-heavy
+// experiments across regions is wildly expensive. Operators who need
+// multi-region can set an explicit Region on each Instance.
+var AWSRegions = []string{"us-east-1"}
+
+// amiCache memoises the resolved Ubuntu AMI per region — AMIs are
+// region-scoped and resolving them costs an API round-trip.
+var amiCache sync.Map // map[region]string
+
+type AWSClient struct {
+	ClientInfo
+	defaultRegion string
+}
+
+func NewAWSClient(cfg Config) (*AWSClient, error) {
+	if cfg.AWSRegion == "" {
+		return nil, errors.New("AWS region is required")
+	}
+	sshKey, err := os.ReadFile(cfg.SSHPubKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read SSH public key at %s: %w", cfg.SSHPubKeyPath, err)
+	}
+	return &AWSClient{
+		ClientInfo: ClientInfo{
+			sshKey: sshKey,
+			cfg:    cfg,
+		},
+		defaultRegion: cfg.AWSRegion,
+	}, nil
+}
+
+func (c *AWSClient) Up(ctx context.Context, workers int) error {
+	zone := c.cfg.AWSZone
+	if zone == "" {
+		zone = AWSDefaultZone
+	}
+
+	insts := make([]Instance, 0)
+	allInstances := append(append(c.cfg.Validators, c.cfg.Observability...), c.cfg.Encoders...)
+	for _, v := range allInstances {
+		if v.Provider != AWS {
+			continue
+		}
+		if v.Region == "" || v.Region == RandomRegion {
+			v.Region = RandomAWSRegion()
+		}
+		if v.Zone == "" {
+			v.Zone = zone
+		}
+		insts = append(insts, v)
+	}
+
+	if len(insts) == 0 {
+		return fmt.Errorf("no instances to create")
+	}
+
+	insts, err := CreateAWSInstances(ctx, insts, string(c.sshKey), c.cfg.SSHKeyName, workers)
+	if err != nil {
+		return fmt.Errorf("failed to create instances: %w", err)
+	}
+
+	for _, inst := range insts {
+		cfg, err := c.cfg.UpdateInstance(inst.Name, inst.PublicIP, inst.PrivateIP)
+		if err != nil {
+			return fmt.Errorf("failed to update config with instance %s: %w", inst.Name, err)
+		}
+		c.cfg = cfg
+	}
+	return nil
+}
+
+func (c *AWSClient) Down(ctx context.Context, workers int) error {
+	insts := make([]Instance, 0)
+	allInstances := append(append(c.cfg.Validators, c.cfg.Observability...), c.cfg.Encoders...)
+	for _, v := range allInstances {
+		if v.Provider != AWS {
+			continue
+		}
+		if v.Region == "" || v.Region == RandomRegion {
+			v.Region = RandomAWSRegion()
+		}
+		insts = append(insts, v)
+	}
+	if len(insts) == 0 {
+		return fmt.Errorf("no instances to destroy")
+	}
+	_, err := DestroyAWSInstances(ctx, insts, workers)
+	return err
+}
+
+func (c *AWSClient) List(ctx context.Context) error {
+	cnt := 0
+	for _, region := range AWSRegions {
+		client, err := newEC2Client(ctx, region)
+		if err != nil {
+			return fmt.Errorf("failed to create EC2 client in %s: %w", region, err)
+		}
+		insts, err := describeTalisInstances(ctx, client)
+		if err != nil {
+			return fmt.Errorf("describe instances in %s: %w", region, err)
+		}
+		for _, inst := range insts {
+			if cnt == 0 {
+				fmt.Printf("%-30s %-10s %-15s %-15s %s\n", "Name", "Status", "Region", "Public IP", "Created")
+				fmt.Printf("%-30s %-10s %-15s %-15s %s\n", "----", "------", "------", "---------", "-------")
+			}
+			state := ""
+			if inst.State != nil {
+				state = string(inst.State.Name)
+			}
+			publicIP := ""
+			if inst.PublicIpAddress != nil {
+				publicIP = *inst.PublicIpAddress
+			}
+			created := ""
+			if inst.LaunchTime != nil {
+				created = inst.LaunchTime.Format(time.RFC3339)
+			}
+			fmt.Printf("%-30s %-10s %-15s %-15s %s\n",
+				instanceNameFromTags(inst.Tags), state, region, publicIP, created)
+			cnt++
+		}
+	}
+	fmt.Println("Total number of talis instances:", cnt)
+	return nil
+}
+
+func (c *AWSClient) GetConfig() Config {
+	return c.cfg
+}
+
+func NewAWSValidator(region string) Instance {
+	if region == "" || region == RandomRegion {
+		region = RandomAWSRegion()
+	}
+	i := NewBaseInstance(Validator)
+	i.Provider = AWS
+	i.Slug = AWSDefaultValidatorInstanceType
+	i.Region = region
+	return i
+}
+
+func NewAWSEncoder(region string) Instance {
+	if region == "" || region == RandomRegion {
+		region = RandomAWSRegion()
+	}
+	i := NewBaseInstance(Encoder)
+	i.Provider = AWS
+	i.Slug = AWSDefaultEncoderInstanceType
+	i.Region = region
+	return i
+}
+
+func NewAWSObservability(region string) Instance {
+	if region == "" || region == RandomRegion {
+		region = RandomAWSRegion()
+	}
+	i := NewBaseInstance(Observability)
+	i.Provider = AWS
+	i.Slug = AWSDefaultObservabilityInstanceType
+	i.Region = region
+	return i
+}
+
+func RandomAWSRegion() string {
+	return AWSRegions[rand.Intn(len(AWSRegions))]
+}
+
+// awsRegionFromEnv returns the region stamped into Config when
+// `--provider aws` is selected. Falls back to us-east-1 to match AWS
+// SDK's historical implicit default.
+func awsRegionFromEnv() string {
+	if r := os.Getenv(EnvVarAWSRegion); r != "" {
+		return r
+	}
+	return "us-east-1"
+}
+
+// resolveAWSZone returns the given zone or AWSDefaultZone.
+func resolveAWSZone(zone string) string {
+	if zone != "" {
+		return zone
+	}
+	return AWSDefaultZone
+}
+
+// newEC2Client constructs a regional EC2 client using the SDK default
+// credential chain (env vars, shared credentials file, IAM role, ...).
+func newEC2Client(ctx context.Context, region string) (*ec2.Client, error) {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config for region %s: %w", region, err)
+	}
+	return ec2.NewFromConfig(awsCfg), nil
+}
+
+// CreateAWSInstances launches EC2 instances in parallel, each pinned to
+// its Instance.Zone + the cluster placement group (where supported),
+// waits for public + private IPs, and returns the filled-in slice.
+func CreateAWSInstances(ctx context.Context, insts []Instance, sshKey, keyName string, workers int) ([]Instance, error) {
+	type result struct {
+		inst         Instance
+		err          error
+		timeRequired time.Duration
+	}
+
+	insts, existing, err := filterExistingAWSInstances(ctx, insts)
+	if err != nil {
+		return nil, err
+	}
+	if len(existing) > 0 {
+		log.Println("Existing instances found, so they are not being created.")
+		for _, v := range existing {
+			log.Println("Skipping", v.Name, v.PublicIP, v.Tags)
+		}
+	}
+
+	total := len(insts)
+	results := make(chan result, total)
+	workerChan := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	wg.Add(total)
+
+	for _, v := range insts {
+		go func(inst Instance) {
+			workerChan <- struct{}{}
+			defer func() {
+				<-workerChan
+				wg.Done()
+			}()
+
+			ctx, cancel := context.WithTimeout(ctx, 7*time.Minute)
+			defer cancel()
+
+			start := time.Now()
+			log.Println("Creating instance", inst.Name, "in region", inst.Region, start.Format(time.RFC3339))
+
+			pubIP, privIP, err := createAWSInstance(ctx, inst, sshKey, keyName)
+			if err != nil {
+				results <- result{inst: inst, err: fmt.Errorf("create %s: %w", inst.Name, err)}
+				return
+			}
+			inst.PublicIP = pubIP
+			inst.PrivateIP = privIP
+			results <- result{inst: inst, err: nil, timeRequired: time.Since(start)}
+		}(v)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var created []Instance
+	for res := range results {
+		if res.err != nil {
+			fmt.Printf("❌ %s failed after %v %v\n", res.inst.Name, res.timeRequired, res.err)
+		} else {
+			created = append(created, res.inst)
+			fmt.Printf("✅ %s is up (public=%s) in %v\n", res.inst.Name, res.inst.PublicIP, res.timeRequired)
+		}
+		fmt.Printf("---- Progress: %d/%d\n", len(created), total)
+	}
+	return created, nil
+}
+
+// createAWSInstance runs the full per-instance provisioning: resolve
+// AMI, ensure key pair + security group + placement group, resolve
+// default subnet in the target AZ, RunInstances, wait for IPs.
+func createAWSInstance(ctx context.Context, inst Instance, sshKey, keyName string) (string, string, error) {
+	client, err := newEC2Client(ctx, inst.Region)
+	if err != nil {
+		return "", "", err
+	}
+
+	amiID, err := resolveUbuntuAMI(ctx, client, inst.Region)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve AMI: %w", err)
+	}
+	if err := ensureAWSKeyPair(ctx, client, keyName, sshKey); err != nil {
+		return "", "", fmt.Errorf("ensure key pair: %w", err)
+	}
+	sgID, err := ensureAWSSecurityGroup(ctx, client)
+	if err != nil {
+		return "", "", fmt.Errorf("ensure security group: %w", err)
+	}
+
+	useCPG := supportsClusterPlacement(inst.Slug)
+	if useCPG {
+		if err := ensureAWSPlacementGroup(ctx, client); err != nil {
+			return "", "", fmt.Errorf("ensure placement group: %w", err)
+		}
+	}
+
+	zone := inst.Zone
+	if zone == "" {
+		zone = AWSDefaultZone
+	}
+	subnetID, err := defaultSubnetInAZ(ctx, client, zone)
+	if err != nil {
+		return "", "", fmt.Errorf("resolve subnet in %s: %w", zone, err)
+	}
+
+	tags := awsTagsFromInstance(inst)
+	userData := base64.StdEncoding.EncodeToString([]byte(awsRootSSHUserData(sshKey, inst.Name)))
+
+	placement := &ec2types.Placement{AvailabilityZone: aws.String(zone)}
+	if useCPG {
+		placement.GroupName = aws.String(AWSPlacementGroupName)
+	}
+
+	runOut, err := client.RunInstances(ctx, &ec2.RunInstancesInput{
+		ImageId:      aws.String(amiID),
+		InstanceType: ec2types.InstanceType(inst.Slug),
+		MinCount:     aws.Int32(1),
+		MaxCount:     aws.Int32(1),
+		KeyName:      aws.String(keyName),
+		UserData:     aws.String(userData),
+		// Use a single NIC so we can force public-IP assignment regardless
+		// of the subnet's MapPublicIpOnLaunch setting. SubnetId and
+		// SecurityGroupIds must live on the interface — the API rejects
+		// both top-level and interface-level settings together.
+		NetworkInterfaces: []ec2types.InstanceNetworkInterfaceSpecification{{
+			DeviceIndex:              aws.Int32(0),
+			SubnetId:                 aws.String(subnetID),
+			Groups:                   []string{sgID},
+			AssociatePublicIpAddress: aws.Bool(true),
+			DeleteOnTermination:      aws.Bool(true),
+		}},
+		Placement: placement,
+		BlockDeviceMappings: []ec2types.BlockDeviceMapping{{
+			DeviceName: aws.String("/dev/sda1"),
+			Ebs: &ec2types.EbsBlockDevice{
+				VolumeSize:          aws.Int32(AWSDefaultRootVolumeGB),
+				VolumeType:          ec2types.VolumeTypeGp3,
+				DeleteOnTermination: aws.Bool(true),
+			},
+		}},
+		MetadataOptions: &ec2types.InstanceMetadataOptionsRequest{
+			HttpTokens:   ec2types.HttpTokensStateRequired,
+			HttpEndpoint: ec2types.InstanceMetadataEndpointStateEnabled,
+		},
+		TagSpecifications: []ec2types.TagSpecification{
+			{ResourceType: ec2types.ResourceTypeInstance, Tags: tags},
+			{ResourceType: ec2types.ResourceTypeVolume, Tags: tags},
+		},
+	})
+	if err != nil {
+		return "", "", fmt.Errorf("run instance: %w", err)
+	}
+	if len(runOut.Instances) == 0 || runOut.Instances[0].InstanceId == nil {
+		return "", "", fmt.Errorf("RunInstances returned no instances")
+	}
+
+	return waitForAWSNetworkIP(ctx, client, *runOut.Instances[0].InstanceId)
+}
+
+// supportsClusterPlacement reports whether the given EC2 instance type
+// can join a cluster placement group. Cluster placement groups require
+// compute/network-optimised families; burstable (t*) is explicitly
+// rejected by the API. Observability nodes default to t3.medium, which
+// falls back to AZ-only placement.
+func supportsClusterPlacement(slug string) bool {
+	return slug != "" && !strings.HasPrefix(slug, "t")
+}
+
+func waitForAWSNetworkIP(ctx context.Context, client *ec2.Client, instanceID string) (string, string, error) {
+	ticker := time.NewTicker(4 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return "", "", ctx.Err()
+		case <-ticker.C:
+			out, err := client.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+				InstanceIds: []string{instanceID},
+			})
+			if err != nil {
+				return "", "", err
+			}
+			inst, ok := firstInstance(out)
+			if !ok {
+				continue
+			}
+			var pubIP, privIP string
+			if inst.PublicIpAddress != nil {
+				pubIP = *inst.PublicIpAddress
+			}
+			if inst.PrivateIpAddress != nil {
+				privIP = *inst.PrivateIpAddress
+			}
+			if pubIP != "" && privIP != "" {
+				return pubIP, privIP, nil
+			}
+		}
+	}
+}
+
+func firstInstance(out *ec2.DescribeInstancesOutput) (ec2types.Instance, bool) {
+	for _, r := range out.Reservations {
+		for _, i := range r.Instances {
+			return i, true
+		}
+	}
+	return ec2types.Instance{}, false
+}
+
+// filterExistingAWSInstances removes instances whose experiment tag
+// already exists in any region covered by the request. Groups by region
+// so each region is queried once.
+func filterExistingAWSInstances(ctx context.Context, insts []Instance) ([]Instance, []Instance, error) {
+	regions := make(map[string]struct{})
+	for _, inst := range insts {
+		regions[inst.Region] = struct{}{}
+	}
+
+	existingTags := make(map[string]bool)
+	for region := range regions {
+		client, err := newEC2Client(ctx, region)
+		if err != nil {
+			return nil, nil, err
+		}
+		tags, err := collectTalisTagKeys(ctx, client)
+		if err != nil {
+			return nil, nil, fmt.Errorf("list existing tags in %s: %w", region, err)
+		}
+		for tag := range tags {
+			existingTags[tag] = true
+		}
+	}
+
+	var newInsts, existing []Instance
+	for _, inst := range insts {
+		experimentTag := GetExperimentTag(inst.Tags)
+		if experimentTag == "" || !existingTags[experimentTag] {
+			newInsts = append(newInsts, inst)
+		} else {
+			existing = append(existing, inst)
+		}
+	}
+	return newInsts, existing, nil
+}
+
+func collectTalisTagKeys(ctx context.Context, client *ec2.Client) (map[string]bool, error) {
+	out := make(map[string]bool)
+	paginator := ec2.NewDescribeInstancesPaginator(client, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("tag-key"), Values: []string{"talis"}},
+			{Name: aws.String("instance-state-name"), Values: []string{"pending", "running", "stopping", "stopped"}},
+		},
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range page.Reservations {
+			for _, i := range r.Instances {
+				for _, t := range i.Tags {
+					if t.Key != nil {
+						out[*t.Key] = true
+					}
+				}
+			}
+		}
+	}
+	return out, nil
+}
+
+func DestroyAWSInstances(ctx context.Context, insts []Instance, workers int) ([]Instance, error) {
+	return destroyAWSInstancesInternal(ctx, insts, workers)
+}
+
+func destroyAWSInstancesInternal(ctx context.Context, insts []Instance, workers int) ([]Instance, error) {
+	type result struct {
+		inst         Instance
+		err          error
+		timeRequired time.Duration
+	}
+
+	results := make(chan result, len(insts))
+	workerChan := make(chan struct{}, workers)
+	var wg sync.WaitGroup
+	wg.Add(len(insts))
+
+	for _, inst := range insts {
+		go func(inst Instance) {
+			workerChan <- struct{}{}
+			defer func() {
+				<-workerChan
+				wg.Done()
+			}()
+			start := time.Now()
+			fmt.Println("⏳ Deleting instance", inst.Name, inst.PublicIP)
+
+			delCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+			defer cancel()
+
+			region := inst.Region
+			if region == "" {
+				found, err := findAWSInstanceRegion(delCtx, inst.Name)
+				if err != nil {
+					results <- result{inst: inst, err: fmt.Errorf("find region for %s: %w", inst.Name, err)}
+					return
+				}
+				region = found
+			}
+
+			client, err := newEC2Client(delCtx, region)
+			if err != nil {
+				results <- result{inst: inst, err: fmt.Errorf("ec2 client %s: %w", region, err)}
+				return
+			}
+
+			instanceID, err := findAWSInstanceID(delCtx, client, inst)
+			if err != nil {
+				results <- result{inst: inst, err: fmt.Errorf("find instance %s: %w", inst.Name, err)}
+				return
+			}
+
+			if _, err := client.TerminateInstances(delCtx, &ec2.TerminateInstancesInput{
+				InstanceIds: []string{instanceID},
+			}); err != nil {
+				results <- result{inst: inst, err: fmt.Errorf("terminate %s: %w", inst.Name, err)}
+				return
+			}
+			results <- result{inst: inst, err: nil, timeRequired: time.Since(start)}
+		}(inst)
+	}
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	var removed []Instance
+	var failed []result
+	for res := range results {
+		if res.err != nil {
+			fmt.Printf("❌ %s failed to delete after %v: %v\n", res.inst.Name, res.timeRequired, res.err)
+			failed = append(failed, res)
+		} else {
+			removed = append(removed, res.inst)
+			fmt.Printf("✅ %s terminated (took %v)\n", res.inst.Name, res.timeRequired)
+		}
+		fmt.Printf("---- Progress: %d/%d\n", len(removed)+len(failed), len(insts))
+	}
+	return removed, nil
+}
+
+// findAWSInstanceID resolves an Instance (by its experiment tag if
+// present, otherwise by Name) to an EC2 instance ID. Filters out
+// already-terminated instances so repeated calls don't return ghosts.
+func findAWSInstanceID(ctx context.Context, client *ec2.Client, inst Instance) (string, error) {
+	filters := []ec2types.Filter{
+		{Name: aws.String("instance-state-name"), Values: []string{"pending", "running", "stopping", "stopped"}},
+	}
+	if experimentTag := GetExperimentTag(inst.Tags); experimentTag != "" {
+		filters = append(filters, ec2types.Filter{Name: aws.String("tag-key"), Values: []string{experimentTag}})
+	} else {
+		filters = append(filters, ec2types.Filter{Name: aws.String("tag:Name"), Values: []string{inst.Name}})
+	}
+
+	paginator := ec2.NewDescribeInstancesPaginator(client, &ec2.DescribeInstancesInput{Filters: filters})
+	var ids []string
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return "", err
+		}
+		for _, r := range page.Reservations {
+			for _, i := range r.Instances {
+				if i.InstanceId != nil {
+					ids = append(ids, *i.InstanceId)
+				}
+			}
+		}
+	}
+
+	switch len(ids) {
+	case 0:
+		return "", fmt.Errorf("no instances found for %s", inst.Name)
+	case 1:
+		return ids[0], nil
+	default:
+		return "", fmt.Errorf("multiple instances match %s: %v", inst.Name, ids)
+	}
+}
+
+func findAWSInstanceRegion(ctx context.Context, name string) (string, error) {
+	for _, region := range AWSRegions {
+		client, err := newEC2Client(ctx, region)
+		if err != nil {
+			continue
+		}
+		paginator := ec2.NewDescribeInstancesPaginator(client, &ec2.DescribeInstancesInput{
+			Filters: []ec2types.Filter{
+				{Name: aws.String("tag:Name"), Values: []string{name}},
+				{Name: aws.String("instance-state-name"), Values: []string{"pending", "running", "stopping", "stopped"}},
+			},
+		})
+		for paginator.HasMorePages() {
+			page, err := paginator.NextPage(ctx)
+			if err != nil {
+				break
+			}
+			for _, r := range page.Reservations {
+				if len(r.Instances) > 0 {
+					return region, nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("instance %s not found in any known AWS region", name)
+}
+
+// destroyAllTalisAWSInstances terminates every EC2 instance tagged
+// "talis" across every known region. Called via `down --all`.
+func destroyAllTalisAWSInstances(ctx context.Context, workers int) ([]Instance, error) {
+	var talisInstances []Instance
+	for _, region := range AWSRegions {
+		client, err := newEC2Client(ctx, region)
+		if err != nil {
+			log.Printf("⚠️  failed to build EC2 client for %s: %v", region, err)
+			continue
+		}
+		insts, err := describeTalisInstances(ctx, client)
+		if err != nil {
+			log.Printf("⚠️  failed to describe instances in %s: %v", region, err)
+			continue
+		}
+		for _, i := range insts {
+			publicIP := ""
+			if i.PublicIpAddress != nil {
+				publicIP = *i.PublicIpAddress
+			}
+			talisInstances = append(talisInstances, Instance{
+				Name:     instanceNameFromTags(i.Tags),
+				PublicIP: publicIP,
+				Region:   region,
+			})
+		}
+	}
+
+	if len(talisInstances) == 0 {
+		log.Println("No talis AWS instances found to destroy")
+		return nil, nil
+	}
+	return destroyAWSInstancesInternal(ctx, talisInstances, workers)
+}
+
+func describeTalisInstances(ctx context.Context, client *ec2.Client) ([]ec2types.Instance, error) {
+	var out []ec2types.Instance
+	paginator := ec2.NewDescribeInstancesPaginator(client, &ec2.DescribeInstancesInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("tag-key"), Values: []string{"talis"}},
+			{Name: aws.String("instance-state-name"), Values: []string{"pending", "running", "stopping", "stopped"}},
+		},
+	})
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			return nil, err
+		}
+		for _, r := range page.Reservations {
+			out = append(out, r.Instances...)
+		}
+	}
+	return out, nil
+}
+
+func checkForRunningAWSExperiments(ctx context.Context, awsRegionConfigured bool, experimentID, chainID string) (bool, error) {
+	if !awsRegionConfigured {
+		return false, nil
+	}
+	for _, region := range AWSRegions {
+		client, err := newEC2Client(ctx, region)
+		if err != nil {
+			return false, fmt.Errorf("failed to create EC2 client in %s: %w", region, err)
+		}
+		insts, err := describeTalisInstances(ctx, client)
+		if err != nil {
+			return false, fmt.Errorf("describe instances in %s: %w", region, err)
+		}
+		for _, i := range insts {
+			for _, t := range i.Tags {
+				if t.Key == nil {
+					continue
+				}
+				if hasAWSExperimentTag(*t.Key, experimentID, chainID) {
+					return true, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}
+
+func hasAWSExperimentTag(tag, experimentID, chainID string) bool {
+	if !strings.HasPrefix(tag, "validator-") &&
+		!strings.HasPrefix(tag, "bridge-") &&
+		!strings.HasPrefix(tag, "light-") &&
+		!strings.HasPrefix(tag, "encoder-") {
+		return false
+	}
+	return strings.Contains(tag, experimentID) && strings.Contains(tag, chainID)
+}
+
+// resolveUbuntuAMI finds the most recent Ubuntu 24.04 AMI in the region.
+// Results are cached in-process since AMI IDs rarely change and the
+// lookup costs an API round-trip.
+func resolveUbuntuAMI(ctx context.Context, client *ec2.Client, region string) (string, error) {
+	if cached, ok := amiCache.Load(region); ok {
+		return cached.(string), nil
+	}
+
+	out, err := client.DescribeImages(ctx, &ec2.DescribeImagesInput{
+		Owners: []string{AWSCanonicalOwnerID},
+		Filters: []ec2types.Filter{
+			{Name: aws.String("name"), Values: []string{AWSUbuntuImageNamePattern}},
+			{Name: aws.String("state"), Values: []string{"available"}},
+			{Name: aws.String("architecture"), Values: []string{"x86_64"}},
+			{Name: aws.String("virtualization-type"), Values: []string{"hvm"}},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("describe images: %w", err)
+	}
+	if len(out.Images) == 0 {
+		return "", fmt.Errorf("no Ubuntu AMIs found in %s", region)
+	}
+
+	sort.Slice(out.Images, func(i, j int) bool {
+		a, b := "", ""
+		if out.Images[i].CreationDate != nil {
+			a = *out.Images[i].CreationDate
+		}
+		if out.Images[j].CreationDate != nil {
+			b = *out.Images[j].CreationDate
+		}
+		return a > b
+	})
+
+	amiID := ""
+	if out.Images[0].ImageId != nil {
+		amiID = *out.Images[0].ImageId
+	}
+	if amiID == "" {
+		return "", fmt.Errorf("selected AMI has no ID in %s", region)
+	}
+	amiCache.Store(region, amiID)
+	return amiID, nil
+}
+
+// ensureAWSKeyPair imports the SSH public key under keyName if it's not
+// already registered in the region. EC2 key pairs are region-scoped, so
+// this runs once per region.
+func ensureAWSKeyPair(ctx context.Context, client *ec2.Client, keyName, publicKey string) error {
+	if keyName == "" {
+		return errors.New("SSH key name is required for AWS — set via --ssh-key-name or TALIS_SSH_KEY_NAME")
+	}
+	if _, err := client.DescribeKeyPairs(ctx, &ec2.DescribeKeyPairsInput{
+		KeyNames: []string{keyName},
+	}); err == nil {
+		return nil
+	}
+	// Any error is treated as "not found"; let ImportKeyPair surface the
+	// real problem if something else is wrong.
+	if _, err := client.ImportKeyPair(ctx, &ec2.ImportKeyPairInput{
+		KeyName:           aws.String(keyName),
+		PublicKeyMaterial: []byte(strings.TrimSpace(publicKey)),
+	}); err != nil {
+		return fmt.Errorf("import key pair: %w", err)
+	}
+	return nil
+}
+
+// ensureAWSSecurityGroup creates (or looks up) a security group in the
+// region's default VPC that allows all inbound traffic from 0.0.0.0/0 —
+// same posture as the GCP firewall rule.
+func ensureAWSSecurityGroup(ctx context.Context, client *ec2.Client) (string, error) {
+	vpcID, err := defaultVPCID(ctx, client)
+	if err != nil {
+		return "", err
+	}
+
+	desc, err := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("group-name"), Values: []string{AWSSecurityGroupName}},
+			{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+		},
+	})
+	if err == nil && len(desc.SecurityGroups) > 0 && desc.SecurityGroups[0].GroupId != nil {
+		return *desc.SecurityGroups[0].GroupId, nil
+	}
+
+	create, err := client.CreateSecurityGroup(ctx, &ec2.CreateSecurityGroupInput{
+		GroupName:   aws.String(AWSSecurityGroupName),
+		Description: aws.String("Talis: allow all inbound traffic on all ports"),
+		VpcId:       aws.String(vpcID),
+	})
+	if err != nil {
+		// Another goroutine may have raced us; try to look it up again.
+		if desc2, err2 := client.DescribeSecurityGroups(ctx, &ec2.DescribeSecurityGroupsInput{
+			Filters: []ec2types.Filter{
+				{Name: aws.String("group-name"), Values: []string{AWSSecurityGroupName}},
+				{Name: aws.String("vpc-id"), Values: []string{vpcID}},
+			},
+		}); err2 == nil && len(desc2.SecurityGroups) > 0 && desc2.SecurityGroups[0].GroupId != nil {
+			return *desc2.SecurityGroups[0].GroupId, nil
+		}
+		return "", fmt.Errorf("create security group: %w", err)
+	}
+	if create.GroupId == nil {
+		return "", fmt.Errorf("CreateSecurityGroup returned empty group id")
+	}
+	groupID := *create.GroupId
+
+	if _, err := client.AuthorizeSecurityGroupIngress(ctx, &ec2.AuthorizeSecurityGroupIngressInput{
+		GroupId: aws.String(groupID),
+		IpPermissions: []ec2types.IpPermission{{
+			IpProtocol: aws.String("-1"), // all protocols
+			IpRanges:   []ec2types.IpRange{{CidrIp: aws.String("0.0.0.0/0")}},
+		}},
+	}); err != nil && !strings.Contains(err.Error(), "InvalidPermission.Duplicate") {
+		return "", fmt.Errorf("authorize ingress: %w", err)
+	}
+	return groupID, nil
+}
+
+// ensureAWSPlacementGroup creates a cluster placement group in the
+// region if one doesn't already exist. Idempotent and race-safe.
+func ensureAWSPlacementGroup(ctx context.Context, client *ec2.Client) error {
+	out, err := client.DescribePlacementGroups(ctx, &ec2.DescribePlacementGroupsInput{
+		GroupNames: []string{AWSPlacementGroupName},
+	})
+	if err == nil && len(out.PlacementGroups) > 0 {
+		return nil
+	}
+	if _, err := client.CreatePlacementGroup(ctx, &ec2.CreatePlacementGroupInput{
+		GroupName: aws.String(AWSPlacementGroupName),
+		Strategy:  ec2types.PlacementStrategyCluster,
+	}); err != nil && !strings.Contains(err.Error(), "InvalidPlacementGroup.Duplicate") {
+		return fmt.Errorf("create placement group: %w", err)
+	}
+	return nil
+}
+
+// defaultSubnetInAZ returns the SubnetId of the default VPC's default
+// subnet in the given AZ. Relies on default-VPC semantics (every account
+// has one unless explicitly deleted) rather than managing subnets.
+func defaultSubnetInAZ(ctx context.Context, client *ec2.Client, az string) (string, error) {
+	out, err := client.DescribeSubnets(ctx, &ec2.DescribeSubnetsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("default-for-az"), Values: []string{"true"}},
+			{Name: aws.String("availability-zone"), Values: []string{az}},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("describe subnets: %w", err)
+	}
+	if len(out.Subnets) == 0 || out.Subnets[0].SubnetId == nil {
+		return "", fmt.Errorf("no default subnet in %s — the account may be missing a default VPC/subnet", az)
+	}
+	return *out.Subnets[0].SubnetId, nil
+}
+
+func defaultVPCID(ctx context.Context, client *ec2.Client) (string, error) {
+	out, err := client.DescribeVpcs(ctx, &ec2.DescribeVpcsInput{
+		Filters: []ec2types.Filter{
+			{Name: aws.String("is-default"), Values: []string{"true"}},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("describe default VPC: %w", err)
+	}
+	if len(out.Vpcs) == 0 || out.Vpcs[0].VpcId == nil {
+		return "", fmt.Errorf("no default VPC found — create one or extend talis to accept an explicit VPC")
+	}
+	return *out.Vpcs[0].VpcId, nil
+}
+
+func awsTagsFromInstance(inst Instance) []ec2types.Tag {
+	tags := make([]ec2types.Tag, 0, len(inst.Tags)+1)
+	tags = append(tags, ec2types.Tag{Key: aws.String("Name"), Value: aws.String(inst.Name)})
+	for _, t := range inst.Tags {
+		tags = append(tags, ec2types.Tag{Key: aws.String(t), Value: aws.String("true")})
+	}
+	return tags
+}
+
+func instanceNameFromTags(tags []ec2types.Tag) string {
+	for _, t := range tags {
+		if t.Key != nil && *t.Key == "Name" && t.Value != nil {
+			return *t.Value
+		}
+	}
+	return ""
+}
+
+// awsRootSSHUserData returns cloud-init user-data that (1) sets the
+// instance hostname to the talis name (validator_init.sh parses
+// `hostname` to pick per-validator keys — AWS's default `ip-172-…`
+// format breaks that parser), and (2) installs the operator's SSH
+// public key into /root/.ssh/authorized_keys so deployment.go can keep
+// using `root@`.
+func awsRootSSHUserData(sshKey, instanceName string) string {
+	key := strings.TrimSpace(sshKey)
+	return fmt.Sprintf(`#cloud-config
+disable_root: false
+preserve_hostname: false
+hostname: %s
+fqdn: %s
+runcmd:
+  - hostnamectl set-hostname %s
+  - mkdir -p /root/.ssh
+  - 'echo "%s" > /root/.ssh/authorized_keys'
+  - chmod 700 /root/.ssh
+  - chmod 600 /root/.ssh/authorized_keys
+  - chown -R root:root /root/.ssh
+`,
+		instanceName,
+		instanceName,
+		instanceName,
+		strings.ReplaceAll(key, `"`, `\"`),
+	)
+}

--- a/tools/talis/client.go
+++ b/tools/talis/client.go
@@ -40,6 +40,9 @@ func NewClient(cfg Config) (Client, error) {
 	if cfg.GoogleCloudProject != "" {
 		return NewGCClient(cfg)
 	}
+	if cfg.AWSRegion != "" {
+		return NewAWSClient(cfg)
+	}
 	return nil, errors.New("no cloud provider credentials found")
 }
 

--- a/tools/talis/config.go
+++ b/tools/talis/config.go
@@ -61,6 +61,7 @@ type Provider string
 const (
 	DigitalOcean Provider = "digitalocean"
 	GoogleCloud  Provider = "googlecloud"
+	AWS          Provider = "aws"
 )
 
 // Instance represents a single instance in the network. It contains
@@ -82,6 +83,11 @@ type Instance struct {
 	// Region is the region in which the instance is created. For example,
 	// "nyc1" for DigitalOcean or "us-east-1" for AWS.
 	Region string `json:"region"`
+	// Zone is the provider-specific availability zone within Region. Empty
+	// means "any zone". Currently only populated for AWS (e.g. "us-east-1a")
+	// so instances can be pinned to a single AZ for free intra-AZ traffic
+	// and minimum latency within a cluster placement group.
+	Zone string `json:"zone,omitempty"`
 	// Name is the name of the instance. This is used to identify the instance
 	// in the network and is also used as the hostname of the instance. It
 	// therefore should be unique.
@@ -158,10 +164,19 @@ type Config struct {
 	SSHKeyName string `json:"ssh_key_name"`
 	// DigitalOceanToken is used to authenticate with DigitalOcean. It can be
 	// provided via an env var or flag.
-	DigitalOceanToken      string   `json:"digitalocean_token"`
-	GoogleCloudProject     string   `json:"google_cloud_project"`
-	GoogleCloudKeyJSONPath string   `json:"google_cloud_key_json_path"`
-	S3Config               S3Config `json:"s3_config"`
+	DigitalOceanToken      string `json:"digitalocean_token"`
+	GoogleCloudProject     string `json:"google_cloud_project"`
+	GoogleCloudKeyJSONPath string `json:"google_cloud_key_json_path"`
+	// AWSRegion is the default region for launching EC2 instances. When set
+	// (and DigitalOceanToken / GoogleCloudProject are empty), NewClient
+	// uses AWS as the compute provider. Credentials come from the standard
+	// AWS SDK credential chain (env vars, ~/.aws/credentials, IAM role).
+	AWSRegion string `json:"aws_region"`
+	// AWSZone is the availability zone within AWSRegion. All AWS instances
+	// get pinned to this AZ + a cluster placement group so intra-cluster
+	// traffic stays free and latency is minimised. Empty means "default AZ".
+	AWSZone  string   `json:"aws_zone"`
+	S3Config S3Config `json:"s3_config"`
 }
 
 func NewConfig(experiment, chainID string) Config {
@@ -208,6 +223,16 @@ func (cfg Config) WithGoogleCloudKeyJSONPath(keyJSONPath string) Config {
 	return cfg
 }
 
+func (cfg Config) WithAWSRegion(region string) Config {
+	cfg.AWSRegion = region
+	return cfg
+}
+
+func (cfg Config) WithAWSZone(zone string) Config {
+	cfg.AWSZone = zone
+	return cfg
+}
+
 func (cfg Config) WithS3Config(s3 S3Config) Config {
 	cfg.S3Config = s3
 	return cfg
@@ -245,6 +270,24 @@ func (cfg Config) WithDigitalOceanEncoder(region string) Config {
 
 func (cfg Config) WithGoogleCloudEncoder(region string) Config {
 	i := NewGoogleCloudEncoder(region).WithExperiment(cfg.Experiment, cfg.ChainID)
+	cfg.Encoders = append(cfg.Encoders, i)
+	return cfg
+}
+
+func (cfg Config) WithAWSValidator(region string) Config {
+	i := NewAWSValidator(region).WithExperiment(cfg.Experiment, cfg.ChainID)
+	cfg.Validators = append(cfg.Validators, i)
+	return cfg
+}
+
+func (cfg Config) WithAWSObservability(region string) Config {
+	i := NewAWSObservability(region).WithExperiment(cfg.Experiment, cfg.ChainID)
+	cfg.Observability = append(cfg.Observability, i)
+	return cfg
+}
+
+func (cfg Config) WithAWSEncoder(region string) Config {
+	i := NewAWSEncoder(region).WithExperiment(cfg.Experiment, cfg.ChainID)
 	cfg.Encoders = append(cfg.Encoders, i)
 	return cfg
 }

--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -725,7 +725,11 @@ func checkForRunningExperiments(ctx context.Context, cfg Config) error {
 
 func destroyAllInstances(ctx context.Context, cfg Config, workers int) error {
 	var wg sync.WaitGroup
-	errCh := make(chan error, 2)
+	// One slot per potential provider goroutine (DO + GCP + AWS). Sized
+	// to match max writers so a three-way all-fail doesn't deadlock on
+	// errCh<- (wg.Wait() below blocks on the goroutine, which blocks on
+	// the channel send if capacity < writers).
+	errCh := make(chan error, 3)
 
 	if cfg.DigitalOceanToken != "" {
 		wg.Go(func() {

--- a/tools/talis/deployment.go
+++ b/tools/talis/deployment.go
@@ -29,6 +29,7 @@ func upCmd() *cobra.Command {
 	var DOAPIToken string
 	var GCProject string
 	var GCKeyJSONPath string
+	var AWSRegion string
 	var workers int
 
 	cmd := &cobra.Command{
@@ -52,6 +53,7 @@ func upCmd() *cobra.Command {
 			cfg.DigitalOceanToken = resolveValue(DOAPIToken, EnvVarDigitalOceanToken, cfg.DigitalOceanToken)
 			cfg.GoogleCloudProject = resolveValue(GCProject, EnvVarGoogleCloudProject, cfg.GoogleCloudProject)
 			cfg.GoogleCloudKeyJSONPath = resolveValue(GCKeyJSONPath, EnvVarGoogleCloudKeyJSONPath, cfg.GoogleCloudKeyJSONPath)
+			cfg.AWSRegion = resolveValue(AWSRegion, EnvVarAWSRegion, cfg.AWSRegion)
 
 			if err := checkForRunningExperiments(cmd.Context(), cfg); err != nil {
 				return err
@@ -81,6 +83,7 @@ func upCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&DOAPIToken, "do-api-token", "t", "", "digital ocean api token (defaults to config or env)")
 	cmd.Flags().StringVar(&GCProject, "gc-project", "", "google cloud project (defaults to config or env)")
 	cmd.Flags().StringVar(&GCKeyJSONPath, "gc-key-json-path", "", "path to google cloud service account key JSON file (defaults to config or env)")
+	cmd.Flags().StringVar(&AWSRegion, "aws-region", "", "AWS default region for EC2 (defaults to config or AWS_DEFAULT_REGION)")
 	cmd.Flags().IntVarP(&workers, "workers", "w", 10, "number of concurrent workers for parallel operations (should be > 0)")
 
 	return cmd
@@ -556,6 +559,7 @@ func downCmd() *cobra.Command {
 	var DOAPIToken string
 	var GCProject string
 	var GCKeyJSONPath string
+	var AWSRegion string
 	var workers int
 	var all bool
 
@@ -574,6 +578,7 @@ func downCmd() *cobra.Command {
 			cfg.DigitalOceanToken = resolveValue(DOAPIToken, EnvVarDigitalOceanToken, cfg.DigitalOceanToken)
 			cfg.GoogleCloudProject = resolveValue(GCProject, EnvVarGoogleCloudProject, cfg.GoogleCloudProject)
 			cfg.GoogleCloudKeyJSONPath = resolveValue(GCKeyJSONPath, EnvVarGoogleCloudKeyJSONPath, cfg.GoogleCloudKeyJSONPath)
+			cfg.AWSRegion = resolveValue(AWSRegion, EnvVarAWSRegion, cfg.AWSRegion)
 
 			if all {
 				return destroyAllInstances(cmd.Context(), cfg, workers)
@@ -606,6 +611,7 @@ func downCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&DOAPIToken, "do-api-token", "t", "", "digital ocean api token (defaults to config or env)")
 	cmd.Flags().StringVar(&GCProject, "gc-project", "", "google cloud project (defaults to config or env)")
 	cmd.Flags().StringVar(&GCKeyJSONPath, "gc-key-json-path", "", "path to google cloud service account key JSON file (defaults to config or env)")
+	cmd.Flags().StringVar(&AWSRegion, "aws-region", "", "AWS default region for EC2 (defaults to config or AWS_DEFAULT_REGION)")
 	cmd.Flags().IntVarP(&workers, "workers", "w", 10, "number of concurrent workers for parallel operations (should be > 0)")
 	cmd.Flags().BoolVar(&all, "all", false, "destroy all talis instances across all providers and all experiments")
 
@@ -632,6 +638,7 @@ func listCmd() *cobra.Command {
 	var DOAPIToken string
 	var GCProject string
 	var GCKeyJSONPath string
+	var AWSRegion string
 
 	cmd := &cobra.Command{
 		Use:   "list",
@@ -648,6 +655,7 @@ func listCmd() *cobra.Command {
 			cfg.DigitalOceanToken = resolveValue(DOAPIToken, EnvVarDigitalOceanToken, cfg.DigitalOceanToken)
 			cfg.GoogleCloudProject = resolveValue(GCProject, EnvVarGoogleCloudProject, cfg.GoogleCloudProject)
 			cfg.GoogleCloudKeyJSONPath = resolveValue(GCKeyJSONPath, EnvVarGoogleCloudKeyJSONPath, cfg.GoogleCloudKeyJSONPath)
+			cfg.AWSRegion = resolveValue(AWSRegion, EnvVarAWSRegion, cfg.AWSRegion)
 
 			client, err := NewClient(cfg)
 			if err != nil {
@@ -663,6 +671,7 @@ func listCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&DOAPIToken, "do-api-token", "t", "", "digital ocean api token (defaults to config or env)")
 	cmd.Flags().StringVar(&GCProject, "gc-project", "", "google cloud project (defaults to config or env)")
 	cmd.Flags().StringVar(&GCKeyJSONPath, "gc-key-json-path", "", "path to google cloud service account key JSON file (defaults to config or env)")
+	cmd.Flags().StringVar(&AWSRegion, "aws-region", "", "AWS default region for EC2 (defaults to config or AWS_DEFAULT_REGION)")
 
 	return cmd
 }
@@ -694,6 +703,16 @@ func checkForRunningExperiments(ctx context.Context, cfg Config) error {
 				hasRunningExperiments = true
 				log.Printf("⚠️  Found experiment '%s' with chainID '%s' already running in Google Cloud", cfg.Experiment, cfg.ChainID)
 			}
+		}
+	}
+
+	if cfg.AWSRegion != "" {
+		running, err := checkForRunningAWSExperiments(ctx, true, cfg.Experiment, cfg.ChainID)
+		if err != nil {
+			log.Printf("⚠️  Warning: failed to check AWS for running experiments: %v", err)
+		} else if running {
+			hasRunningExperiments = true
+			log.Printf("⚠️  Found experiment '%s' with chainID '%s' already running in AWS", cfg.Experiment, cfg.ChainID)
 		}
 	}
 
@@ -733,10 +752,19 @@ func destroyAllInstances(ctx context.Context, cfg Config, workers int) error {
 		})
 	}
 
+	if cfg.AWSRegion != "" || os.Getenv(EnvVarAWSAccessKeyID) != "" {
+		wg.Go(func() {
+			log.Println("Destroying all AWS instances...")
+			if _, err := destroyAllTalisAWSInstances(ctx, workers); err != nil {
+				errCh <- fmt.Errorf("AWS: %w", err)
+			}
+		})
+	}
+
 	wg.Wait()
 	close(errCh)
 
-	errs := make([]error, 0, 2)
+	errs := make([]error, 0, 3)
 	for err := range errCh {
 		errs = append(errs, err)
 	}

--- a/tools/talis/env.go
+++ b/tools/talis/env.go
@@ -26,8 +26,10 @@ func initEnvCmd() *cobra.Command {
 				envContent = generateDigitalOceanEnv()
 			case "googlecloud":
 				envContent = generateGoogleCloudEnv()
+			case "aws":
+				envContent = generateAWSEnv()
 			default:
-				return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud)", provider)
+				return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud, aws)", provider)
 			}
 
 			// Check if .env already exists
@@ -49,7 +51,7 @@ func initEnvCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "Cloud provider (digitalocean or googlecloud)")
+	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "Cloud provider (digitalocean, googlecloud, aws)")
 
 	return cmd
 }
@@ -100,5 +102,36 @@ GOOGLE_CLOUD_KEY_JSON_PATH=
 # AWS_SECRET_ACCESS_KEY=
 # AWS_S3_BUCKET=
 # AWS_S3_ENDPOINT=https://fra1.digitaloceanspaces.com
+`
+}
+
+func generateAWSEnv() string {
+	return `# Provider Configuration
+PROVIDER=aws
+
+# AWS Credentials (used for both EC2 and the S3 payload bucket)
+# Create an access key at: https://console.aws.amazon.com/iam/home#/security_credentials
+# The user must have EC2 permissions (RunInstances, Terminate, Describe*,
+# ImportKeyPair, CreateSecurityGroup/AuthorizeSecurityGroupIngress,
+# CreatePlacementGroup, DescribeVpcs/DescribeSubnets, DescribeImages) and
+# S3 (PutObject, GetObject) on the payload bucket.
+#
+# You can also leave these unset and use 'aws configure --profile <name>' +
+# AWS_PROFILE=<name> — the Go SDK picks up shared credentials automatically.
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+
+# Region for EC2 and (by default) the S3 payload bucket.
+AWS_DEFAULT_REGION=us-east-1
+
+# SSH Configuration
+# TALIS_SSH_KEY_PATH is the local path to your SSH public key. The key is
+# imported to EC2 (once per region) under TALIS_SSH_KEY_NAME.
+# TALIS_SSH_KEY_PATH=~/.ssh/id_ed25519.pub
+# TALIS_SSH_KEY_NAME=your-username
+
+# S3 Payload Bucket (optional — omit and use 'deploy --direct-payload-upload')
+# Must be an S3 bucket you own in AWS_DEFAULT_REGION.
+# AWS_S3_BUCKET=
 `
 }

--- a/tools/talis/init.go
+++ b/tools/talis/init.go
@@ -46,6 +46,7 @@ func initCmd() *cobra.Command {
 		provider            string
 		observabilityRegion string
 		observabilitySlug   string
+		awsZone             string
 	)
 
 	cmd := &cobra.Command{
@@ -108,14 +109,23 @@ func initCmd() *cobra.Command {
 					cfg = cfg.WithGoogleCloudObservability(observabilityRegion).
 						WithGoogleCloudProject(os.Getenv(EnvVarGoogleCloudProject)).
 						WithGoogleCloudKeyJSONPath(os.Getenv(EnvVarGoogleCloudKeyJSONPath))
+				case "aws":
+					cfg = cfg.WithAWSObservability(observabilityRegion).
+						WithAWSRegion(awsRegionFromEnv()).
+						WithAWSZone(resolveAWSZone(awsZone))
 				default:
-					return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud)", provider)
+					return fmt.Errorf("unknown provider %q (supported: digitalocean, googlecloud, aws)", provider)
 				}
 				enablePrometheus = true
 
 				if observabilitySlug != "" && len(cfg.Observability) > 0 {
 					cfg.Observability[0].Slug = observabilitySlug
 				}
+			} else if provider == "aws" {
+				// Stamp AWSRegion / AWSZone so NewClient later routes to
+				// AWSClient even when the user doesn't want an obs node.
+				cfg = cfg.WithAWSRegion(awsRegionFromEnv()).
+					WithAWSZone(resolveAWSZone(awsZone))
 			}
 
 			if err := cfg.Save(rootDir); err != nil {
@@ -163,9 +173,10 @@ func initCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("experiment")
 	cmd.Flags().StringArrayVarP(&tables, "tables", "t", []string{"consensus_round_state", "consensus_block", "mempool_tx"}, "the traces that will be collected")
 	cmd.Flags().BoolVar(&withObservability, "with-observability", false, "add a observability node and enable Prometheus on validators")
-	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "provider for observability node when --with-observability is set (digitalocean, googlecloud)")
+	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "provider for observability node when --with-observability is set (digitalocean, googlecloud, aws)")
 	cmd.Flags().StringVar(&observabilityRegion, "observability-region", "random", "region for the observability node — set to match your validator region to reduce scrape latency")
-	cmd.Flags().StringVar(&observabilitySlug, "observability-slug", "", "instance size for the observability node (default: provider's default — "+DODefaultObservabilitySlug+" for DigitalOcean, "+GCDefaultObservabilityMachineType+" for Google Cloud)")
+	cmd.Flags().StringVar(&observabilitySlug, "observability-slug", "", "instance size for the observability node (default: provider's default — "+DODefaultObservabilitySlug+" for DigitalOcean, "+GCDefaultObservabilityMachineType+" for Google Cloud, "+AWSDefaultObservabilityInstanceType+" for AWS)")
+	cmd.Flags().StringVar(&awsZone, "aws-zone", "", "availability zone for AWS instances (default: "+AWSDefaultZone+"). All AWS instances share this AZ + a cluster placement group for free intra-AZ traffic and low latency.")
 
 	defaultKeyPath := filepath.Join(homeDir, ".ssh", "id_ed25519.pub")
 	cmd.Flags().StringVarP(&SSHPubKeyPath, "ssh-pub-key-path", "s", defaultKeyPath, "path to the user's SSH public key")


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1543/feattalis-add-aws-ec2-as-a-compute-provider

## Summary

Bring AWS up to parity with the existing DigitalOcean and Google Cloud providers so talis can launch Celestia / fibre experiments on EC2.

- **Surface**: `--provider aws` on `talis init`, `talis add`, and `talis init-env`. New `--slug` override on `add` (works for all providers) and `--aws-zone` on `init` + `--aws-region` on up/down/list.
- **Core**: new `tools/talis/aws.go` (~700 LOC) wraps the EC2 lifecycle — AMI resolution (Canonical Ubuntu 24.04 filter + in-proc cache), key-pair import, security group, cluster placement group, default-subnet lookup, RunInstances, wait-for-IPs, TerminateInstances, destroy-all, and the existing-experiment check for the shared `checkForRunningExperiments` gate.
- **Defaults** mirror the DO layout: validator `c6in.4xlarge` (network-enhanced, 25 Gbps baseline), encoder `c6in.2xlarge`, obs `t3.medium`. Single-region/single-AZ (`us-east-1` / `us-east-1a`) because AWS cross-region traffic is $0.09/GB — overridable via `--aws-zone` and `--aws-region`. Single-AZ layout enables a cluster placement group for minimum latency.
- **Hostname fix**: cloud-init user-data calls `hostnamectl set-hostname <inst.Name>` at boot. `validator_init.sh` parses `hostname` to pick per-validator keys; AWS's default `ip-172-31-X-Y` hostname breaks the parser. Root SSH is also enabled here so `deployment.go` can keep using `root@`.
- **No S3 or init-script changes** in this PR. Operators can reuse `AWS_*` env vars for the payload bucket (shared with EC2 creds) or use `deploy --direct-payload-upload`. A follow-up PR un-shares the S3 env vars so AWS compute + DO Spaces coexist cleanly; another adds local-NVMe support for i-family instances.

## Files

| File | Change |
|---|---|
| `tools/talis/aws.go` *(new)* | Full EC2 implementation |
| `tools/talis/config.go` | `AWS` Provider const, `AWSRegion` + `AWSZone` on `Config`, `Zone` on `Instance`, builders |
| `tools/talis/client.go` | `NewClient` dispatches to `NewAWSClient` when `cfg.AWSRegion` is set |
| `tools/talis/add.go` | `--provider aws` + `--slug` flag |
| `tools/talis/init.go` | `--provider aws`, `--aws-zone`, stamps region/zone into config |
| `tools/talis/env.go` | `generateAWSEnv` template + switch case |
| `tools/talis/deployment.go` | `--aws-region` on up/down/list, AWS branches in check/destroy-all |
| `go.mod` / `go.sum` | `github.com/aws/aws-sdk-go-v2/service/ec2` |

## Test plan

- [x] `go vet ./tools/talis/...` clean
- [x] `go test ./tools/talis/...` clean
- [x] `talis init --help`, `talis add --help`, `talis up --help`, `talis init-env --help` all surface new flags
- [x] End-to-end smoke: launched 1× c6in.4xlarge validator in us-east-1 via `talis up`, verified KeyPair import, SG, placement group, hostname (`validator-0`), root SSH, and `talis down` terminates cleanly
- [x] Full 10-validator + 10-encoder + 1-observability run in `us-east-1d`: genesis + deploy + setup-fibre + start-fibre + fibre-txsim (upload-only, 1 MB blobs) → chain produces blocks, fibre server metrics in Prometheus, Pyroscope receives fibre-txsim profiles

## Not in scope (follow-ups)

- Untangle `AWS_*` env vars so DO Spaces / AWS S3 can coexist without collision (separate PR).
- Use local NVMe instance-store on i-family defaults for the fibre state dir (separate PR — unblocks the pebble-disk bottleneck observed at high blob sizes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7142" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
