### PR TITLE
feat(talis): tie S3 payload bucket env vars to the compute provider

### DIFF
--- a/tools/talis/README.md
+++ b/tools/talis/README.md
@@ -122,11 +122,11 @@ the celestia-app configs (config.toml and app.toml) can be manually edited here,
   "google_cloud_project": "pulled from env var if available",
   "google_cloud_key_json_path": "pulled from env var if available",
   "s3_config": {
-    "region": "pulled from AWS_DEFAULT_REGION env var if available",
-    "access_key_id": "pulled from AWS_ACCESS_KEY_ID env var if available",
-    "secret_access_key": "pulled from AWS_SECRET_ACCESS_KEY env var if available",
-    "bucket_name": "pulled from AWS_S3_BUCKET env var if available",
-    "endpoint": "pulled from AWS_S3_ENDPOINT env var if available. Can be left empty if targeting an AWS S3 bucket"
+    "region": "AWS_DEFAULT_REGION (--provider=aws) | DO_SPACES_REGION (digitalocean/googlecloud)",
+    "access_key_id": "AWS_ACCESS_KEY_ID (--provider=aws) | DO_SPACES_ACCESS_KEY_ID (digitalocean/googlecloud)",
+    "secret_access_key": "AWS_SECRET_ACCESS_KEY (--provider=aws) | DO_SPACES_SECRET_ACCESS_KEY (digitalocean/googlecloud)",
+    "bucket_name": "AWS_S3_BUCKET (--provider=aws) | DO_SPACES_BUCKET (digitalocean/googlecloud)",
+    "endpoint": "DO_SPACES_ENDPOINT (digitalocean/googlecloud); empty for --provider=aws → real AWS S3"
   }
 }
 ```
@@ -134,7 +134,7 @@ the celestia-app configs (config.toml and app.toml) can be manually edited here,
 Notes:
 
 - **Only use one cloud provider per experiment.** Fill out either DigitalOcean or Google Cloud fields, not both. Filling them both might end up ruining other experiments or having stuck experiments that need to be removed by hand.
-- The AWS config supports any S3-compatible bucket. So it can be used with Digital Ocean and other cloud providers.
+- S3 payload-bucket env vars are scoped per provider so AWS compute and DigitalOcean Spaces setups don't stomp on each other. The AWS provider uses `AWS_*` (real AWS S3, no endpoint override). DigitalOcean and Google Cloud providers use `DO_SPACES_*` against an S3-compatible endpoint.
 - Example: The S3 endpoint for Digital Ocean is: `https://<region>.digitaloceanspaces.com/`.
 
 ### add

--- a/tools/talis/config.go
+++ b/tools/talis/config.go
@@ -179,7 +179,11 @@ type Config struct {
 	S3Config S3Config `json:"s3_config"`
 }
 
