### PR TITLE
docs: note that verify data is false in release notes

### DIFF
--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -10,6 +10,10 @@ This guide provides notes for major version releases. These notes may be helpful
 
 The `celestia-appd update-config` command is deprecated. The config values it used to apply are now enforced by the binary at startup, so running it when initialising a new node is no longer necessary. The command still works for now but prints a deprecation warning and will be removed in a future release.
 
+#### Block Sync: `verify_data` Default Changed to `false`
+
+The default value of `verify_data` in the `[blocksync]` section of `config.toml` is now `false`. Consensus nodes no longer re-run `ProcessProposal` on each block during block sync, which meaningfully speeds up syncing. This is safe because every block received during block sync is already signed by 2/3+ of the voting power; normal validation resumes once the node switches to consensus mode. Set `verify_data = true` in `config.toml` to restore the previous behaviour.
+
 ## v8.0.0
 
 ### Node Operators (v8.0.0)


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-1553/mention-setting-verify-data-to-false-in-release-notes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7162" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
