### PR TITLE
feat(fibre/row): introduce `row.Pool` and `row.Assembler`

### DIFF
--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -79,17 +79,17 @@ func NewBlobConfigFromParams(blobVersion uint8, params ProtocolParams) (BlobConf
 	}
 
 	maxRowSize := params.MaxRowSize(blobVersion)
-	pool := row.New(maxRowSize, row.AssemblerBatchRows(params.ParityRows()), params.CodecWorkRows())
-	assembler, err := row.NewAssembler(params.Rows, params.ParityRows(), pool)
+	assembler, err := row.NewAssembler(params.Rows, params.ParityRows(), maxRowSize)
 	if err != nil {
 		return BlobConfig{}, fmt.Errorf("creating row assembler: %w", err)
 	}
 
+	workPool := row.NewPool(maxRowSize, params.CodecWorkRows())
 	coder, err := rsema1d.NewCoder(&rsema1d.Config{
 		K:           params.Rows,
 		N:           params.ParityRows(),
 		WorkerCount: runtime.GOMAXPROCS(0),
-	}, reedsolomon.WithWorkAllocator(pool))
+	}, reedsolomon.WithWorkAllocator(workPool))
 	if err != nil {
 		return BlobConfig{}, fmt.Errorf("creating rsema1d coder: %w", err)
 	}

--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/celestiaorg/celestia-app/v9/fibre/internal/row"
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
 	"github.com/klauspost/reedsolomon"
@@ -18,6 +19,8 @@ var (
 	ErrBlobTooLarge = errors.New("blob size exceeds maximum allowed size")
 	// ErrBlobCommitmentMismatch is returned when the reconstructed commitment doesn't match the expected one.
 	ErrBlobCommitmentMismatch = errors.New("commitment mismatch: reconstructed data doesn't match expected commitment")
+	// ErrBlobConsumed is returned when a blob is reused after being uploaded.
+	ErrBlobConsumed = errors.New("blob cannot be reused after upload")
 )
 
 // BlobConfig contains configuration parameters for blob encoding and decoding.
@@ -35,11 +38,26 @@ type BlobConfig struct {
 	MaxDataSize int
 	// CodingWorkers is the number of workers to use for encoding and decoding rsema1d.
 	CodingWorkers int
+
+	// Coder is a cached Reed-Solomon encoder/decoder for encoding blobs.
+	Coder *rsema1d.Coder
+	// Assembler builds pooled row layouts for encoding blobs.
+	Assembler *row.Assembler
 }
 
+// defaultBlobConfigV0 is the shared default config, created at init time.
+var defaultBlobConfigV0 = func() BlobConfig {
+	cfg, err := NewBlobConfigFromParams(0, DefaultProtocolParams)
+	if err != nil {
+		panic(fmt.Sprintf("creating default blob config v0: %v", err))
+	}
+	return cfg
+}()
+
 // DefaultBlobConfigV0 returns a [BlobConfig] with default values for version 0.
+// The config is created once at init and shared across all callers.
 func DefaultBlobConfigV0() BlobConfig {
-	return NewBlobConfigFromParams(0, DefaultProtocolParams)
+	return defaultBlobConfigV0
 }
 
 // BlobConfigForVersion returns the [BlobConfig] for the given blob version.
