### PR TITLE
fix: pre-pull minor-version images with retry in TestMinorVersionCompatibility

### DIFF
--- a/test/docker-e2e/e2e_minor_version_compatibility_test.go
+++ b/test/docker-e2e/e2e_minor_version_compatibility_test.go
@@ -98,6 +98,14 @@ func (s *CelestiaTestSuite) buildMixedVersionChain(ctx context.Context, versionT
 	baseTag := versionTags[0]
 	baseCfg := dockerchain.DefaultConfig(s.client, s.network).WithTag(baseTag)
 
+	// Pre-pull all per-tag images with retry so that transient ghcr.io errors
+	// surface as infra noise rather than test failures. PullImage is idempotent
+	// and becomes a no-op once the image is cached locally.
+	for _, tag := range versionTags {
+		img := tastoracontainertypes.NewImage(baseCfg.Image, tag, "10001:10001")
+		s.Require().NoError(pullImageWithRetry(ctx, s.client, img), "failed to pre-pull image %s", img.Ref())
+	}
+
 	validators := make([]genesis.Validator, len(versionTags))
 	for i := range len(versionTags) {
 		validators[i] = genesis.NewDefaultValidator(fmt.Sprintf("validator%d", i))

--- a/test/docker-e2e/image_pull_retry.go
+++ b/test/docker-e2e/image_pull_retry.go
@@ -1,0 +1,45 @@
+package docker_e2e
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	tastoracontainertypes "github.com/celestiaorg/tastora/framework/docker/container"
+	tastoratypes "github.com/celestiaorg/tastora/framework/types"
+)
+
+// retryPull invokes op up to maxAttempts times, sleeping baseDelay*2^attempt
+// between attempts, and aborts early if ctx is cancelled. Returns the final
+// op error on exhaustion.
+func retryPull(ctx context.Context, maxAttempts int, baseDelay time.Duration, op func() error) error {
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("retryPull: %w", err)
+		}
+		lastErr = op()
+		if lastErr == nil {
+			return nil
+		}
+		if attempt == maxAttempts-1 {
+			break
+		}
+		delay := baseDelay << attempt
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return fmt.Errorf("retryPull: %w", ctx.Err())
+		}
+	}
+	return fmt.Errorf("retryPull exhausted after %d attempts: %w", maxAttempts, lastErr)
+}
+
+// pullImageWithRetry pulls the given image via tastora's idempotent PullImage,
+// retrying on transient registry errors (e.g. ghcr.io timeouts). Safe to call
+// on images that are already cached locally — PullImage is a no-op in that case.
+func pullImageWithRetry(ctx context.Context, client tastoratypes.TastoraDockerClient, image tastoracontainertypes.Image) error {
+	return retryPull(ctx, 3, 2*time.Second, func() error {
+		return image.PullImage(ctx, client)
+	})
+}

--- a/test/docker-e2e/image_pull_retry_test.go
+++ b/test/docker-e2e/image_pull_retry_test.go
@@ -1,0 +1,66 @@
+package docker_e2e
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryPull_SucceedsOnFirstAttempt(t *testing.T) {
+	calls := 0
+	err := retryPull(context.Background(), 3, time.Millisecond, func() error {
+		calls++
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls)
+}
+
+func TestRetryPull_SucceedsAfterTransientFailures(t *testing.T) {
+	calls := 0
+	err := retryPull(context.Background(), 3, time.Millisecond, func() error {
+		calls++
+		if calls < 3 {
+			return fmt.Errorf("transient error %d", calls)
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryPull_FailsAfterExhaustion(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("ghcr boom")
+	err := retryPull(context.Background(), 3, time.Millisecond, func() error {
+		calls++
+		return sentinel
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel, "final error should wrap the last op error")
+	assert.Equal(t, 3, calls)
+}
+
+func TestRetryPull_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := retryPull(ctx, 5, 10*time.Second, func() error {
+		calls++
+		if calls == 1 {
+			cancel()
+		}
+		return errors.New("boom")
+	})
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Equal(t, 1, calls, "should not invoke op again after ctx cancellation")
+}


### PR DESCRIPTION
## Summary

- `TestMinorVersionCompatibility/v6_minor_versions` aborted on any transient `ghcr.io` pull error (see post-merge CI run [24667508191](https://github.com/celestiaorg/celestia-app/actions/runs/24667508191/job/72129669852), which failed on `ghcr.io/celestiaorg/celestia-app:v6.0.2-arabica` with `context deadline exceeded`). Tastora's `Image.PullImage` / `Job.EnsurePulled` have no retry, so a single registry blip fails the whole test.
- Adds `retryPull` (generic) and `pullImageWithRetry` helpers. Pre-pulls every per-tag image with exponential backoff (3 attempts, 2s→4s→8s) at the top of `buildMixedVersionChain`, before the chain build. `PullImage` is idempotent, so the call becomes a no-op once images are cached.

## Test plan

- [x] `go test -v -run TestRetryPull ./test/docker-e2e/...` passes (4 cases: first-attempt success, transient-then-success, exhaustion, ctx cancellation)
- [x] `go build ./...` and `go vet ./...` clean in the `test/docker-e2e` module
- [ ] CI `test / test-docker-e2e (TestMinorVersionCompatibility)` passes

Closes #7139
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7148" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
