### PR TITLE
fix: re-roll privval gRPC port in testnode retry

### DIFF
--- a/test/util/testnode/network.go
+++ b/test/util/testnode/network.go
@@ -36,12 +36,7 @@ func NewNetworkWithRetry(t testing.TB, config *Config, maxRetries int) (cctx Con
 			if isPortBindingError(err) {
 				t.Logf("port binding error on attempt %d/%d, retrying after %ds: %v", attempt+1, maxRetries, attempt+1, err)
 				time.Sleep(time.Duration(attempt+1) * time.Second)
-				config.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-				config.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-				config.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-				config.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
-				config.AppConfig.API.Enable = true
-				config.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
+				reassignListenPorts(config)
 				continue
 			}
 			t.Fatalf("Failed to start network after %d attempts: %v", attempt+1, err)
@@ -122,6 +117,20 @@ func tryStartNetwork(t testing.TB, config *Config) (cctx Context, rpcAddr, grpcA
 	}
 
 	return cctx, config.TmConfig.RPC.ListenAddress, config.AppConfig.GRPC.Address, cleanup, nil
+}
+
+// reassignListenPorts reassigns every listener address in config to a new free
+// port. It must cover every port-bearing field set in DefaultTendermintConfig
+// and DefaultAppConfig; missing any one of them makes the retry loop in
+// NewNetworkWithRetry re-use a stale port on every attempt (see #7137).
+func reassignListenPorts(config *Config) {
+	config.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
+	config.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
+	config.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
+	config.TmConfig.PrivValidatorGRPCListenAddr = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
+	config.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
+	config.AppConfig.API.Enable = true
+	config.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
 }
 
 // isPortBindingError checks if an error is related to port binding failures

--- a/test/util/testnode/network_test.go
+++ b/test/util/testnode/network_test.go
@@ -1,0 +1,41 @@
+package testnode
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReassignListenPorts exercises every listen-port field that the retry
+// path in NewNetworkWithRetry must re-roll after a port binding error. If any
+// of these fields is missed, a transient collision on that port will recur on
+// every retry and the test will fail after maxRetries attempts (see #7137).
+func TestReassignListenPorts(t *testing.T) {
+	cfg := DefaultConfig()
+
+	before := struct {
+		tmRPC     string
+		tmP2P     string
+		tmRPCGRPC string
+		tmPrivVal string
+		appGRPC   string
+		appAPI    string
+	}{
+		tmRPC:     cfg.TmConfig.RPC.ListenAddress,
+		tmP2P:     cfg.TmConfig.P2P.ListenAddress,
+		tmRPCGRPC: cfg.TmConfig.RPC.GRPCListenAddress,
+		tmPrivVal: cfg.TmConfig.PrivValidatorGRPCListenAddr,
+		appGRPC:   cfg.AppConfig.GRPC.Address,
+		appAPI:    cfg.AppConfig.API.Address,
+	}
+
+	reassignListenPorts(cfg)
+
+	assert.NotEqual(t, before.tmRPC, cfg.TmConfig.RPC.ListenAddress, "TmConfig.RPC.ListenAddress should be reassigned")
+	assert.NotEqual(t, before.tmP2P, cfg.TmConfig.P2P.ListenAddress, "TmConfig.P2P.ListenAddress should be reassigned")
+	assert.NotEqual(t, before.tmRPCGRPC, cfg.TmConfig.RPC.GRPCListenAddress, "TmConfig.RPC.GRPCListenAddress should be reassigned")
+	assert.NotEqual(t, before.tmPrivVal, cfg.TmConfig.PrivValidatorGRPCListenAddr, "TmConfig.PrivValidatorGRPCListenAddr should be reassigned")
+	assert.NotEqual(t, before.appGRPC, cfg.AppConfig.GRPC.Address, "AppConfig.GRPC.Address should be reassigned")
+	assert.NotEqual(t, before.appAPI, cfg.AppConfig.API.Address, "AppConfig.API.Address should be reassigned")
+	assert.True(t, cfg.AppConfig.API.Enable, "AppConfig.API.Enable should remain true")
+}


### PR DESCRIPTION
## Summary

- The retry path in `NewNetworkWithRetry` reassigned every listener address **except** `TmConfig.PrivValidatorGRPCListenAddr`. When that port collided (e.g., post-merge CI run [24666582764](https://github.com/celestiaorg/celestia-app/actions/runs/24666582764/job/72125730971)), all 5 retries reused the same stale port and the test aborted with `bind: address already in use` on port `52843` every attempt.
- Extracts the port reassignment into `reassignListenPorts()` so every port-bearing field is covered in one place, preventing the two code paths (`DefaultTendermintConfig`/`DefaultAppConfig` initialization vs. the retry block) from drifting again.
- Adds a unit test `TestReassignListenPorts` that asserts each listener field changes after the call — would have caught the original omission.

## Test plan

- [x] `go test -v -run TestReassignListenPorts ./test/util/testnode/` passes
- [x] `go test ./test/util/testnode/...` passes (25s, no regressions)
- [ ] CI runs `pkg/user` tests cleanly

Closes #7137
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7146" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
