### PR TITLE
chore(deps): bump rustls-webpki from 0.103.10 to 0.103.12 in /tools/lumina-latency-monitor

### DIFF
--- a/tools/lumina-latency-monitor/Cargo.lock
+++ b/tools/lumina-latency-monitor/Cargo.lock
@@ -697,7 +697,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.111",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2240,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- Bumps `rustls-webpki` 0.103.10 → 0.103.12 in `tools/lumina-latency-monitor/Cargo.lock` (transitive dep via `celestia-grpc` `tls-ring`).
- Resolves two open Dependabot alerts:
  - GHSA-xgp8-3hg3-c2mh — name constraints incorrectly accepted wildcard names (low)
  - GHSA-965h-392x-2mh5 — name constraints for URI names incorrectly accepted (low)
- Cargo.lock-only change; no `Cargo.toml` edits needed.
- Includes a benign Cargo resolver re-association for `data-encoding-macro-internal`'s `syn` proc-macro dep (2.0.111 → 1.0.109); the crate's version and checksum are unchanged and both syn majors remain in the tree.

Closes PROTOCO-1549

## Test plan
- [x] `cargo fmt --all -- --check` passes locally
- [x] `cargo test --workspace` passes locally
- [x] `cargo build --release` passes locally
- [ ] CI job `rust-lumina-latency-monitor` green on PR (clippy runs against newer stable in CI; local Homebrew clippy 1.88 is stale)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7151" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