-func NewConfig(experiment, chainID string) Config {
+// NewConfig builds a fresh talis config. The provider determines which
+// env vars populate the S3 payload bucket: AWS reads AWS_*, DigitalOcean
+// and GoogleCloud read DO_SPACES_*. Any other value yields a zero
+// S3Config — populate it yourself via WithS3Config.
+func NewConfig(experiment, chainID string, provider Provider) Config {
 	return Config{
 		Validators:    []Instance{},
 		Bridges:       []Instance{},
@@ -188,13 +192,35 @@ func NewConfig(experiment, chainID string) Config {
 		Encoders:      []Instance{},
 		Experiment:    experiment,
 		ChainID:       TalisChainID(chainID),
-		S3Config: S3Config{
+		S3Config:      s3ConfigFromEnv(provider),
+	}
+}
+
+// s3ConfigFromEnv returns the S3 payload-bucket config for the given
+// compute provider. Each provider pulls from its own, non-overlapping
+// env var prefix so AWS and DigitalOcean Spaces setups never stomp on
+// each other. Unknown providers return a zero S3Config so callers can
+// populate it explicitly via WithS3Config.
+func s3ConfigFromEnv(provider Provider) S3Config {
+	switch provider {
+	case AWS:
+		return S3Config{
 			AccessKeyID:     os.Getenv(EnvVarAWSAccessKeyID),
 			SecretAccessKey: os.Getenv(EnvVarAWSSecretAccessKey),
-			BucketName:      os.Getenv(EnvVarS3Bucket),
+			BucketName:      os.Getenv(EnvVarAWSS3Bucket),
 			Region:          os.Getenv(EnvVarAWSRegion),
-			Endpoint:        os.Getenv(EnvVarS3Endpoint),
-		},
+			// Endpoint intentionally empty → real AWS S3.
+		}
+	case DigitalOcean, GoogleCloud:
+		return S3Config{
+			AccessKeyID:     os.Getenv(EnvVarDOSpacesAccessKeyID),
+			SecretAccessKey: os.Getenv(EnvVarDOSpacesSecretAccessKey),
+			BucketName:      os.Getenv(EnvVarDOSpacesBucket),
+			Region:          os.Getenv(EnvVarDOSpacesRegion),
+			Endpoint:        os.Getenv(EnvVarDOSpacesEndpoint),
+		}
+	default:
+		return S3Config{}
 	}
 }
 

--- a/tools/talis/env.go
+++ b/tools/talis/env.go
@@ -68,13 +68,13 @@ DIGITALOCEAN_TOKEN=
 # TALIS_SSH_KEY_PATH=~/.ssh/id_ed25519.pub
 # TALIS_SSH_KEY_NAME=your-username
 
-# S3/DigitalOcean Spaces Configuration (optional - for payload distribution)
+# DigitalOcean Spaces (optional - for payload distribution)
 # Create a Space and generate API keys at: https://cloud.digitalocean.com/spaces
-# AWS_DEFAULT_REGION=fra1
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_S3_BUCKET=
-# AWS_S3_ENDPOINT=https://fra1.digitaloceanspaces.com
+# DO_SPACES_REGION=fra1
+# DO_SPACES_ACCESS_KEY_ID=
+# DO_SPACES_SECRET_ACCESS_KEY=
+# DO_SPACES_BUCKET=
+# DO_SPACES_ENDPOINT=https://fra1.digitaloceanspaces.com
 `
 }
 
@@ -95,13 +95,12 @@ GOOGLE_CLOUD_KEY_JSON_PATH=
 # TALIS_SSH_KEY_PATH=~/.ssh/id_ed25519.pub
 # TALIS_SSH_KEY_NAME=your-username
 
-# S3/DigitalOcean Spaces Configuration (optional - for payload distribution)
-# You can use DigitalOcean Spaces for S3-compatible storage
-# AWS_DEFAULT_REGION=fra1
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_S3_BUCKET=
-# AWS_S3_ENDPOINT=https://fra1.digitaloceanspaces.com
+# DigitalOcean Spaces (optional - for payload distribution)
+# DO_SPACES_REGION=fra1
+# DO_SPACES_ACCESS_KEY_ID=
+# DO_SPACES_SECRET_ACCESS_KEY=
+# DO_SPACES_BUCKET=
+# DO_SPACES_ENDPOINT=https://fra1.digitaloceanspaces.com
 `
 }
 

--- a/tools/talis/init.go
+++ b/tools/talis/init.go
@@ -24,13 +24,19 @@ const (
 	EnvVarDigitalOceanToken      = "DIGITALOCEAN_TOKEN"
 	EnvVarGoogleCloudProject     = "GOOGLE_CLOUD_PROJECT"
 	EnvVarGoogleCloudKeyJSONPath = "GOOGLE_CLOUD_KEY_JSON_PATH"
-	EnvVarAWSAccessKeyID         = "AWS_ACCESS_KEY_ID"
-	EnvVarAWSSecretAccessKey     = "AWS_SECRET_ACCESS_KEY"
-	EnvVarAWSRegion              = "AWS_DEFAULT_REGION"
-	EnvVarS3Bucket               = "AWS_S3_BUCKET"
-	EnvVarS3Endpoint             = "AWS_S3_ENDPOINT"
-	EnvVarChainID                = "CHAIN_ID"
-	mebibyte                     = 1_048_576
+	// S3 payload bucket env vars. AWS_* feed --provider=aws (real AWS S3,
+	// no endpoint). DO_SPACES_* feed --provider=digitalocean/googlecloud.
+	EnvVarAWSAccessKeyID          = "AWS_ACCESS_KEY_ID"
+	EnvVarAWSSecretAccessKey      = "AWS_SECRET_ACCESS_KEY"
+	EnvVarAWSRegion               = "AWS_DEFAULT_REGION"
+	EnvVarAWSS3Bucket             = "AWS_S3_BUCKET"
+	EnvVarDOSpacesAccessKeyID     = "DO_SPACES_ACCESS_KEY_ID"
+	EnvVarDOSpacesSecretAccessKey = "DO_SPACES_SECRET_ACCESS_KEY"
+	EnvVarDOSpacesRegion          = "DO_SPACES_REGION"
+	EnvVarDOSpacesBucket          = "DO_SPACES_BUCKET"
+	EnvVarDOSpacesEndpoint        = "DO_SPACES_ENDPOINT"
+	EnvVarChainID                 = "CHAIN_ID"
+	mebibyte                      = 1_048_576
 )
 
 func initCmd() *cobra.Command {
@@ -94,7 +100,7 @@ func initCmd() *cobra.Command {
 			}
 
 			// todo: use the number of validators, bridges, and lights to create the config
-			cfg := NewConfig(experiment, chainID).
+			cfg := NewConfig(experiment, chainID, Provider(provider)).
 				WithSSHPubKeyPath(SSHPubKeyPath).
 				WithSSHKeyName(SSHKeyName)
 
@@ -173,7 +179,7 @@ func initCmd() *cobra.Command {
 	_ = cmd.MarkFlagRequired("experiment")
 	cmd.Flags().StringArrayVarP(&tables, "tables", "t", []string{"consensus_round_state", "consensus_block", "mempool_tx"}, "the traces that will be collected")
 	cmd.Flags().BoolVar(&withObservability, "with-observability", false, "add a observability node and enable Prometheus on validators")
-	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "provider for observability node when --with-observability is set (digitalocean, googlecloud, aws)")
+	cmd.Flags().StringVarP(&provider, "provider", "p", "digitalocean", "compute provider (digitalocean, googlecloud, aws); also selects S3 env-var prefix (AWS_* vs DO_SPACES_*)")
 	cmd.Flags().StringVar(&observabilityRegion, "observability-region", "random", "region for the observability node — set to match your validator region to reduce scrape latency")
 	cmd.Flags().StringVar(&observabilitySlug, "observability-slug", "", "instance size for the observability node (default: provider's default — "+DODefaultObservabilitySlug+" for DigitalOcean, "+GCDefaultObservabilityMachineType+" for Google Cloud, "+AWSDefaultObservabilityInstanceType+" for AWS)")
 	cmd.Flags().StringVar(&awsZone, "aws-zone", "", "availability zone for AWS instances (default: "+AWSDefaultZone+"). All AWS instances share this AZ + a cluster placement group for free intra-AZ traffic and low latency.")

--- a/tools/talis/kpi_reproduction_steps.md
+++ b/tools/talis/kpi_reproduction_steps.md
@@ -44,14 +44,14 @@ This document provides instructions for reproducing the core-app KPIs. These KPI
 
 5. **S3 bucket for faster deployment (optional):**
 
-   For faster deployments using S3 upload instead of direct payload upload, configure an S3 bucket:
+   For faster deployments using S3 upload instead of direct payload upload, configure an S3 bucket. With `--provider=googlecloud` (or `digitalocean`), the bucket env vars use the `DO_SPACES_*` prefix:
 
    ```bash
-   AWS_ACCESS_KEY_ID=your-access-key
-   AWS_SECRET_ACCESS_KEY=your-secret-key
-   AWS_DEFAULT_REGION=fra1
-   AWS_S3_ENDPOINT=https://fra1.digitaloceanspaces.com
-   AWS_S3_BUCKET=your-bucket-name
+   DO_SPACES_ACCESS_KEY_ID=your-access-key
+   DO_SPACES_SECRET_ACCESS_KEY=your-secret-key
+   DO_SPACES_REGION=fra1
+   DO_SPACES_ENDPOINT=https://fra1.digitaloceanspaces.com
+   DO_SPACES_BUCKET=your-bucket-name
    ```
 
 ## Talis Network Deployment


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1544/feattalis-tie-s3-payload-bucket-env-vars-to-the-compute-provider

## Summary

Every provider used to read the same `AWS_*` env vars for the S3 payload bucket. With AWS EC2 as a compute provider, those vars mean two different things and cohabiting AWS compute + DO Spaces in one shell silently cross-contaminates creds.

Give each provider its own, non-overlapping env var prefix:

- `--provider=aws` → `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `AWS_S3_BUCKET` (real AWS S3, no endpoint)
- `--provider=digitalocean` / `googlecloud` → `DO_SPACES_*`

## Test plan

- [x] `go vet ./tools/talis/...`, `go test ./tools/talis/...` clean
- [x] DO workflow with `DO_SPACES_*` + `--provider=digitalocean` — payload S3 path works
- [x] AWS workflow with `AWS_*` + `--provider=aws` — payload lands in AWS S3