### PR TITLE
feat(fibre): bound upload memory budget by bytes

### DIFF
--- a/fibre/client.go
+++ b/fibre/client.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	clock "github.com/filecoin-project/go-clock"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/semaphore"
 )
 
 // DefaultKeyName is the default key name for the client.
@@ -38,8 +39,9 @@ type Client struct {
 	metrics *clientMetrics
 	clock   clock.Clock
 
-	clientCache *fibregrpc.ClientCache
-	downloadSem chan struct{}
+	clientCache  *fibregrpc.ClientCache
+	uploadBudget *semaphore.Weighted
+	downloadSem  chan struct{}
 
 	// closeWg tracks subroutines spawned by Upload/Download operations.
 	// Close() waits for this WaitGroup to ensure all operations complete before releasing resources.
@@ -79,15 +81,16 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		Config:      cfg,
-		keyring:     kr,
-		state:       stateClient,
-		log:         cfg.Log,
-		tracer:      cfg.Tracer,
-		metrics:     metrics,
-		clock:       cfg.Clock,
-		clientCache: fibregrpc.NewClientCache(cfg.NewClientFn, DefaultProtocolParams.MaxValidatorCount),
-		downloadSem: make(chan struct{}, cfg.DownloadConcurrency),
+		Config:       cfg,
+		keyring:      kr,
+		state:        stateClient,
+		log:          cfg.Log,
+		tracer:       cfg.Tracer,
+		metrics:      metrics,
+		clock:        cfg.Clock,
+		clientCache:  fibregrpc.NewClientCache(cfg.NewClientFn, DefaultProtocolParams.MaxValidatorCount),
+		uploadBudget: semaphore.NewWeighted(cfg.UploadMemoryBudget),
+		downloadSem:  make(chan struct{}, cfg.DownloadConcurrency),
 	}, nil
 }
 

