### PR TITLE
fix(fibre): bound UploadShard RPC with per-call deadline

### DIFF
--- a/fibre/client_config.go
+++ b/fibre/client_config.go
@@ -3,6 +3,7 @@ package fibre
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	fibregrpc "github.com/celestiaorg/celestia-app/v9/fibre/internal/grpc"
 	"github.com/celestiaorg/celestia-app/v9/fibre/state"
@@ -12,6 +13,13 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 )
+
+// DefaultUploadShardTimeout is the default per-RPC deadline for a single
+// UploadShard call. Matches 2× the observed p99 for healthy uploads
+// (~2.5 s) with headroom — generous for slow-but-healthy validators,
+// tight enough that a network-black-holed or struggling validator can't
+// hold a goroutine / semaphore slot for the full TCP SYN retry window.
+const DefaultUploadShardTimeout = 10 * time.Second
 
 // ClientConfig contains configuration options for the Fibre [Client].
 type ClientConfig struct {
@@ -35,6 +43,16 @@ type ClientConfig struct {
 	UploadConcurrency int
 	// DownloadConcurrency is the maximum number of concurrent read requests to validators.
 	DownloadConcurrency int
+
+	// UploadShardTimeout bounds a single UploadShard RPC (dial + send +
+	// validator signature response). Without this bound, a validator that
+	// goes silent (network partition, frozen process, saturated peer) can
+	// park its client goroutine and semaphore slot for the full TCP SYN
+	// retry window (75+ seconds), which collapses upload throughput across
+	// the whole cluster even though the 2/3 quorum threshold is met by
+	// healthy validators.
+	// Zero → DefaultUploadShardTimeout.
+	UploadShardTimeout time.Duration
 
 	// StateClientFn creates a [state.Client] for communicating with a celestia-app node.
 	// If nil, [Validate] creates one from [StateAddress].
@@ -74,6 +92,7 @@ func NewClientConfigFromParams(p ProtocolParams) ClientConfig {
 		MaxMessageSize:      p.MaxMessageSize(),
 		UploadConcurrency:   p.MaxValidatorCount,
 		DownloadConcurrency: p.ValidatorsForReconstruction(),
+		UploadShardTimeout:  DefaultUploadShardTimeout,
 	}
 }
 
@@ -99,6 +118,9 @@ func (cfg *ClientConfig) Validate() error {
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clock.New()
+	}
+	if cfg.UploadShardTimeout <= 0 {
+		cfg.UploadShardTimeout = DefaultUploadShardTimeout
 	}
 	return nil
 }

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -283,7 +283,9 @@ func (c *Client) uploadTo(
 
 	// actually push the data to the validator
 	rpcStart := time.Now()
-	resp, err := client.UploadShard(ctx, req)
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, c.Config.UploadShardTimeout)
+	defer rpcCancel()
+	resp, err := client.UploadShard(rpcCtx, req)
 	c.metrics.observeUploadToRPC(ctx, rpcStart, err == nil, valAddrStr)
 	if err != nil {
 		log.WarnContext(ctx, "failed to upload rows", "error", err)


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1555/fibre-bound-uploadshard-rpc-with-per-call-deadline

## Summary

- **Problem:** The Fibre client `UploadShard` RPC inherits the caller context with no per-call deadline. When a validator goes silent (network partition, frozen process, saturated peer), the underlying TCP dial retries for ~75 s (the TCP SYN retry window), and every such dial parks a client goroutine and holds an `UploadConcurrency` semaphore slot. Healthy uploads queue behind them and throughput collapses cluster-wide even though the 2/3 quorum threshold is met by the healthy validators.
- **Reproduction:** One validator blackholed via `iptables -I INPUT ... -j DROP` dropped throughput from ~8 uploads / 30 s to ~2 uploads / 30 s (-75%), with per-upload latency rising from ~6 s to 10-18 s. Lifting the DROP rule immediately restored throughput.
- **Fix:** Wrap the single `client.UploadShard(ctx, req)` call site with `context.WithTimeout`, bounded by a new `ClientConfig.UploadShardTimeout` field. `Validate()` falls back to the default when the field is zero.
- **Default value rationale:** 10 s is ~2x the observed p99 for healthy uploads (~2.5 s healthy p99 -> 10 s gives generous headroom for slow-but-healthy validators) and is well inside the ~75 s TCP SYN retry window, so a black-holed validator is shed quickly instead of parking a goroutine/semaphore slot for over a minute.

## Test plan

- [ ] Unit tests for the timeout path (TBD — not included in this draft)
- [ ] Cluster verification with `iptables -I INPUT ... -j DROP` on one validator — confirm throughput stays at baseline (pending)
- [ ] Confirm healthy cluster throughput and latency are unchanged

Draft because cluster verification is in flight.