### PR TITLE
feat(fibre): prune peer registry on validator-set rotation

### DIFF
--- a/fibre/client.go
+++ b/fibre/client.go
@@ -39,7 +39,7 @@ type Client struct {
 	clock   clock.Clock
 
 	clientCache *fibregrpc.ClientCache
-	uploadSem   chan struct{}
+	peers       *peerRegistry
 	downloadSem chan struct{}
 
 	// closeWg tracks subroutines spawned by Upload/Download operations.
@@ -87,8 +87,8 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 		tracer:      cfg.Tracer,
 		metrics:     metrics,
 		clock:       cfg.Clock,
-		clientCache: fibregrpc.NewClientCache(cfg.NewClientFn, cfg.UploadConcurrency),
-		uploadSem:   make(chan struct{}, cfg.UploadConcurrency),
+		clientCache: fibregrpc.NewClientCache(cfg.NewClientFn, DefaultProtocolParams.MaxValidatorCount),
+		peers:       newPeerRegistry(cfg.CircuitFailureThreshold, cfg.CircuitCooldown),
 		downloadSem: make(chan struct{}, cfg.DownloadConcurrency),
 	}, nil
 }

--- a/fibre/client_config.go
+++ b/fibre/client_config.go
@@ -3,6 +3,7 @@ package fibre
 import (
 	"fmt"
 	"log/slog"
+	"time"
 
 	fibregrpc "github.com/celestiaorg/celestia-app/v9/fibre/internal/grpc"
 	"github.com/celestiaorg/celestia-app/v9/fibre/state"
@@ -11,6 +12,27 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
+)
+
+// Upload-path defaults. Sized to match Fibre's 2/3-quorum contract: a
+// dead peer must not degrade throughput beyond a one-time cost when its
+// circuit first opens.
+const (
+	// DefaultDialTimeout bounds the initial TCP/TLS dial. Sized well below
+	// the ~75 s TCP SYN retry window so a black-holed validator is shed
+	// quickly rather than parking a goroutine on a kernel retry loop.
+	DefaultDialTimeout = 3 * time.Second
+	// DefaultRPCTimeout bounds the full UploadShard RPC after the dial
+	// succeeds. Generous enough for slow-but-healthy peers; tight enough
+	// that a frozen peer is cut loose.
+	DefaultRPCTimeout = 15 * time.Second
+	// DefaultCircuitFailureThreshold is the number of consecutive RPC
+	// failures to a single peer before its circuit opens and further
+	// attempts are short-circuited for DefaultCircuitCooldown.
+	DefaultCircuitFailureThreshold = 3
+	// DefaultCircuitCooldown is how long a peer's circuit stays open
+	// before a half-open probe is allowed.
+	DefaultCircuitCooldown = 30 * time.Second
 )
 
 // ClientConfig contains configuration options for the Fibre [Client].