--- a/fibre/client_config.go
+++ b/fibre/client_config.go
@@ -14,9 +14,15 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
-// Upload-path timeout defaults. Layered so a black-holed peer is shed
+// Upload-path defaults. Layered timeouts so a black-holed peer is shed
 // fast at dial time without killing healthy-but-slow peers in the RPC.
 const (
+	// DefaultUploadMemoryBudget is the default cap on in-flight upload
+	// bytes. The accounting unit is blob.UploadSize() — each admitted
+	// Upload reserves its own blob's worth of budget until it returns.
+	// Sized to allow roughly 4 concurrent max-size (128 MiB) uploads
+	// on a validator-grade node.
+	DefaultUploadMemoryBudget int64 = 512 * 1024 * 1024
 	// DefaultDialTimeout bounds the initial TCP/TLS dial. Sized well below
 	// the ~75 s TCP SYN retry window so a black-holed validator is shed
 	// quickly rather than parking a goroutine on a kernel retry loop.
@@ -44,6 +50,14 @@ type ClientConfig struct {
 	MinRowsPerValidator int
 	// MaxMessageSize is the maximum gRPC message size for upload requests.
 	MaxMessageSize int
+
+	// UploadMemoryBudget bounds in-flight upload bytes. Each Upload()
+	// reserves blob.UploadSize() from the budget at entry and releases
+	// on exit; concurrent uploads coexist as long as their combined
+	// size fits. Small blobs pack efficiently; an oversized blob fails
+	// fast rather than deadlocking. Callers should size this to their
+	// memory budget for upload buffers.
+	UploadMemoryBudget int64
 
 	// DialTimeout bounds initial connection establishment to a validator.
 	// Sized well below the TCP SYN retry window so a black-holed peer is
@@ -92,6 +106,7 @@ func NewClientConfigFromParams(p ProtocolParams) ClientConfig {
 		LivenessThreshold:   p.LivenessThreshold,
 		MinRowsPerValidator: p.MinRowsPerValidator(),
 		MaxMessageSize:      p.MaxMessageSize(),
+		UploadMemoryBudget:  DefaultUploadMemoryBudget,
 		DialTimeout:         DefaultDialTimeout,
 		RPCTimeout:          DefaultRPCTimeout,
 		DownloadConcurrency: p.ValidatorsForReconstruction(),
@@ -122,6 +137,9 @@ func (cfg *ClientConfig) Validate() error {
 		cfg.Clock = clock.New()
 	}
 
+	if cfg.UploadMemoryBudget <= 0 {
+		cfg.UploadMemoryBudget = DefaultUploadMemoryBudget
+	}
 	if cfg.DialTimeout <= 0 {
 		cfg.DialTimeout = DefaultDialTimeout
 	}

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -58,6 +58,19 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 		return result, ErrClientClosed
 	}
 
+	// Admission: reserve this blob's worth of bytes from the upload
+	// memory budget. Concurrent uploads share the budget; small blobs
+	// pack efficiently. An oversized blob fails fast rather than
+	// blocking forever on a reservation that can never be satisfied.
+	uploadBytes := int64(blob.UploadSize())
+	if uploadBytes > c.Config.UploadMemoryBudget {
+		return result, fmt.Errorf("fibre: upload size %d exceeds memory budget %d", uploadBytes, c.Config.UploadMemoryBudget)
+	}
+	if err := c.uploadBudget.Acquire(ctx, uploadBytes); err != nil {
+		return result, err
+	}
+	defer c.uploadBudget.Release(uploadBytes)
+
 	opt := uploadOptions{keyName: c.Config.DefaultKeyName}
 	for _, o := range opts {
 		o(&opt)


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1557/fibre-blob-level-memory-admission-for-concurrent-uploads

## Summary

Cap in-flight upload memory by **bytes**, not by a coarse blob count. `ClientConfig.UploadMemoryBudget` (default 512 MiB) is drawn down by each `Upload()` proportional to `blob.UploadSize()` and released on exit. Concurrent uploads share the budget: small blobs pack tightly, a max-size blob takes its actual share, and an oversized blob fails fast rather than deadlocking.

## Why bytes, not blobs

Memory is what we're bounding. Blob sizes vary ~1 MiB to 128 MiB — a "number of blobs" cap is a coarse proxy that either over-admits small blobs (wasting memory headroom by counting them like big ones) or under-admits them (wasting concurrency). Byte accounting collapses this into one honest knob: "how much RAM am I willing to spend on in-flight upload buffers?"

## Why this is separate from #7154

#7154 removed the old `UploadConcurrency` semaphore because its unit (one RPC) didn't match any real resource — wrong abstraction for failure isolation. The *memory-admission* concern it implicitly addressed is a different problem with a different right answer, and deserves its own PR and defaults discussion.

## Change

- New `ClientConfig.UploadMemoryBudget` (int64 bytes, default 512 MiB) with `Validate()` clamping.
- `Client.uploadBudget` is a `golang.org/x/sync/semaphore.Weighted` (already an indirect dep; now direct).
- `Upload()` reserves `blob.UploadSize()` at entry via `Acquire(ctx, n)` and `Release(n)` on exit. An oversized blob returns a clear error; ctx cancellation during wait returns `ctx.Err()`.

## Sizing guidance

The default (512 MiB) accommodates roughly 4 concurrent max-size (128 MiB) blobs on a validator-grade node. Tune against:

```
UploadMemoryBudget = max_memory_for_upload_buffers
                   ≳ 1 × max_blob_size     (so uploads aren't serialised)
                   ≲ safe_fraction_of_ram  (leave room for everything else)
```

An oversized blob (`UploadSize > UploadMemoryBudget`) returns an error at `Upload()` entry — a config that would otherwise deadlock is surfaced immediately.

## Depends on

#7154 — builds on the `ClientConfig` / `Client` surface introduced there. Base branch is `chore/fibre-upload-isolation`.

## Test plan

- [x] Builds and full fibre test suite passes
- [ ] Bench: burst of small blobs should pack and finish; burst of large blobs should serialise; oversized blob returns error immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