@@ -55,21 +73,39 @@ func BlobConfigForVersion(version uint8) (BlobConfig, error) {
 
 // NewBlobConfigFromParams creates a [BlobConfig] with values derived from the given [ProtocolParams].
 // Use this when you need a config with non-default protocol parameters (e.g., for testing).
-func NewBlobConfigFromParams(blobVersion uint8, p ProtocolParams) BlobConfig {
+func NewBlobConfigFromParams(blobVersion uint8, params ProtocolParams) (BlobConfig, error) {
 	if blobVersion != 0 {
-		panic(fmt.Sprintf("unsupported blob version: %d", blobVersion))
+		return BlobConfig{}, fmt.Errorf("unsupported blob version: %d", blobVersion)
+	}
+
+	maxRowSize := params.MaxRowSize(blobVersion)
+	pool := row.New(maxRowSize, row.AssemblerBatchRows(params.ParityRows()), params.CodecWorkRows())
+	assembler, err := row.NewAssembler(params.Rows, params.ParityRows(), pool)
+	if err != nil {
+		return BlobConfig{}, fmt.Errorf("creating row assembler: %w", err)
+	}
+
+	coder, err := rsema1d.NewCoder(&rsema1d.Config{
+		K:           params.Rows,
+		N:           params.ParityRows(),
+		WorkerCount: runtime.GOMAXPROCS(0),
+	}, reedsolomon.WithWorkAllocator(pool))
+	if err != nil {
+		return BlobConfig{}, fmt.Errorf("creating rsema1d coder: %w", err)
 	}
 
 	return BlobConfig{
 		BlobVersion:  blobVersion,
-		OriginalRows: p.Rows,
-		ParityRows:   p.ParityRows(),
+		OriginalRows: params.Rows,
+		ParityRows:   params.ParityRows(),
 		RowSize: func(dataLen int) int {
-			return p.RowSize(blobVersion, dataLen+blobHeaderLen)
+			return params.RowSize(blobVersion, dataLen+blobHeaderLen)
 		},
-		MaxDataSize:   p.MaxBlobSize - blobHeaderLen, // subtract the header overhead
+		MaxDataSize:   params.MaxBlobSize - blobHeaderLen,
 		CodingWorkers: runtime.GOMAXPROCS(0),
-	}
+		Coder:         coder,
+		Assembler:     assembler,
+	}, nil
 }
 
 // TotalRows returns the total number of rows (OriginalRows + ParityRows).
@@ -93,7 +129,6 @@ type Blob struct {
 	extendedData *rsema1d.ExtendedData
 	id           BlobID
 	originalID   BlobID
-	rlcCoeffs    []field.GF128
 
 	// holds meta fields about the blob
 	header blobHeaderV0
@@ -102,13 +137,25 @@ type Blob struct {
 
 	// fields for reconstruction
 	rows [][]byte
+
+	consumed atomic.Bool
+
+	// asm owns pooled row storage from the assembler. Nil for reconstructed
+	// blobs.
+	asm *row.Assembly
 }
 
 // NewBlob creates a new [Blob] instance by encoding the data.
-// It takes the data and a [BlobConfig].
+// It takes ownership of data and may reuse it directly as backing storage for
+// original rows. Callers must not modify data after calling NewBlob.
+//
 // The data is prefixed with a header containing the blob version and data size.
 // Returns [ErrBlobTooLarge] if the data size exceeds BlobConfig.MaxDataSize.
-func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
+//
+// The returned blob holds pooled row buffers from the [row.Assembler].
+// Pooled storage is released automatically when [Client.Upload] completes.
+// Data must not be modified after ownership is transferred to the blob.
+func NewBlob(data []byte, cfg BlobConfig) (*Blob, error) {
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data cannot be empty")
 	}
@@ -116,26 +163,20 @@ func NewBlob(data []byte, cfg BlobConfig) (d *Blob, err error) {
 		return nil, fmt.Errorf("%w: data size %d exceeds maximum %d", ErrBlobTooLarge, len(data), cfg.MaxDataSize)
 	}
 
-	d = &Blob{
-		cfg:    cfg,
-		header: newBlobHeaderV0(len(data)),
-		data:   data,
-	}
-
-	rows := d.header.encodeToRows(data, cfg)
-	var rsemaCommitment rsema1d.Commitment
-	d.extendedData, rsemaCommitment, d.rlcCoeffs, err = rsema1d.Encode(rows, &rsema1d.Config{
-		K:           cfg.OriginalRows,
-		N:           cfg.ParityRows,
-		RowSize:     len(rows[0]),
-		WorkerCount: cfg.CodingWorkers,
-	})
+	header := newBlobHeaderV0(len(data))
+	extendedData, asm, err := header.encode(data, cfg)
 	if err != nil {
-		return nil, fmt.Errorf("encoding data: %w", err)
+		return nil, err
 	}
-	d.id = NewBlobID(cfg.BlobVersion, rsemaCommitment)
 
-	return d, nil
+	return &Blob{
+		cfg:          cfg,
+		extendedData: extendedData,
+		id:           NewBlobID(cfg.BlobVersion, extendedData.Commitment()),
+		header:       header,
+		data:         data,
+		asm:          asm,
+	}, nil
 }
 
 // NewEmptyBlob creates a new [Blob] instance for receiving and reconstructing data.
@@ -191,9 +232,12 @@ func (d *Blob) Config() BlobConfig {
 	return d.cfg
 }
 
-// RLCCoeffs returns RLC coefficients of the original data.
-func (d *Blob) RLCCoeffs() []field.GF128 {
-	return d.rlcCoeffs
+// RLC returns the computed random linear combination values for the original rows.
+func (d *Blob) RLC() []field.GF128 {
+	if d.extendedData == nil {
+		return nil
+	}
+	return d.extendedData.RLC()
 }
 
 // RowSize returns the size of each row in bytes.
@@ -220,12 +264,16 @@ func (d *Blob) Data() []byte {
 	return d.data
 }
 
-// Row returns the [rsema1d.RowInclusionProof] for the given index from the extended data.
+// Row returns the [rsema1d.RowInclusionProof] for the given index. Rows are
+// served until the blob's pooled storage is released; after release, every
+// call returns an error.
 func (d *Blob) Row(index int) (*rsema1d.RowInclusionProof, error) {
 	if d.extendedData == nil {
 		return nil, fmt.Errorf("no extended data available")
 	}
-
+	if d.asm.Released() {
+		return nil, fmt.Errorf("row %d: storage has been released", index)
+	}
 	return d.extendedData.GenerateRowInclusionProof(index)
 }
 
@@ -389,7 +437,7 @@ func (d *Blob) Reconstruct(opts ...ReconstructOption) error {
 		RowSize:     len(d.rows[0]), // NOTE: successful reconstruct must fill all rows, so if this ever panics something is really wrong
 		WorkerCount: d.cfg.CodingWorkers,
 	}
-	extendedData, reconstructedCommitment, rlcCoeffs, err := rsema1d.EncodeParity(d.rows, config)
+	extendedData, reconstructedCommitment, _, err := rsema1d.EncodeParity(d.rows, config)
 	if err != nil {
 		return fmt.Errorf("encoding parity: %w", err)
 	}
@@ -408,12 +456,16 @@ func (d *Blob) Reconstruct(opts ...ReconstructOption) error {
 
 	d.data = originalData
 	d.extendedData = extendedData
-	d.rlcCoeffs = rlcCoeffs
 	if opt.skipCommitmentCheck {
 		d.originalID = d.id
 		d.id = NewBlobID(d.cfg.BlobVersion, Commitment(reconstructedCommitment))
 	}
 	return nil
+}
+
+// consume marks the blob as owned by an upload. Returns false if already consumed.
+func (d *Blob) consume() bool {
+	return d.consumed.CompareAndSwap(false, true)
 }
 
 const (
@@ -440,42 +492,21 @@ func newBlobHeaderV0(dataSize int) blobHeaderV0 {
 	}
 }
 
-// encodeToRows encodes the data into rows with version 0 header format.
-// Returns OriginalRows rows of calculated rowSize bytes each, padding with zeros as needed.
-// The first row contains the header followed by data.
-func (h blobHeaderV0) encodeToRows(data []byte, cfg BlobConfig) [][]byte {
+// encode assembles rows from data, writes the blob header, and produces the
+// commitment via the [rsema1d.Coder]. Returns the extended data and an
+// [Assembly] that owns the pooled row storage for the blob's lifetime.
+func (h blobHeaderV0) encode(data []byte, cfg BlobConfig) (*rsema1d.ExtendedData, *row.Assembly, error) {
 	rowSize := cfg.RowSize(len(data))
-	rows := make([][]byte, cfg.OriginalRows)
+	asm := cfg.Assembler.Assemble(data, rowSize, blobHeaderLen)
+	rows := asm.Rows()
+	h.marshalTo(rows[0])
 
-	// First row: allocate and write header + beginning of data
-	rows[0] = make([]byte, rowSize)
-	h.encode(rows[0])
-
-	// Copy as much data as fits in the first row after the header
-	firstRowDataSize := min(rowSize-blobHeaderLen, len(data))
-	copy(rows[0][blobHeaderLen:], data[:firstRowDataSize])
-
-	// Remaining rows: use slices from data (offset by what we already used)
-	dataOffset := firstRowDataSize
-	for i := 1; i < cfg.OriginalRows; i++ {
-		start := dataOffset
-		end := start + rowSize
-		dataOffset += rowSize
-
-		if end <= len(data) {
-			// Full row available in data - use slice directly
-			rows[i] = data[start:end:end]
-			continue
-		}
-		// Some or no data left - allocate zero-filled padded row
-		rows[i] = make([]byte, rowSize)
-		if start < len(data) {
-			// Partial row - insert the remaining data into the row
-			copy(rows[i], data[start:])
-		}
+	extData, err := cfg.Coder.Encode(rows)
+	if err != nil {
+		asm.Free()
+		return nil, nil, fmt.Errorf("encoding data: %w", err)
 	}
-
-	return rows
+	return extData, asm, nil
 }
 
 // decodeFromRows decodes the data from rows with version 0 header format.
@@ -491,7 +522,7 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	}
 
 	// decode header from first row
-	if err := h.decode(rows[0]); err != nil {
+	if err := h.unmarshalFrom(rows[0]); err != nil {
 		return nil, fmt.Errorf("decoding header: %w", err)
 	}
 
@@ -525,18 +556,18 @@ func (h *blobHeaderV0) decodeFromRows(rows [][]byte, cfg BlobConfig) ([]byte, er
 	return data, nil
 }
 
-// encode writes the version 0 blob header into the provided buffer.
+// marshalTo writes the version 0 blob header into the provided buffer.
 // The buffer must be at least blobHeaderLen bytes long.
 // Always writes version byte as 0.
-func (h blobHeaderV0) encode(buf []byte) {
+func (h blobHeaderV0) marshalTo(buf []byte) {
 	buf[0] = 0 // version 0
 	binary.BigEndian.PutUint32(buf[blobVersionLen:blobHeaderLen], h.dataSize)
 }
 
-// decode reads the blob header from the provided buffer.
+// unmarshalFrom reads the blob header from the provided buffer.
 // The buffer must be at least blobHeaderLen bytes long.
 // Returns an error if the version byte is not 0.
-func (h *blobHeaderV0) decode(buf []byte) error {
+func (h *blobHeaderV0) unmarshalFrom(buf []byte) error {
 	if buf[0] != 0 {
 		return fmt.Errorf("invalid blob version: expected 0, got %d", buf[0])
 	}

--- a/fibre/blob_test.go
+++ b/fibre/blob_test.go
@@ -7,7 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
+func TestBlobHeaderV0_MarshalRoundTrip(t *testing.T) {
+	sizes := []int{1, 10, 500, 5000, 1024, 1 << 20}
+
+	for _, size := range sizes {
+		h := newBlobHeaderV0(size)
+		buf := make([]byte, blobHeaderLen)
+		h.marshalTo(buf)
+
+		var got blobHeaderV0
+		require.NoError(t, got.unmarshalFrom(buf))
+		require.Equal(t, uint32(size), got.dataSize)
+	}
+}
+
+func TestNewBlob_EncodeDecodeRoundTrip(t *testing.T) {
 	cfg := DefaultBlobConfigV0()
 
 	tests := []struct {
@@ -15,60 +29,26 @@ func TestBlobHeaderV0_EncodeToRows_DecodeFromRows(t *testing.T) {
 		dataSize int
 	}{
 		{"single byte", 1},
-		{"small data", 10},
-		{"medium data", 500},
-		{"large data", 5000},
+		{"small", 10},
+		{"medium", 500},
+		{"large", 5000},
 		{"1 KiB", 1024},
-		{"1 MiB", 1024 * 1024},
+		{"1 MiB", 1 << 20},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create test data with recognizable pattern
 			data := make([]byte, tt.dataSize)
 			for i := range data {
 				data[i] = byte(i % 256)
 			}
 
-			// Encode
-			header := newBlobHeaderV0(len(data))
-			rows := header.encodeToRows(data, cfg)
+			blob, err := NewBlob(data, cfg)
+			require.NoError(t, err)
+			defer blob.asm.Free()
 
-			// Verify correct number of rows
-			if len(rows) != cfg.OriginalRows {
-				t.Fatalf("encodeToRows() returned %d rows, want %d", len(rows), cfg.OriginalRows)
-			}
-
-			// Verify all rows have same size
-			expectedRowSize := cfg.RowSize(len(data))
-			for i, row := range rows {
-				if len(row) != expectedRowSize {
-					t.Errorf("row %d size = %d, want %d", i, len(row), expectedRowSize)
-				}
-			}
-
-			// Decode
-			var decodeHeader blobHeaderV0
-			decodedData, err := decodeHeader.decodeFromRows(rows, cfg)
-			if err != nil {
-				t.Fatalf("decodeFromRows() error = %v", err)
-			}
-
-			// Verify round-trip
-			if len(decodedData) != len(data) {
-				t.Errorf("decodeFromRows() data length mismatch, got %d bytes, want %d bytes", len(decodedData), len(data))
-			}
-			for i := range data {
-				if decodedData[i] != data[i] {
-					t.Errorf("decodeFromRows() data mismatch at index %d, got %d, want %d", i, decodedData[i], data[i])
-					break
-				}
-			}
-
-			// Verify header was decoded correctly
-			if decodeHeader.dataSize != uint32(tt.dataSize) {
-				t.Errorf("decodeFromRows() header.dataSize = %d, want %d", decodeHeader.dataSize, tt.dataSize)
-			}
+			require.Equal(t, tt.dataSize, blob.DataSize())
+			require.Equal(t, data, blob.Data())
 		})
 	}
 }
@@ -79,6 +59,7 @@ func TestBlob_Reconstruct(t *testing.T) {
 
 	blob, err := NewBlob(testData, cfg)
 	require.NoError(t, err)
+	defer blob.asm.Free()
 
 	totalRows := cfg.OriginalRows + cfg.ParityRows
 	allRows := make([]*rsema1d.RowInclusionProof, totalRows)
@@ -93,16 +74,12 @@ func TestBlob_Reconstruct(t *testing.T) {
 		require.NoError(t, err)
 
 		for _, row := range rows {
-			err = reconstructBlob.VerifyRow(row)
-			require.NoError(t, err)
+			require.NoError(t, reconstructBlob.VerifyRow(row))
 			require.True(t, reconstructBlob.SetRow(row))
 		}
 
-		err = reconstructBlob.Reconstruct()
-		require.NoError(t, err)
-
-		reconstructedData := reconstructBlob.Data()
-		require.Equal(t, testData, reconstructedData)
+		require.NoError(t, reconstructBlob.Reconstruct())
+		require.Equal(t, testData, reconstructBlob.Data())
 	}
 
 	t.Run("FirstKRows", func(t *testing.T) {
@@ -123,4 +100,17 @@ func TestBlob_Reconstruct(t *testing.T) {
 		}
 		testReconstruct(t, mixedRows)
 	})
+}
+
+func TestBlob_RowAfterRelease(t *testing.T) {
+	blob, err := NewBlob([]byte("test"), DefaultBlobConfigV0())
+	require.NoError(t, err)
+
+	_, err = blob.Row(0)
+	require.NoError(t, err)
+
+	blob.asm.Free()
+
+	_, err = blob.Row(0)
+	require.Error(t, err)
 }

--- a/fibre/client_download_test.go
+++ b/fibre/client_download_test.go
@@ -529,7 +529,7 @@ func (d *downloadMockClient) DownloadShard(ctx context.Context, req *types.Downl
 	}
 
 	if req.WithRlc {
-		rlcCoeffs := blob.RLCCoeffs()
+		rlcCoeffs := blob.RLC()
 		coeffBytes := make([]byte, len(rlcCoeffs)*16)
 		for i, c := range rlcCoeffs {
 			b := field.ToBytes128(c)

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -87,18 +87,21 @@ func TestClientServerUploadDownload(t *testing.T) {
 						return fmt.Errorf("generating random data for blob %d: %w", blobIdx, err)
 					}
 
-					blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
-					if err != nil {
-						return fmt.Errorf("creating blob %d: %w", blobIdx, err)
-					}
-
 					slotIdx := clientIdx*tt.blobsPerClient + blobIdx
 					allPromiseHashes[slotIdx] = make([][]byte, 0, tt.duplicate)
 
 					// upload blob (possibly multiple times at different heights)
+					// each upload requires a fresh blob since Upload takes ownership
 					for uploadIdx := range tt.duplicate {
 						if tt.duplicate > 1 {
 							env.SetHeight(uint64(100 + uploadIdx*100))
+						}
+						blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+						if err != nil {
+							return fmt.Errorf("creating blob %d (upload %d): %w", blobIdx, uploadIdx, err)
+						}
+						if uploadIdx == 0 {
+							allBlobIDs[slotIdx] = blob.ID()
 						}
 						signedPromise, err := client.Upload(ctx, testNamespace, blob)
 						if err != nil {
@@ -112,7 +115,6 @@ func TestClientServerUploadDownload(t *testing.T) {
 						allPromiseHashes[slotIdx] = append(allPromiseHashes[slotIdx], promiseHash)
 					}
 
-					allBlobIDs[slotIdx] = blob.ID()
 					allData[slotIdx] = data
 				}
 

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -346,6 +346,11 @@ func (c *Client) uploadShards(
 	blob *Blob,
 	sigSet *validator.SignatureSet,
 ) error {
+	if len(requests) == 0 {
+		blob.asm.Free()
+		return nil
+	}
+
 	var (
 		responses            atomic.Uint32         // tracks finished responses
 		responsesExhaustedCh = make(chan struct{}) // closes when all responses complete

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -49,8 +49,23 @@ func WithAwaitAllSignatures() UploadOption {
 // It creates a [PaymentPromise], uploads the data to validators, and collects signatures confirming the upload.
 // Returns a [SignedPaymentPromise] containing the promise and validator signatures.
 // May keep uploading data in background after returning successfully.
+//
+// Upload takes ownership of the blob and releases its pooled storage when all
+// background uploads complete. The blob must not be reused after calling Upload;
+// create a new one with [NewBlob] for each upload.
+//
 // Returns [ErrClientClosed] if the client has been closed.
 func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opts ...UploadOption) (result SignedPaymentPromise, err error) {
+	if !blob.consume() {
+		return result, ErrBlobConsumed
+	}
+	defer func() {
+		// don't cleanup on success as uploads may still be running
+		if err != nil {
+			blob.asm.Free()
+		}
+	}()
+
 	if !c.started.Load() {
 		return result, errors.New("fibre client is not started")
 	}
@@ -120,7 +135,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 		span.SetStatus(codes.Error, "failed to convert payment promise to proto")
 		return result, fmt.Errorf("converting payment promise to proto: %w", err)
 	}
-	requests := makeUploadRequests(shardMap, promiseProto, blob.RLCCoeffs())
+	requests := makeUploadRequests(shardMap, promiseProto, blob.RLC())
 	threshold := c.Config.SafetyThreshold
 	if opt.awaitAll {
 		threshold = cmtmath.Fraction{Numerator: 1, Denominator: 1}
@@ -233,6 +248,10 @@ func (c *Client) uploadTo(
 	blob *Blob,
 	sigSet *validator.SignatureSet,
 ) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
 	ctx, cancel := context.WithCancel(ctx) // GRPC calls require context cancelling upon completion
 	defer cancel()
 
@@ -337,26 +356,22 @@ func (c *Client) uploadShards(
 		sigsCollectedCh   = make(chan struct{}) // closes when enough signatures are collected
 	)
 
+	// spawn unconditionally even under ctx cancellation: each goroutine exits
+	// fast via uploadTo(ctx) and runs its defer, so the "last one frees" path
+	// fires naturally without a separate drain step.
 	for val, req := range requests {
-		// acquire semaphore before spawning goroutine
-		select {
-		case c.uploadSem <- struct{}{}:
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+		c.uploadSem <- struct{}{}
 
 		c.closeWg.Add(1)
 		go func(val *core.Validator, req *types.UploadShardRequest) {
 			defer func() {
-				// release semaphore
 				<-c.uploadSem
 
-				// increment responses and mark as completed if so
 				if int(responses.Add(1)) == len(requests) {
 					close(responsesExhaustedCh)
+					blob.asm.Free()
 				}
 
-				// unblock Close
 				c.closeWg.Done()
 			}()
 
@@ -368,13 +383,11 @@ func (c *Client) uploadShards(
 	}
 
 	select {
-	case <-responsesExhaustedCh: // no more responses to wait for
-	case <-sigsCollectedCh: // enough signatures collected
-	case <-ctx.Done():
+	case <-responsesExhaustedCh: // every goroutine finished; terminal Free already fired
 		return ctx.Err()
+	case <-sigsCollectedCh: // detach: remaining goroutines finish in background
+		return nil
 	}
-
-	return nil
 }
 
 // makeUploadRequests constructs the requests map for all validators.

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -389,10 +389,12 @@ func (c *Client) uploadShards(
 
 	select {
 	case <-responsesExhaustedCh: // every goroutine finished; terminal Free already fired
-		return ctx.Err()
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 	case <-sigsCollectedCh: // detach: remaining goroutines finish in background
-		return nil
 	}
+	return nil
 }
 
 // makeUploadRequests constructs the requests map for all validators.

--- a/fibre/client_upload_test.go
+++ b/fibre/client_upload_test.go
@@ -33,6 +33,7 @@ func TestClientUpload(t *testing.T) {
 		{"AllValidatorsReceiveData", testClientUploadAllValidatorsReceiveData},
 		{"AwaitAllSignatures", testClientUploadAwaitAllSignatures},
 		{"ClosedClient", testClientUploadClosedClient},
+		{"BlobConsumed", testClientUploadBlobConsumed},
 	}
 
 	for _, tt := range tests {
@@ -184,6 +185,19 @@ func testClientUploadClosedClient(t *testing.T) {
 	// attempt to upload after closing
 	_, err := client.Upload(t.Context(), testNamespace, blob)
 	require.ErrorIs(t, err, fibre.ErrClientClosed, "expected ErrClientClosed when uploading to closed client")
+}
+
+func testClientUploadBlobConsumed(t *testing.T) {
+	client := makeTestUploadClient(t, 100, nil)
+	t.Cleanup(func() { require.NoError(t, client.Stop(t.Context())) })
+
+	blob := makeTestBlobV0(t, 256*1024)
+
+	_, err := client.Upload(t.Context(), testNamespace, blob)
+	require.NoError(t, err)
+
+	_, err = client.Upload(t.Context(), testNamespace, blob)
+	require.ErrorIs(t, err, fibre.ErrBlobConsumed)
 }
 
 // makeTestUploadClient creates an upload client for testing.

--- a/fibre/internal/row/assembler.go
+++ b/fibre/internal/row/assembler.go
@@ -11,9 +11,10 @@ import (
 // encoding. It owns a [Pool] sized for its slab shape; callers don't
 // need to know the exact row count it requests internally.
 //
-// Original rows are a hybrid view over the input data (zero-copy where
-// possible); parity rows plus head and tail come from a single pool
-// slab.
+// Original rows are a hybrid view over the input data: full middle
+// rows alias data zero-copy, while two partial rows — row 0 (reserves
+// firstRowOffset bytes for a header) and the truncated trailing row —
+// come from a single pool slab alongside the parity rows.
 //
 // Assembler is safe for concurrent use.
 type Assembler struct {
@@ -27,8 +28,8 @@ type Assembler struct {
 }
 
 // NewAssembler creates an Assembler for originalRows original rows and
-// parityRows parity rows. It constructs an internal [Pool] sized for the
-// assembler's slab shape (parityRows + head + tail) and bounded by
+// parityRows parity rows. It constructs an internal [Pool] sized for
+// the assembler's slab shape (parityRows + partialRows) and bounded by
 // maxRowSize. maxRowSize must be a positive multiple of 64.
 func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) {
 	if originalRows <= 0 || parityRows <= 0 {
@@ -37,7 +38,7 @@ func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) 
 	return &Assembler{
 		originalRows: originalRows,
 		parityRows:   parityRows,
-		pool:         NewPool(maxRowSize, parityRows+extraRows),
+		pool:         NewPool(maxRowSize, parityRows+partialRows),
 		zeroRow:      reedsolomon.AllocAligned(1, maxRowSize)[0],
 	}, nil
 }
@@ -47,9 +48,9 @@ func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) 
 // to access the rows; [Assembly.Free] releases the pooled storage.
 //
 // rows[:originalRows] are original rows: row 0 reserves firstRowOffset
-// bytes for a blob header, full middle rows alias data directly (zero-copy),
-// a partial tail row is copied to a pooled buffer, and empty trailing
-// rows share one zeroed row.
+// bytes for a header before its data, full middle rows alias data
+// directly (zero-copy), a truncated trailing row is copied into a
+// partial buffer, and any further empty rows share one zeroed row.
 // rows[originalRows:] are zeroed parity rows from a pooled slab.
 //
 // The caller must not modify data or rows until [Assembly.Free] is called.
@@ -57,50 +58,52 @@ func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) 
 func (a *Assembler) Assemble(data []byte, rowSize, firstRowOffset int) *Assembly {
 	rows := make([][]byte, a.originalRows+a.parityRows)
 
-	pooled := a.pool.Get(a.parityRows+extraRows, rowSize)
-	for i := range a.parityRows {
-		rows[a.originalRows+i] = pooled[i]
-		clear(pooled[i])
+	// pull one slab worth of buffers and zero them. Partial buffers must
+	// be zeroed because we only write the data-backed portion below; the
+	// parity rows because the encoder expects them clean on entry.
+	pooled := a.pool.Get(a.parityRows+partialRows, rowSize)
+	for _, p := range pooled {
+		clear(p)
 	}
-	// zero head/tail too: fillOriginal only writes the portions backed
-	// by data, so bytes past the written region would carry stale
-	// content from a prior use of the pooled slab.
-	head, tail := pooled[a.parityRows], pooled[a.parityRows+1]
-	clear(head)
-	clear(tail)
-	a.fillOriginal(rows[:a.originalRows], data, rowSize, firstRowOffset, head, tail, a.zeroRow[:rowSize])
 
-	return &Assembly{
-		pool:  a.pool,
-		slots: pooled,
-		rows:  rows,
-	}
-}
+	// land pooled in one move: partial buffers at the originals tail
+	// (overwritten as we fill below), parity in the parity range.
+	copy(rows[a.originalRows-partialRows:], pooled)
 
-// fillOriginal populates original rows as a hybrid view over data.
-// head hosts row 0 (prefix offset + data start); tail hosts any partial
-// trailing row; full middle rows alias data directly; empty rows share
-// the zero row.
-func (a *Assembler) fillOriginal(rows [][]byte, data []byte, rowSize, offset int, head, tail, zero []byte) {
-	rows[0] = head
-	n := min(rowSize-offset, len(data))
-	copy(head[offset:], data[:n])
+	// row 0 reserves firstRowOffset bytes for a header, then the data
+	// prefix. Backed by the first partial buffer (now at
+	// rows[originalRows-partialRows]).
+	rows[0] = rows[a.originalRows-partialRows]
+	n := min(rowSize-firstRowOffset, len(data))
+	copy(rows[0][firstRowOffset:], data[:n])
 
+	// full middle rows alias data zero-copy.
 	i := 1
-	for i < len(rows) && n+rowSize <= len(data) {
+	for i < a.originalRows && n+rowSize <= len(data) {
 		rows[i] = data[n : n+rowSize]
 		n += rowSize
 		i++
 	}
 
-	if i < len(rows) && n < len(data) {
-		rows[i] = tail
-		copy(tail, data[n:])
+	// truncated trailing row: copy the remaining bytes into the second
+	// partial buffer. Skipped when data fits perfectly (n == len(data))
+	// or fills every original — in either case the second partial is
+	// allocated but unused, returned to the pool on Free.
+	if i < a.originalRows && n < len(data) {
+		rows[i] = rows[a.originalRows-partialRows+1]
+		copy(rows[i], data[n:])
 		i++
 	}
 
-	for j := i; j < len(rows); j++ {
-		rows[j] = zero
+	// any remaining originals are empty — alias the shared zero row.
+	for j := i; j < a.originalRows; j++ {
+		rows[j] = a.zeroRow[:rowSize]
+	}
+
+	return &Assembly{
+		pool:  a.pool,
+		slots: pooled,
+		rows:  rows,
 	}
 }
 
@@ -112,7 +115,7 @@ func (a *Assembler) fillOriginal(rows [][]byte, data []byte, rowSize, offset int
 type Assembly struct {
 	mu    sync.RWMutex
 	pool  *Pool
-	slots [][]byte // [parity..., head, tail]; nil after Free
+	slots [][]byte // [partial[0], partial[1], parity...]; nil after Free
 	rows  [][]byte // originalRows+parityRows assembled view; nil after Free
 }
 
@@ -142,8 +145,8 @@ func (a *Assembly) Released() bool {
 	return a.slots == nil
 }
 
-// Free returns the pooled slab (parity + head + tail) back to the pool.
-// Subsequent calls are no-ops. Safe to call concurrently.
+// Free returns the pooled slab (parity + partial-row buffers) back to
+// the pool. Subsequent calls are no-ops. Safe to call concurrently.
 func (a *Assembly) Free() {
 	if a == nil {
 		return
@@ -157,5 +160,7 @@ func (a *Assembly) Free() {
 	a.slots, a.rows = nil, nil
 }
 
-// extraRows is the per-blob overhead beyond parity: head + tail.
-const extraRows = 2
+// partialRows is the per-blob overhead beyond parity: two partial-row
+// buffers (row 0 with the prefixed header, and the truncated trailing
+// row) that the assembler owns rather than aliasing.
+const partialRows = 2

--- a/fibre/internal/row/assembler.go
+++ b/fibre/internal/row/assembler.go
@@ -1,0 +1,164 @@
+package row
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/klauspost/reedsolomon"
+)
+
+// Assembler assembles originalRows+parityRows row sets for Reed-Solomon
+// encoding.
+//
+// Original rows are a hybrid view over the input data (zero-copy where
+// possible); parity rows plus head and tail come from a single pool batch
+// at row count [AssemblerBatchRows](parityRows).
+//
+// Assembler is safe for concurrent use.
+type Assembler struct {
+	originalRows int
+	parityRows   int
+	pool         *Pool
+	// zeroRow is the shared, immutable all-zeros row that empty trailing
+	// original rows alias. Sized to the pool's maxRowSize; aliased
+	// sub-slices are used for each blob's rowSize.
+	zeroRow []byte
+}
+
+// NewAssembler creates an Assembler for originalRows original rows and
+// parityRows parity rows backed by the given pool. The pool must accept the row
+// count [AssemblerBatchRows](parityRows).
+func NewAssembler(originalRows, parityRows int, pool *Pool) (*Assembler, error) {
+	if originalRows <= 0 || parityRows <= 0 {
+		return nil, fmt.Errorf("originalRows=%d parityRows=%d must be positive", originalRows, parityRows)
+	}
+	return &Assembler{
+		originalRows: originalRows,
+		parityRows:   parityRows,
+		pool:         pool,
+		zeroRow:      reedsolomon.AllocAligned(1, pool.maxRowSize)[0],
+	}, nil
+}
+
+// Assemble returns an [Assembly] holding the originalRows+parityRows
+// row view for encoding data at the given rowSize. Use [Assembly.Rows]
+// to access the rows; [Assembly.Free] releases the pooled storage.
+//
+// rows[:originalRows] are original rows: row 0 reserves firstRowOffset
+// bytes for a blob header, full middle rows alias data directly (zero-copy),
+// a partial tail row is copied to a pooled buffer, and empty trailing
+// rows share one zeroed row.
+// rows[originalRows:] are zeroed parity rows from a pooled batch.
+//
+// The caller must not modify data or rows until [Assembly.Free] is called.
+// Rows that alias data or the shared zero row are immutable.
+func (a *Assembler) Assemble(data []byte, rowSize, firstRowOffset int) *Assembly {
+	rows := make([][]byte, a.originalRows+a.parityRows)
+
+	pooled := a.pool.Get(AssemblerBatchRows(a.parityRows), rowSize)
+	for i := range a.parityRows {
+		rows[a.originalRows+i] = pooled[i]
+		clear(pooled[i])
+	}
+	// zero head/tail too: fillOriginal only writes the portions backed
+	// by data, so bytes past the written region would carry stale
+	// content from a prior use of the pooled batch.
+	head, tail := pooled[a.parityRows], pooled[a.parityRows+1]
+	clear(head)
+	clear(tail)
+	a.fillOriginal(rows[:a.originalRows], data, rowSize, firstRowOffset, head, tail, a.zeroRow[:rowSize])
+
+	return &Assembly{
+		pool:  a.pool,
+		slots: pooled,
+		rows:  rows,
+	}
+}
+
+// fillOriginal populates original rows as a hybrid view over data.
+// head hosts row 0 (prefix offset + data start); tail hosts any partial
+// trailing row; full middle rows alias data directly; empty rows share
+// the zero row.
+func (a *Assembler) fillOriginal(rows [][]byte, data []byte, rowSize, offset int, head, tail, zero []byte) {
+	rows[0] = head
+	n := min(rowSize-offset, len(data))
+	copy(head[offset:], data[:n])
+
+	i := 1
+	for i < len(rows) && n+rowSize <= len(data) {
+		rows[i] = data[n : n+rowSize]
+		n += rowSize
+		i++
+	}
+
+	if i < len(rows) && n < len(data) {
+		rows[i] = tail
+		copy(tail, data[n:])
+		i++
+	}
+
+	for j := i; j < len(rows); j++ {
+		rows[j] = zero
+	}
+}
+
+// Assembly owns the pooled batch produced by a single [Assembler.Assemble]
+// call. Release is all-or-nothing via [Assembly.Free]; the batch is
+// returned to the pool as one unit.
+//
+// Assembly is safe for concurrent use.
+type Assembly struct {
+	mu    sync.RWMutex
+	pool  *Pool
+	slots [][]byte // [parity..., head, tail]; nil after Free
+	rows  [][]byte // originalRows+parityRows assembled view; nil after Free
+}
+
+// Rows returns the originalRows+parityRows assembled row view. Returns
+// nil after [Assembly.Free].
+//
+// The returned slice shares its backing array with the Assembly; callers
+// must not use it concurrently with Free, which nils the field. In practice
+// Rows is intended for the encode phase before any Free has been issued.
+func (a *Assembly) Rows() [][]byte {
+	if a == nil {
+		return nil
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.rows
+}
+
+// Released reports whether [Assembly.Free] has run. After release the pooled
+// storage has been returned to the pool and all rows are invalid.
+func (a *Assembly) Released() bool {
+	if a == nil {
+		return false
+	}
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.slots == nil
+}
+
+// Free returns the pooled batch (parity + head + tail) back to the pool.
+// Subsequent calls are no-ops. Safe to call concurrently.
+func (a *Assembly) Free() {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.slots == nil {
+		return
+	}
+	a.pool.Put(a.slots)
+	a.slots, a.rows = nil, nil
+}
+
+// extraRows is the per-blob overhead beyond parity: head + tail.
+const extraRows = 2
+
+// AssemblerBatchRows returns the row count the assembler's pooled batch
+// occupies: parityRows + head + tail. Exported so callers can size a
+// [Pool] for the assembler without reaching into its internals.
+func AssemblerBatchRows(parityRows int) int { return parityRows + extraRows }

--- a/fibre/internal/row/assembler.go
+++ b/fibre/internal/row/assembler.go
@@ -8,12 +8,12 @@ import (
 )
 
 // Assembler assembles originalRows+parityRows row sets for Reed-Solomon
-// encoding. It owns a [Pool] sized for its batch shape; callers don't
+// encoding. It owns a [Pool] sized for its slab shape; callers don't
 // need to know the exact row count it requests internally.
 //
 // Original rows are a hybrid view over the input data (zero-copy where
 // possible); parity rows plus head and tail come from a single pool
-// batch.
+// slab.
 //
 // Assembler is safe for concurrent use.
 type Assembler struct {
@@ -28,7 +28,7 @@ type Assembler struct {
 
 // NewAssembler creates an Assembler for originalRows original rows and
 // parityRows parity rows. It constructs an internal [Pool] sized for the
-// assembler's batch shape (parityRows + head + tail) and bounded by
+// assembler's slab shape (parityRows + head + tail) and bounded by
 // maxRowSize. maxRowSize must be a positive multiple of 64.
 func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) {
 	if originalRows <= 0 || parityRows <= 0 {
@@ -50,7 +50,7 @@ func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) 
 // bytes for a blob header, full middle rows alias data directly (zero-copy),
 // a partial tail row is copied to a pooled buffer, and empty trailing
 // rows share one zeroed row.
-// rows[originalRows:] are zeroed parity rows from a pooled batch.
+// rows[originalRows:] are zeroed parity rows from a pooled slab.
 //
 // The caller must not modify data or rows until [Assembly.Free] is called.
 // Rows that alias data or the shared zero row are immutable.
@@ -64,7 +64,7 @@ func (a *Assembler) Assemble(data []byte, rowSize, firstRowOffset int) *Assembly
 	}
 	// zero head/tail too: fillOriginal only writes the portions backed
 	// by data, so bytes past the written region would carry stale
-	// content from a prior use of the pooled batch.
+	// content from a prior use of the pooled slab.
 	head, tail := pooled[a.parityRows], pooled[a.parityRows+1]
 	clear(head)
 	clear(tail)
@@ -104,8 +104,8 @@ func (a *Assembler) fillOriginal(rows [][]byte, data []byte, rowSize, offset int
 	}
 }
 
-// Assembly owns the pooled batch produced by a single [Assembler.Assemble]
-// call. Release is all-or-nothing via [Assembly.Free]; the batch is
+// Assembly owns the pooled slab produced by a single [Assembler.Assemble]
+// call. Release is all-or-nothing via [Assembly.Free]; the slab is
 // returned to the pool as one unit.
 //
 // Assembly is safe for concurrent use.
@@ -142,7 +142,7 @@ func (a *Assembly) Released() bool {
 	return a.slots == nil
 }
 
-// Free returns the pooled batch (parity + head + tail) back to the pool.
+// Free returns the pooled slab (parity + head + tail) back to the pool.
 // Subsequent calls are no-ops. Safe to call concurrently.
 func (a *Assembly) Free() {
 	if a == nil {

--- a/fibre/internal/row/assembler.go
+++ b/fibre/internal/row/assembler.go
@@ -8,11 +8,12 @@ import (
 )
 
 // Assembler assembles originalRows+parityRows row sets for Reed-Solomon
-// encoding.
+// encoding. It owns a [Pool] sized for its batch shape; callers don't
+// need to know the exact row count it requests internally.
 //
 // Original rows are a hybrid view over the input data (zero-copy where
-// possible); parity rows plus head and tail come from a single pool batch
-// at row count [AssemblerBatchRows](parityRows).
+// possible); parity rows plus head and tail come from a single pool
+// batch.
 //
 // Assembler is safe for concurrent use.
 type Assembler struct {
@@ -20,23 +21,24 @@ type Assembler struct {
 	parityRows   int
 	pool         *Pool
 	// zeroRow is the shared, immutable all-zeros row that empty trailing
-	// original rows alias. Sized to the pool's maxRowSize; aliased
-	// sub-slices are used for each blob's rowSize.
+	// original rows alias. Sized to maxRowSize; aliased sub-slices are
+	// used for each blob's rowSize.
 	zeroRow []byte
 }
 
 // NewAssembler creates an Assembler for originalRows original rows and
-// parityRows parity rows backed by the given pool. The pool must accept the row
-// count [AssemblerBatchRows](parityRows).
-func NewAssembler(originalRows, parityRows int, pool *Pool) (*Assembler, error) {
+// parityRows parity rows. It constructs an internal [Pool] sized for the
+// assembler's batch shape (parityRows + head + tail) and bounded by
+// maxRowSize. maxRowSize must be a positive multiple of 64.
+func NewAssembler(originalRows, parityRows, maxRowSize int) (*Assembler, error) {
 	if originalRows <= 0 || parityRows <= 0 {
 		return nil, fmt.Errorf("originalRows=%d parityRows=%d must be positive", originalRows, parityRows)
 	}
 	return &Assembler{
 		originalRows: originalRows,
 		parityRows:   parityRows,
-		pool:         pool,
-		zeroRow:      reedsolomon.AllocAligned(1, pool.maxRowSize)[0],
+		pool:         NewPool(maxRowSize, parityRows+extraRows),
+		zeroRow:      reedsolomon.AllocAligned(1, maxRowSize)[0],
 	}, nil
 }
 
@@ -55,7 +57,7 @@ func NewAssembler(originalRows, parityRows int, pool *Pool) (*Assembler, error) 
 func (a *Assembler) Assemble(data []byte, rowSize, firstRowOffset int) *Assembly {
 	rows := make([][]byte, a.originalRows+a.parityRows)
 
-	pooled := a.pool.Get(AssemblerBatchRows(a.parityRows), rowSize)
+	pooled := a.pool.Get(a.parityRows+extraRows, rowSize)
 	for i := range a.parityRows {
 		rows[a.originalRows+i] = pooled[i]
 		clear(pooled[i])
@@ -157,8 +159,3 @@ func (a *Assembly) Free() {
 
 // extraRows is the per-blob overhead beyond parity: head + tail.
 const extraRows = 2
-
-// AssemblerBatchRows returns the row count the assembler's pooled batch
-// occupies: parityRows + head + tail. Exported so callers can size a
-// [Pool] for the assembler without reaching into its internals.
-func AssemblerBatchRows(parityRows int) int { return parityRows + extraRows }

--- a/fibre/internal/row/assembler_bench_test.go
+++ b/fibre/internal/row/assembler_bench_test.go
@@ -1,0 +1,123 @@
+package row
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+)
+
+// BenchmarkAssemblyReleased measures the hot read path. During upload each
+// per-validator goroutine calls Blob.Row → Assembly.Released once per row.
+// The parallel variant exposes reader-vs-reader RWMutex contention.
+func BenchmarkAssemblyReleased(b *testing.B) {
+	const k, n = 4096, 12288
+	const maxRow = 32832
+	a, err := NewAssembler(k, n, newAssemblerPool(k, n, maxRow))
+	if err != nil {
+		b.Fatal(err)
+	}
+	data := []byte("x")
+	asm := a.Assemble(data, 64, 0)
+	defer asm.Free()
+
+	b.Run("serial", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		for b.Loop() {
+			_ = asm.Released()
+		}
+	})
+
+	b.Run("parallel", func(b *testing.B) {
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.RunParallel(func(pb *testing.PB) {
+			for pb.Next() {
+				_ = asm.Released()
+			}
+		})
+	})
+}
+
+func BenchmarkAssemblerAssembleRelease(b *testing.B) {
+	const k, n = 4096, 12288
+	const maxRow = 32832
+	cases := []struct {
+		name    string
+		rowSize int
+	}{
+		{"64", 64},
+		{"1024", 1024},
+		{"32832", 32832},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			a, err := NewAssembler(k, n, newAssemblerPool(k, n, maxRow))
+			if err != nil {
+				b.Fatal(err)
+			}
+			dataLen := max(1, tc.rowSize-5)
+			data := make([]byte, dataLen)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				asm := a.Assemble(data, tc.rowSize, 5)
+				rows := asm.Rows()
+				rows[0][0]++
+				asm.Free()
+			}
+		})
+	}
+}
+
+func BenchmarkAssemblerEncode(b *testing.B) {
+	cases := []struct {
+		name       string
+		k, n       int
+		rowSize    int
+		maxRowSize int
+	}{
+		{"32x32x64", 32, 32, 64, 256},
+		{"256x256x1024", 256, 256, 1024, 4096},
+		{"256x256x4096", 256, 256, 4096, 4096},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			codec := &rsema1d.Config{K: tc.k, N: tc.n, WorkerCount: 1}
+			coder, err := rsema1d.NewCoder(codec)
+			if err != nil {
+				b.Fatal(err)
+			}
+			a, err := NewAssembler(tc.k, tc.n, newAssemblerPool(tc.k, tc.n, tc.maxRowSize))
+			if err != nil {
+				b.Fatal(err)
+			}
+
+			data := make([]byte, max(1, tc.k*tc.rowSize-5))
+			for i := range data {
+				data[i] = byte(i)
+			}
+
+			// warm up
+			asm := a.Assemble(data, tc.rowSize, 5)
+			if _, err := coder.Encode(asm.Rows()); err != nil {
+				b.Fatal(err)
+			}
+			asm.Free()
+
+			b.ReportAllocs()
+			b.SetBytes(int64(tc.k * tc.rowSize))
+			b.ResetTimer()
+			for b.Loop() {
+				asm := a.Assemble(data, tc.rowSize, 5)
+				if _, err := coder.Encode(asm.Rows()); err != nil {
+					b.Fatal(err)
+				}
+				asm.Free()
+			}
+		})
+	}
+}

--- a/fibre/internal/row/assembler_bench_test.go
+++ b/fibre/internal/row/assembler_bench_test.go
@@ -12,7 +12,7 @@ import (
 func BenchmarkAssemblyReleased(b *testing.B) {
 	const k, n = 4096, 12288
 	const maxRow = 32832
-	a, err := NewAssembler(k, n, newAssemblerPool(k, n, maxRow))
+	a, err := NewAssembler(k, n, maxRow)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -53,7 +53,7 @@ func BenchmarkAssemblerAssembleRelease(b *testing.B) {
 
 	for _, tc := range cases {
 		b.Run(tc.name, func(b *testing.B) {
-			a, err := NewAssembler(k, n, newAssemblerPool(k, n, maxRow))
+			a, err := NewAssembler(k, n, maxRow)
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -91,7 +91,7 @@ func BenchmarkAssemblerEncode(b *testing.B) {
 			if err != nil {
 				b.Fatal(err)
 			}
-			a, err := NewAssembler(tc.k, tc.n, newAssemblerPool(tc.k, tc.n, tc.maxRowSize))
+			a, err := NewAssembler(tc.k, tc.n, tc.maxRowSize)
 			if err != nil {
 				b.Fatal(err)
 			}

--- a/fibre/internal/row/assembler_test.go
+++ b/fibre/internal/row/assembler_test.go
@@ -6,15 +6,9 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
 )
 
-// newAssemblerPool builds a pool that accepts the assembler batch
-// (n+extraRows) plus a work-row count for the companion codec.
-func newAssemblerPool(k, n, maxRowSize int) *Pool {
-	return New(maxRowSize, n+extraRows, k+n)
-}
-
 func TestAssembler_Assemble(t *testing.T) {
 	const k, n = 4, 2
-	a, err := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+	a, err := NewAssembler(k, n, 256)
 	if err != nil {
 		t.Fatalf("NewAssembler: %v", err)
 	}
@@ -72,10 +66,10 @@ func TestAssembler_Assemble(t *testing.T) {
 }
 
 func TestAssembler_InvalidConfig(t *testing.T) {
-	if _, err := NewAssembler(0, 4, newAssemblerPool(4, 4, 64)); err == nil {
+	if _, err := NewAssembler(0, 4, 64); err == nil {
 		t.Fatal("expected error for non-positive k")
 	}
-	if _, err := NewAssembler(4, 0, newAssemblerPool(4, 4, 64)); err == nil {
+	if _, err := NewAssembler(4, 0, 64); err == nil {
 		t.Fatal("expected error for non-positive n")
 	}
 }
@@ -87,7 +81,7 @@ func TestAssembler_ReuseDirty(t *testing.T) {
 	const k, n, rowSize, offset = 4, 4, 64, 7
 	codec := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
 	coder, _ := rsema1d.NewCoder(codec)
-	a, _ := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+	a, _ := NewAssembler(k, n, 256)
 
 	// first encode dirties parity slots in the pool
 	data1 := make([]byte, k*rowSize-offset)
@@ -137,7 +131,7 @@ func TestAssembler_ReusePartialPadding(t *testing.T) {
 	const k, n, rowSize, offset = 4, 4, 64, 7
 	codec := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
 	coder, _ := rsema1d.NewCoder(codec)
-	a, _ := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+	a, _ := NewAssembler(k, n, 256)
 
 	big := make([]byte, k*rowSize-offset)
 	for i := range big {
@@ -198,7 +192,7 @@ func freshRows(data []byte, total, rowSize, offset int) [][]byte {
 // observe the transition atomically and repeated calls are no-ops.
 func TestAssembly_Free(t *testing.T) {
 	const k, n = 4, 4
-	a, _ := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+	a, _ := NewAssembler(k, n, 256)
 
 	data := make([]byte, 4*64-3)
 	asm := a.Assemble(data, 64, 3)

--- a/fibre/internal/row/assembler_test.go
+++ b/fibre/internal/row/assembler_test.go
@@ -1,0 +1,222 @@
+package row
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d"
+)
+
+// newAssemblerPool builds a pool that accepts the assembler batch
+// (n+extraRows) plus a work-row count for the companion codec.
+func newAssemblerPool(k, n, maxRowSize int) *Pool {
+	return New(maxRowSize, n+extraRows, k+n)
+}
+
+func TestAssembler_Assemble(t *testing.T) {
+	const k, n = 4, 2
+	a, err := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+	if err != nil {
+		t.Fatalf("NewAssembler: %v", err)
+	}
+
+	rowSize := 64
+	offset := 5
+	// data spans: partial first row + 1 full row + 3 bytes into a third row
+	data := make([]byte, rowSize-offset+rowSize+3)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+
+	asm := a.Assemble(data, rowSize, offset)
+	defer asm.Free()
+	rows := asm.Rows()
+
+	if len(rows) != k+n {
+		t.Fatalf("got %d rows, want %d", len(rows), k+n)
+	}
+	for i, r := range rows {
+		if len(r) != rowSize {
+			t.Fatalf("row %d: len %d, want %d", i, len(r), rowSize)
+		}
+	}
+
+	// full middle row aliases input data
+	fullRowStart := rowSize - offset
+	rows[1][0] ^= 0xFF
+	if rows[1][0] != data[fullRowStart] {
+		t.Fatal("full middle row does not alias input data")
+	}
+
+	// partial tail row is a copy, not an alias
+	tailStart := fullRowStart + rowSize
+	rows[2][0] ^= 0xFF
+	if rows[2][0] == data[tailStart] {
+		t.Fatal("partial tail row unexpectedly aliases input data")
+	}
+
+	// empty original rows share a single backing array
+	for i := 3; i < k; i++ {
+		if &rows[3][0] != &rows[i][0] {
+			t.Fatal("empty original rows do not share the zero row")
+		}
+	}
+
+	// parity rows are zeroed
+	for i := k; i < k+n; i++ {
+		for j, b := range rows[i] {
+			if b != 0 {
+				t.Fatalf("parity row %d byte %d = %d, want 0", i, j, b)
+			}
+		}
+	}
+}
+
+func TestAssembler_InvalidConfig(t *testing.T) {
+	if _, err := NewAssembler(0, 4, newAssemblerPool(4, 4, 64)); err == nil {
+		t.Fatal("expected error for non-positive k")
+	}
+	if _, err := NewAssembler(4, 0, newAssemblerPool(4, 4, 64)); err == nil {
+		t.Fatal("expected error for non-positive n")
+	}
+}
+
+// TestAssembler_ReuseDirty verifies that reusing the assembler does not
+// leak state between encodes: parity rows are zeroed on reallocation and the
+// pooled encoding matches a fresh from-scratch encoding of the same data.
+func TestAssembler_ReuseDirty(t *testing.T) {
+	const k, n, rowSize, offset = 4, 4, 64, 7
+	codec := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
+	coder, _ := rsema1d.NewCoder(codec)
+	a, _ := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+
+	// first encode dirties parity slots in the pool
+	data1 := make([]byte, k*rowSize-offset)
+	for i := range data1 {
+		data1[i] = byte(i + 1)
+	}
+	asm1 := a.Assemble(data1, rowSize, offset)
+	if _, err := coder.Encode(asm1.Rows()); err != nil {
+		t.Fatalf("first Encode: %v", err)
+	}
+	asm1.Free()
+
+	// second encode — parity must be clean on reuse
+	data2 := make([]byte, k*rowSize-offset)
+	for i := range data2 {
+		data2[i] = byte(i*3 + 7)
+	}
+	asm2 := a.Assemble(data2, rowSize, offset)
+	defer asm2.Free()
+	rows2 := asm2.Rows()
+
+	for i := k; i < k+n; i++ {
+		for j, b := range rows2[i] {
+			if b != 0 {
+				t.Fatalf("parity row %d byte %d = %d, want 0", i, j, b)
+			}
+		}
+	}
+
+	// pooled commitment must match a fresh from-scratch encoding
+	extPool, err := coder.Encode(rows2)
+	if err != nil {
+		t.Fatalf("pooled Encode: %v", err)
+	}
+	extFresh, err := coder.Encode(freshRows(data2, k+n, rowSize, offset))
+	if err != nil {
+		t.Fatalf("fresh Encode: %v", err)
+	}
+	if extPool.Commitment() != extFresh.Commitment() {
+		t.Fatal("pooled and fresh commitments differ")
+	}
+}
+
+// A small blob reusing a pooled batch from a larger one must not carry
+// the larger blob's bytes in head/tail padding.
+func TestAssembler_ReusePartialPadding(t *testing.T) {
+	const k, n, rowSize, offset = 4, 4, 64, 7
+	codec := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
+	coder, _ := rsema1d.NewCoder(codec)
+	a, _ := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+
+	big := make([]byte, k*rowSize-offset)
+	for i := range big {
+		big[i] = 0xFF
+	}
+	asm1 := a.Assemble(big, rowSize, offset)
+	if _, err := coder.Encode(asm1.Rows()); err != nil {
+		t.Fatalf("first Encode: %v", err)
+	}
+	asm1.Free()
+
+	const small = 10
+	tiny := make([]byte, small)
+	for i := range tiny {
+		tiny[i] = byte(i + 1)
+	}
+	asm2 := a.Assemble(tiny, rowSize, offset)
+	defer asm2.Free()
+	rows2 := asm2.Rows()
+
+	for i := offset + small; i < rowSize; i++ {
+		if rows2[0][i] != 0 {
+			t.Fatalf("head[%d] = 0x%x after pool reuse, want 0", i, rows2[0][i])
+		}
+	}
+
+	extPool, err := coder.Encode(rows2)
+	if err != nil {
+		t.Fatalf("pooled Encode: %v", err)
+	}
+	extFresh, err := coder.Encode(freshRows(tiny, k+n, rowSize, offset))
+	if err != nil {
+		t.Fatalf("fresh Encode: %v", err)
+	}
+	if extPool.Commitment() != extFresh.Commitment() {
+		t.Fatal("pooled and fresh commitments differ — stale padding leaked")
+	}
+}
+
+// freshRows rebuilds the originalRows+parityRows layout that Assemble
+// produces, using fresh allocations instead of pooled storage. Used by
+// ReuseDirty to cross-check.
+func freshRows(data []byte, total, rowSize, offset int) [][]byte {
+	rows := make([][]byte, total)
+	for i := range rows {
+		rows[i] = make([]byte, rowSize)
+	}
+	head := min(rowSize-offset, len(data))
+	copy(rows[0][offset:], data[:head])
+	for i, off := 1, head; i < total && off < len(data); i++ {
+		n := copy(rows[i], data[off:])
+		off += n
+	}
+	return rows
+}
+
+// TestAssembly_Free covers whole-batch release: Rows() and Released()
+// observe the transition atomically and repeated calls are no-ops.
+func TestAssembly_Free(t *testing.T) {
+	const k, n = 4, 4
+	a, _ := NewAssembler(k, n, newAssemblerPool(k, n, 256))
+
+	data := make([]byte, 4*64-3)
+	asm := a.Assemble(data, 64, 3)
+
+	if asm.Released() {
+		t.Fatal("fresh Assembly should not report Released")
+	}
+	if asm.Rows() == nil {
+		t.Fatal("fresh Assembly should expose Rows")
+	}
+
+	asm.Free()
+	asm.Free() // idempotent
+
+	if !asm.Released() {
+		t.Fatal("Released() should be true after Free")
+	}
+	if asm.Rows() != nil {
+		t.Fatal("Rows() should be nil after Free")
+	}
+}

--- a/fibre/internal/row/assembler_test.go
+++ b/fibre/internal/row/assembler_test.go
@@ -125,7 +125,7 @@ func TestAssembler_ReuseDirty(t *testing.T) {
 	}
 }
 
-// A small blob reusing a pooled batch from a larger one must not carry
+// A small blob reusing a pooled slab from a larger one must not carry
 // the larger blob's bytes in head/tail padding.
 func TestAssembler_ReusePartialPadding(t *testing.T) {
 	const k, n, rowSize, offset = 4, 4, 64, 7
@@ -188,7 +188,7 @@ func freshRows(data []byte, total, rowSize, offset int) [][]byte {
 	return rows
 }
 
-// TestAssembly_Free covers whole-batch release: Rows() and Released()
+// TestAssembly_Free covers whole-slab release: Rows() and Released()
 // observe the transition atomically and repeated calls are no-ops.
 func TestAssembly_Free(t *testing.T) {
 	const k, n = 4, 4

--- a/fibre/internal/row/assembler_test.go
+++ b/fibre/internal/row/assembler_test.go
@@ -41,11 +41,11 @@ func TestAssembler_Assemble(t *testing.T) {
 		t.Fatal("full middle row does not alias input data")
 	}
 
-	// partial tail row is a copy, not an alias
-	tailStart := fullRowStart + rowSize
+	// the partial trailing row is a copy, not an alias
+	partialStart := fullRowStart + rowSize
 	rows[2][0] ^= 0xFF
-	if rows[2][0] == data[tailStart] {
-		t.Fatal("partial tail row unexpectedly aliases input data")
+	if rows[2][0] == data[partialStart] {
+		t.Fatal("partial trailing row unexpectedly aliases input data")
 	}
 
 	// empty original rows share a single backing array
@@ -126,7 +126,7 @@ func TestAssembler_ReuseDirty(t *testing.T) {
 }
 
 // A small blob reusing a pooled slab from a larger one must not carry
-// the larger blob's bytes in head/tail padding.
+// the larger blob's bytes in the prefixed/partial buffers.
 func TestAssembler_ReusePartialPadding(t *testing.T) {
 	const k, n, rowSize, offset = 4, 4, 64, 7
 	codec := &rsema1d.Config{K: k, N: n, WorkerCount: 1}
@@ -154,7 +154,7 @@ func TestAssembler_ReusePartialPadding(t *testing.T) {
 
 	for i := offset + small; i < rowSize; i++ {
 		if rows2[0][i] != 0 {
-			t.Fatalf("head[%d] = 0x%x after pool reuse, want 0", i, rows2[0][i])
+			t.Fatalf("prefixed[%d] = 0x%x after pool reuse, want 0", i, rows2[0][i])
 		}
 	}
 
@@ -179,9 +179,9 @@ func freshRows(data []byte, total, rowSize, offset int) [][]byte {
 	for i := range rows {
 		rows[i] = make([]byte, rowSize)
 	}
-	head := min(rowSize-offset, len(data))
-	copy(rows[0][offset:], data[:head])
-	for i, off := 1, head; i < total && off < len(data); i++ {
+	n := min(rowSize-offset, len(data))
+	copy(rows[0][offset:], data[:n])
+	for i, off := 1, n; i < total && off < len(data); i++ {
 		n := copy(rows[i], data[off:])
 		off += n
 	}

--- a/fibre/internal/row/mmap_other.go
+++ b/fibre/internal/row/mmap_other.go
@@ -16,4 +16,4 @@ func mmapAlloc(size int) ([]byte, error) {
 
 // mmapFree is unreachable on non-unix since no slab is ever flagged
 // mmapped; defined for symmetry with the unix build.
-func mmapFree(data []byte) error { return nil }
+func mmapFree(data []byte) {}

--- a/fibre/internal/row/mmap_other.go
+++ b/fibre/internal/row/mmap_other.go
@@ -14,6 +14,6 @@ func mmapAlloc(size int) ([]byte, error) {
 	return nil, errors.New("row: mmap not supported on this platform")
 }
 
-// mmapFree is unreachable on non-unix since no batch is ever flagged
+// mmapFree is unreachable on non-unix since no slab is ever flagged
 // mmapped; defined for symmetry with the unix build.
 func mmapFree(data []byte) error { return nil }

--- a/fibre/internal/row/mmap_other.go
+++ b/fibre/internal/row/mmap_other.go
@@ -1,0 +1,19 @@
+//go:build !unix
+
+package row
+
+import "errors"
+
+// disableMmap is forced true on platforms without POSIX mmap (notably
+// Windows): allocBacking then always falls through to the Go-heap path.
+const disableMmap = true
+
+// mmapAlloc is never called on non-unix (disableMmap gates the call
+// site) but must exist for the package to build.
+func mmapAlloc(size int) ([]byte, error) {
+	return nil, errors.New("row: mmap not supported on this platform")
+}
+
+// mmapFree is unreachable on non-unix since no batch is ever flagged
+// mmapped; defined for symmetry with the unix build.
+func mmapFree(data []byte) error { return nil }

--- a/fibre/internal/row/mmap_other.go
+++ b/fibre/internal/row/mmap_other.go
@@ -5,7 +5,7 @@ package row
 import "errors"
 
 // disableMmap is forced true on platforms without POSIX mmap (notably
-// Windows): allocBacking then always falls through to the Go-heap path.
+// Windows): alloc then always falls through to the Go-heap path.
 const disableMmap = true
 
 // mmapAlloc is never called on non-unix (disableMmap gates the call

--- a/fibre/internal/row/mmap_unix.go
+++ b/fibre/internal/row/mmap_unix.go
@@ -12,7 +12,7 @@ import (
 
 // disableMmap routes all allocations through the Go heap when FIBRE_ROW_NO_MMAP
 // is set. Useful for pprof alloc_space sampling, which doesn't see mmap'd
-// pages and would otherwise miss large-batch churn.
+// pages and would otherwise miss large-slab churn.
 var disableMmap = os.Getenv("FIBRE_ROW_NO_MMAP") != ""
 
 // mmapAlloc allocates size bytes via mmap, invisible to Go's GC.

--- a/fibre/internal/row/mmap_unix.go
+++ b/fibre/internal/row/mmap_unix.go
@@ -4,6 +4,7 @@ package row
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"runtime"
 
@@ -35,9 +36,34 @@ func mmapAlloc(size int) ([]byte, error) {
 	return data, nil
 }
 
-// mmapFree releases mmap'd memory back to the OS.
-func mmapFree(data []byte) error {
-	return unix.Munmap(data)
+// mmapFree releases mmap'd memory off-thread via a single drain
+// goroutine. munmap of touched pages costs ~60 µs at 1 MiB and
+// parallelizing it regresses throughput, so serializing on one core
+// wins. Falls back to inline munmap on full channel.
+func mmapFree(data []byte) {
+	select {
+	case munmapCh <- data:
+	default:
+		munmap(data)
+	}
+}
+
+var munmapCh = make(chan []byte, 128)
+
+func init() {
+	go munmapDrain()
+}
+
+func munmapDrain() {
+	for region := range munmapCh {
+		munmap(region)
+	}
+}
+
+func munmap(data []byte) {
+	if err := unix.Munmap(data); err != nil {
+		slog.Error("row: munmap failed", "size", len(data), "err", err)
+	}
 }
 
 // linuxMadvDontDumpCode is the MADV_DONTDUMP advice value on Linux; x/sys

--- a/fibre/internal/row/mmap_unix.go
+++ b/fibre/internal/row/mmap_unix.go
@@ -1,0 +1,45 @@
+//go:build unix
+
+package row
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+)
+
+// disableMmap routes all allocations through the Go heap when FIBRE_ROW_NO_MMAP
+// is set. Useful for pprof alloc_space sampling, which doesn't see mmap'd
+// pages and would otherwise miss large-batch churn.
+var disableMmap = os.Getenv("FIBRE_ROW_NO_MMAP") != ""
+
+// mmapAlloc allocates size bytes via mmap, invisible to Go's GC.
+// The returned slice is page-aligned (and therefore SIMD-aligned).
+// Caller must call mmapFree when done.
+func mmapAlloc(size int) ([]byte, error) {
+	pageSize := unix.Getpagesize()
+	size = (size + pageSize - 1) &^ (pageSize - 1)
+
+	data, err := unix.Mmap(-1, 0, size,
+		unix.PROT_READ|unix.PROT_WRITE,
+		unix.MAP_PRIVATE|unix.MAP_ANON)
+	if err != nil {
+		return nil, fmt.Errorf("mmap(%d): %w", size, err)
+	}
+	if runtime.GOOS == "linux" {
+		// exclude large scratch buffers from core dumps; failure is non-fatal.
+		_ = unix.Madvise(data, linuxMadvDontDumpCode)
+	}
+	return data, nil
+}
+
+// mmapFree releases mmap'd memory back to the OS.
+func mmapFree(data []byte) error {
+	return unix.Munmap(data)
+}
+
+// linuxMadvDontDumpCode is the MADV_DONTDUMP advice value on Linux; x/sys
+// doesn't export a cross-platform constant since it's Linux-specific.
+const linuxMadvDontDumpCode = 16

--- a/fibre/internal/row/pool.go
+++ b/fibre/internal/row/pool.go
@@ -1,0 +1,416 @@
+// Package row provides a bucketed allocator of fixed-shape row batches.
+//
+// A batch is the indivisible allocation unit: rowCount rows of rowSize
+// bytes each. A Get(rowCount, rowSize) is served from the exact bucket
+// or from a larger-rowSize bucket within a slack window on the same
+// rowCount — never smaller. Failing both, a new batch is allocated at
+// the exact requested key.
+//
+// Retention is demand-driven: each bucket has a generation counter that
+// advances on every Get to that bucket. A free batch becomes evictable
+// once bucket.generation exceeds its lastFreeGen by evictionThreshold.
+// When the pool goes fully idle (no in-use batches), an idle timer arms
+// and drops every free batch after idleGrace if nothing arrives.
+//
+// Contract: buffers from [Pool.Get] must be returned together via
+// [Pool.Put]; callers must not re-slice or split across calls. Put
+// validates via a back-pointer embedded in each batch's region and
+// panics on any violation — double-free, foreign pointer, or a pointer
+// to a batch that has already been released. A pointer whose backing
+// array lies near the start of a page can fault when Put reads the
+// header below it, so callers must not pass buffers this pool never
+// allocated.
+package row
+
+import (
+	"fmt"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/klauspost/reedsolomon"
+)
+
+// Structural constants — invariants of the layout, not tuning knobs.
+const (
+	// rowSizeAlign is the quantum for both rowSize and the minimum
+	// accepted rowSize; SIMD-aligned to 64 bytes.
+	rowSizeAlign = 64
+
+	// headerSize prefixes every batch's backing region. Sized to keep
+	// data 64-byte (SIMD) aligned; the first word is a back-pointer to
+	// the owning *batch, used by Put to recover it from a carved buffer.
+	headerSize = 64
+)
+
+// Pool tunables — safe to adjust, governed by workload characteristics.
+const (
+	// slack: max number of rowSizeAlign slot steps above the exact match
+	// a free batch may occupy for upward fallback. Waste per reused batch
+	// is slack*rowSizeAlign*rowCount bytes — constant per row, so safe to
+	// apply at any rowSize. With defaults and Celestia's shape: ≤1.5 MiB
+	// on the assembler batch, ≤4 MiB on the codec-work batch.
+	slack = 2
+
+	// evictionThreshold: generation ticks a free batch must age through
+	// before becoming evictable.
+	evictionThreshold = 4
+
+	// idleGrace: wait after full idle before every free batch is dropped.
+	idleGrace = 30 * time.Second
+
+	// mmapThreshold: minimum batch size routed through mmap instead of
+	// the Go heap. Above this, allocations stay invisible to GOGC's
+	// heap-doubling pacer so the codec's multi-MiB work buffers don't
+	// trigger OOMs.
+	mmapThreshold = 1 << 20
+)
+
+// Pool is a bucketed allocator of fixed-shape row batches.
+//
+// Buckets live in a single flat slots slice laid out as len(rowCounts)
+// partitions of (maxRowSize/rowSizeAlign) entries each. A partition is
+// identified by a rowCount (rowCounts[partIdx]); within a partition,
+// slot i is the bucket for rowSize (i+1)*64. Exact lookup and upward
+// fallback are contiguous pointer reads.
+//
+// Pool achieves 0(1) for both Put and Get.
+//
+// Safe for concurrent use.
+type Pool struct {
+	mu sync.Mutex
+
+	maxRowSize int
+	rowCounts  []int // accepted row counts; fixed at New()
+
+	// slots[partIdx*(maxRowSize/rowSizeAlign) + sizeIdx] holds the bucket
+	// for (rowCounts[partIdx], (sizeIdx+1)*rowSizeAlign).
+	slots []*bucket
+
+	// batches anchors every live *batch on the Go heap — a batch's header
+	// inside its (possibly mmap'd) backing region is invisible to GC, so
+	// we must hold a Go-heap reference here for as long as the batch lives.
+	// Swap-delete on evict via batch.poolIdx keeps removal O(1).
+	batches []*batch
+
+	inUse     int
+	idleTimer *time.Timer
+}
+
+// bucket holds free batches for one (rowCount, rowSize) pair and its
+// generation counter. free is a FIFO by release time: Put appends; reuse
+// pops the back (LIFO warmth); aged eviction pops the front (oldest first).
+type bucket struct {
+	rowSize, rowCount int
+	generation        uint64
+	free              []*batch
+}
+
+// batch's backing region is laid out as
+//
+//	[ header (headerSize bytes) | data (rowSize * rowCount bytes) ]
+//
+// The first word of the header stores a back-pointer to this *batch so
+// Put recovers the batch from the caller's first carved buffer by
+// subtracting headerSize and loading a pointer. The data slice is not
+// stored on the batch — it's computed on demand as
+// region[headerSize : headerSize + bucket.rowSize*bucket.rowCount],
+// keeping the struct in a single cache line.
+type batch struct {
+	bucket      *bucket
+	region      []byte // full backing region including the header
+	mmapped     bool
+	inUse       bool
+	lastFreeGen uint64
+	poolIdx     int // index in pool.batches; updated on swap-delete
+}
+
+// New creates a Pool accepting the given row count classes. At least one
+// rowCount must be supplied; each must be positive and distinct values
+// get separate partitions (duplicates are harmless but waste a slot
+// table). maxRowSize must be a positive multiple of 64. The pool is
+// deliberately codec-agnostic: callers decide which row counts it sees
+// (e.g. [AssemblerBatchRows] and ProtocolParams.CodecWorkRows).
+func New(maxRowSize int, rowCounts ...int) *Pool {
+	if maxRowSize < rowSizeAlign || maxRowSize%rowSizeAlign != 0 {
+		panic(fmt.Sprintf("row: maxRowSize %d must be a positive multiple of %d", maxRowSize, rowSizeAlign))
+	}
+	if len(rowCounts) == 0 {
+		panic("row: at least one rowCount must be supplied")
+	}
+	for _, rc := range rowCounts {
+		if rc <= 0 {
+			panic(fmt.Sprintf("row: rowCount %d must be positive", rc))
+		}
+	}
+	return &Pool{
+		maxRowSize: maxRowSize,
+		rowCounts:  append([]int(nil), rowCounts...),
+		slots:      make([]*bucket, len(rowCounts)*(maxRowSize/rowSizeAlign)),
+	}
+}
+
+// Get returns n buffers of size bytes each, carved from one batch.
+// size must be a positive multiple of 64 in [64, maxRowSize] and n must
+// be one of the row counts this pool was built for; violations panic.
+// Implements [reedsolomon.WorkAllocator].
+func (p *Pool) Get(n, size int) [][]byte {
+	if n == 0 {
+		return nil
+	}
+	if size < rowSizeAlign || size > p.maxRowSize || size%rowSizeAlign != 0 {
+		panic(fmt.Sprintf("row: size %d invalid (want positive multiple of %d, <= %d)", size, rowSizeAlign, p.maxRowSize))
+	}
+	partIdx := p.partition(n)
+	if partIdx < 0 {
+		panic(fmt.Sprintf("row: row count %d not accepted by this pool", n))
+	}
+
+	bk, b := p.tryAcquire(partIdx, n, size)
+	if b == nil {
+		// mmap outside the lock
+		region, mmapped := allocBacking(headerSize + bk.rowSize*bk.rowCount)
+		b = p.install(bk, region, mmapped)
+	}
+
+	return carve(b.region[headerSize:headerSize+n*size], n, size)
+}
+
+// tryAcquire prepares the bucket (creating it
+// if needed), advances its generation, runs aged eviction, and tries to
+// hand out a free batch via exact match or upward-slack fallback.
+// Returns the bucket plus either a ready-to-use batch, or nil if the
+// caller must allocate a new batch at the bucket's key.
+func (p *Pool) tryAcquire(partIdx, n, size int) (*bucket, *batch) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.cancelIdleTimer()
+
+	partBase := partIdx * (p.maxRowSize / rowSizeAlign)
+	reqIdx := size/rowSizeAlign - 1
+	slotIdx := partBase + reqIdx
+	bk := p.slots[slotIdx]
+	if bk == nil {
+		bk = &bucket{rowSize: size, rowCount: n}
+		p.slots[slotIdx] = bk
+	}
+	bk.generation++
+	p.evict(bk)
+
+	b := popFree(bk)
+	if b == nil {
+		b = p.fallback(partBase, reqIdx)
+	}
+	if b != nil {
+		b.inUse = true
+		p.inUse++
+	}
+	return bk, b
+}
+
+// install wraps a freshly-allocated region into a batch bound to bk,
+// anchors it in p.batches, and marks it in-use. Cancels any idle-drop
+// timer a concurrent Put armed while the caller was mmap'ing.
+func (p *Pool) install(bk *bucket, region []byte, mmapped bool) *batch {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.cancelIdleTimer()
+
+	b := &batch{
+		bucket:  bk,
+		region:  region,
+		mmapped: mmapped,
+		inUse:   true,
+		poolIdx: len(p.batches),
+	}
+	*(**batch)(unsafe.Pointer(unsafe.SliceData(region))) = b
+	p.batches = append(p.batches, b)
+	p.inUse++
+	return b
+}
+
+// cancelIdleTimer stops and clears the idle-drop timer if armed. Caller
+// holds p.mu.
+func (p *Pool) cancelIdleTimer() {
+	if p.idleTimer != nil {
+		p.idleTimer.Stop()
+		p.idleTimer = nil
+	}
+}
+
+// Put returns the batch backing bufs to its owning bucket. Panics on
+// any contract violation — empty bufs, a pointer that doesn't resolve
+// to a live batch (foreign or released), or a double-free.
+func (p *Pool) Put(bufs [][]byte) {
+	if len(bufs) == 0 {
+		panic("row: Put called with empty bufs")
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	b := batchFromBuf(bufs[0])
+	if b == nil {
+		panic("row: Put called with empty buffer")
+	}
+	if b.poolIdx >= len(p.batches) || p.batches[b.poolIdx] != b {
+		panic("row: Put called with foreign or released batch")
+	}
+	if !b.inUse {
+		panic("row: double free")
+	}
+	b.inUse = false
+	b.lastFreeGen = b.bucket.generation
+	b.bucket.free = append(b.bucket.free, b)
+	p.inUse--
+
+	if p.inUse == 0 {
+		p.idleTimer = time.AfterFunc(idleGrace, p.dropIdle)
+	}
+}
+
+// Batches returns the total count of live batches. For tests and
+// observability; takes the pool lock.
+func (p *Pool) Batches() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return len(p.batches)
+}
+
+// partition returns the partition index for rowCount, or -1 if
+// rowCount is not one of this pool's accepted classes. rowCounts is
+// fixed at New() so this scan (≤3 entries in practice) is lock-free.
+func (p *Pool) partition(rowCount int) int {
+	for i, rc := range p.rowCounts {
+		if rc == rowCount {
+			return i
+		}
+	}
+	return -1
+}
+
+// fallback walks up to slack slots above reqIdx within the current
+// partition and returns a popped free batch from the first larger-class
+// bucket that has one. Consuming from a larger bucket advances its
+// generation and runs its aged-eviction, so its other free batches age
+// on consumption just as they would under a direct Get.
+func (p *Pool) fallback(partBase, reqIdx int) *batch {
+	maxIdx := min(reqIdx+slack, p.maxRowSize/rowSizeAlign-1)
+	for i := reqIdx + 1; i <= maxIdx; i++ {
+		bk := p.slots[partBase+i]
+		if bk == nil {
+			continue
+		}
+		if b := popFree(bk); b != nil {
+			bk.generation++
+			p.evict(bk)
+			return b
+		}
+	}
+	return nil
+}
+
+// evict drops the oldest free batch from bk if it has aged
+// past evictionThreshold. bk.free is FIFO so the head is always the
+// oldest candidate; generations advance by one per Get, so at most one
+// batch transitions to evictable per call.
+func (p *Pool) evict(bk *bucket) {
+	if len(bk.free) == 0 {
+		return
+	}
+	oldest := bk.free[0]
+	if bk.generation-oldest.lastFreeGen < evictionThreshold {
+		return
+	}
+	p.release(oldest)
+	bk.free[0] = nil // drop the reference in the backing array before reslicing
+	bk.free = bk.free[1:]
+}
+
+// release drops a batch's backing memory and unlinks it from
+// p.batches via swap-delete.
+func (p *Pool) release(b *batch) {
+	last := len(p.batches) - 1
+	if b.poolIdx != last {
+		moved := p.batches[last]
+		p.batches[b.poolIdx] = moved
+		moved.poolIdx = b.poolIdx
+	}
+	p.batches[last] = nil
+	p.batches = p.batches[:last]
+	if b.mmapped {
+		_ = mmapFree(b.region)
+	}
+}
+
+// dropIdle is the idle-timer callback: if the pool is still fully
+// idle, drop every free batch; otherwise no-op.
+func (p *Pool) dropIdle() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.idleTimer = nil
+	if p.inUse != 0 {
+		return
+	}
+	for _, bk := range p.slots {
+		if bk == nil {
+			continue
+		}
+		for _, b := range bk.free {
+			p.release(b)
+		}
+		bk.free = nil
+	}
+}
+
+// popFree pops the most recently freed batch from bk, or returns nil.
+func popFree(bk *bucket) *batch {
+	n := len(bk.free)
+	if n == 0 {
+		return nil
+	}
+	b := bk.free[n-1]
+	bk.free[n-1] = nil
+	bk.free = bk.free[:n-1]
+	return b
+}
+
+// batchFromBuf recovers the owning *batch from a buffer carved by this
+// pool, via the back-pointer stored headerSize bytes below the buffer's
+// base. The caller (Put) validates the returned *batch against p.batches
+// before trusting it, so a wrong-but-readable pointer is caught there.
+// A pointer whose backing array begins within headerSize of the start of
+// a page can fault here — contract forbids passing such buffers.
+func batchFromBuf(buf []byte) *batch {
+	if len(buf) == 0 {
+		return nil
+	}
+	base := unsafe.Pointer(unsafe.SliceData(buf))
+	return *(**batch)(unsafe.Pointer(uintptr(base) - headerSize))
+}
+
+// carve slices data into n equal-sized buffers using full-slice expressions
+// so sub-buffers can't append past their length into neighbors.
+func carve(data []byte, n, size int) [][]byte {
+	bufs := make([][]byte, n)
+	for i := range n {
+		start, end := i*size, (i+1)*size
+		bufs[i] = data[start:end:end]
+	}
+	return bufs
+}
+
+// allocBacking returns aligned backing bytes for a batch. Large batches
+// go through mmap (off-heap); smaller ones through the SIMD-aligned
+// Go-heap allocator.
+func allocBacking(size int) (data []byte, mmapped bool) {
+	if !disableMmap && size >= mmapThreshold {
+		if d, err := mmapAlloc(size); err == nil {
+			return d, true
+		}
+	}
+	return reedsolomon.AllocAligned(1, size)[0], false
+}
+
+var _ reedsolomon.WorkAllocator = (*Pool)(nil)

--- a/fibre/internal/row/pool.go
+++ b/fibre/internal/row/pool.go
@@ -26,7 +26,6 @@ package row
 import (
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 	"unsafe"
 
@@ -104,9 +103,6 @@ type bucket struct {
 	gen        uint64
 	free, used []*slab
 	idleTimer  *time.Timer
-
-	// freeLen mirrors len(free) for an unsynchronized peek in [Pool.find].
-	freeLen atomic.Int32
 }
 
 // NewPool creates a Pool serving the given rowCount. maxRowSize must
@@ -139,21 +135,11 @@ func (p *Pool) Get(n, size int) [][]byte {
 		panic(fmt.Sprintf("row: size %d invalid (want positive multiple of %d, <= %d)", size, rowSizeAlign, p.maxRowSize))
 	}
 
-	// find → maybe new → pop, retrying on race-loss. a failed pop means
-	// a peer Get drained the chosen bucket between our peek and take;
-	// re-finding picks up free slabs from any slack-window bucket on
-	// retry. bounded by concurrent contention.
-	for {
-		bk, ok := p.find(size)
-		if !ok {
-			bk.new(n * size)
-		}
-		b := bk.pop()
-		if b == nil {
-			continue
-		}
-		return b.carve(n, size)
+	bk, s := p.pop(size)
+	if s == nil {
+		s = bk.new(n * size)
 	}
+	return s.carve(n, size)
 }
 
 // Put returns the slab backing bufs to its owning bucket. Panics on
@@ -185,44 +171,39 @@ func (p *Pool) Slabs() int {
 	return n
 }
 
-// find walks from size's exact bucket up through the slack window and
-// returns (bk, true) for the first with freeLen > 0. The atomic peek
-// skips empty buckets without locking — stale reads are benign. On a
-// clean miss returns (exact bucket, false) for the caller's slow-path
-// new.
-func (p *Pool) find(size int) (*bucket, bool) {
+// pop walks size's exact bucket up through the slack window and tries
+// to recycle a free slab. Returns (bk, slab) for the first hit, or
+// (exact bucket, nil) on a clean miss for the caller's slow-path
+// [bucket.new].
+func (p *Pool) pop(size int) (*bucket, *slab) {
 	sizeIdx := size/rowSizeAlign - 1
 	maxIdx := min(sizeIdx+slack, len(p.buckets)-1)
 	for i := sizeIdx; i <= maxIdx; i++ {
 		bk := &p.buckets[i]
-		if bk.freeLen.Load() > 0 {
-			return bk, true
+		if s := bk.pop(); s != nil {
+			return bk, s
 		}
 	}
-	return &p.buckets[sizeIdx], false
+	return &p.buckets[sizeIdx], nil
 }
 
-// new allocates a fresh slab and parks it on bk's free queue for the
-// caller's follow-up [bucket.pop]. alloc runs outside the lock — a
-// multi-MiB mmap would dominate Get p95 if held across it. Concurrent
-// slow paths each install their own slab; the surplus self-heals via
-// aged eviction.
-func (bk *bucket) new(dataSize int) {
-	region, mmapped := alloc(headerSize + dataSize)
+// new allocates a fresh slab at bk's exact key and adopts it directly
+// into bk.used. alloc runs outside the lock — a multi-MiB mmap would
+// dominate Get p95 if held across it.
+func (bk *bucket) new(dataSize int) *slab {
+	region, free := alloc(headerSize + dataSize)
 
 	bk.Lock()
 	defer bk.Unlock()
 
-	b := &slab{
-		bucket:  bk,
-		region:  region,
-		mmapped: mmapped,
-		lastPut: bk.gen, // anchor against premature aged eviction
+	s := &slab{
+		bucket: bk,
+		region: region,
+		free:   free,
 	}
-	writeSlabPtr(region, b)
-	bk.cancelIdle() // a Get is in flight; bk is not idle anymore
-	bk.free = append(bk.free, b)
-	bk.freeLen.Store(int32(len(bk.free)))
+	writeSlabPtr(region, s)
+	bk.use(s)
+	return s
 }
 
 // put hands b back to bk. The bk.used[b.usedIdx] == b identity check
@@ -248,18 +229,14 @@ func (bk *bucket) put(b *slab) {
 
 	b.lastPut = bk.gen
 	bk.free = append(bk.free, b)
-	bk.freeLen.Store(int32(len(bk.free)))
 
 	if len(bk.used) == 0 {
 		bk.armIdle()
 	}
 }
 
-// pop is the sole path by which a slab transitions from free to used.
-// Pops the most recently freed slab (LIFO), cancels the idle timer,
-// advances generation, runs aged eviction, and links the slab into
-// bk.used — all under one lock. Returns nil if bk.free is empty
-// (caller's freeLen peek was stale, or a peer raced ahead).
+// pop dequeues the most recently freed slab (LIFO) and adopts it into
+// bk.used. Returns nil if bk.free is empty.
 func (bk *bucket) pop() *slab {
 	bk.Lock()
 	defer bk.Unlock()
@@ -268,18 +245,24 @@ func (bk *bucket) pop() *slab {
 	if n == 0 {
 		return nil
 	}
-	b := bk.free[n-1]
+	s := bk.free[n-1]
 	bk.free[n-1] = nil
 	bk.free = bk.free[:n-1]
-	bk.freeLen.Store(int32(n - 1))
 
+	bk.use(s)
+	return s
+}
+
+// use cancels the idle timer, advances generation, runs aged eviction,
+// and links s into bk.used. Caller holds bk.mu. Invoked from both the
+// recycle path ([bucket.pop]) and the fresh-alloc path ([bucket.new]).
+func (bk *bucket) use(s *slab) {
 	bk.cancelIdle()
 	bk.gen++
 	bk.evict()
 
-	b.usedIdx = len(bk.used)
-	bk.used = append(bk.used, b)
-	return b
+	s.usedIdx = len(bk.used)
+	bk.used = append(bk.used, s)
 }
 
 // evict drops the oldest free slab if it has aged past
@@ -288,16 +271,15 @@ func (bk *bucket) evict() {
 	if len(bk.free) == 0 {
 		return
 	}
+
 	oldest := bk.free[0]
 	if bk.gen-oldest.lastPut < evictionThreshold {
 		return
 	}
-	if oldest.mmapped {
-		_ = mmapFree(oldest.region)
-	}
+
+	oldest.free(oldest.region)
 	bk.free[0] = nil // drop the backing-array reference before reslicing
 	bk.free = bk.free[1:]
-	bk.freeLen.Store(int32(len(bk.free)))
 }
 
 // armIdle schedules a per-bucket drop after idleGrace. Lazily creates
@@ -309,6 +291,7 @@ func (bk *bucket) armIdle() {
 		bk.idleTimer = time.AfterFunc(idleGrace, bk.dropIdle)
 		return
 	}
+
 	bk.idleTimer.Reset(idleGrace)
 }
 
@@ -325,16 +308,15 @@ func (bk *bucket) cancelIdle() {
 func (bk *bucket) dropIdle() {
 	bk.Lock()
 	defer bk.Unlock()
+
 	if len(bk.used) != 0 {
 		return
 	}
+
 	for _, b := range bk.free {
-		if b.mmapped {
-			_ = mmapFree(b.region)
-		}
+		b.free(b.region)
 	}
 	bk.free = nil
-	bk.freeLen.Store(0)
 }
 
 // slab's backing region is laid out as
@@ -346,8 +328,8 @@ func (bk *bucket) dropIdle() {
 type slab struct {
 	bucket *bucket
 
-	region  []byte // full backing region including the header
-	mmapped bool
+	region []byte       // full backing region including the header
+	free   func([]byte) // releases region; mmapFree for off-heap, noopFree for Go-heap
 
 	lastPut uint64
 	usedIdx int // index in bucket.used; updated on swap-delete
@@ -383,16 +365,19 @@ func (b *slab) carve(n, size int) [][]byte {
 	return bufs
 }
 
-// alloc returns aligned backing bytes for a slab. Large allocations
-// go through mmap (off-heap, invisible to GC); smaller ones use the
-// SIMD-aligned Go-heap allocator.
-func alloc(size int) (data []byte, mmapped bool) {
+// alloc returns a backing region and the matching release callback.
+// Large allocations go through mmap (off-heap, invisible to GC) and
+// pair with [mmapFree]; smaller ones use the SIMD-aligned Go-heap
+// allocator and pair with noopFree (GC reclaims).
+func alloc(size int) (data []byte, free func([]byte)) {
 	if !disableMmap && size >= mmapThreshold {
 		if d, err := mmapAlloc(size); err == nil {
-			return d, true
+			return d, mmapFree
 		}
 	}
-	return reedsolomon.AllocAligned(1, size)[0], false
+	return reedsolomon.AllocAligned(1, size)[0], noopFree
 }
+
+func noopFree([]byte) {}
 
 var _ reedsolomon.WorkAllocator = (*Pool)(nil)

--- a/fibre/internal/row/pool.go
+++ b/fibre/internal/row/pool.go
@@ -1,23 +1,23 @@
-// Package row provides a bucketed allocator of fixed-shape row batches.
+// Package row provides a bucketed allocator of fixed-shape row slabs.
 //
-// A batch is the indivisible allocation unit: rowCount rows of rowSize
+// A slab is the indivisible allocation unit: rowCount rows of rowSize
 // bytes each. A Get(rowCount, rowSize) is served from the exact bucket
 // or from a larger-rowSize bucket within a slack window on the same
-// rowCount — never smaller. Failing both, a new batch is allocated at
+// rowCount — never smaller. Failing both, a new slab is allocated at
 // the exact requested key.
 //
 // Retention is demand-driven: each bucket has a generation counter that
-// advances on every Get to that bucket. A free batch becomes evictable
+// advances on every Get to that bucket. A free slab becomes evictable
 // once bucket.gen exceeds its lastPut by evictionThreshold. When a
-// bucket goes fully idle (no in-use batches), an independent per-bucket
-// idle timer arms and drops that bucket's free batches after idleGrace
+// bucket goes fully idle (no in-use slabs), an independent per-bucket
+// idle timer arms and drops that bucket's free slabs after idleGrace
 // if no Get arrives.
 //
 // Contract: buffers from [Pool.Get] must be returned together via
 // [Pool.Put] to the same Pool that issued them; callers must not
 // re-slice or split across calls. Put validates a back-pointer embedded
-// in each batch's region and panics on double-free or already-released
-// batches. Passing buffers from a different Pool instance is undefined
+// in each slab's region and panics on double-free or already-released
+// slabs. Passing buffers from a different Pool instance is undefined
 // behavior. A pointer whose backing array lies near the start of a page
 // can fault when Put reads the header below it, so callers must not
 // pass buffers this pool never allocated.
@@ -39,37 +39,37 @@ const (
 	// accepted rowSize; SIMD-aligned to 64 bytes.
 	rowSizeAlign = 64
 
-	// headerSize prefixes every batch's backing region. Sized to keep
+	// headerSize prefixes every slab's backing region. Sized to keep
 	// data 64-byte (SIMD) aligned; the first word is a back-pointer to
-	// the owning *batch, used by Put to recover it from a carved buffer.
+	// the owning *slab, used by Put to recover it from a carved buffer.
 	headerSize = 64
 )
 
 // Pool tunables — safe to adjust, governed by workload characteristics.
 const (
 	// slack: max number of rowSizeAlign slot steps above the exact match
-	// a free batch may occupy for upward fallback. Waste per reused batch
+	// a free slab may occupy for upward fallback. Waste per reused slab
 	// is slack*rowSizeAlign*rowCount bytes — constant per row, so safe to
 	// apply at any rowSize. With defaults and Celestia's shape: ≤1.5 MiB
-	// on the assembler batch, ≤4 MiB on the codec-work batch.
+	// on the assembler slab, ≤4 MiB on the codec-work slab (~5.5MiB total)
 	slack = 2
 
-	// evictionThreshold: generation ticks a free batch must age through
+	// evictionThreshold: generation ticks a free slab must age through
 	// before becoming evictable.
 	evictionThreshold = 4
 
 	// idleGrace: wait after a bucket goes fully idle before its free
-	// batches are dropped.
+	// slabs are dropped.
 	idleGrace = 30 * time.Second
 
-	// mmapThreshold: minimum batch size routed through mmap instead of
+	// mmapThreshold: minimum slab size routed through mmap instead of
 	// the Go heap. Above this, allocations stay invisible to GOGC's
 	// heap-doubling pacer so the codec's multi-MiB work buffers don't
 	// trigger OOMs.
 	mmapThreshold = 1 << 20 // 1 MiB
 )
 
-// Pool is a bucketed allocator of fixed-shape row batches for a single
+// Pool is a bucketed allocator of fixed-shape row slabs for a single
 // row count. Callers needing multiple row counts construct one Pool
 // each.
 //
@@ -89,20 +89,20 @@ type Pool struct {
 	buckets []bucket
 }
 
-// bucket holds free and in-use batches for one (rowCount, rowSize)
+// bucket holds free and in-use slabs for one (rowCount, rowSize)
 // pair. Every state mutation is serialized by the embedded mutex.
 //
 // free is a FIFO by release time: reuse pops the back (LIFO warmth),
 // aged eviction pops the front (oldest first). used anchors live
-// in-use batches on the Go heap — the header back-pointer inside a
+// in-use slabs on the Go heap — the header back-pointer inside a
 // (possibly mmap'd) region is invisible to GC, so a Go-heap reference
-// must outlive the batch. idleTimer arms when used goes empty and
-// drops free batches after idleGrace if no Get arrives.
+// must outlive the slab. idleTimer arms when used goes empty and
+// drops free slabs after idleGrace if no Get arrives.
 type bucket struct {
 	sync.Mutex
 
 	gen        uint64
-	free, used []*batch
+	free, used []*slab
 	idleTimer  *time.Timer
 
 	// freeLen mirrors len(free) for an unsynchronized peek in [Pool.find].
@@ -125,7 +125,7 @@ func NewPool(maxRowSize, rowCount int) *Pool {
 	}
 }
 
-// Get returns n buffers of size bytes each, carved from one batch.
+// Get returns n buffers of size bytes each, carved from one slab.
 // n must equal the pool's rowCount; size must be a positive multiple
 // of 64 in [64, maxRowSize]. Violations panic.
 func (p *Pool) Get(n, size int) [][]byte {
@@ -141,7 +141,7 @@ func (p *Pool) Get(n, size int) [][]byte {
 
 	// find → maybe new → pop, retrying on race-loss. a failed pop means
 	// a peer Get drained the chosen bucket between our peek and take;
-	// re-finding picks up free batches from any slack-window bucket on
+	// re-finding picks up free slabs from any slack-window bucket on
 	// retry. bounded by concurrent contention.
 	for {
 		bk, ok := p.find(size)
@@ -156,14 +156,14 @@ func (p *Pool) Get(n, size int) [][]byte {
 	}
 }
 
-// Put returns the batch backing bufs to its owning bucket. Panics on
-// empty bufs, an already-released batch, or a double-free. Passing
+// Put returns the slab backing bufs to its owning bucket. Panics on
+// empty bufs, an already-released slab, or a double-free. Passing
 // bufs from a different Pool is undefined behavior.
 func (p *Pool) Put(bufs [][]byte) {
 	if len(bufs) == 0 {
 		panic("row: Put called with empty bufs")
 	}
-	b := batchFromBuf(bufs[0])
+	b := slabFromBuf(bufs[0])
 	if b == nil {
 		panic("row: Put called with empty buffer")
 	}
@@ -171,10 +171,10 @@ func (p *Pool) Put(bufs [][]byte) {
 	b.bucket.put(b)
 }
 
-// Batches returns the total count of live batches (in-use plus free)
+// Slabs returns the total count of live slabs (in-use plus free)
 // across all buckets. For tests and observability; locks each bucket
 // briefly.
-func (p *Pool) Batches() int {
+func (p *Pool) Slabs() int {
 	n := 0
 	for i := range p.buckets {
 		bk := &p.buckets[i]
@@ -202,10 +202,10 @@ func (p *Pool) find(size int) (*bucket, bool) {
 	return &p.buckets[sizeIdx], false
 }
 
-// new allocates a fresh batch and parks it on bk's free queue for the
+// new allocates a fresh slab and parks it on bk's free queue for the
 // caller's follow-up [bucket.pop]. alloc runs outside the lock — a
 // multi-MiB mmap would dominate Get p95 if held across it. Concurrent
-// slow paths each install their own batch; the surplus self-heals via
+// slow paths each install their own slab; the surplus self-heals via
 // aged eviction.
 func (bk *bucket) new(dataSize int) {
 	region, mmapped := alloc(headerSize + dataSize)
@@ -213,13 +213,13 @@ func (bk *bucket) new(dataSize int) {
 	bk.Lock()
 	defer bk.Unlock()
 
-	b := &batch{
+	b := &slab{
 		bucket:  bk,
 		region:  region,
 		mmapped: mmapped,
 		lastPut: bk.gen, // anchor against premature aged eviction
 	}
-	writeBatchPtr(region, b)
+	writeSlabPtr(region, b)
 	bk.cancelIdle() // a Get is in flight; bk is not idle anymore
 	bk.free = append(bk.free, b)
 	bk.freeLen.Store(int32(len(bk.free)))
@@ -228,12 +228,12 @@ func (bk *bucket) new(dataSize int) {
 // put hands b back to bk. The bk.used[b.usedIdx] == b identity check
 // catches double-free and stale references in one shot. Arms the idle
 // timer when used goes empty.
-func (bk *bucket) put(b *batch) {
+func (bk *bucket) put(b *slab) {
 	bk.Lock()
 	defer bk.Unlock()
 
 	if b.usedIdx >= len(bk.used) || bk.used[b.usedIdx] != b {
-		panic("row: Put called with released or already-freed batch")
+		panic("row: Put called with released or already-freed slab")
 	}
 
 	// swap-delete from bk.used.
@@ -255,12 +255,12 @@ func (bk *bucket) put(b *batch) {
 	}
 }
 
-// pop is the sole path by which a batch transitions from free to used.
-// Pops the most recently freed batch (LIFO), cancels the idle timer,
-// advances generation, runs aged eviction, and links the batch into
+// pop is the sole path by which a slab transitions from free to used.
+// Pops the most recently freed slab (LIFO), cancels the idle timer,
+// advances generation, runs aged eviction, and links the slab into
 // bk.used — all under one lock. Returns nil if bk.free is empty
 // (caller's freeLen peek was stale, or a peer raced ahead).
-func (bk *bucket) pop() *batch {
+func (bk *bucket) pop() *slab {
 	bk.Lock()
 	defer bk.Unlock()
 
@@ -282,7 +282,7 @@ func (bk *bucket) pop() *batch {
 	return b
 }
 
-// evict drops the oldest free batch if it has aged past
+// evict drops the oldest free slab if it has aged past
 // evictionThreshold. At most one per call. Caller holds bk.mu.
 func (bk *bucket) evict() {
 	if len(bk.free) == 0 {
@@ -319,7 +319,7 @@ func (bk *bucket) cancelIdle() {
 	}
 }
 
-// dropIdle is the idle-timer callback: drops bk's free batches if bk
+// dropIdle is the idle-timer callback: drops bk's free slabs if bk
 // is still fully idle when it fires. Leaves idleTimer non-nil so the
 // next armIdle reuses it via Reset.
 func (bk *bucket) dropIdle() {
@@ -337,13 +337,13 @@ func (bk *bucket) dropIdle() {
 	bk.freeLen.Store(0)
 }
 
-// batch's backing region is laid out as
+// slab's backing region is laid out as
 //
 //	[ header (headerSize bytes) | data (rowSize * rowCount bytes) ]
 //
-// The first word of the header stores a back-pointer to this *batch so
+// The first word of the header stores a back-pointer to this *slab so
 // Put can recover it from any carved buffer by subtracting headerSize.
-type batch struct {
+type slab struct {
 	bucket *bucket
 
 	region  []byte // full backing region including the header
@@ -353,28 +353,28 @@ type batch struct {
 	usedIdx int // index in bucket.used; updated on swap-delete
 }
 
-// batchFromBuf recovers the owning *batch by reading the back-pointer
+// slabFromBuf recovers the owning *slab by reading the back-pointer
 // stored headerSize bytes below the buffer's base. Symmetric with
-// writeBatchPtr. A buffer whose backing array begins within headerSize
+// writeSlabPtr. A buffer whose backing array begins within headerSize
 // of a page start can fault here — contract forbids passing such buffers.
-func batchFromBuf(buf []byte) *batch {
+func slabFromBuf(buf []byte) *slab {
 	if len(buf) == 0 {
 		return nil
 	}
 	base := unsafe.Pointer(unsafe.SliceData(buf))
-	return *(**batch)(unsafe.Pointer(uintptr(base) - headerSize))
+	return *(**slab)(unsafe.Pointer(uintptr(base) - headerSize))
 }
 
-// writeBatchPtr stamps b's address into region's header so batchFromBuf
+// writeSlabPtr stamps b's address into region's header so slabFromBuf
 // can recover it from any buffer carved out of region[headerSize:].
-func writeBatchPtr(region []byte, b *batch) {
-	*(**batch)(unsafe.Pointer(unsafe.SliceData(region))) = b
+func writeSlabPtr(region []byte, b *slab) {
+	*(**slab)(unsafe.Pointer(unsafe.SliceData(region))) = b
 }
 
 // carve returns n contiguous []byte views of length size each into b's
 // data region. Each slice is capacity-clamped so callers can't append
 // past their row.
-func (b *batch) carve(n, size int) [][]byte {
+func (b *slab) carve(n, size int) [][]byte {
 	bufs := make([][]byte, n)
 	for i := range bufs {
 		off := headerSize + i*size
@@ -383,7 +383,7 @@ func (b *batch) carve(n, size int) [][]byte {
 	return bufs
 }
 
-// alloc returns aligned backing bytes for a batch. Large allocations
+// alloc returns aligned backing bytes for a slab. Large allocations
 // go through mmap (off-heap, invisible to GC); smaller ones use the
 // SIMD-aligned Go-heap allocator.
 func alloc(size int) (data []byte, mmapped bool) {

--- a/fibre/internal/row/pool.go
+++ b/fibre/internal/row/pool.go
@@ -8,30 +8,32 @@
 //
 // Retention is demand-driven: each bucket has a generation counter that
 // advances on every Get to that bucket. A free batch becomes evictable
-// once bucket.generation exceeds its lastFreeGen by evictionThreshold.
-// When the pool goes fully idle (no in-use batches), an idle timer arms
-// and drops every free batch after idleGrace if nothing arrives.
+// once bucket.gen exceeds its lastPut by evictionThreshold. When a
+// bucket goes fully idle (no in-use batches), an independent per-bucket
+// idle timer arms and drops that bucket's free batches after idleGrace
+// if no Get arrives.
 //
 // Contract: buffers from [Pool.Get] must be returned together via
-// [Pool.Put]; callers must not re-slice or split across calls. Put
-// validates via a back-pointer embedded in each batch's region and
-// panics on any violation — double-free, foreign pointer, or a pointer
-// to a batch that has already been released. A pointer whose backing
-// array lies near the start of a page can fault when Put reads the
-// header below it, so callers must not pass buffers this pool never
-// allocated.
+// [Pool.Put] to the same Pool that issued them; callers must not
+// re-slice or split across calls. Put validates a back-pointer embedded
+// in each batch's region and panics on double-free or already-released
+// batches. Passing buffers from a different Pool instance is undefined
+// behavior. A pointer whose backing array lies near the start of a page
+// can fault when Put reads the header below it, so callers must not
+// pass buffers this pool never allocated.
 package row
 
 import (
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unsafe"
 
 	"github.com/klauspost/reedsolomon"
 )
 
-// Structural constants — invariants of the layout, not tuning knobs.
+// Structural constants — invariants of the memory layout, not tuning knobs.
 const (
 	// rowSizeAlign is the quantum for both rowSize and the minimum
 	// accepted rowSize; SIMD-aligned to 64 bytes.
@@ -56,316 +58,212 @@ const (
 	// before becoming evictable.
 	evictionThreshold = 4
 
-	// idleGrace: wait after full idle before every free batch is dropped.
+	// idleGrace: wait after a bucket goes fully idle before its free
+	// batches are dropped.
 	idleGrace = 30 * time.Second
 
 	// mmapThreshold: minimum batch size routed through mmap instead of
 	// the Go heap. Above this, allocations stay invisible to GOGC's
 	// heap-doubling pacer so the codec's multi-MiB work buffers don't
 	// trigger OOMs.
-	mmapThreshold = 1 << 20
+	mmapThreshold = 1 << 20 // 1 MiB
 )
 
-// Pool is a bucketed allocator of fixed-shape row batches.
+// Pool is a bucketed allocator of fixed-shape row batches for a single
+// row count. Callers needing multiple row counts construct one Pool
+// each.
 //
-// Buckets live in a single flat slots slice laid out as len(rowCounts)
-// partitions of (maxRowSize/rowSizeAlign) entries each. A partition is
-// identified by a rowCount (rowCounts[partIdx]); within a partition,
-// slot i is the bucket for rowSize (i+1)*64. Exact lookup and upward
-// fallback are contiguous pointer reads.
+// Buckets live by-value in a flat slice indexed by rowSize/64 - 1, so
+// exact lookup is a single index. Concurrency is bucket-local: Pool's
+// own state is fixed at [NewPool] and never mutates; each bucket carries
+// its own mutex and idle-drop timer. Disjoint buckets serve Get/Put in
+// parallel.
 //
-// Pool achieves 0(1) for both Put and Get.
-//
-// Safe for concurrent use.
+// O(1) for both Put and Get. Safe for concurrent use.
+// Implements [reedsolomon.WorkAllocator].
 type Pool struct {
-	mu sync.Mutex
-
+	rowCount   int
 	maxRowSize int
-	rowCounts  []int // accepted row counts; fixed at New()
 
-	// slots[partIdx*(maxRowSize/rowSizeAlign) + sizeIdx] holds the bucket
-	// for (rowCounts[partIdx], (sizeIdx+1)*rowSizeAlign).
-	slots []*bucket
-
-	// batches anchors every live *batch on the Go heap — a batch's header
-	// inside its (possibly mmap'd) backing region is invisible to GC, so
-	// we must hold a Go-heap reference here for as long as the batch lives.
-	// Swap-delete on evict via batch.poolIdx keeps removal O(1).
-	batches []*batch
-
-	inUse     int
-	idleTimer *time.Timer
+	// buckets[sizeIdx] is the bucket for rowSize (sizeIdx+1)*rowSizeAlign.
+	buckets []bucket
 }
 
-// bucket holds free batches for one (rowCount, rowSize) pair and its
-// generation counter. free is a FIFO by release time: Put appends; reuse
-// pops the back (LIFO warmth); aged eviction pops the front (oldest first).
+// bucket holds free and in-use batches for one (rowCount, rowSize)
+// pair. Every state mutation is serialized by the embedded mutex.
+//
+// free is a FIFO by release time: reuse pops the back (LIFO warmth),
+// aged eviction pops the front (oldest first). used anchors live
+// in-use batches on the Go heap — the header back-pointer inside a
+// (possibly mmap'd) region is invisible to GC, so a Go-heap reference
+// must outlive the batch. idleTimer arms when used goes empty and
+// drops free batches after idleGrace if no Get arrives.
 type bucket struct {
-	rowSize, rowCount int
-	generation        uint64
-	free              []*batch
+	sync.Mutex
+
+	gen        uint64
+	free, used []*batch
+	idleTimer  *time.Timer
+
+	// freeLen mirrors len(free) for an unsynchronized peek in [Pool.find].
+	freeLen atomic.Int32
 }
 
-// batch's backing region is laid out as
-//
-//	[ header (headerSize bytes) | data (rowSize * rowCount bytes) ]
-//
-// The first word of the header stores a back-pointer to this *batch so
-// Put recovers the batch from the caller's first carved buffer by
-// subtracting headerSize and loading a pointer. The data slice is not
-// stored on the batch — it's computed on demand as
-// region[headerSize : headerSize + bucket.rowSize*bucket.rowCount],
-// keeping the struct in a single cache line.
-type batch struct {
-	bucket      *bucket
-	region      []byte // full backing region including the header
-	mmapped     bool
-	inUse       bool
-	lastFreeGen uint64
-	poolIdx     int // index in pool.batches; updated on swap-delete
-}
-
-// New creates a Pool accepting the given row count classes. At least one
-// rowCount must be supplied; each must be positive and distinct values
-// get separate partitions (duplicates are harmless but waste a slot
-// table). maxRowSize must be a positive multiple of 64. The pool is
-// deliberately codec-agnostic: callers decide which row counts it sees
-// (e.g. [AssemblerBatchRows] and ProtocolParams.CodecWorkRows).
-func New(maxRowSize int, rowCounts ...int) *Pool {
+// NewPool creates a Pool serving the given rowCount. maxRowSize must
+// be a positive multiple of 64; rowCount must be positive.
+func NewPool(maxRowSize, rowCount int) *Pool {
 	if maxRowSize < rowSizeAlign || maxRowSize%rowSizeAlign != 0 {
 		panic(fmt.Sprintf("row: maxRowSize %d must be a positive multiple of %d", maxRowSize, rowSizeAlign))
 	}
-	if len(rowCounts) == 0 {
-		panic("row: at least one rowCount must be supplied")
-	}
-	for _, rc := range rowCounts {
-		if rc <= 0 {
-			panic(fmt.Sprintf("row: rowCount %d must be positive", rc))
-		}
+	if rowCount <= 0 {
+		panic(fmt.Sprintf("row: rowCount %d must be positive", rowCount))
 	}
 	return &Pool{
+		rowCount:   rowCount,
 		maxRowSize: maxRowSize,
-		rowCounts:  append([]int(nil), rowCounts...),
-		slots:      make([]*bucket, len(rowCounts)*(maxRowSize/rowSizeAlign)),
+		buckets:    make([]bucket, maxRowSize/rowSizeAlign),
 	}
 }
 
 // Get returns n buffers of size bytes each, carved from one batch.
-// size must be a positive multiple of 64 in [64, maxRowSize] and n must
-// be one of the row counts this pool was built for; violations panic.
-// Implements [reedsolomon.WorkAllocator].
+// n must equal the pool's rowCount; size must be a positive multiple
+// of 64 in [64, maxRowSize]. Violations panic.
 func (p *Pool) Get(n, size int) [][]byte {
 	if n == 0 {
 		return nil
 	}
+	if n != p.rowCount {
+		panic(fmt.Sprintf("row: rowCount %d does not match pool's %d", n, p.rowCount))
+	}
 	if size < rowSizeAlign || size > p.maxRowSize || size%rowSizeAlign != 0 {
 		panic(fmt.Sprintf("row: size %d invalid (want positive multiple of %d, <= %d)", size, rowSizeAlign, p.maxRowSize))
 	}
-	partIdx := p.partition(n)
-	if partIdx < 0 {
-		panic(fmt.Sprintf("row: row count %d not accepted by this pool", n))
-	}
 
-	bk, b := p.tryAcquire(partIdx, n, size)
-	if b == nil {
-		// mmap outside the lock
-		region, mmapped := allocBacking(headerSize + bk.rowSize*bk.rowCount)
-		b = p.install(bk, region, mmapped)
+	// find → maybe new → pop, retrying on race-loss. a failed pop means
+	// a peer Get drained the chosen bucket between our peek and take;
+	// re-finding picks up free batches from any slack-window bucket on
+	// retry. bounded by concurrent contention.
+	for {
+		bk, ok := p.find(size)
+		if !ok {
+			bk.new(n * size)
+		}
+		b := bk.pop()
+		if b == nil {
+			continue
+		}
+		return b.carve(n, size)
 	}
-
-	return carve(b.region[headerSize:headerSize+n*size], n, size)
 }
 
-// tryAcquire prepares the bucket (creating it
-// if needed), advances its generation, runs aged eviction, and tries to
-// hand out a free batch via exact match or upward-slack fallback.
-// Returns the bucket plus either a ready-to-use batch, or nil if the
-// caller must allocate a new batch at the bucket's key.
-func (p *Pool) tryAcquire(partIdx, n, size int) (*bucket, *batch) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	p.cancelIdleTimer()
-
-	partBase := partIdx * (p.maxRowSize / rowSizeAlign)
-	reqIdx := size/rowSizeAlign - 1
-	slotIdx := partBase + reqIdx
-	bk := p.slots[slotIdx]
-	if bk == nil {
-		bk = &bucket{rowSize: size, rowCount: n}
-		p.slots[slotIdx] = bk
+// Put returns the batch backing bufs to its owning bucket. Panics on
+// empty bufs, an already-released batch, or a double-free. Passing
+// bufs from a different Pool is undefined behavior.
+func (p *Pool) Put(bufs [][]byte) {
+	if len(bufs) == 0 {
+		panic("row: Put called with empty bufs")
 	}
-	bk.generation++
-	p.evict(bk)
-
-	b := popFree(bk)
+	b := batchFromBuf(bufs[0])
 	if b == nil {
-		b = p.fallback(partBase, reqIdx)
+		panic("row: Put called with empty buffer")
 	}
-	if b != nil {
-		b.inUse = true
-		p.inUse++
-	}
-	return bk, b
+
+	b.bucket.put(b)
 }
 
-// install wraps a freshly-allocated region into a batch bound to bk,
-// anchors it in p.batches, and marks it in-use. Cancels any idle-drop
-// timer a concurrent Put armed while the caller was mmap'ing.
-func (p *Pool) install(bk *bucket, region []byte, mmapped bool) *batch {
-	p.mu.Lock()
-	defer p.mu.Unlock()
+// Batches returns the total count of live batches (in-use plus free)
+// across all buckets. For tests and observability; locks each bucket
+// briefly.
+func (p *Pool) Batches() int {
+	n := 0
+	for i := range p.buckets {
+		bk := &p.buckets[i]
+		bk.Lock()
+		n += len(bk.used) + len(bk.free)
+		bk.Unlock()
+	}
+	return n
+}
 
-	p.cancelIdleTimer()
+// find walks from size's exact bucket up through the slack window and
+// returns (bk, true) for the first with freeLen > 0. The atomic peek
+// skips empty buckets without locking — stale reads are benign. On a
+// clean miss returns (exact bucket, false) for the caller's slow-path
+// new.
+func (p *Pool) find(size int) (*bucket, bool) {
+	sizeIdx := size/rowSizeAlign - 1
+	maxIdx := min(sizeIdx+slack, len(p.buckets)-1)
+	for i := sizeIdx; i <= maxIdx; i++ {
+		bk := &p.buckets[i]
+		if bk.freeLen.Load() > 0 {
+			return bk, true
+		}
+	}
+	return &p.buckets[sizeIdx], false
+}
+
+// new allocates a fresh batch and parks it on bk's free queue for the
+// caller's follow-up [bucket.pop]. alloc runs outside the lock — a
+// multi-MiB mmap would dominate Get p95 if held across it. Concurrent
+// slow paths each install their own batch; the surplus self-heals via
+// aged eviction.
+func (bk *bucket) new(dataSize int) {
+	region, mmapped := alloc(headerSize + dataSize)
+
+	bk.Lock()
+	defer bk.Unlock()
 
 	b := &batch{
 		bucket:  bk,
 		region:  region,
 		mmapped: mmapped,
-		inUse:   true,
-		poolIdx: len(p.batches),
+		lastPut: bk.gen, // anchor against premature aged eviction
 	}
-	*(**batch)(unsafe.Pointer(unsafe.SliceData(region))) = b
-	p.batches = append(p.batches, b)
-	p.inUse++
-	return b
+	writeBatchPtr(region, b)
+	bk.cancelIdle() // a Get is in flight; bk is not idle anymore
+	bk.free = append(bk.free, b)
+	bk.freeLen.Store(int32(len(bk.free)))
 }
 
-// cancelIdleTimer stops and clears the idle-drop timer if armed. Caller
-// holds p.mu.
-func (p *Pool) cancelIdleTimer() {
-	if p.idleTimer != nil {
-		p.idleTimer.Stop()
-		p.idleTimer = nil
-	}
-}
+// put hands b back to bk. The bk.used[b.usedIdx] == b identity check
+// catches double-free and stale references in one shot. Arms the idle
+// timer when used goes empty.
+func (bk *bucket) put(b *batch) {
+	bk.Lock()
+	defer bk.Unlock()
 
-// Put returns the batch backing bufs to its owning bucket. Panics on
-// any contract violation — empty bufs, a pointer that doesn't resolve
-// to a live batch (foreign or released), or a double-free.
-func (p *Pool) Put(bufs [][]byte) {
-	if len(bufs) == 0 {
-		panic("row: Put called with empty bufs")
+	if b.usedIdx >= len(bk.used) || bk.used[b.usedIdx] != b {
+		panic("row: Put called with released or already-freed batch")
 	}
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
-	b := batchFromBuf(bufs[0])
-	if b == nil {
-		panic("row: Put called with empty buffer")
+	// swap-delete from bk.used.
+	last := len(bk.used) - 1
+	if b.usedIdx != last {
+		moved := bk.used[last]
+		bk.used[b.usedIdx] = moved
+		moved.usedIdx = b.usedIdx
 	}
-	if b.poolIdx >= len(p.batches) || p.batches[b.poolIdx] != b {
-		panic("row: Put called with foreign or released batch")
-	}
-	if !b.inUse {
-		panic("row: double free")
-	}
-	b.inUse = false
-	b.lastFreeGen = b.bucket.generation
-	b.bucket.free = append(b.bucket.free, b)
-	p.inUse--
+	bk.used[last] = nil
+	bk.used = bk.used[:last]
 
-	if p.inUse == 0 {
-		p.idleTimer = time.AfterFunc(idleGrace, p.dropIdle)
+	b.lastPut = bk.gen
+	bk.free = append(bk.free, b)
+	bk.freeLen.Store(int32(len(bk.free)))
+
+	if len(bk.used) == 0 {
+		bk.armIdle()
 	}
 }
 
-// Batches returns the total count of live batches. For tests and
-// observability; takes the pool lock.
-func (p *Pool) Batches() int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return len(p.batches)
-}
+// pop is the sole path by which a batch transitions from free to used.
+// Pops the most recently freed batch (LIFO), cancels the idle timer,
+// advances generation, runs aged eviction, and links the batch into
+// bk.used — all under one lock. Returns nil if bk.free is empty
+// (caller's freeLen peek was stale, or a peer raced ahead).
+func (bk *bucket) pop() *batch {
+	bk.Lock()
+	defer bk.Unlock()
 
-// partition returns the partition index for rowCount, or -1 if
-// rowCount is not one of this pool's accepted classes. rowCounts is
-// fixed at New() so this scan (≤3 entries in practice) is lock-free.
-func (p *Pool) partition(rowCount int) int {
-	for i, rc := range p.rowCounts {
-		if rc == rowCount {
-			return i
-		}
-	}
-	return -1
-}
-
-// fallback walks up to slack slots above reqIdx within the current
-// partition and returns a popped free batch from the first larger-class
-// bucket that has one. Consuming from a larger bucket advances its
-// generation and runs its aged-eviction, so its other free batches age
-// on consumption just as they would under a direct Get.
-func (p *Pool) fallback(partBase, reqIdx int) *batch {
-	maxIdx := min(reqIdx+slack, p.maxRowSize/rowSizeAlign-1)
-	for i := reqIdx + 1; i <= maxIdx; i++ {
-		bk := p.slots[partBase+i]
-		if bk == nil {
-			continue
-		}
-		if b := popFree(bk); b != nil {
-			bk.generation++
-			p.evict(bk)
-			return b
-		}
-	}
-	return nil
-}
-
-// evict drops the oldest free batch from bk if it has aged
-// past evictionThreshold. bk.free is FIFO so the head is always the
-// oldest candidate; generations advance by one per Get, so at most one
-// batch transitions to evictable per call.
-func (p *Pool) evict(bk *bucket) {
-	if len(bk.free) == 0 {
-		return
-	}
-	oldest := bk.free[0]
-	if bk.generation-oldest.lastFreeGen < evictionThreshold {
-		return
-	}
-	p.release(oldest)
-	bk.free[0] = nil // drop the reference in the backing array before reslicing
-	bk.free = bk.free[1:]
-}
-
-// release drops a batch's backing memory and unlinks it from
-// p.batches via swap-delete.
-func (p *Pool) release(b *batch) {
-	last := len(p.batches) - 1
-	if b.poolIdx != last {
-		moved := p.batches[last]
-		p.batches[b.poolIdx] = moved
-		moved.poolIdx = b.poolIdx
-	}
-	p.batches[last] = nil
-	p.batches = p.batches[:last]
-	if b.mmapped {
-		_ = mmapFree(b.region)
-	}
-}
-
-// dropIdle is the idle-timer callback: if the pool is still fully
-// idle, drop every free batch; otherwise no-op.
-func (p *Pool) dropIdle() {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.idleTimer = nil
-	if p.inUse != 0 {
-		return
-	}
-	for _, bk := range p.slots {
-		if bk == nil {
-			continue
-		}
-		for _, b := range bk.free {
-			p.release(b)
-		}
-		bk.free = nil
-	}
-}
-
-// popFree pops the most recently freed batch from bk, or returns nil.
-func popFree(bk *bucket) *batch {
 	n := len(bk.free)
 	if n == 0 {
 		return nil
@@ -373,15 +271,92 @@ func popFree(bk *bucket) *batch {
 	b := bk.free[n-1]
 	bk.free[n-1] = nil
 	bk.free = bk.free[:n-1]
+	bk.freeLen.Store(int32(n - 1))
+
+	bk.cancelIdle()
+	bk.gen++
+	bk.evict()
+
+	b.usedIdx = len(bk.used)
+	bk.used = append(bk.used, b)
 	return b
 }
 
-// batchFromBuf recovers the owning *batch from a buffer carved by this
-// pool, via the back-pointer stored headerSize bytes below the buffer's
-// base. The caller (Put) validates the returned *batch against p.batches
-// before trusting it, so a wrong-but-readable pointer is caught there.
-// A pointer whose backing array begins within headerSize of the start of
-// a page can fault here — contract forbids passing such buffers.
+// evict drops the oldest free batch if it has aged past
+// evictionThreshold. At most one per call. Caller holds bk.mu.
+func (bk *bucket) evict() {
+	if len(bk.free) == 0 {
+		return
+	}
+	oldest := bk.free[0]
+	if bk.gen-oldest.lastPut < evictionThreshold {
+		return
+	}
+	if oldest.mmapped {
+		_ = mmapFree(oldest.region)
+	}
+	bk.free[0] = nil // drop the backing-array reference before reslicing
+	bk.free = bk.free[1:]
+	bk.freeLen.Store(int32(len(bk.free)))
+}
+
+// armIdle schedules a per-bucket drop after idleGrace. Lazily creates
+// the timer on first arm and reuses via Reset afterwards. Reset is
+// safe without a preceding Stop: cancelIdle/dropIdle leave the timer
+// stopped or expired before any subsequent arm. Caller holds bk.mu.
+func (bk *bucket) armIdle() {
+	if bk.idleTimer == nil {
+		bk.idleTimer = time.AfterFunc(idleGrace, bk.dropIdle)
+		return
+	}
+	bk.idleTimer.Reset(idleGrace)
+}
+
+// cancelIdle stops the idle-drop timer if armed. Caller holds bk.mu.
+func (bk *bucket) cancelIdle() {
+	if bk.idleTimer != nil {
+		bk.idleTimer.Stop()
+	}
+}
+
+// dropIdle is the idle-timer callback: drops bk's free batches if bk
+// is still fully idle when it fires. Leaves idleTimer non-nil so the
+// next armIdle reuses it via Reset.
+func (bk *bucket) dropIdle() {
+	bk.Lock()
+	defer bk.Unlock()
+	if len(bk.used) != 0 {
+		return
+	}
+	for _, b := range bk.free {
+		if b.mmapped {
+			_ = mmapFree(b.region)
+		}
+	}
+	bk.free = nil
+	bk.freeLen.Store(0)
+}
+
+// batch's backing region is laid out as
+//
+//	[ header (headerSize bytes) | data (rowSize * rowCount bytes) ]
+//
+// The first word of the header stores a back-pointer to this *batch so
+// Put can recover it from any carved buffer by subtracting headerSize.
+type batch struct {
+	bucket *bucket
+
+	region  []byte // full backing region including the header
+	mmapped bool
+
+	lastPut uint64
+	usedIdx int // index in bucket.used; updated on swap-delete
+}
+
+// batchFromBuf recovers the owning *batch by reading the back-pointer
+// stored headerSize bytes below the buffer's base. Symmetric with
+// writeBatchPtr. A buffer whose backing array begins within headerSize
+// of a page start can fault here — contract forbids passing such buffers.
 func batchFromBuf(buf []byte) *batch {
 	if len(buf) == 0 {
 		return nil
@@ -390,21 +365,28 @@ func batchFromBuf(buf []byte) *batch {
 	return *(**batch)(unsafe.Pointer(uintptr(base) - headerSize))
 }
 
-// carve slices data into n equal-sized buffers using full-slice expressions
-// so sub-buffers can't append past their length into neighbors.
-func carve(data []byte, n, size int) [][]byte {
+// writeBatchPtr stamps b's address into region's header so batchFromBuf
+// can recover it from any buffer carved out of region[headerSize:].
+func writeBatchPtr(region []byte, b *batch) {
+	*(**batch)(unsafe.Pointer(unsafe.SliceData(region))) = b
+}
+
+// carve returns n contiguous []byte views of length size each into b's
+// data region. Each slice is capacity-clamped so callers can't append
+// past their row.
+func (b *batch) carve(n, size int) [][]byte {
 	bufs := make([][]byte, n)
-	for i := range n {
-		start, end := i*size, (i+1)*size
-		bufs[i] = data[start:end:end]
+	for i := range bufs {
+		off := headerSize + i*size
+		bufs[i] = b.region[off : off+size : off+size]
 	}
 	return bufs
 }
 
-// allocBacking returns aligned backing bytes for a batch. Large batches
-// go through mmap (off-heap); smaller ones through the SIMD-aligned
-// Go-heap allocator.
-func allocBacking(size int) (data []byte, mmapped bool) {
+// alloc returns aligned backing bytes for a batch. Large allocations
+// go through mmap (off-heap, invisible to GC); smaller ones use the
+// SIMD-aligned Go-heap allocator.
+func alloc(size int) (data []byte, mmapped bool) {
 	if !disableMmap && size >= mmapThreshold {
 		if d, err := mmapAlloc(size); err == nil {
 			return d, true

--- a/fibre/internal/row/pool_bench_test.go
+++ b/fibre/internal/row/pool_bench_test.go
@@ -1,0 +1,137 @@
+package row
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+const (
+	benchRowCount = 6
+	benchMaxRow   = 4096
+)
+
+// BenchmarkPool_GetPut_Reuse measures the hot-path steady-state cost
+// when an exact-match bucket is primed: every iteration pops a free
+// batch and puts it back, exercising the common case after startup.
+func BenchmarkPool_GetPut_Reuse(b *testing.B) {
+	p := New(benchMaxRow, benchRowCount)
+	p.Put(p.Get(benchRowCount, 64)) // seed
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		p.Put(p.Get(benchRowCount, 64))
+	}
+}
+
+// BenchmarkPool_GetPut_Fallback measures the upward-slack fallback path.
+// The 64-byte bucket is never populated; the 128-byte bucket holds the
+// reusable batch, so every Get scans slots within the slack window
+// before popping.
+func BenchmarkPool_GetPut_Fallback(b *testing.B) {
+	p := New(benchMaxRow, benchRowCount)
+	p.Put(p.Get(benchRowCount, 128)) // seed the fallback-target bucket
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		// Each Get(64) falls back into slot for 128, pops its batch,
+		// and Put returns it to the same 128 bucket (via batch.bucket).
+		p.Put(p.Get(benchRowCount, 64))
+	}
+}
+
+// BenchmarkPool_Concurrent stresses Pool.mu under contention.
+func BenchmarkPool_Concurrent(b *testing.B) {
+	p := New(benchMaxRow, benchRowCount)
+	p.Put(p.Get(benchRowCount, 64)) // seed
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			p.Put(p.Get(benchRowCount, 64))
+		}
+	})
+}
+
+// BenchmarkPool_AllocContentionTail measures the tail-latency penalty
+// reuse-path Gets pay while another goroutine is doing a fresh
+// allocation under Pool.mu. Holds for the reuse case even though the
+// reuse path itself is O(1) — any in-flight allocation (especially mmap)
+// stalls everyone waiting on the lock.
+//
+// Shape: rowCount=1024 × rowSize=1024 → ~1 MiB batch, above mmapThreshold,
+// so fresh allocs go through the mmap syscall. Worker 0 periodically
+// asks for a novel size (no bucket → alloc); other workers hammer the
+// reuse path.
+//
+// Reports p50/p99/p99.99/max as extra benchmark metrics; a bimodal
+// distribution (p50 ≪ p99) is the fingerprint of lock-held alloc tail.
+func BenchmarkPool_AllocContentionTail(b *testing.B) {
+	const rowCount = 1024
+	const baseSize = 1024    // batch size ≈ 1 MiB → mmap path
+	const maxRow = 64 * 1024 // leaves room for novel sizes
+	const allocEveryN = 256  // ~0.4% of ops force a fresh alloc
+	const workers = 16
+
+	p := New(maxRow, rowCount)
+	p.Put(p.Get(rowCount, baseSize)) // seed the reuse bucket
+
+	workerLat := make([][]time.Duration, workers)
+	for i := range workerLat {
+		workerLat[i] = make([]time.Duration, 0, b.N/workers+16)
+	}
+	var counter atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	b.ResetTimer()
+	for w := range workers {
+		go func(id int) {
+			defer wg.Done()
+			for {
+				i := counter.Add(1) - 1
+				if i >= int64(b.N) {
+					return
+				}
+				size := baseSize
+				if id == 0 && i > 0 && i%allocEveryN == 0 {
+					// novel size → exact bucket empty, outside slack → fresh alloc+mmap
+					size = baseSize + rowSizeAlign*int(1+(i/allocEveryN)%32)
+					if size > maxRow {
+						size = baseSize
+					}
+				}
+				t0 := time.Now()
+				bufs := p.Get(rowCount, size)
+				dt := time.Since(t0)
+				p.Put(bufs)
+				workerLat[id] = append(workerLat[id], dt)
+			}
+		}(w)
+	}
+	wg.Wait()
+	b.StopTimer()
+
+	total := 0
+	for _, wl := range workerLat {
+		total += len(wl)
+	}
+	all := make([]time.Duration, 0, total)
+	for _, wl := range workerLat {
+		all = append(all, wl...)
+	}
+	slices.Sort(all)
+
+	if len(all) == 0 {
+		return
+	}
+	b.ReportMetric(float64(all[len(all)*50/100].Nanoseconds()), "p50-ns")
+	b.ReportMetric(float64(all[len(all)*99/100].Nanoseconds()), "p99-ns")
+	b.ReportMetric(float64(all[min(len(all)-1, len(all)*9999/10000)].Nanoseconds()), "p99.99-ns")
+	b.ReportMetric(float64(all[len(all)-1].Nanoseconds()), "max-ns")
+}

--- a/fibre/internal/row/pool_bench_test.go
+++ b/fibre/internal/row/pool_bench_test.go
@@ -56,6 +56,49 @@ func BenchmarkPool_Concurrent(b *testing.B) {
 	})
 }
 
+// BenchmarkPool_EvictMmappedTouched measures Pool throughput under
+// sustained eviction of touched mmapped slabs. Pre-seeds the free queue
+// with touched slabs, then hammers Get/Put in parallel. Each Get
+// advances the bucket generation and evicts the oldest aged slab; the
+// per-eviction munmap fires inside the bucket lock until we move it
+// out. Touching every page on each Get ensures evicted slabs always
+// hit the slow munmap path.
+func BenchmarkPool_EvictMmappedTouched(b *testing.B) {
+	const rowCount = 256
+	const rowSize = 4096 // 1 MiB → mmap path
+	const seed = 16
+	p := NewPool(rowSize, rowCount)
+
+	// pre-seed the free queue with touched slabs.
+	bufs := make([][][]byte, seed)
+	for i := range bufs {
+		bufs[i] = p.Get(rowCount, rowSize)
+		for _, row := range bufs[i] {
+			for j := 0; j < len(row); j += 4096 {
+				row[j] = 1
+			}
+		}
+	}
+	for _, buf := range bufs {
+		p.Put(buf)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := p.Get(rowCount, rowSize)
+			// touch every page so the slab is fully faulted by the time it evicts.
+			for _, row := range buf {
+				for j := 0; j < len(row); j += 4096 {
+					row[j] = 1
+				}
+			}
+			p.Put(buf)
+		}
+	})
+}
+
 // BenchmarkPool_AllocContentionTail measures the tail-latency penalty
 // reuse-path Gets pay while another goroutine is doing a fresh
 // allocation. Worker 0 periodically asks for a novel size (no bucket

--- a/fibre/internal/row/pool_bench_test.go
+++ b/fibre/internal/row/pool_bench_test.go
@@ -17,7 +17,7 @@ const (
 // when an exact-match bucket is primed: every iteration pops a free
 // batch and puts it back, exercising the common case after startup.
 func BenchmarkPool_GetPut_Reuse(b *testing.B) {
-	p := New(benchMaxRow, benchRowCount)
+	p := NewPool(benchMaxRow, benchRowCount)
 	p.Put(p.Get(benchRowCount, 64)) // seed
 
 	b.ReportAllocs()
@@ -29,24 +29,22 @@ func BenchmarkPool_GetPut_Reuse(b *testing.B) {
 
 // BenchmarkPool_GetPut_Fallback measures the upward-slack fallback path.
 // The 64-byte bucket is never populated; the 128-byte bucket holds the
-// reusable batch, so every Get scans slots within the slack window
-// before popping.
+// reusable batch, so every Get scans within the slack window before
+// popping. Put routes back to the 128 bucket via batch.bucket.
 func BenchmarkPool_GetPut_Fallback(b *testing.B) {
-	p := New(benchMaxRow, benchRowCount)
+	p := NewPool(benchMaxRow, benchRowCount)
 	p.Put(p.Get(benchRowCount, 128)) // seed the fallback-target bucket
 
 	b.ReportAllocs()
 	b.ResetTimer()
 	for b.Loop() {
-		// Each Get(64) falls back into slot for 128, pops its batch,
-		// and Put returns it to the same 128 bucket (via batch.bucket).
 		p.Put(p.Get(benchRowCount, 64))
 	}
 }
 
-// BenchmarkPool_Concurrent stresses Pool.mu under contention.
+// BenchmarkPool_Concurrent stresses bucket-level lock contention.
 func BenchmarkPool_Concurrent(b *testing.B) {
-	p := New(benchMaxRow, benchRowCount)
+	p := NewPool(benchMaxRow, benchRowCount)
 	p.Put(p.Get(benchRowCount, 64)) // seed
 
 	b.ReportAllocs()
@@ -60,17 +58,13 @@ func BenchmarkPool_Concurrent(b *testing.B) {
 
 // BenchmarkPool_AllocContentionTail measures the tail-latency penalty
 // reuse-path Gets pay while another goroutine is doing a fresh
-// allocation under Pool.mu. Holds for the reuse case even though the
-// reuse path itself is O(1) — any in-flight allocation (especially mmap)
-// stalls everyone waiting on the lock.
+// allocation. Worker 0 periodically asks for a novel size (no bucket
+// → alloc+mmap); the others hammer the reuse path. Reports
+// p50/p99/p99.99/max — a bimodal distribution (p50 ≪ p99) signals
+// lock-held alloc tail.
 //
-// Shape: rowCount=1024 × rowSize=1024 → ~1 MiB batch, above mmapThreshold,
-// so fresh allocs go through the mmap syscall. Worker 0 periodically
-// asks for a novel size (no bucket → alloc); other workers hammer the
-// reuse path.
-//
-// Reports p50/p99/p99.99/max as extra benchmark metrics; a bimodal
-// distribution (p50 ≪ p99) is the fingerprint of lock-held alloc tail.
+// Shape: ~1 MiB batches (above mmapThreshold) so fresh allocs go
+// through mmap.
 func BenchmarkPool_AllocContentionTail(b *testing.B) {
 	const rowCount = 1024
 	const baseSize = 1024    // batch size ≈ 1 MiB → mmap path
@@ -78,7 +72,7 @@ func BenchmarkPool_AllocContentionTail(b *testing.B) {
 	const allocEveryN = 256  // ~0.4% of ops force a fresh alloc
 	const workers = 16
 
-	p := New(maxRow, rowCount)
+	p := NewPool(maxRow, rowCount)
 	p.Put(p.Get(rowCount, baseSize)) // seed the reuse bucket
 
 	workerLat := make([][]time.Duration, workers)

--- a/fibre/internal/row/pool_bench_test.go
+++ b/fibre/internal/row/pool_bench_test.go
@@ -15,7 +15,7 @@ const (
 
 // BenchmarkPool_GetPut_Reuse measures the hot-path steady-state cost
 // when an exact-match bucket is primed: every iteration pops a free
-// batch and puts it back, exercising the common case after startup.
+// slab and puts it back, exercising the common case after startup.
 func BenchmarkPool_GetPut_Reuse(b *testing.B) {
 	p := NewPool(benchMaxRow, benchRowCount)
 	p.Put(p.Get(benchRowCount, 64)) // seed
@@ -29,8 +29,8 @@ func BenchmarkPool_GetPut_Reuse(b *testing.B) {
 
 // BenchmarkPool_GetPut_Fallback measures the upward-slack fallback path.
 // The 64-byte bucket is never populated; the 128-byte bucket holds the
-// reusable batch, so every Get scans within the slack window before
-// popping. Put routes back to the 128 bucket via batch.bucket.
+// reusable slab, so every Get scans within the slack window before
+// popping. Put routes back to the 128 bucket via slab.bucket.
 func BenchmarkPool_GetPut_Fallback(b *testing.B) {
 	p := NewPool(benchMaxRow, benchRowCount)
 	p.Put(p.Get(benchRowCount, 128)) // seed the fallback-target bucket
@@ -63,11 +63,11 @@ func BenchmarkPool_Concurrent(b *testing.B) {
 // p50/p99/p99.99/max — a bimodal distribution (p50 ≪ p99) signals
 // lock-held alloc tail.
 //
-// Shape: ~1 MiB batches (above mmapThreshold) so fresh allocs go
+// Shape: ~1 MiB slabs (above mmapThreshold) so fresh allocs go
 // through mmap.
 func BenchmarkPool_AllocContentionTail(b *testing.B) {
 	const rowCount = 1024
-	const baseSize = 1024    // batch size ≈ 1 MiB → mmap path
+	const baseSize = 1024    // slab size ≈ 1 MiB → mmap path
 	const maxRow = 64 * 1024 // leaves room for novel sizes
 	const allocEveryN = 256  // ~0.4% of ops force a fresh alloc
 	const workers = 16

--- a/fibre/internal/row/pool_test.go
+++ b/fibre/internal/row/pool_test.go
@@ -19,7 +19,7 @@ func newPool(t testing.TB) *Pool {
 	return NewPool(testMaxRow, testAssemblerBatchRows)
 }
 
-// Primary row count used by most tests (assembler batch).
+// Primary row count used by most tests (assembler slab).
 func assemblerRowCount() int { return testAssemblerBatchRows }
 
 func TestPool_GetPutExact(t *testing.T) {
@@ -43,14 +43,14 @@ func TestPool_GetPutExact(t *testing.T) {
 	}
 
 	p.Put(bufs)
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d after Put, want 1", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d after Put, want 1", got)
 	}
 
-	// second Get at exact key reuses the same batch.
+	// second Get at exact key reuses the same slab.
 	more := p.Get(rc, 64)
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d after exact-match reuse, want 1", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d after exact-match reuse, want 1", got)
 	}
 	p.Put(more)
 }
@@ -93,7 +93,7 @@ func TestPool_DoubleFreePanics(t *testing.T) {
 	p.Put(bufs)
 	defer func() {
 		if recover() == nil {
-			t.Fatal("second Put of same batch should panic")
+			t.Fatal("second Put of same slab should panic")
 		}
 	}()
 	p.Put(bufs)
@@ -116,7 +116,7 @@ func TestPool_GetZeroReturnsNil(t *testing.T) {
 	}
 }
 
-// A free batch of a larger class serves a smaller request within slack.
+// A free slab of a larger class serves a smaller request within slack.
 func TestPool_FallbackWithinSlack(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
@@ -126,23 +126,23 @@ func TestPool_FallbackWithinSlack(t *testing.T) {
 
 	// request 256: reqIdx=3, maxIdx=reqIdx+slack=5 (size 384). 320 fits → reuse.
 	small := p.Get(rc, 256)
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d after slack fallback, want 1 (reused 320 slab)", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d after slack fallback, want 1 (reused 320 slab)", got)
 	}
 	if len(small[0]) != 256 {
 		t.Fatalf("returned len=%d, want 256 (requested)", len(small[0]))
 	}
 	p.Put(small)
 
-	// on return, batch goes back to its backing bucket (320), not 256.
+	// on return, slab goes back to its backing bucket (320), not 256.
 	again := p.Get(rc, 320)
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d after backing-bucket reuse, want 1", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d after backing-bucket reuse, want 1", got)
 	}
 	p.Put(again)
 }
 
-// A free batch outside the slack window is NOT a fallback candidate.
+// A free slab outside the slack window is NOT a fallback candidate.
 func TestPool_FallbackOutsideSlack(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
@@ -152,8 +152,8 @@ func TestPool_FallbackOutsideSlack(t *testing.T) {
 
 	// request 64: reqIdx=0, maxIdx=reqIdx+slack=2 (size 192). 512 is above → grow.
 	small := p.Get(rc, 64)
-	if got := p.Batches(); got != 2 {
-		t.Fatalf("Batches=%d after out-of-slack grow, want 2", got)
+	if got := p.Slabs(); got != 2 {
+		t.Fatalf("Slabs=%d after out-of-slack grow, want 2", got)
 	}
 	p.Put(small)
 }
@@ -163,21 +163,21 @@ func TestPool_FallbackNeverAllocates(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
-	// no 320 batch exists; request 256 → grows new 256 batch (exact key).
+	// no 320 slab exists; request 256 → grows new 256 slab (exact key).
 	a := p.Get(rc, 256)
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d, want 1", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d, want 1", got)
 	}
 	p.Put(a)
 	// request 320 now: allocate new.
 	b := p.Get(rc, 320)
-	if got := p.Batches(); got != 2 {
-		t.Fatalf("Batches=%d, want 2 (separate 256 and 320 batches)", got)
+	if got := p.Slabs(); got != 2 {
+		t.Fatalf("Slabs=%d, want 2 (separate 256 and 320 slabs)", got)
 	}
 	p.Put(b)
 }
 
-// Free batches are reused LIFO: the most recently Put batch is the next
+// Free slabs are reused LIFO: the most recently Put slab is the next
 // one served by Get.
 func TestPool_LIFOReuse(t *testing.T) {
 	p := newPool(t)
@@ -195,40 +195,40 @@ func TestPool_LIFOReuse(t *testing.T) {
 
 	next := p.Get(rc, 64)
 	if &next[0][0] != bAddr {
-		t.Fatal("LIFO reuse: expected most-recently-freed batch")
+		t.Fatal("LIFO reuse: expected most-recently-freed slab")
 	}
 	p.Put(next)
 }
 
 // Consuming from a larger bucket via fallback advances that bucket's
-// generation and runs its aged eviction, so its other free batches age
+// generation and runs its aged eviction, so its other free slabs age
 // and evict under fallback-driven demand (not only direct Gets).
 func TestPool_FallbackAgesLargerBucket(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
-	// populate the 320-rowSize bucket with two free batches via direct Gets.
+	// populate the 320-rowSize bucket with two free slabs via direct Gets.
 	a := p.Get(rc, 320)
 	b := p.Get(rc, 320)
 	p.Put(a)
 	p.Put(b)
-	if got := p.Batches(); got != 2 {
-		t.Fatalf("Batches=%d before aging, want 2", got)
+	if got := p.Slabs(); got != 2 {
+		t.Fatalf("Slabs=%d before aging, want 2", got)
 	}
 
 	// drive fallback Gets at a smaller in-slack rowSize. LIFO pop means
-	// the most-recently-Put 320 batch cycles; the other sits at the head
+	// the most-recently-Put 320 slab cycles; the other sits at the head
 	// of the free queue with a frozen lastPut and ages out.
 	for range evictionThreshold {
 		x := p.Get(rc, 256)
 		p.Put(x)
 	}
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d after fallback-driven aging, want 1", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d after fallback-driven aging, want 1", got)
 	}
 }
 
-// A free batch aged past evictionThreshold is evicted on the next Get to
+// A free slab aged past evictionThreshold is evicted on the next Get to
 // its bucket.
 func TestPool_AgedEviction(t *testing.T) {
 	p := newPool(t)
@@ -238,22 +238,22 @@ func TestPool_AgedEviction(t *testing.T) {
 	b := p.Get(rc, 64)
 	p.Put(a)
 	p.Put(b)
-	if got := p.Batches(); got != 2 {
-		t.Fatalf("Batches=%d before age, want 2", got)
+	if got := p.Slabs(); got != 2 {
+		t.Fatalf("Slabs=%d before age, want 2", got)
 	}
 
-	// drive enough Gets to age both free batches past evictionThreshold.
+	// drive enough Gets to age both free slabs past evictionThreshold.
 	for range evictionThreshold + 1 {
 		more := p.Get(rc, 64)
 		p.Put(more)
 	}
 	_ = p.Get(rc, 64)
-	if got := p.Batches(); got > 2 {
-		t.Fatalf("Batches=%d, want <= 2 (aged eviction)", got)
+	if got := p.Slabs(); got > 2 {
+		t.Fatalf("Slabs=%d, want <= 2 (aged eviction)", got)
 	}
 }
 
-// The per-bucket idle timer, when fired, drops every free batch in that
+// The per-bucket idle timer, when fired, drops every free slab in that
 // bucket. The timer callback is invoked directly to avoid waiting
 // idleGrace in tests.
 func TestPool_IdleDropsBucket(t *testing.T) {
@@ -265,37 +265,37 @@ func TestPool_IdleDropsBucket(t *testing.T) {
 	p.Put(a)
 	p.Put(b)
 
-	if got := p.Batches(); got != 2 {
-		t.Fatalf("Batches=%d before idle, want 2", got)
+	if got := p.Slabs(); got != 2 {
+		t.Fatalf("Slabs=%d before idle, want 2", got)
 	}
 	bucketAt(p, 64).dropIdle()
-	if got := p.Batches(); got != 0 {
-		t.Fatalf("Batches=%d after idle drop, want 0", got)
+	if got := p.Slabs(); got != 0 {
+		t.Fatalf("Slabs=%d after idle drop, want 0", got)
 	}
 }
 
 // Per-bucket idle timer regression: a dormant bucket gets cleaned up
 // independently of other buckets' activity. Pool-wide idle previously
-// pinned aged free batches in dormant buckets while any other bucket
-// had in-use batches, leaking memory until the entire pool went idle.
+// pinned aged free slabs in dormant buckets while any other bucket
+// had in-use slabs, leaking memory until the entire pool went idle.
 func TestPool_IdleDropsDormantBucketIndependently(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
-	// bucket A (rowSize 64): allocate and return — has free batches, no in-use.
+	// bucket A (rowSize 64): allocate and return — has free slabs, no in-use.
 	x := p.Get(rc, 64)
 	p.Put(x)
 
-	// bucket B (rowSize 128): keep one batch in-use perpetually.
+	// bucket B (rowSize 128): keep one slab in-use perpetually.
 	y := p.Get(rc, 128)
 	defer p.Put(y)
 
 	// trigger A's idle timer specifically. Even though B is non-idle,
-	// A must drop its free batches.
+	// A must drop its free slabs.
 	bucketAt(p, 64).dropIdle()
 
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d, want 1 (only B's in-use batch survives)", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d, want 1 (only B's in-use slab survives)", got)
 	}
 }
 
@@ -354,11 +354,11 @@ func TestPool_NoAliasWrites(t *testing.T) {
 	}
 }
 
-// TestPool_GCAnchor verifies that an in-use batch survives GC cycles.
-// While in use, the only Go-heap reference to *batch is its bucket's
+// TestPool_GCAnchor verifies that an in-use slab survives GC cycles.
+// While in use, the only Go-heap reference to *slab is its bucket's
 // used slice — the header back-pointer is an unsafe store GC doesn't
 // trace, and the caller's bufs share the region's backing array, not
-// the batch struct. Without the anchor, GC could reap *batch between
+// the slab struct. Without the anchor, GC could reap *slab between
 // Get and Put and Put would read a dangling pointer.
 func TestPool_GCAnchor(t *testing.T) {
 	p := newPool(t)
@@ -371,7 +371,7 @@ func TestPool_GCAnchor(t *testing.T) {
 	}
 
 	// force multiple GC cycles. If the anchor is broken, a sweep during
-	// one of these frees the *batch struct; subsequent Put would read a
+	// one of these frees the *slab struct; subsequent Put would read a
 	// stale pointer.
 	runtime.GC()
 	runtime.GC()
@@ -384,11 +384,11 @@ func TestPool_GCAnchor(t *testing.T) {
 	}
 
 	p.Put(bufs)
-	if got := p.Batches(); got != 1 {
-		t.Fatalf("Batches=%d after GC+Put, want 1", got)
+	if got := p.Slabs(); got != 1 {
+		t.Fatalf("Slabs=%d after GC+Put, want 1", got)
 	}
 
-	// reuse must return the same underlying region, proving the batch
+	// reuse must return the same underlying region, proving the slab
 	// was tracked (not silently discarded as "foreign").
 	again := p.Get(rc, 64)
 	if &again[0][0] != firstAddr {

--- a/fibre/internal/row/pool_test.go
+++ b/fibre/internal/row/pool_test.go
@@ -5,24 +5,18 @@ import (
 	"runtime"
 	"sync"
 	"testing"
-	"unsafe"
 )
 
-// Test shape — small values so tests stay fast. Mirrors the layout
-// the pool sees in production: one row count for the assembler batch
-// (parity + head + tail) and a distinct one for codec work buffers.
+// Test shape — small values so tests stay fast.
 const (
 	testAssemblerBatchRows = 6  // e.g. parityRows+2 with parityRows=4
 	testCodecWorkRows      = 16 // e.g. 2·ceilPow2(parityRows) with parityRows=4
 	testMaxRow             = 4096
 )
 
-// Row counts a pool built with these constants will accept.
-var testRowCounts = []int{testAssemblerBatchRows, testCodecWorkRows}
-
 func newPool(t testing.TB) *Pool {
 	t.Helper()
-	return New(testMaxRow, testAssemblerBatchRows, testCodecWorkRows)
+	return NewPool(testMaxRow, testAssemblerBatchRows)
 }
 
 // Primary row count used by most tests (assembler batch).
@@ -71,37 +65,16 @@ func TestPool_InvalidSizePanics(t *testing.T) {
 	p.Get(assemblerRowCount(), 63)
 }
 
-// Different row counts live in different partitions — no row-count fallback.
-func TestPool_RowCountsSeparate(t *testing.T) {
-	if len(testRowCounts) < 2 {
-		t.Skip("need at least two distinct row counts")
-	}
-	p := newPool(t)
-
-	a := p.Get(testRowCounts[0], 64)
-	b := p.Get(testRowCounts[1], 64)
-	if got := p.Batches(); got != 2 {
-		t.Fatalf("Batches=%d, want 2 (disjoint row counts)", got)
-	}
-	p.Put(a)
-	p.Put(b)
-}
-
-func TestPool_UnacceptedRowCountPanics(t *testing.T) {
+// Get with rowCount != pool.rowCount panics — a Pool serves only one
+// row count.
+func TestPool_RowCountMismatchPanics(t *testing.T) {
 	p := newPool(t)
 	defer func() {
 		if recover() == nil {
-			t.Fatal("Get with unaccepted row count should panic")
+			t.Fatal("Get with rowCount != pool.rowCount should panic")
 		}
 	}()
-	// A row count not in testRowCounts.
-	unaccepted := 9999
-	for _, rc := range testRowCounts {
-		if rc == unaccepted {
-			t.Fatalf("unaccepted=%d collides with an accepted class", unaccepted)
-		}
-	}
-	p.Get(unaccepted, 64)
+	p.Get(testCodecWorkRows, 64)
 }
 
 func TestPool_OversizeRowPanics(t *testing.T) {
@@ -136,22 +109,6 @@ func TestPool_PutEmptyPanics(t *testing.T) {
 	p.Put(nil)
 }
 
-func TestPool_PutForeignBatchPanics(t *testing.T) {
-	a := newPool(t)
-	b := newPool(t)
-	// Keep bufs in-use on pool a so it stays live; hand them to pool b,
-	// which should reject via the identity check in p.batches.
-	bufs := a.Get(assemblerRowCount(), 64)
-	defer a.Put(bufs)
-
-	defer func() {
-		if recover() == nil {
-			t.Fatal("Put of a batch from another pool should panic")
-		}
-	}()
-	b.Put(bufs)
-}
-
 func TestPool_GetZeroReturnsNil(t *testing.T) {
 	p := newPool(t)
 	if bufs := p.Get(0, 64); bufs != nil {
@@ -167,7 +124,7 @@ func TestPool_FallbackWithinSlack(t *testing.T) {
 	big := p.Get(rc, 320)
 	p.Put(big)
 
-	// Request 256: reqIdx=3, maxIdx=reqIdx+slack=5 (size 384). 320 fits → reuse.
+	// request 256: reqIdx=3, maxIdx=reqIdx+slack=5 (size 384). 320 fits → reuse.
 	small := p.Get(rc, 256)
 	if got := p.Batches(); got != 1 {
 		t.Fatalf("Batches=%d after slack fallback, want 1 (reused 320 slab)", got)
@@ -177,7 +134,7 @@ func TestPool_FallbackWithinSlack(t *testing.T) {
 	}
 	p.Put(small)
 
-	// On return, batch goes back to its backing bucket (320), not 256.
+	// on return, batch goes back to its backing bucket (320), not 256.
 	again := p.Get(rc, 320)
 	if got := p.Batches(); got != 1 {
 		t.Fatalf("Batches=%d after backing-bucket reuse, want 1", got)
@@ -193,7 +150,7 @@ func TestPool_FallbackOutsideSlack(t *testing.T) {
 	big := p.Get(rc, 512)
 	p.Put(big)
 
-	// Request 64: reqIdx=0, maxIdx=reqIdx+slack=2 (size 192). 512 is above → grow.
+	// request 64: reqIdx=0, maxIdx=reqIdx+slack=2 (size 192). 512 is above → grow.
 	small := p.Get(rc, 64)
 	if got := p.Batches(); got != 2 {
 		t.Fatalf("Batches=%d after out-of-slack grow, want 2", got)
@@ -206,13 +163,13 @@ func TestPool_FallbackNeverAllocates(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
-	// No 320 batch exists; request 256 → grows new 256 batch (exact key).
+	// no 320 batch exists; request 256 → grows new 256 batch (exact key).
 	a := p.Get(rc, 256)
 	if got := p.Batches(); got != 1 {
 		t.Fatalf("Batches=%d, want 1", got)
 	}
 	p.Put(a)
-	// Request 320 now: allocate new.
+	// request 320 now: allocate new.
 	b := p.Get(rc, 320)
 	if got := p.Batches(); got != 2 {
 		t.Fatalf("Batches=%d, want 2 (separate 256 and 320 batches)", got)
@@ -250,7 +207,7 @@ func TestPool_FallbackAgesLargerBucket(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
-	// Populate the 320-rowSize bucket with two free batches via direct Gets.
+	// populate the 320-rowSize bucket with two free batches via direct Gets.
 	a := p.Get(rc, 320)
 	b := p.Get(rc, 320)
 	p.Put(a)
@@ -259,9 +216,9 @@ func TestPool_FallbackAgesLargerBucket(t *testing.T) {
 		t.Fatalf("Batches=%d before aging, want 2", got)
 	}
 
-	// Drive fallback Gets at a smaller in-slack rowSize. LIFO pop means
+	// drive fallback Gets at a smaller in-slack rowSize. LIFO pop means
 	// the most-recently-Put 320 batch cycles; the other sits at the head
-	// of the free queue with a frozen lastFreeGen and ages out.
+	// of the free queue with a frozen lastPut and ages out.
 	for range evictionThreshold {
 		x := p.Get(rc, 256)
 		p.Put(x)
@@ -285,7 +242,7 @@ func TestPool_AgedEviction(t *testing.T) {
 		t.Fatalf("Batches=%d before age, want 2", got)
 	}
 
-	// Drive enough Gets to age both free batches past evictionThreshold.
+	// drive enough Gets to age both free batches past evictionThreshold.
 	for range evictionThreshold + 1 {
 		more := p.Get(rc, 64)
 		p.Put(more)
@@ -296,9 +253,10 @@ func TestPool_AgedEviction(t *testing.T) {
 	}
 }
 
-// The idle timer, when fired, drops every batch. The timer callback is
-// invoked directly to avoid waiting idleGrace in tests.
-func TestPool_IdleDropsEverything(t *testing.T) {
+// The per-bucket idle timer, when fired, drops every free batch in that
+// bucket. The timer callback is invoked directly to avoid waiting
+// idleGrace in tests.
+func TestPool_IdleDropsBucket(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
@@ -310,27 +268,69 @@ func TestPool_IdleDropsEverything(t *testing.T) {
 	if got := p.Batches(); got != 2 {
 		t.Fatalf("Batches=%d before idle, want 2", got)
 	}
-	p.dropIdle()
+	bucketAt(p, 64).dropIdle()
 	if got := p.Batches(); got != 0 {
 		t.Fatalf("Batches=%d after idle drop, want 0", got)
 	}
 }
 
-// The idle timer arms on transition to full idle and cancels on the next Get.
-func TestPool_IdleTimerArmedAndCancelled(t *testing.T) {
+// Per-bucket idle timer regression: a dormant bucket gets cleaned up
+// independently of other buckets' activity. Pool-wide idle previously
+// pinned aged free batches in dormant buckets while any other bucket
+// had in-use batches, leaking memory until the entire pool went idle.
+func TestPool_IdleDropsDormantBucketIndependently(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
 
-	a := p.Get(rc, 64)
-	p.Put(a)
-	if p.idleTimer == nil {
-		t.Fatal("idle timer should arm when pool goes fully idle")
+	// bucket A (rowSize 64): allocate and return — has free batches, no in-use.
+	x := p.Get(rc, 64)
+	p.Put(x)
+
+	// bucket B (rowSize 128): keep one batch in-use perpetually.
+	y := p.Get(rc, 128)
+	defer p.Put(y)
+
+	// trigger A's idle timer specifically. Even though B is non-idle,
+	// A must drop its free batches.
+	bucketAt(p, 64).dropIdle()
+
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d, want 1 (only B's in-use batch survives)", got)
+	}
+}
+
+// The per-bucket idle timer arms on transition to fully-free and is
+// stopped on the next Get to that bucket. The timer object itself is
+// retained for reuse, so the test asserts on its armed/stopped state
+// (via Stop's return) rather than nil-ness.
+func TestPool_IdleTimerArmedAndCancelled(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+	bk := bucketAt(p, 64)
+
+	if bk.idleTimer != nil {
+		t.Fatal("idle timer should not exist before first idle transition")
 	}
 
-	_ = p.Get(rc, 64)
-	if p.idleTimer != nil {
-		t.Fatal("idle timer should be cancelled by Get")
+	a := p.Get(rc, 64)
+	p.Put(a)
+	if bk.idleTimer == nil {
+		t.Fatal("idle timer should be created when bucket goes fully free")
 	}
+
+	b := p.Get(rc, 64)
+	defer p.Put(b)
+	// Get's cancelIdle should have stopped the timer; a redundant Stop
+	// returns false because the timer is no longer active.
+	if bk.idleTimer.Stop() {
+		t.Fatal("idle timer should already be stopped after Get")
+	}
+}
+
+// bucketAt returns the bucket pointer for the given rowSize so tests
+// can poke at bucket-level state directly.
+func bucketAt(p *Pool, size int) *bucket {
+	return &p.buckets[size/rowSizeAlign-1]
 }
 
 // Write-aliasing check: data written through one carved view must not land
@@ -355,11 +355,11 @@ func TestPool_NoAliasWrites(t *testing.T) {
 }
 
 // TestPool_GCAnchor verifies that an in-use batch survives GC cycles.
-// While in use, the only Go-heap reference to *batch is p.batches — the
-// header back-pointer is an unsafe store GC doesn't trace, and the
-// caller's bufs share the region's backing array, not the batch struct.
-// Without the anchor, GC could reap *batch between Get and Put and Put
-// would read a dangling pointer.
+// While in use, the only Go-heap reference to *batch is its bucket's
+// used slice — the header back-pointer is an unsafe store GC doesn't
+// trace, and the caller's bufs share the region's backing array, not
+// the batch struct. Without the anchor, GC could reap *batch between
+// Get and Put and Put would read a dangling pointer.
 func TestPool_GCAnchor(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
@@ -370,13 +370,13 @@ func TestPool_GCAnchor(t *testing.T) {
 		b[0] = byte(i + 1)
 	}
 
-	// Force multiple GC cycles. If the anchor is broken, a sweep during
+	// force multiple GC cycles. If the anchor is broken, a sweep during
 	// one of these frees the *batch struct; subsequent Put would read a
 	// stale pointer.
 	runtime.GC()
 	runtime.GC()
 
-	// Data must survive GC (bufs anchor the region's backing array).
+	// data must survive GC (bufs anchor the region's backing array).
 	for i, b := range bufs {
 		if b[0] != byte(i+1) {
 			t.Fatalf("buf %d corrupted across GC: got %d want %d", i, b[0], byte(i+1))
@@ -388,7 +388,7 @@ func TestPool_GCAnchor(t *testing.T) {
 		t.Fatalf("Batches=%d after GC+Put, want 1", got)
 	}
 
-	// Reuse must return the same underlying region, proving the batch
+	// reuse must return the same underlying region, proving the batch
 	// was tracked (not silently discarded as "foreign").
 	again := p.Get(rc, 64)
 	if &again[0][0] != firstAddr {
@@ -397,9 +397,9 @@ func TestPool_GCAnchor(t *testing.T) {
 	p.Put(again)
 }
 
-// TestPool_CarveBlocksAppend verifies the full-slice expression in
-// carve — a carved buf has cap==len, so append forces a new backing
-// array rather than bleeding into the next row.
+// TestPool_CarveBlocksAppend verifies the full-slice expressions Get
+// uses to carve views — each buf has cap==len, so append forces a new
+// backing array rather than bleeding into the next row.
 func TestPool_CarveBlocksAppend(t *testing.T) {
 	p := newPool(t)
 	rc := assemblerRowCount()
@@ -407,52 +407,15 @@ func TestPool_CarveBlocksAppend(t *testing.T) {
 	defer p.Put(bufs)
 
 	if cap(bufs[0]) != len(bufs[0]) {
-		t.Fatalf("bufs[0] cap=%d len=%d — carve leaked capacity past len",
+		t.Fatalf("bufs[0] cap=%d len=%d — capacity leaked past len",
 			cap(bufs[0]), len(bufs[0]))
 	}
 
-	// Mark bufs[1] then append to bufs[0]; neighbor must not change.
+	// mark bufs[1] then append to bufs[0]; neighbor must not change.
 	bufs[1][0] = 0xAA
 	_ = append(bufs[0], 0xBB)
 	if bufs[1][0] != 0xAA {
-		t.Fatal("append on carved bufs[0] bled into bufs[1] — carve missing full-slice expression")
-	}
-}
-
-// TestPool_StructLayout pins the size of the pool's hot data structures
-// so accidental bloat or sub-optimal field ordering shows up as a test
-// failure. The expected sizes are minimal for the current fields on a
-// 64-bit platform; any intentional addition should update them.
-func TestPool_StructLayout(t *testing.T) {
-	cases := []struct {
-		name string
-		got  uintptr
-		want uintptr
-	}{
-		{"Pool", unsafe.Sizeof(Pool{}), 104},
-		{"bucket", unsafe.Sizeof(bucket{}), 48},
-		{"batch", unsafe.Sizeof(batch{}), 56},
-	}
-	for _, c := range cases {
-		if c.got != c.want {
-			t.Errorf("sizeof(%s) = %d, want %d — update the expected size if the change is intentional, but double-check field ordering first",
-				c.name, c.got, c.want)
-		}
-	}
-
-	// batch must fit in a single 64-byte cache line.
-	if unsafe.Sizeof(batch{}) > 64 {
-		t.Errorf("sizeof(batch) = %d > 64, spills past one cache line", unsafe.Sizeof(batch{}))
-	}
-
-	// headerSize must hold at least a *batch back-pointer and keep the
-	// following data region 64-byte aligned.
-	ptrSize := unsafe.Sizeof((*batch)(nil))
-	if uintptr(headerSize) < ptrSize {
-		t.Errorf("headerSize %d < sizeof(*batch) %d", headerSize, ptrSize)
-	}
-	if headerSize%rowSizeAlign != 0 {
-		t.Errorf("headerSize %d not a multiple of rowSizeAlign %d", headerSize, rowSizeAlign)
+		t.Fatal("append on bufs[0] bled into bufs[1] — missing full-slice expression in carve")
 	}
 }
 

--- a/fibre/internal/row/pool_test.go
+++ b/fibre/internal/row/pool_test.go
@@ -1,0 +1,482 @@
+package row
+
+import (
+	"bytes"
+	"runtime"
+	"sync"
+	"testing"
+	"unsafe"
+)
+
+// Test shape — small values so tests stay fast. Mirrors the layout
+// the pool sees in production: one row count for the assembler batch
+// (parity + head + tail) and a distinct one for codec work buffers.
+const (
+	testAssemblerBatchRows = 6  // e.g. parityRows+2 with parityRows=4
+	testCodecWorkRows      = 16 // e.g. 2·ceilPow2(parityRows) with parityRows=4
+	testMaxRow             = 4096
+)
+
+// Row counts a pool built with these constants will accept.
+var testRowCounts = []int{testAssemblerBatchRows, testCodecWorkRows}
+
+func newPool(t testing.TB) *Pool {
+	t.Helper()
+	return New(testMaxRow, testAssemblerBatchRows, testCodecWorkRows)
+}
+
+// Primary row count used by most tests (assembler batch).
+func assemblerRowCount() int { return testAssemblerBatchRows }
+
+func TestPool_GetPutExact(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	bufs := p.Get(rc, 64)
+	if len(bufs) != rc {
+		t.Fatalf("Get returned %d bufs, want %d", len(bufs), rc)
+	}
+	for _, b := range bufs {
+		if len(b) != 64 {
+			t.Fatalf("len=%d, want 64", len(b))
+		}
+	}
+
+	bufs[0][0] = 1
+	bufs[1][0] = 2
+	if bufs[0][0] == bufs[1][0] {
+		t.Fatal("adjacent buffers alias")
+	}
+
+	p.Put(bufs)
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d after Put, want 1", got)
+	}
+
+	// second Get at exact key reuses the same batch.
+	more := p.Get(rc, 64)
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d after exact-match reuse, want 1", got)
+	}
+	p.Put(more)
+}
+
+func TestPool_InvalidSizePanics(t *testing.T) {
+	p := newPool(t)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Get with non-multiple-of-64 size should panic")
+		}
+	}()
+	p.Get(assemblerRowCount(), 63)
+}
+
+// Different row counts live in different partitions — no row-count fallback.
+func TestPool_RowCountsSeparate(t *testing.T) {
+	if len(testRowCounts) < 2 {
+		t.Skip("need at least two distinct row counts")
+	}
+	p := newPool(t)
+
+	a := p.Get(testRowCounts[0], 64)
+	b := p.Get(testRowCounts[1], 64)
+	if got := p.Batches(); got != 2 {
+		t.Fatalf("Batches=%d, want 2 (disjoint row counts)", got)
+	}
+	p.Put(a)
+	p.Put(b)
+}
+
+func TestPool_UnacceptedRowCountPanics(t *testing.T) {
+	p := newPool(t)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Get with unaccepted row count should panic")
+		}
+	}()
+	// A row count not in testRowCounts.
+	unaccepted := 9999
+	for _, rc := range testRowCounts {
+		if rc == unaccepted {
+			t.Fatalf("unaccepted=%d collides with an accepted class", unaccepted)
+		}
+	}
+	p.Get(unaccepted, 64)
+}
+
+func TestPool_OversizeRowPanics(t *testing.T) {
+	p := newPool(t)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Get with rowSize > maxRowSize should panic")
+		}
+	}()
+	p.Get(assemblerRowCount(), testMaxRow+1)
+}
+
+func TestPool_DoubleFreePanics(t *testing.T) {
+	p := newPool(t)
+	bufs := p.Get(assemblerRowCount(), 64)
+	p.Put(bufs)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("second Put of same batch should panic")
+		}
+	}()
+	p.Put(bufs)
+}
+
+func TestPool_PutEmptyPanics(t *testing.T) {
+	p := newPool(t)
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Put with empty bufs should panic")
+		}
+	}()
+	p.Put(nil)
+}
+
+func TestPool_PutForeignBatchPanics(t *testing.T) {
+	a := newPool(t)
+	b := newPool(t)
+	// Keep bufs in-use on pool a so it stays live; hand them to pool b,
+	// which should reject via the identity check in p.batches.
+	bufs := a.Get(assemblerRowCount(), 64)
+	defer a.Put(bufs)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("Put of a batch from another pool should panic")
+		}
+	}()
+	b.Put(bufs)
+}
+
+func TestPool_GetZeroReturnsNil(t *testing.T) {
+	p := newPool(t)
+	if bufs := p.Get(0, 64); bufs != nil {
+		t.Fatalf("Get(0, _) = %v, want nil", bufs)
+	}
+}
+
+// A free batch of a larger class serves a smaller request within slack.
+func TestPool_FallbackWithinSlack(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	big := p.Get(rc, 320)
+	p.Put(big)
+
+	// Request 256: reqIdx=3, maxIdx=reqIdx+slack=5 (size 384). 320 fits → reuse.
+	small := p.Get(rc, 256)
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d after slack fallback, want 1 (reused 320 slab)", got)
+	}
+	if len(small[0]) != 256 {
+		t.Fatalf("returned len=%d, want 256 (requested)", len(small[0]))
+	}
+	p.Put(small)
+
+	// On return, batch goes back to its backing bucket (320), not 256.
+	again := p.Get(rc, 320)
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d after backing-bucket reuse, want 1", got)
+	}
+	p.Put(again)
+}
+
+// A free batch outside the slack window is NOT a fallback candidate.
+func TestPool_FallbackOutsideSlack(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	big := p.Get(rc, 512)
+	p.Put(big)
+
+	// Request 64: reqIdx=0, maxIdx=reqIdx+slack=2 (size 192). 512 is above → grow.
+	small := p.Get(rc, 64)
+	if got := p.Batches(); got != 2 {
+		t.Fatalf("Batches=%d after out-of-slack grow, want 2", got)
+	}
+	p.Put(small)
+}
+
+// Fallback never triggers a new allocation at a larger key.
+func TestPool_FallbackNeverAllocates(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	// No 320 batch exists; request 256 → grows new 256 batch (exact key).
+	a := p.Get(rc, 256)
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d, want 1", got)
+	}
+	p.Put(a)
+	// Request 320 now: allocate new.
+	b := p.Get(rc, 320)
+	if got := p.Batches(); got != 2 {
+		t.Fatalf("Batches=%d, want 2 (separate 256 and 320 batches)", got)
+	}
+	p.Put(b)
+}
+
+// Free batches are reused LIFO: the most recently Put batch is the next
+// one served by Get.
+func TestPool_LIFOReuse(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	a := p.Get(rc, 64)
+	b := p.Get(rc, 64)
+	aAddr := &a[0][0]
+	bAddr := &b[0][0]
+	if aAddr == bAddr {
+		t.Fatal("distinct Gets should return distinct backing memory")
+	}
+	p.Put(a)
+	p.Put(b) // most recently freed
+
+	next := p.Get(rc, 64)
+	if &next[0][0] != bAddr {
+		t.Fatal("LIFO reuse: expected most-recently-freed batch")
+	}
+	p.Put(next)
+}
+
+// Consuming from a larger bucket via fallback advances that bucket's
+// generation and runs its aged eviction, so its other free batches age
+// and evict under fallback-driven demand (not only direct Gets).
+func TestPool_FallbackAgesLargerBucket(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	// Populate the 320-rowSize bucket with two free batches via direct Gets.
+	a := p.Get(rc, 320)
+	b := p.Get(rc, 320)
+	p.Put(a)
+	p.Put(b)
+	if got := p.Batches(); got != 2 {
+		t.Fatalf("Batches=%d before aging, want 2", got)
+	}
+
+	// Drive fallback Gets at a smaller in-slack rowSize. LIFO pop means
+	// the most-recently-Put 320 batch cycles; the other sits at the head
+	// of the free queue with a frozen lastFreeGen and ages out.
+	for range evictionThreshold {
+		x := p.Get(rc, 256)
+		p.Put(x)
+	}
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d after fallback-driven aging, want 1", got)
+	}
+}
+
+// A free batch aged past evictionThreshold is evicted on the next Get to
+// its bucket.
+func TestPool_AgedEviction(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	a := p.Get(rc, 64)
+	b := p.Get(rc, 64)
+	p.Put(a)
+	p.Put(b)
+	if got := p.Batches(); got != 2 {
+		t.Fatalf("Batches=%d before age, want 2", got)
+	}
+
+	// Drive enough Gets to age both free batches past evictionThreshold.
+	for range evictionThreshold + 1 {
+		more := p.Get(rc, 64)
+		p.Put(more)
+	}
+	_ = p.Get(rc, 64)
+	if got := p.Batches(); got > 2 {
+		t.Fatalf("Batches=%d, want <= 2 (aged eviction)", got)
+	}
+}
+
+// The idle timer, when fired, drops every batch. The timer callback is
+// invoked directly to avoid waiting idleGrace in tests.
+func TestPool_IdleDropsEverything(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	a := p.Get(rc, 64)
+	b := p.Get(rc, 64)
+	p.Put(a)
+	p.Put(b)
+
+	if got := p.Batches(); got != 2 {
+		t.Fatalf("Batches=%d before idle, want 2", got)
+	}
+	p.dropIdle()
+	if got := p.Batches(); got != 0 {
+		t.Fatalf("Batches=%d after idle drop, want 0", got)
+	}
+}
+
+// The idle timer arms on transition to full idle and cancels on the next Get.
+func TestPool_IdleTimerArmedAndCancelled(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	a := p.Get(rc, 64)
+	p.Put(a)
+	if p.idleTimer == nil {
+		t.Fatal("idle timer should arm when pool goes fully idle")
+	}
+
+	_ = p.Get(rc, 64)
+	if p.idleTimer != nil {
+		t.Fatal("idle timer should be cancelled by Get")
+	}
+}
+
+// Write-aliasing check: data written through one carved view must not land
+// in a neighbor.
+func TestPool_NoAliasWrites(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+	bufs := p.Get(rc, 64)
+	defer p.Put(bufs)
+
+	for i, b := range bufs {
+		for j := range b {
+			b[j] = byte(i + 1)
+		}
+	}
+	for i, b := range bufs {
+		want := bytes.Repeat([]byte{byte(i + 1)}, 64)
+		if !bytes.Equal(b, want) {
+			t.Fatalf("bufs[%d] corrupted by neighbor write", i)
+		}
+	}
+}
+
+// TestPool_GCAnchor verifies that an in-use batch survives GC cycles.
+// While in use, the only Go-heap reference to *batch is p.batches — the
+// header back-pointer is an unsafe store GC doesn't trace, and the
+// caller's bufs share the region's backing array, not the batch struct.
+// Without the anchor, GC could reap *batch between Get and Put and Put
+// would read a dangling pointer.
+func TestPool_GCAnchor(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	bufs := p.Get(rc, 64)
+	firstAddr := &bufs[0][0]
+	for i, b := range bufs {
+		b[0] = byte(i + 1)
+	}
+
+	// Force multiple GC cycles. If the anchor is broken, a sweep during
+	// one of these frees the *batch struct; subsequent Put would read a
+	// stale pointer.
+	runtime.GC()
+	runtime.GC()
+
+	// Data must survive GC (bufs anchor the region's backing array).
+	for i, b := range bufs {
+		if b[0] != byte(i+1) {
+			t.Fatalf("buf %d corrupted across GC: got %d want %d", i, b[0], byte(i+1))
+		}
+	}
+
+	p.Put(bufs)
+	if got := p.Batches(); got != 1 {
+		t.Fatalf("Batches=%d after GC+Put, want 1", got)
+	}
+
+	// Reuse must return the same underlying region, proving the batch
+	// was tracked (not silently discarded as "foreign").
+	again := p.Get(rc, 64)
+	if &again[0][0] != firstAddr {
+		t.Fatal("reuse did not return original region — anchor or tracking broken")
+	}
+	p.Put(again)
+}
+
+// TestPool_CarveBlocksAppend verifies the full-slice expression in
+// carve — a carved buf has cap==len, so append forces a new backing
+// array rather than bleeding into the next row.
+func TestPool_CarveBlocksAppend(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+	bufs := p.Get(rc, 64)
+	defer p.Put(bufs)
+
+	if cap(bufs[0]) != len(bufs[0]) {
+		t.Fatalf("bufs[0] cap=%d len=%d — carve leaked capacity past len",
+			cap(bufs[0]), len(bufs[0]))
+	}
+
+	// Mark bufs[1] then append to bufs[0]; neighbor must not change.
+	bufs[1][0] = 0xAA
+	_ = append(bufs[0], 0xBB)
+	if bufs[1][0] != 0xAA {
+		t.Fatal("append on carved bufs[0] bled into bufs[1] — carve missing full-slice expression")
+	}
+}
+
+// TestPool_StructLayout pins the size of the pool's hot data structures
+// so accidental bloat or sub-optimal field ordering shows up as a test
+// failure. The expected sizes are minimal for the current fields on a
+// 64-bit platform; any intentional addition should update them.
+func TestPool_StructLayout(t *testing.T) {
+	cases := []struct {
+		name string
+		got  uintptr
+		want uintptr
+	}{
+		{"Pool", unsafe.Sizeof(Pool{}), 104},
+		{"bucket", unsafe.Sizeof(bucket{}), 48},
+		{"batch", unsafe.Sizeof(batch{}), 56},
+	}
+	for _, c := range cases {
+		if c.got != c.want {
+			t.Errorf("sizeof(%s) = %d, want %d — update the expected size if the change is intentional, but double-check field ordering first",
+				c.name, c.got, c.want)
+		}
+	}
+
+	// batch must fit in a single 64-byte cache line.
+	if unsafe.Sizeof(batch{}) > 64 {
+		t.Errorf("sizeof(batch) = %d > 64, spills past one cache line", unsafe.Sizeof(batch{}))
+	}
+
+	// headerSize must hold at least a *batch back-pointer and keep the
+	// following data region 64-byte aligned.
+	ptrSize := unsafe.Sizeof((*batch)(nil))
+	if uintptr(headerSize) < ptrSize {
+		t.Errorf("headerSize %d < sizeof(*batch) %d", headerSize, ptrSize)
+	}
+	if headerSize%rowSizeAlign != 0 {
+		t.Errorf("headerSize %d not a multiple of rowSizeAlign %d", headerSize, rowSizeAlign)
+	}
+}
+
+func TestPool_Concurrent(t *testing.T) {
+	p := newPool(t)
+	rc := assemblerRowCount()
+
+	const goroutines = 16
+	const iters = 200
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := range goroutines {
+		go func(id int) {
+			defer wg.Done()
+			for range iters {
+				bufs := p.Get(rc, 64)
+				for _, b := range bufs {
+					for i := range b {
+						b[i] = byte(id)
+					}
+				}
+				p.Put(bufs)
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/fibre/protocol_params.go
+++ b/fibre/protocol_params.go
@@ -86,6 +86,29 @@ func (p ProtocolParams) ParityRows() int {
 	return p.TotalRows() - p.Rows
 }
 
+// CodecWorkRows returns the peak row count the leopard-GF16 codec asks
+// a reedsolomon.WorkAllocator for during Encode or Reconstruct — i.e.
+// max(2·ceilPow2(N), ceilPow2(ceilPow2(N)+K)). For the default shape
+// (K=4096, N=12288) this is 32768, or 8×K rows of work buffer on top
+// of 1×K original + 3×K parity, so peak memory during an Encode is
+// ~12× the original data. Callers must size row allocators for this
+// value, not TotalRows.
+func (p ProtocolParams) CodecWorkRows() int {
+	m := ceilPow2(p.ParityRows())
+	return max(2*m, ceilPow2(m+p.Rows))
+}
+
+// ceilPow2 returns the smallest power of two >= n. n must be positive.
+func ceilPow2(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	if n&(n-1) == 0 {
+		return n
+	}
+	return 1 << bits.Len(uint(n-1))
+}
+
 // MaxRowsPerValidator returns the maximum number of rows a single validator could receive.
 // Based on max stake of 1-SafetyThreshold: ceil(Rows * (1-SafetyThreshold) / livenessThreshold).
 // Validators with >1-SafetyThreshold stake are capped at Rows in Assign.

--- a/fibre/server_download_test.go
+++ b/fibre/server_download_test.go
@@ -156,7 +156,7 @@ func storeTestShard(t *testing.T, server *fibre.Server, blob *fibre.Blob) {
 	}
 
 	// flatten RLC coefficients for storage
-	rlcCoeffs := blob.RLCCoeffs()
+	rlcCoeffs := blob.RLC()
 	coeffBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, c := range rlcCoeffs {
 		b := field.ToBytes128(c)

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -206,8 +206,8 @@ func makeTestRequest(
 		}
 	}
 
-	// flatten RLC coefficients
-	rlcCoeffs := blob.RLCCoeffs()
+	// flatten RLC values
+	rlcCoeffs := blob.RLC()
 	rlcCoeffsBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, coeff := range rlcCoeffs {
 		b := field.ToBytes128(coeff)

--- a/fibre/store_bench_test.go
+++ b/fibre/store_bench_test.go
@@ -200,7 +200,8 @@ func BenchmarkStoreWriteRowsConcurrent(b *testing.B) {
 }
 
 func benchmarkStoreWriteRows(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -306,7 +307,8 @@ func benchmarkStoreWriteRows(b *testing.B, params fibre.ProtocolParams, validato
 }
 
 func benchmarkStoreWriteRowsConcurrent(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int, concurrency int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -527,7 +529,8 @@ func BenchmarkStoreReadRowsConcurrent(b *testing.B) {
 }
 
 func benchmarkStoreReadRows(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 
@@ -615,7 +618,8 @@ func benchmarkStoreReadRows(b *testing.B, params fibre.ProtocolParams, validator
 }
 
 func benchmarkStoreReadRowsConcurrent(b *testing.B, params fibre.ProtocolParams, validators int, blobSize int, concurrency int) {
-	cfg := fibre.NewBlobConfigFromParams(0, params)
+	cfg, cfgErr := fibre.NewBlobConfigFromParams(0, params)
+	require.NoError(b, cfgErr)
 
 	dataSize := min(blobSize, cfg.MaxDataSize)
 

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -331,7 +331,7 @@ func makeShardWithRLC(t *testing.T, blob *fibre.Blob, indices ...int) *types.Blo
 	t.Helper()
 	shard := makeShardFrom(t, blob, indices...)
 
-	rlcCoeffs := blob.RLCCoeffs()
+	rlcCoeffs := blob.RLC()
 	coeffBytes := make([]byte, len(rlcCoeffs)*16)
 	for i, c := range rlcCoeffs {
 		b := field.ToBytes128(c)

--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	golang.org/x/term v0.42.0
 	google.golang.org/api v0.276.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9
@@ -433,7 +434,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20251125195548-87e1e737ad39 // indirect
 	golang.org/x/mod v0.34.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.43.0 // indirect

--- a/pkg/rsema1d/coder.go
+++ b/pkg/rsema1d/coder.go
@@ -15,12 +15,15 @@ type Coder struct {
 }
 
 // NewCoder creates a Coder with cached Reed-Solomon encoder.
-func NewCoder(cfg *Config) (*Coder, error) {
+// Optional reedsolomon.Option values are forwarded to the underlying encoder
+// (e.g., reedsolomon.WithWorkAllocator to control work buffer allocation).
+func NewCoder(cfg *Config, opts ...reedsolomon.Option) (*Coder, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	enc, err := reedsolomon.New(cfg.K, cfg.N, reedsolomon.WithLeopardGF16(true))
+	rsOpts := append([]reedsolomon.Option{reedsolomon.WithLeopardGF16(true)}, opts...)
+	enc, err := reedsolomon.New(cfg.K, cfg.N, rsOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create encoder: %w", err)
 	}


### PR DESCRIPTION
## Summary
Introduces `row.Pool` - a bucketed slab allocator for fixed-shape row batches and  `row.Assembler` that assembles original data into rows in a zero-copy manner and uses the Pool to assemble the parity rows with zero per-encode allocations in the steady state. Additionally, the Pool plugs directly into the leopard encoder's [WorkAllocator](https://github.com/klauspost/reedsolomon/pull/331), so the codec work buffers (8x of original data) are reused and efficiently, similarly achieving zero allocations in the steady state. 

In the end, as seen in the results table, the win is across all the dimensions: latency, throughput, and memory usage. 

## Context
Third and final iteration of the encoding memory layout for Fibre.

The 2nd iteration ([#7091](https://github.com/celestiaorg/celestia-app/pull/7091)) rested on the intuition that freeing the rows for each validator as soon as `Upload` finished with them would keep peak memory lower than holding the full blob's rows through the tail-latency drain. Since `Upload` returns after 2/3 of validators have acked, carrying all 128 MiB through the remaining tail felt obviously wasteful.

In practice, this was a premature optimization that generated more complexity than it repaid. Per-validator releases are adversarial to the allocator: the rows that go free at any moment are a random subset of the blob, so the freed memory lands as fragmented holes rather than reusable slots. During implementation, it became clear that fragmentation is an issue with several rounds of optimization layered on top to compensate; however, they were only putting complex makeup on a pig.

In a sync review, @walldiss flagged the complexity of the slab allocator as an issue that reduces trust in it. We agreed to eliminate per-validator releases to reduce complexity. It was a great call that also confirmed the optimization was flawed in the end. 

The 3rd iteration drops per-validator release entirely in favor of whole-batch pooling. It is significantly simpler, and more importantly, it behaves *better* under load: steady-state memory tracks the count of concurrent in-flight encodes rather than worker count × blob size. For example, 10 workers × 128 MiB blobs no longer pin ~10 GiB of work buffers; memory settles around whatever the network bottleneck is.

This steady state never emerged in the 2nd iteration because fragmented reuse forced fresh allocation for nearly every encode, and the allocator couldn't recycle a random scatter of freed rows into a contiguous batch-shaped request, so memory grew until every worker effectively held its own reservation.

## Results
 ```
  ┌──────────────┬─────────┬────────────┬─────────┬─────────┬─────────┬─────────────┬──────────┬──────────┬─────────────┬─────────────┐
  │    Config    │ Variant │ Throughput │ Uploads │ Upl avg │ Upl p99 │ Confirm avg │ RSS avg  │ RSS max  │ Alloc total │ Codec alloc │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │ 1 of 128 MiB │ before  │ 9.6 MB/s   │ 18      │ 5.48s   │ 5.81s   │ 10.06s      │ 3.8 GiB  │ 8.7 GiB  │ 47.9 GB     │ 29.19 GB    │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │              │ after   │ 13.5 MB/s  │ 24      │ 4.08s   │ 4.75s   │ 8.65s       │ 2.1 GiB  │ 4.3 GiB  │ 24.8 GB     │ 0.35 GB     │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │              │ Δ       │ +40.5%     │ +33%    │ −25.5%  │ −18%    │ −14%        │ −44%     │ −51%     │ −48%        │ −98.8%      │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │ 8 of 128 MiB │ before  │ 16.0 MB/s  │ 30      │ 24.90s  │ 40.10s  │ 29.42s      │ 15.1 GiB │ 37.8 GiB │ 104.2 GB    │ 60.14 GB    │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │              │ after   │ 20.8 MB/s  │ 39      │ 18.87s  │ 25.22s  │ 23.41s      │ 11.8 GiB │ 25.3 GiB │ 42.8 GB     │ 0.46 GB     │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │              │ Δ       │ +30%       │ +30%    │ −24%    │ −37%    │ −20%        │ −22%     │ −33%     │ −59%        │ −99.2%      │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │ 64 of 16 MiB │ before  │ 0.7 MB/s   │ 10      │ 18.33s  │ 18.80s  │ 22.91s      │ 1.9 GiB  │ 16.8 GiB │ 59.2 GB     │ 16.57 GB    │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │              │ after   │ 0.7 MB/s   │ 10      │ 9.28s   │ 9.50s   │ 14.72s      │ 2.0 GiB  │ 11.4 GiB │ 44.1 GB     │ 0.70 GB     │
  ├──────────────┼─────────┼────────────┼─────────┼─────────┼─────────┼─────────────┼──────────┼──────────┼─────────────┼─────────────┤
  │              │ Δ       │ 0%         │ 0%      │ −49%    │ −49%    │ −36%        │ +6%      │ −32%     │ −26%        │ −95.8%      │
  └──────────────┴─────────┴────────────┴─────────┴─────────┴─────────┴─────────────┴──────────┴──────────┴─────────────┴─────────────┘

```
  
<!-- devin-review-badge-begin -->


<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7159" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