@@ -31,8 +53,23 @@ type ClientConfig struct {
 	// MaxMessageSize is the maximum gRPC message size for upload requests.
 	MaxMessageSize int
 
-	// UploadConcurrency is the maximum number of concurrent uploads to validators.
-	UploadConcurrency int
+	// DialTimeout bounds initial connection establishment to a validator.
+	// Sized well below the TCP SYN retry window so a black-holed peer is
+	// shed quickly.
+	DialTimeout time.Duration
+
+	// RPCTimeout bounds a single UploadShard RPC (after dial succeeds).
+	RPCTimeout time.Duration
+
+	// CircuitFailureThreshold is the number of consecutive RPC failures
+	// to a single peer before its circuit opens.
+	CircuitFailureThreshold int
+
+	// CircuitCooldown is how long a peer's circuit stays open after
+	// failures cross the threshold. After cooldown a single half-open
+	// probe is allowed; success closes the circuit, failure re-opens it.
+	CircuitCooldown time.Duration
+
 	// DownloadConcurrency is the maximum number of concurrent read requests to validators.
 	DownloadConcurrency int
 
@@ -66,14 +103,17 @@ func DefaultClientConfig() ClientConfig {
 // Use this when you need a config with non-default protocol parameters (e.g., for testing).
 func NewClientConfigFromParams(p ProtocolParams) ClientConfig {
 	return ClientConfig{
-		DefaultKeyName:      DefaultKeyName,
-		StateAddress:        "127.0.0.1:9090",
-		SafetyThreshold:     p.SafetyThreshold,
-		LivenessThreshold:   p.LivenessThreshold,
-		MinRowsPerValidator: p.MinRowsPerValidator(),
-		MaxMessageSize:      p.MaxMessageSize(),
-		UploadConcurrency:   p.MaxValidatorCount,
-		DownloadConcurrency: p.ValidatorsForReconstruction(),
+		DefaultKeyName:          DefaultKeyName,
+		StateAddress:            "127.0.0.1:9090",
+		SafetyThreshold:         p.SafetyThreshold,
+		LivenessThreshold:       p.LivenessThreshold,
+		MinRowsPerValidator:     p.MinRowsPerValidator(),
+		MaxMessageSize:          p.MaxMessageSize(),
+		DialTimeout:             DefaultDialTimeout,
+		RPCTimeout:              DefaultRPCTimeout,
+		CircuitFailureThreshold: DefaultCircuitFailureThreshold,
+		CircuitCooldown:         DefaultCircuitCooldown,
+		DownloadConcurrency:     p.ValidatorsForReconstruction(),
 	}
 }
 
@@ -99,6 +139,27 @@ func (cfg *ClientConfig) Validate() error {
 	}
 	if cfg.Clock == nil {
 		cfg.Clock = clock.New()
+	}
+
+	if cfg.DialTimeout <= 0 {
+		cfg.DialTimeout = DefaultDialTimeout
+	}
+	if cfg.RPCTimeout <= 0 {
+		cfg.RPCTimeout = DefaultRPCTimeout
+	}
+	if cfg.CircuitFailureThreshold <= 0 {
+		cfg.CircuitFailureThreshold = DefaultCircuitFailureThreshold
+	}
+	if cfg.CircuitCooldown <= 0 {
+		cfg.CircuitCooldown = DefaultCircuitCooldown
+	}
+	// A DialTimeout that is >= RPCTimeout is nonsensical: the dial
+	// budget would consume the entire RPC budget, leaving no time
+	// for the actual UploadShard after connection establishment.
+	// Reject explicitly rather than silently producing unusable
+	// behavior, since the two knobs are easy to flip by accident.
+	if cfg.DialTimeout >= cfg.RPCTimeout {
+		return fmt.Errorf("DialTimeout (%s) must be less than RPCTimeout (%s)", cfg.DialTimeout, cfg.RPCTimeout)
 	}
 	return nil
 }

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -224,18 +224,21 @@ func (c *Client) signedPromise(ns share.Namespace, blob *Blob, height uint64, ke
 	return promise, nil
 }
 
-// uploadTo uploads blob shard to a single validator and adds the response signature to the signature set.
-// Returns true if enough signatures have been collected after adding this signature.
+// uploadTo uploads a blob shard to a single validator and adds the response
+// signature to the signature set. It splits the network budget into two
+// layers: a short DialTimeout for connection establishment (so a black-holed
+// peer is shed fast) and a longer RPCTimeout for the UploadShard call.
+//
+// Returns:
+//   - hasEnough: true if sigSet now holds enough signatures for quorum;
+//   - err: non-nil on any failure (dial, proof, RPC, signature parse/add).
 func (c *Client) uploadTo(
 	ctx context.Context,
 	val *core.Validator,
 	req *types.UploadShardRequest,
 	blob *Blob,
 	sigSet *validator.SignatureSet,
-) bool {
-	ctx, cancel := context.WithCancel(ctx) // GRPC calls require context cancelling upon completion
-	defer cancel()
-
+) (hasEnough bool, err error) {
 	log := c.log.With(
 		"validator", val.Address.String(),
 		"blob_commitment", blob.ID().Commitment(),
@@ -257,39 +260,48 @@ func (c *Client) uploadTo(
 		c.metrics.observeUploadTo(ctx, uploadStart, uploadOk, blob.UploadSize(), valAddrStr)
 	}()
 
-	// get a new or cached client with active connection
-	client, err := c.clientCache.GetClient(ctx, val)
+	// Dial under a tight deadline so a network-black-holed validator
+	// cannot park this goroutine on the TCP SYN retry window.
+	dialCtx, dialCancel := context.WithTimeout(ctx, c.Config.DialTimeout)
+	client, err := c.clientCache.GetClient(dialCtx, val)
+	dialCancel()
 	if err != nil {
 		log.WarnContext(ctx, "can't get grpc.FibreClient", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "can't get grpc.FibreClient")
-		return false
+		return false, err
 	}
 	span.AddEvent("client_acquired")
 
 	// get proofs and rows here in per request routine which is in parallel which ~39% faster for max blob size
 	for i, rowPb := range req.Shard.Rows {
-		row, err := blob.Row(int(rowPb.Index))
-		if err != nil {
-			log.WarnContext(ctx, "failed to generate proof for row", "row_index", rowPb.Index, "error", err)
-			span.RecordError(err, trace.WithAttributes(attribute.Int("row_index", int(rowPb.Index))))
+		row, rowErr := blob.Row(int(rowPb.Index))
+		if rowErr != nil {
+			log.WarnContext(ctx, "failed to generate proof for row", "row_index", rowPb.Index, "error", rowErr)
+			span.RecordError(rowErr, trace.WithAttributes(attribute.Int("row_index", int(rowPb.Index))))
 			span.SetStatus(codes.Error, "failed to generate proof for row")
-			return false
+			return false, rowErr
 		}
 		req.Shard.Rows[i].Data = row.Row
 		req.Shard.Rows[i].Proof = row.RowProof.RowProof
 	}
 	span.AddEvent("proofs_generated")
 
-	// actually push the data to the validator
+	// Run the RPC under a separate (longer) deadline. Separating dial
+	// from RPC means a healthy-but-slow peer is not killed by a tight
+	// dial budget, while a silent peer is shed by the dial budget
+	// before it gets near the RPC budget.
+	rpcCtx, rpcCancel := context.WithTimeout(ctx, c.Config.RPCTimeout)
+	defer rpcCancel()
+
 	rpcStart := time.Now()
-	resp, err := client.UploadShard(ctx, req)
+	resp, err := client.UploadShard(rpcCtx, req)
 	c.metrics.observeUploadToRPC(ctx, rpcStart, err == nil, valAddrStr)
 	if err != nil {
 		log.WarnContext(ctx, "failed to upload rows", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to upload rows")
-		return false
+		return false, err
 	}
 	span.AddEvent("rows_uploaded")
 
@@ -299,28 +311,54 @@ func (c *Client) uploadTo(
 		log.WarnContext(ctx, "failed to parse signature", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to parse signature")
-		return false
+		return false, err
 	}
 
 	// apply signature response and check if we have enough
-	hasEnough, err := sigSet.Add(val, signature)
+	hasEnough, err = sigSet.Add(val, signature)
 	if err != nil {
 		log.WarnContext(ctx, "failed to add signature", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to add signature")
-		return false
+		return false, err
 	}
 
 	uploadOk = true
 	log.DebugContext(ctx, "successfully uploaded to validator")
 	span.AddEvent("signature_verified")
 	span.SetStatus(codes.Ok, "")
-	return hasEnough
+	return hasEnough, nil
 }
 
-// uploadShards pushes assigned [types.BlobShard]s to all validators concurrently and collects signature responses.
-// Returns when either all the responses are exhausted or signatures collected or the context is done.
-// It continues uploading to every validator even after necessary amount of signatures is reached.
+// uploadShards pushes assigned [types.BlobShard]s to all validators and
+// collects signature responses. Returns when quorum is reached, all
+// responses are in, or the caller's context is done.
+//
+// Design notes (2/3 quorum isolation):
+//
+//   - Fan-out is non-blocking: all goroutines are spawned up front.
+//     The circuit breaker check happens INSIDE each goroutine, so a
+//     slow or dead peer cannot delay other peers' goroutines from
+//     starting. This is the root-cause fix for the single-black-holed-
+//     validator throughput collapse that the old global RPC semaphore
+//     caused by serializing the fan-out loop behind slot acquires.
+//
+//   - Circuit breaker: after a peer accumulates consecutive failures,
+//     subsequent blob uploads skip that peer instantly for a cooldown
+//     window — amortizing the dead-peer cost across many blobs.
+//
+//   - Best-effort post-quorum delivery: uploadShards returns as soon
+//     as quorum is reached, but background fan-out goroutines continue
+//     delivering shards to the remaining validators. More validators
+//     holding the data means downloaders have more peers to read from.
+//     Background goroutines are tracked via [c.closeWg] and inherit
+//     the caller's ctx, so they unwind on client stop or caller cancel.
+//
+//   - Peer-failure attribution: the breaker records RPC failures unless
+//     the caller's ctx is done — in which case the failure is likely
+//     our teardown rather than a peer fault. This keeps flaky peers
+//     penalized under normal load while not poisoning breaker state
+//     during a graceful shutdown.
 func (c *Client) uploadShards(
 	ctx context.Context,
 	requests map[*core.Validator]*types.UploadShardRequest,
@@ -328,52 +366,90 @@ func (c *Client) uploadShards(
 	sigSet *validator.SignatureSet,
 ) error {
 	var (
-		responses            atomic.Uint32         // tracks finished responses
-		responsesExhaustedCh = make(chan struct{}) // closes when all responses complete
+		responses            atomic.Uint32
+		responsesExhaustedCh = make(chan struct{})
+		sigsCollectedOnce    atomic.Bool
+		sigsCollectedCh      = make(chan struct{})
 	)
 
-	var (
-		sigsCollectedOnce atomic.Bool
-		sigsCollectedCh   = make(chan struct{}) // closes when enough signatures are collected
-	)
+	// Empty request map: nothing to do; the sigSet will surface the
+	// "no signatures" error to the caller.
+	if len(requests) == 0 {
+		return nil
+	}
 
 	for val, req := range requests {
-		// acquire semaphore before spawning goroutine
-		select {
-		case c.uploadSem <- struct{}{}:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-
 		c.closeWg.Add(1)
 		go func(val *core.Validator, req *types.UploadShardRequest) {
 			defer func() {
-				// release semaphore
-				<-c.uploadSem
-
-				// increment responses and mark as completed if so
 				if int(responses.Add(1)) == len(requests) {
 					close(responsesExhaustedCh)
 				}
-
-				// unblock Close
 				c.closeWg.Done()
 			}()
 
-			isDone := c.uploadTo(ctx, val, req, blob, sigSet)
-			if isDone && sigsCollectedOnce.CompareAndSwap(false, true) {
+			valAddrStr := val.Address.String()
+			brk := c.peers.get(valAddrStr)
+
+			// Circuit breaker: skip peers known to be dead. Their cost
+			// is paid once (when the circuit first opens) and amortized
+			// across subsequent blob uploads.
+			allowed, halfOpenProbe := brk.Allow(c.clock.Now())
+			if !allowed {
+				return
+			}
+			// If Allow consumed the half-open probe slot we own the
+			// obligation to either record an outcome or reset the
+			// probe, or the breaker wedges in half-open forever.
+			halfOpenHandled := false
+			defer func() {
+				if halfOpenProbe && !halfOpenHandled {
+					brk.resetHalfOpen()
+				}
+			}()
+
+			hasEnough, err := c.uploadTo(ctx, val, req, blob, sigSet)
+			if err != nil {
+				// Don't penalize a peer when the caller's ctx is done —
+				// that's our teardown, not a peer fault. Any other
+				// failure (including RPCTimeout hit) flows into the
+				// breaker so flaky peers are still penalized.
+				if ctx.Err() != nil {
+					return
+				}
+				halfOpenHandled = true
+				newState, changed := brk.RecordFailure(c.clock.Now())
+				if changed {
+					c.log.WarnContext(ctx, "circuit breaker state changed",
+						"validator", valAddrStr,
+						"new_state", newState.String(),
+					)
+				}
+				return
+			}
+			halfOpenHandled = true
+			newState, changed := brk.RecordSuccess()
+			if changed {
+				c.log.InfoContext(ctx, "circuit breaker state changed",
+					"validator", valAddrStr,
+					"new_state", newState.String(),
+				)
+			}
+
+			if hasEnough && sigsCollectedOnce.CompareAndSwap(false, true) {
 				close(sigsCollectedCh)
 			}
 		}(val, req)
 	}
 
 	select {
-	case <-responsesExhaustedCh: // no more responses to wait for
-	case <-sigsCollectedCh: // enough signatures collected
+	case <-responsesExhaustedCh:
+	case <-sigsCollectedCh:
+		// Quorum reached; uploadShards returns, but background
+		// goroutines continue best-effort delivery to remaining peers.
 	case <-ctx.Done():
 		return ctx.Err()
 	}
-
 	return nil
 }
 

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -71,6 +71,9 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 	)
 	defer span.End()
 
+	uploadDone := c.metrics.observeUpload(ctx, blob.UploadSize())
+	defer func() { uploadDone(err) }()
+
 	// 1) get validator set
 	valSet, err := c.state.Head(ctx)
 	if err != nil {
@@ -362,6 +365,17 @@ func (c *Client) uploadShards(
 	blob *Blob,
 	sigSet *validator.SignatureSet,
 ) error {
+	// Prune peer registry to the current validator set so rotated-out
+	// peers don't hold breaker state, and newly-rotated-in peers with
+	// reused addresses don't inherit a stale reputation.
+	if len(requests) > 0 {
+		keep := make(map[string]struct{}, len(requests))
+		for val := range requests {
+			keep[val.Address.String()] = struct{}{}
+		}
+		c.peers.prune(keep)
+	}
+
 	var (
 		responses            atomic.Uint32
 		responsesExhaustedCh = make(chan struct{})

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -71,9 +71,6 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 	)
 	defer span.End()
 
-	uploadDone := c.metrics.observeUpload(ctx, blob.UploadSize())
-	defer func() { uploadDone(err) }()
-
 	// 1) get validator set
 	valSet, err := c.state.Head(ctx)
 	if err != nil {

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -96,8 +96,6 @@ func testClientUploadSucceedsWithOneThirdFailuresHighConcurrency(t *testing.T) {
 	const numValidators = 100
 	client := makeTestUploadClient(t, numValidators, func(cfg *fibre.ClientConfig) {
 		cfg.NewClientFn = failingClientFn(33, cfg.NewClientFn) // Fail 1/3 of validators
-
-		cfg.UploadConcurrency = numValidators // set concurrency >= validators to test code path where semaphore doesn't limit
 	})
 	t.Cleanup(func() { require.NoError(t, client.Stop(t.Context())) })
 
@@ -139,7 +137,10 @@ func testClientUploadAllValidatorsReceiveData(t *testing.T) {
 	_, err := client.Upload(t.Context(), testNamespace, blob)
 	require.NoError(t, err)
 
-	// close waits for all background upload goroutines to complete
+	// Upload returns at quorum but background goroutines continue
+	// best-effort delivery to the remaining peers. Stop waits on
+	// closeWg so by the time it returns every validator has been
+	// contacted.
 	require.NoError(t, client.Stop(t.Context()))
 
 	// verify all validators received data

--- a/fibre/peer.go
+++ b/fibre/peer.go
@@ -1,0 +1,186 @@
+package fibre
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// peerRegistry maps validator address → per-peer circuit breaker.
+// A dead or flaky peer's circuit is opened on failure and subsequent
+// blob uploads skip that peer instantly for the cooldown window,
+// amortizing the dead-peer cost across many blobs.
+type peerRegistry struct {
+	failureThreshold int
+	cooldown         time.Duration
+
+	mu       sync.Mutex
+	breakers map[string]*breaker
+}
+
+func newPeerRegistry(failureThreshold int, cooldown time.Duration) *peerRegistry {
+	return &peerRegistry{
+		failureThreshold: failureThreshold,
+		cooldown:         cooldown,
+		breakers:         make(map[string]*breaker),
+	}
+}
+
+// get returns the breaker for addr, lazily creating one on first use.
+func (r *peerRegistry) get(addr string) *breaker {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	b, ok := r.breakers[addr]
+	if !ok {
+		b = newBreaker(r.failureThreshold, r.cooldown)
+		r.breakers[addr] = b
+	}
+	return b
+}
+
+// breakerState is the state of a circuit breaker.
+type breakerState int32
+
+const (
+	breakerClosed breakerState = iota
+	breakerOpen
+	breakerHalfOpen
+)
+
+// String renders a breaker state for logs and traces.
+func (s breakerState) String() string {
+	switch s {
+	case breakerClosed:
+		return "closed"
+	case breakerOpen:
+		return "open"
+	case breakerHalfOpen:
+		return "half-open"
+	}
+	return "unknown"
+}
+
+// breaker is a per-peer circuit breaker.
+//
+//   - closed: normal operation; consecutive failures increment a counter.
+//     A closed-state Allow hits a lock-free fast path backed by
+//     atomicState, so the steady-state all-healthy case never contends
+//     on the mutex.
+//   - open: failures crossed threshold; Allow rejects until cooldown elapses.
+//   - half-open: cooldown elapsed; exactly one probe may proceed.
+//     Success → closed. Failure → open (reset timer).
+//
+// If a half-open probe caller returns without recording an outcome
+// (e.g. parent goroutine cancelled before the RPC issued), it must
+// call resetHalfOpen so the breaker does not wedge with
+// halfOpenInFlight=true forever.
+type breaker struct {
+	failureThreshold int
+	cooldown         time.Duration
+
+	// atomicState mirrors state for the lock-free fast path in Allow.
+	// Writers update both under mu; readers may load without the lock.
+	atomicState atomic.Int32
+
+	mu               sync.Mutex
+	state            breakerState
+	consecutiveFail  int
+	openedAt         time.Time
+	halfOpenInFlight bool
+}
+
+func newBreaker(failureThreshold int, cooldown time.Duration) *breaker {
+	return &breaker{
+		failureThreshold: failureThreshold,
+		cooldown:         cooldown,
+		// atomicState defaults to 0 == breakerClosed.
+	}
+}
+
+// Allow reports whether a request should be attempted given the current
+// time. The second return value reports whether this call consumed the
+// half-open probe slot — if true, the caller MUST end by calling exactly
+// one of RecordSuccess, RecordFailure, or resetHalfOpen so the probe
+// state does not wedge.
+func (b *breaker) Allow(now time.Time) (allowed, halfOpenProbe bool) {
+	// Fast path: steady-state closed, no mutex. Covers the overwhelmingly
+	// common case where every peer is healthy.
+	if breakerState(b.atomicState.Load()) == breakerClosed {
+		return true, false
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	switch b.state {
+	case breakerClosed:
+		return true, false
+	case breakerOpen:
+		if now.Sub(b.openedAt) < b.cooldown {
+			return false, false
+		}
+		b.setStateLocked(breakerHalfOpen)
+		b.halfOpenInFlight = true
+		return true, true
+	case breakerHalfOpen:
+		if b.halfOpenInFlight {
+			return false, false
+		}
+		b.halfOpenInFlight = true
+		return true, true
+	}
+	return false, false
+}
+
+// RecordSuccess closes the circuit and resets failure counters.
+// Returns the resulting state and whether it changed, so callers can
+// emit a single log line on transitions without racing.
+func (b *breaker) RecordSuccess() (newState breakerState, changed bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	old := b.state
+	b.consecutiveFail = 0
+	b.halfOpenInFlight = false
+	b.setStateLocked(breakerClosed)
+	return b.state, old != b.state
+}
+
+// RecordFailure increments the failure counter and opens the circuit if
+// the threshold is crossed. A half-open probe failing re-opens the
+// circuit immediately. Returns the resulting state and whether it
+// changed.
+func (b *breaker) RecordFailure(now time.Time) (newState breakerState, changed bool) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	old := b.state
+	b.consecutiveFail++
+	b.halfOpenInFlight = false
+	switch b.state {
+	case breakerHalfOpen:
+		b.setStateLocked(breakerOpen)
+		b.openedAt = now
+	case breakerClosed:
+		if b.consecutiveFail >= b.failureThreshold {
+			b.setStateLocked(breakerOpen)
+			b.openedAt = now
+		}
+	}
+	return b.state, old != b.state
+}
+
+// resetHalfOpen releases the half-open in-flight flag without changing
+// state. Use this when a caller that consumed the half-open probe slot
+// exits before recording an outcome (e.g. cancelled before the RPC
+// issued). Safe to call unconditionally; no-op outside half-open.
+func (b *breaker) resetHalfOpen() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.state == breakerHalfOpen {
+		b.halfOpenInFlight = false
+	}
+}
+
+// setStateLocked updates both the guarded state and the atomic mirror
+// used by the lock-free fast path in Allow. Caller holds b.mu.
+func (b *breaker) setStateLocked(s breakerState) {
+	b.state = s
+	b.atomicState.Store(int32(s))
+}

--- a/fibre/peer.go
+++ b/fibre/peer.go
@@ -38,6 +38,20 @@ func (r *peerRegistry) get(addr string) *breaker {
 	return b
 }
 
+// prune drops entries whose addresses are not present in keep. Called
+// when the validator set changes so a rotated-out peer's breaker state
+// doesn't linger and, more importantly, doesn't get misapplied to a
+// newly-joined peer that happens to take the same address.
+func (r *peerRegistry) prune(keep map[string]struct{}) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for addr := range r.breakers {
+		if _, ok := keep[addr]; !ok {
+			delete(r.breakers, addr)
+		}
+	}
+}
+
 // breakerState is the state of a circuit breaker.
 type breakerState int32
 

--- a/fibre/peer_test.go
+++ b/fibre/peer_test.go
@@ -1,0 +1,198 @@
+package fibre
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBreakerClosedFastPath verifies the steady-state Allow path does
+// not consume half-open probe slots.
+func TestBreakerClosedFastPath(t *testing.T) {
+	b := newBreaker(3, 100*time.Millisecond)
+	now := time.Now()
+
+	for range 1000 {
+		allowed, probe := b.Allow(now)
+		require.True(t, allowed)
+		require.False(t, probe, "closed state must never report a half-open probe")
+	}
+}
+
+// TestBreakerOpensAfterThreshold verifies that N consecutive failures
+// move the breaker to open and subsequent Allow calls reject until
+// the cooldown elapses.
+func TestBreakerOpensAfterThreshold(t *testing.T) {
+	const threshold = 3
+	const cooldown = 100 * time.Millisecond
+	b := newBreaker(threshold, cooldown)
+	now := time.Now()
+
+	// Below threshold: still closed.
+	for i := 0; i < threshold-1; i++ {
+		state, changed := b.RecordFailure(now)
+		require.Equal(t, breakerClosed, state)
+		require.False(t, changed, "should not transition below threshold")
+		allowed, _ := b.Allow(now)
+		require.True(t, allowed)
+	}
+
+	// Crossing threshold: transition to open.
+	state, changed := b.RecordFailure(now)
+	require.Equal(t, breakerOpen, state)
+	require.True(t, changed)
+
+	// Still open during cooldown.
+	allowed, _ := b.Allow(now)
+	require.False(t, allowed)
+
+	// Cooldown elapsed: Allow admits exactly one half-open probe.
+	later := now.Add(cooldown + time.Millisecond)
+	allowed1, probe1 := b.Allow(later)
+	require.True(t, allowed1)
+	require.True(t, probe1, "first caller after cooldown must get the half-open probe")
+
+	// Second concurrent caller while probe in flight: rejected.
+	allowed2, probe2 := b.Allow(later)
+	require.False(t, allowed2)
+	require.False(t, probe2)
+}
+
+// TestBreakerHalfOpenSuccessCloses verifies a successful half-open
+// probe closes the circuit and resets the failure counter.
+func TestBreakerHalfOpenSuccessCloses(t *testing.T) {
+	b := newBreaker(2, 50*time.Millisecond)
+	now := time.Now()
+
+	b.RecordFailure(now)
+	b.RecordFailure(now)
+	allowed, _ := b.Allow(now)
+	require.False(t, allowed, "should be open")
+
+	later := now.Add(100 * time.Millisecond)
+	_, probe := b.Allow(later)
+	require.True(t, probe)
+
+	state, changed := b.RecordSuccess()
+	require.Equal(t, breakerClosed, state)
+	require.True(t, changed)
+
+	// After close, next Allow hits the fast path as closed.
+	allowed, probe = b.Allow(later)
+	require.True(t, allowed)
+	require.False(t, probe)
+}
+
+// TestBreakerHalfOpenFailureReopens verifies a failed half-open probe
+// re-opens the circuit and resets the cooldown clock.
+func TestBreakerHalfOpenFailureReopens(t *testing.T) {
+	b := newBreaker(2, 50*time.Millisecond)
+	t0 := time.Now()
+
+	b.RecordFailure(t0)
+	b.RecordFailure(t0)
+	// open.
+
+	t1 := t0.Add(100 * time.Millisecond)
+	_, probe := b.Allow(t1)
+	require.True(t, probe)
+
+	state, changed := b.RecordFailure(t1)
+	require.Equal(t, breakerOpen, state)
+	require.True(t, changed, "half-open -> open is a state change")
+
+	// Still rejecting just after the re-open.
+	allowed, _ := b.Allow(t1)
+	require.False(t, allowed)
+
+	// After another full cooldown, probe is admitted again.
+	t2 := t1.Add(100 * time.Millisecond)
+	_, probe = b.Allow(t2)
+	require.True(t, probe)
+}
+
+// TestBreakerResetHalfOpen — the regression test for the wedge bug.
+// If a goroutine consumes the half-open probe slot and then exits
+// (e.g. parent cancelled before the RPC fired) without recording
+// success or failure, resetHalfOpen must free the probe slot so the
+// breaker does not stay stuck rejecting forever.
+func TestBreakerResetHalfOpen(t *testing.T) {
+	b := newBreaker(1, 10*time.Millisecond)
+	t0 := time.Now()
+
+	b.RecordFailure(t0)
+	// open.
+
+	t1 := t0.Add(20 * time.Millisecond)
+	_, probe := b.Allow(t1)
+	require.True(t, probe, "first caller after cooldown gets probe")
+
+	// Second caller: denied while probe in flight.
+	allowed2, _ := b.Allow(t1)
+	require.False(t, allowed2)
+
+	// Probe caller exits without recording: the wedge scenario.
+	b.resetHalfOpen()
+
+	// Next caller must now get the probe — previously this would
+	// have wedged forever with halfOpenInFlight=true.
+	_, probe3 := b.Allow(t1)
+	require.True(t, probe3, "after resetHalfOpen, probe slot must be available again")
+}
+
+// TestBreakerResetHalfOpenNoOpOutsideHalfOpen verifies the reset is
+// safe to call unconditionally — it must be a no-op when the breaker
+// is closed or open, so callers can defer it without needing to know
+// whether they actually consumed the probe slot.
+func TestBreakerResetHalfOpenNoOpOutsideHalfOpen(t *testing.T) {
+	b := newBreaker(3, 100*time.Millisecond)
+	now := time.Now()
+
+	// closed: reset is a no-op.
+	b.resetHalfOpen()
+	allowed, _ := b.Allow(now)
+	require.True(t, allowed)
+
+	// open: reset does not transition state.
+	b.RecordFailure(now)
+	b.RecordFailure(now)
+	b.RecordFailure(now)
+	b.resetHalfOpen()
+	allowed, _ = b.Allow(now)
+	require.False(t, allowed, "open breaker must still reject after resetHalfOpen")
+}
+
+// TestBreakerSuccessResetsConsecutiveFailures verifies a success
+// between failures resets the "consecutive" counter.
+func TestBreakerSuccessResetsConsecutiveFailures(t *testing.T) {
+	const threshold = 3
+	b := newBreaker(threshold, 100*time.Millisecond)
+	now := time.Now()
+
+	b.RecordFailure(now)
+	b.RecordFailure(now)
+	b.RecordSuccess()
+	// consecutiveFail back to 0.
+	b.RecordFailure(now)
+	b.RecordFailure(now)
+	allowed, _ := b.Allow(now)
+	require.True(t, allowed, "2 failures after a success should not open the threshold=3 breaker")
+
+	b.RecordFailure(now)
+	allowed, _ = b.Allow(now)
+	require.False(t, allowed, "3rd consecutive failure should open")
+}
+
+// TestPeerRegistryGetIsIdempotent verifies repeated get(addr) returns
+// the same breaker (state must not reset on re-access).
+func TestPeerRegistryGetIsIdempotent(t *testing.T) {
+	r := newPeerRegistry(3, 100*time.Millisecond)
+
+	b1 := r.get("val-a")
+	b2 := r.get("val-a")
+	require.Same(t, b1, b2)
+
+	b3 := r.get("val-b")
+	require.NotSame(t, b1, b3)
+}

--- a/fibre/peer_test.go
+++ b/fibre/peer_test.go
@@ -196,3 +196,17 @@ func TestPeerRegistryGetIsIdempotent(t *testing.T) {
 	b3 := r.get("val-b")
 	require.NotSame(t, b1, b3)
 }
+
+// TestPeerRegistryPrune verifies prune drops entries not in keep and
+// preserves entries that are. Crucially, a rotated-out address that
+// re-joins gets a fresh breaker — no stale reputation transfer.
+func TestPeerRegistryPrune(t *testing.T) {
+	r := newPeerRegistry(3, 100*time.Millisecond)
+	kept := r.get("keep-me")
+	dropped := r.get("drop-me")
+
+	r.prune(map[string]struct{}{"keep-me": {}})
+
+	require.Same(t, kept, r.get("keep-me"), "kept entry must survive prune")
+	require.NotSame(t, dropped, r.get("drop-me"), "dropped entry must be recreated fresh after prune")
+}


### PR DESCRIPTION
Closes: https://linear.app/celestia/issue/PROTOCO-1558/fibre-prune-peer-registry-on-validator-set-rotation

## Summary

The `peerRegistry` added in #7154 tracks circuit breaker state per validator address. Entries are created lazily and never removed. This PR adds `prune(keep)` and calls it at the start of each `uploadShards` against the current validator set.

## Motivation

Two issues without pruning:

1. **Unbounded map growth.** Validator-set rotation produces orphan entries that persist for the process lifetime. Each entry is only ~80 bytes, but the leak is unbounded in principle.

2. **Stale reputation transfer** (the operationally interesting one). If validator A is removed from the set, then some time later validator B joins with the *same address* (address reuse after key rotation, for instance), B inherits A's breaker state. If A's circuit was open when it left, B starts life as "skip me" even though it's a different peer.

Both are resolved by pruning to the current validator set on every upload.

## Why this is separate from #7154

Orthogonal to failure isolation: pruning doesn't change behavior for steady validator sets, only for rotation. Keeping it separate means each PR is about one thing — #7154 fixes the 75s cliff, this fixes the long-term state hygiene.

## Change

- New `peerRegistry.prune(keep)` method.
- Call `c.peers.prune(keep)` at the top of `uploadShards` with the addresses from the current `requests` map.
- New `TestPeerRegistryPrune`.

## Depends on

#7154. Base branch is `chore/fibre-upload-isolation`.

## Test plan

- [x] Unit test covers: kept entry preserved, dropped entry recreated fresh (no stale state transfer), map cleaned.
- [x] Full fibre test suite passes.
- [ ] Longer-term: benchmark or telemetry showing the map size stays bounded across validator-set rotations in a testnet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
