### PR TITLE
chore: update all v8 refs to mainnet release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,10 +29,10 @@ before:
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v7_arm64.tar.gz v7.0.2-mocha
     - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v7_amd64.tar.gz v7.0.2-mocha
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v7_amd64.tar.gz v7.0.2-mocha
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v8_arm64.tar.gz v8.0.1-mocha
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v8_arm64.tar.gz v8.0.1-mocha
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v8_amd64.tar.gz v8.0.1-mocha
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v8_amd64.tar.gz v8.0.1-mocha
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v8_arm64.tar.gz v8.0.3
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v8_arm64.tar.gz v8.0.3
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v8_amd64.tar.gz v8.0.3
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v8_amd64.tar.gz v8.0.3
 
 builds:
   - id: darwin-amd64-multiplexer

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ CELESTIA_V4_VERSION := v4.1.0
 CELESTIA_V5_VERSION := v5.0.12
 CELESTIA_V6_VERSION := v6.4.4
 CELESTIA_V7_VERSION := v7.0.2-mocha
-CELESTIA_V8_VERSION := v8.0.1-mocha
+CELESTIA_V8_VERSION := v8.0.3
 
 ## help: Get more info on make commands.
 help: Makefile

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -23,7 +23,7 @@ ARG CELESTIA_VERSION_V4="v4.1.0"
 ARG CELESTIA_VERSION_V5="v5.0.12"
 ARG CELESTIA_VERSION_V6="v6.4.4"
 ARG CELESTIA_VERSION_V7="v7.0.2-mocha"
-ARG CELESTIA_VERSION_V8="v8.0.1-mocha"
+ARG CELESTIA_VERSION_V8="v8.0.3"
 
 # Stage 1: this base image contains already released v3 binaries which can be embedded in the multiplexer.
 FROM ${CELESTIA_APP_REPOSITORY}:${CELESTIA_VERSION_V3} AS base-v3

--- a/internal/embedding/data.go
+++ b/internal/embedding/data.go
@@ -15,7 +15,7 @@ const (
 	v5Version = "v5.0.12"
 	v6Version = "v6.4.4"
 	v7Version = "v7.0.2-mocha"
-	v8Version = "v8.0.1-mocha"
+	v8Version = "v8.0.3"
 )
 
 // CelestiaAppV3 returns the compressed platform specific Celestia binary and


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-1435/update-the-referenced-mocha-v8-release-with-mainnet-ones
