### PR TITLE
perf(fibre): batched RLC verify for shard uploads

### DIFF
--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -207,15 +207,21 @@ func (s *Server) verifyShard(_ context.Context, blobCfg BlobConfig, promise *Pay
 		return fmt.Errorf("creating verification context: %w", err)
 	}
 
-	for _, rowPb := range shard.Rows {
+	// Batched verify: parse every row up-front, then run one vectorized RLC
+	// pass over the whole shard. All rows in a shard share the same
+	// verificationCtx and therefore the same RLC coefficients, which is the
+	// precondition computeRLCVectorized needs to amortize the SIMD kernel
+	// setup across the batch.
+	rows := make([]*rsema1d.RowProof, len(shard.Rows))
+	for i, rowPb := range shard.Rows {
 		row, err := parseRow(rowPb)
 		if err != nil {
 			return err
 		}
-
-		if err := rsema1d.VerifyRowWithContext(row, promise.Commitment, verificationCtx); err != nil {
-			return fmt.Errorf("verification failed for row %d: %w", row.Index, err)
-		}
+		rows[i] = row
+	}
+	if err := rsema1d.VerifyRowsWithContext(rows, promise.Commitment, verificationCtx); err != nil {
+		return fmt.Errorf("shard row verification failed: %w", err)
 	}
 
 	// set RLC root, keep coefficients as-is for storage

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -10,40 +10,18 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/merkle"
 )
 
-// minBatchedVerifyK is the smallest batch size where computeRLCVectorized is
-// faster per-row than the scalar Kernel. Measured on Intel c6id.8xlarge
-// (AVX-512 + GFNI). Below this threshold, fall back to scalar VerifyRowWithContext
-// which avoids the zero-row padding overhead of the vectorized path.
-const minBatchedVerifyK = 8
-
 // VerifyRowsWithContext verifies N row proofs against the same commitment in a
-// single batched RLC computation. When len(proofs) ≥ minBatchedVerifyK it
-// replaces N calls to computeRLC with one computeRLCVectorized call, amortizing
-// the SIMD GF(2^16) kernel setup across all rows.
+// single batched RLC computation. Replaces N calls to computeRLC with one
+// computeRLCVectorized call, amortizing the SIMD GF(2^16) kernel setup across
+// all rows.
 //
 // Per-row Merkle proof verification and RLC/commitment comparisons still happen
-// individually. Returns the first error encountered, matching the fail-fast
-// semantics of a loop over VerifyRowWithContext.
+// individually. Returns the first error encountered, naming the offending row.
 func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *VerificationContext) error {
 	if context == nil {
 		return errors.New("received nil context in verifier")
 	}
 	if len(proofs) == 0 {
-		return nil
-	}
-
-	// Below the break-even, per-row SIMD would pad each batch up to K=32 and
-	// pay more than a scalar computeRLCKernel call. Fall back to the existing
-	// scalar loop which is alloc-free.
-	if len(proofs) < minBatchedVerifyK {
-		for _, p := range proofs {
-			if p == nil {
-				return errors.New("received nil proof in verifier")
-			}
-			if err := VerifyRowWithContext(p, commitment, context); err != nil {
-				return fmt.Errorf("row %d: %w", p.Index, err)
-			}
-		}
 		return nil
 	}
 
@@ -95,24 +73,17 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 		rowRoots[i] = rowRoot
 	}
 
-	// 3. Derive coefficients once, using the same sync.Once cache as the
-	// scalar path so subsequent verify calls on this context hit the cache.
-	context.coeffsOnce.Do(func() {
-		context.coeffs = deriveCoefficients(rowRoots[0], len(proofs[0].Row))
-	})
-	if len(context.coeffs) != len(proofs[0].Row)/2 {
-		return fmt.Errorf("row size mismatch: cached coefficients for %d bytes, got %d",
-			len(context.coeffs)*2, len(proofs[0].Row))
-	}
+	// 3. Derive coefficients from the first row's root. In a valid shard
+	// every row root is identical, so the choice of row 0 is arbitrary; the
+	// downstream commitment check rejects the batch if any row root differs.
+	coeffs := deriveCoefficients(rowRoots[0], len(proofs[0].Row))
 
-	// 4. Batched RLC: one vectorized pass over all rows instead of len(proofs)
-	// scalar calls. This is where the per-row cost drops from ~540 µs to ~50
-	// µs at K≥32 on AVX-512 + GFNI.
+	// 4. Batched RLC: one vectorized pass over all rows.
 	rows := make([][]byte, len(proofs))
 	for i, p := range proofs {
 		rows[i] = p.Row
 	}
-	computedRLCs := computeRLCVectorized(rows, context.coeffs, context.config)
+	computedRLCs := computeRLCVectorized(rows, coeffs, context.config)
 
 	// 5. Per-row commitment + RLC checks (cheap, keep in a tight loop).
 	for i, p := range proofs {

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -1,0 +1,129 @@
+package rsema1d
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math/bits"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/merkle"
+)
+
+// minBatchedVerifyK is the smallest batch size where computeRLCVectorized is
+// faster per-row than the scalar Kernel. Measured on Intel c6id.8xlarge
+// (AVX-512 + GFNI). Below this threshold, fall back to scalar VerifyRowWithContext
+// which avoids the zero-row padding overhead of the vectorized path.
+const minBatchedVerifyK = 8
+
+// VerifyRowsWithContext verifies N row proofs against the same commitment in a
+// single batched RLC computation. When len(proofs) ≥ minBatchedVerifyK it
+// replaces N calls to computeRLC with one computeRLCVectorized call, amortizing
+// the SIMD GF(2^16) kernel setup across all rows.
+//
+// Per-row Merkle proof verification and RLC/commitment comparisons still happen
+// individually. Returns the first error encountered, matching the fail-fast
+// semantics of a loop over VerifyRowWithContext.
+func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *VerificationContext) error {
+	if context == nil {
+		return errors.New("received nil context in verifier")
+	}
+	if len(proofs) == 0 {
+		return nil
+	}
+
+	// Below the break-even, per-row SIMD would pad each batch up to K=32 and
+	// pay more than a scalar computeRLCKernel call. Fall back to the existing
+	// scalar loop which is alloc-free.
+	if len(proofs) < minBatchedVerifyK {
+		for _, p := range proofs {
+			if err := VerifyRowWithContext(p, commitment, context); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// 1. Validate every proof's shape up-front (index range, row sizes, proof
+	// depths) before doing any heavy compute. This matches the checks inside
+	// VerifyRowWithContext but lets us fail fast without ever running the RLC.
+	kPadded := nextPowerOfTwo(context.config.K)
+	totalPadded := nextPowerOfTwo(kPadded + context.config.N)
+	expectedProofDepth := bits.Len(uint(totalPadded)) - 1
+	rowSize := context.config.RowSize
+	if rowSize == 0 {
+		rowSize = len(proofs[0].Row)
+	}
+	for _, p := range proofs {
+		if p == nil {
+			return errors.New("received nil proof in verifier")
+		}
+		if p.Index < 0 || p.Index >= context.config.K+context.config.N {
+			return fmt.Errorf("index %d out of range [0, %d)", p.Index, context.config.K+context.config.N)
+		}
+		if context.config.RowSize > 0 && len(p.Row) != context.config.RowSize {
+			return fmt.Errorf("row size mismatch: expected %d, got %d", context.config.RowSize, len(p.Row))
+		}
+		if len(p.Row) != rowSize {
+			return fmt.Errorf("batched verify requires equal-sized rows: row %d has %d bytes, expected %d",
+				p.Index, len(p.Row), rowSize)
+		}
+		if len(p.RowProof) != expectedProofDepth {
+			return fmt.Errorf("row proof depth mismatch: expected %d, got %d", expectedProofDepth, len(p.RowProof))
+		}
+		if p.Index >= len(context.rlcExtended) {
+			return fmt.Errorf("index %d out of range", p.Index)
+		}
+	}
+
+	// 2. Verify every Merkle proof and collect the computed rowRoot per row. In
+	// a valid shard, every rowRoot is identical (they all come from the same
+	// row tree), but we check each independently so tampering with any single
+	// row still fails.
+	rowRoots := make([][32]byte, len(proofs))
+	for i, p := range proofs {
+		treeIndex := mapIndexToTreePosition(p.Index, context.config)
+		rowRoot, err := merkle.ComputeRootFromProof(p.Row, treeIndex, p.RowProof)
+		if err != nil {
+			return fmt.Errorf("failed to compute row root for row %d: %w", p.Index, err)
+		}
+		rowRoots[i] = rowRoot
+	}
+
+	// 3. Derive coefficients once, using the same sync.Once cache as the
+	// scalar path so subsequent verify calls on this context hit the cache.
+	context.coeffsOnce.Do(func() {
+		context.coeffs = deriveCoefficients(rowRoots[0], len(proofs[0].Row))
+	})
+	if len(context.coeffs) != len(proofs[0].Row)/2 {
+		return fmt.Errorf("row size mismatch: cached coefficients for %d bytes, got %d",
+			len(context.coeffs)*2, len(proofs[0].Row))
+	}
+
+	// 4. Batched RLC: one vectorized pass over all rows instead of len(proofs)
+	// scalar calls. This is where the per-row cost drops from ~540 µs to ~50
+	// µs at K≥32 on AVX-512 + GFNI.
+	rows := make([][]byte, len(proofs))
+	for i, p := range proofs {
+		rows[i] = p.Row
+	}
+	computedRLCs := computeRLCVectorized(rows, context.coeffs, context.config)
+
+	// 5. Per-row commitment + RLC checks (cheap, keep in a tight loop).
+	for i, p := range proofs {
+		if !field.Equal128(computedRLCs[i], context.rlcExtended[p.Index]) {
+			return fmt.Errorf("row %d: computed RLC does not match expected value", p.Index)
+		}
+
+		h := sha256.New()
+		h.Write(rowRoots[i][:])
+		h.Write(context.rlcOrigRoot[:])
+		var computedCommitment [32]byte
+		h.Sum(computedCommitment[:0])
+		if commitment != computedCommitment {
+			return fmt.Errorf("row %d: commitment verification failed", p.Index)
+		}
+	}
+
+	return nil
+}

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -56,6 +56,13 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 		}
 	}
 
+	// Guard against rowSize values that would cause computeRLCVectorized to
+	// divide by zero (numChunks == 0). Config.Validate covers config.RowSize,
+	// but variable-size mode (RowSize == 0) derives rowSize from proofs[0].
+	if rowSize == 0 || rowSize%chunkSize != 0 {
+		return fmt.Errorf("row size must be a positive multiple of %d, got %d", chunkSize, rowSize)
+	}
+
 	// Verify each row's Merkle proof independently so tampering with any
 	// single row fails, even though all rowRoots are identical in a valid shard.
 	rowRoots := make([][32]byte, len(proofs))

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -37,8 +37,11 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 	// scalar loop which is alloc-free.
 	if len(proofs) < minBatchedVerifyK {
 		for _, p := range proofs {
+			if p == nil {
+				return errors.New("received nil proof in verifier")
+			}
 			if err := VerifyRowWithContext(p, commitment, context); err != nil {
-				return err
+				return fmt.Errorf("row %d: %w", p.Index, err)
 			}
 		}
 		return nil
@@ -64,14 +67,14 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 			return fmt.Errorf("index %d out of range [0, %d)", p.Index, context.config.K+context.config.N)
 		}
 		if context.config.RowSize > 0 && len(p.Row) != context.config.RowSize {
-			return fmt.Errorf("row size mismatch: expected %d, got %d", context.config.RowSize, len(p.Row))
+			return fmt.Errorf("row %d: row size mismatch: expected %d, got %d", p.Index, context.config.RowSize, len(p.Row))
 		}
 		if len(p.Row) != rowSize {
 			return fmt.Errorf("batched verify requires equal-sized rows: row %d has %d bytes, expected %d",
 				p.Index, len(p.Row), rowSize)
 		}
 		if len(p.RowProof) != expectedProofDepth {
-			return fmt.Errorf("row proof depth mismatch: expected %d, got %d", expectedProofDepth, len(p.RowProof))
+			return fmt.Errorf("row %d: proof depth mismatch: expected %d, got %d", p.Index, expectedProofDepth, len(p.RowProof))
 		}
 		if p.Index >= len(context.rlcExtended) {
 			return fmt.Errorf("index %d out of range", p.Index)

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -25,11 +25,8 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 		return nil
 	}
 
-	// 1. Validate every proof's shape up-front (index range, row sizes, proof
-	// depths) before doing any heavy compute. This matches the checks inside
-	// VerifyRowWithContext but lets us fail fast without ever running the RLC.
-	// Nil-checks come before any proofs[0] dereference so a nil first element
-	// returns an error instead of panicking.
+	// Validate every proof's shape before any heavy compute. The nil-check
+	// has to run before the proofs[0] dereference inside the loop.
 	kPadded := nextPowerOfTwo(context.config.K)
 	totalPadded := nextPowerOfTwo(kPadded + context.config.N)
 	expectedProofDepth := bits.Len(uint(totalPadded)) - 1
@@ -59,10 +56,8 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 		}
 	}
 
-	// 2. Verify every Merkle proof and collect the computed rowRoot per row. In
-	// a valid shard, every rowRoot is identical (they all come from the same
-	// row tree), but we check each independently so tampering with any single
-	// row still fails.
+	// Verify each row's Merkle proof independently so tampering with any
+	// single row fails, even though all rowRoots are identical in a valid shard.
 	rowRoots := make([][32]byte, len(proofs))
 	for i, p := range proofs {
 		treeIndex := mapIndexToTreePosition(p.Index, context.config)
@@ -73,25 +68,23 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 		rowRoots[i] = rowRoot
 	}
 
-	// 3. Derive coefficients from the first row's root. In a valid shard
-	// every row root is identical, so the choice of row 0 is arbitrary; the
-	// downstream commitment check rejects the batch if any row root differs.
+	// Choice of rowRoots[0] is arbitrary — all are equal in a valid shard,
+	// and the per-row commitment check below rejects the batch if any differ.
 	coeffs := deriveCoefficients(rowRoots[0], len(proofs[0].Row))
 
-	// 4. Batched RLC: one vectorized pass over all rows.
 	rows := make([][]byte, len(proofs))
 	for i, p := range proofs {
 		rows[i] = p.Row
 	}
 	computedRLCs := computeRLCVectorized(rows, coeffs, context.config)
 
-	// 5. Per-row commitment + RLC checks (cheap, keep in a tight loop).
+	h := sha256.New()
 	for i, p := range proofs {
 		if !field.Equal128(computedRLCs[i], context.rlcExtended[p.Index]) {
 			return fmt.Errorf("row %d: computed RLC does not match expected value", p.Index)
 		}
 
-		h := sha256.New()
+		h.Reset()
 		h.Write(rowRoots[i][:])
 		h.Write(context.rlcOrigRoot[:])
 		var computedCommitment [32]byte

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -47,16 +47,18 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 	// 1. Validate every proof's shape up-front (index range, row sizes, proof
 	// depths) before doing any heavy compute. This matches the checks inside
 	// VerifyRowWithContext but lets us fail fast without ever running the RLC.
+	// Nil-checks come before any proofs[0] dereference so a nil first element
+	// returns an error instead of panicking.
 	kPadded := nextPowerOfTwo(context.config.K)
 	totalPadded := nextPowerOfTwo(kPadded + context.config.N)
 	expectedProofDepth := bits.Len(uint(totalPadded)) - 1
 	rowSize := context.config.RowSize
-	if rowSize == 0 {
-		rowSize = len(proofs[0].Row)
-	}
-	for _, p := range proofs {
+	for i, p := range proofs {
 		if p == nil {
 			return errors.New("received nil proof in verifier")
+		}
+		if i == 0 && rowSize == 0 {
+			rowSize = len(p.Row)
 		}
 		if p.Index < 0 || p.Index >= context.config.K+context.config.N {
 			return fmt.Errorf("index %d out of range [0, %d)", p.Index, context.config.K+context.config.N)

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -2,6 +2,7 @@ package rsema1d
 
 import (
 	"math/rand/v2"
+	"strings"
 	"testing"
 )
 
@@ -146,6 +147,69 @@ func TestVerifyRowsWithContextNilProof(t *testing.T) {
 		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
 			t.Fatalf("nil proof at position %d was accepted", nilPos)
 		}
+	}
+}
+
+// TestVerifyRowsWithContextErrorIncludesRow asserts that every error returned
+// from VerifyRowsWithContext names the offending row's data index, so the
+// fibre wrapper at server_upload.go can identify which row was malformed.
+// Covers the shape-validation branches and the scalar fallback path.
+func TestVerifyRowsWithContextErrorIncludesRow(t *testing.T) {
+	cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+	data := make([][]byte, cfg.K)
+	r := rand.New(rand.NewPCG(23, 23))
+	for i := range data {
+		data[i] = make([]byte, cfg.RowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	ed, commitment, rlcOrig, err := Encode(data, cfg)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	makeBatch := func(n int) []*RowProof {
+		proofs := make([]*RowProof, n)
+		for i := range proofs {
+			p, err := ed.GenerateRowProof(i)
+			if err != nil {
+				t.Fatalf("GenerateRowProof: %v", err)
+			}
+			row := append([]byte(nil), p.Row...)
+			proofs[i] = &RowProof{Index: p.Index, Row: row, RowProof: p.RowProof}
+		}
+		return proofs
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(p *RowProof)
+		size   int // batch size (≥ minBatchedVerifyK exercises batched, < hits fallback)
+	}{
+		{"row_size_mismatch", func(p *RowProof) { p.Row = p.Row[:len(p.Row)/2] }, minBatchedVerifyK + 4},
+		{"proof_depth_mismatch", func(p *RowProof) { p.RowProof = p.RowProof[:len(p.RowProof)-1] }, minBatchedVerifyK + 4},
+		{"scalar_fallback_tampered_row", func(p *RowProof) { p.Row[0] ^= 0xFF }, 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+			if err != nil {
+				t.Fatalf("CreateVerificationContext: %v", err)
+			}
+			proofs := makeBatch(tt.size)
+			bad := proofs[2]
+			tt.mutate(bad)
+			err = VerifyRowsWithContext(proofs, commitment, ctx)
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			want := "row " + itoa(bad.Index)
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("error missing %q: %q", want, err.Error())
+			}
+		})
 	}
 }
 

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -7,9 +7,7 @@ import (
 )
 
 // TestVerifyRowsWithContextMatchesScalar locks in that batched verify accepts
-// valid row proofs that the scalar path accepts — across the K values that
-// matter in production (≥ minBatchedVerifyK plus some small ones to exercise
-// the scalar fallback).
+// valid row proofs that the scalar path accepts.
 func TestVerifyRowsWithContextMatchesScalar(t *testing.T) {
 	for _, nProofs := range []int{1, 4, 8, 16, 32, 64} {
 		t.Run("N="+itoa(nProofs), func(t *testing.T) {
@@ -130,12 +128,12 @@ func TestVerifyRowsWithContextNilProof(t *testing.T) {
 	// path inside VerifyRowsWithContext.
 	verifyCfg := &Config{K: encodeCfg.K, N: encodeCfg.N, WorkerCount: 1}
 
-	for _, nilPos := range []int{0, minBatchedVerifyK / 2, minBatchedVerifyK} {
+	for _, nilPos := range []int{0, 4, 8} {
 		ctx, _, err := CreateVerificationContext(rlcOrig, verifyCfg)
 		if err != nil {
 			t.Fatalf("CreateVerificationContext: %v", err)
 		}
-		proofs := make([]*RowProof, minBatchedVerifyK+4)
+		proofs := make([]*RowProof, 12)
 		for i := range proofs {
 			p, err := ed.GenerateRowProof(i)
 			if err != nil {
@@ -150,10 +148,9 @@ func TestVerifyRowsWithContextNilProof(t *testing.T) {
 	}
 }
 
-// TestVerifyRowsWithContextErrorIncludesRow asserts that every error returned
-// from VerifyRowsWithContext names the offending row's data index, so the
+// TestVerifyRowsWithContextErrorIncludesRow asserts that the row size mismatch
+// and proof depth mismatch errors name the offending row's data index, so the
 // fibre wrapper at server_upload.go can identify which row was malformed.
-// Covers the shape-validation branches and the scalar fallback path.
 func TestVerifyRowsWithContextErrorIncludesRow(t *testing.T) {
 	cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
 	data := make([][]byte, cfg.K)
@@ -169,27 +166,12 @@ func TestVerifyRowsWithContextErrorIncludesRow(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 
-	makeBatch := func(n int) []*RowProof {
-		proofs := make([]*RowProof, n)
-		for i := range proofs {
-			p, err := ed.GenerateRowProof(i)
-			if err != nil {
-				t.Fatalf("GenerateRowProof: %v", err)
-			}
-			row := append([]byte(nil), p.Row...)
-			proofs[i] = &RowProof{Index: p.Index, Row: row, RowProof: p.RowProof}
-		}
-		return proofs
-	}
-
 	tests := []struct {
 		name   string
 		mutate func(p *RowProof)
-		size   int // batch size (≥ minBatchedVerifyK exercises batched, < hits fallback)
 	}{
-		{"row_size_mismatch", func(p *RowProof) { p.Row = p.Row[:len(p.Row)/2] }, minBatchedVerifyK + 4},
-		{"proof_depth_mismatch", func(p *RowProof) { p.RowProof = p.RowProof[:len(p.RowProof)-1] }, minBatchedVerifyK + 4},
-		{"scalar_fallback_tampered_row", func(p *RowProof) { p.Row[0] ^= 0xFF }, 4},
+		{"row_size_mismatch", func(p *RowProof) { p.Row = p.Row[:len(p.Row)/2] }},
+		{"proof_depth_mismatch", func(p *RowProof) { p.RowProof = p.RowProof[:len(p.RowProof)-1] }},
 	}
 
 	for _, tt := range tests {
@@ -198,7 +180,15 @@ func TestVerifyRowsWithContextErrorIncludesRow(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CreateVerificationContext: %v", err)
 			}
-			proofs := makeBatch(tt.size)
+			proofs := make([]*RowProof, 12)
+			for i := range proofs {
+				p, err := ed.GenerateRowProof(i)
+				if err != nil {
+					t.Fatalf("GenerateRowProof: %v", err)
+				}
+				row := append([]byte(nil), p.Row...)
+				proofs[i] = &RowProof{Index: p.Index, Row: row, RowProof: p.RowProof}
+			}
 			bad := proofs[2]
 			tt.mutate(bad)
 			err = VerifyRowsWithContext(proofs, commitment, ctx)

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -106,10 +106,10 @@ func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
 	}
 }
 
-// TestVerifyRowsWithContextNilProof covers the edge case where a caller passes
-// a nil proof element. The nil-first case is specifically tested with a
-// context whose config.RowSize == 0 — that path dereferences proofs[0] to
-// derive the expected row size, and would panic without the nil pre-check.
+// TestVerifyRowsWithContextNilProof covers nil elements at several positions.
+// Position 0 is exercised with config.RowSize == 0 because that path reads
+// proofs[0].Row to derive the expected row size — the nil-check at the top
+// of the loop has to run before the dereference.
 func TestVerifyRowsWithContextNilProof(t *testing.T) {
 	encodeCfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
 	data := make([][]byte, encodeCfg.K)

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -7,63 +7,6 @@ import (
 	"testing"
 )
 
-// TestVerifyRowsWithContextMatchesScalar locks in that batched verify accepts
-// valid row proofs that the scalar path accepts.
-func TestVerifyRowsWithContextMatchesScalar(t *testing.T) {
-	for _, nProofs := range []int{1, 4, 8, 16, 32, 64} {
-		t.Run("N="+strconv.Itoa(nProofs), func(t *testing.T) {
-			// Build a realistic extended data set: K=64 rows of 1024 bytes,
-			// then sample nProofs rows out of the K+N total.
-			cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
-			data := make([][]byte, cfg.K)
-			r := rand.New(rand.NewPCG(uint64(nProofs), 1))
-			for i := range data {
-				data[i] = make([]byte, cfg.RowSize)
-				for j := range data[i] {
-					data[i][j] = byte(r.IntN(256))
-				}
-			}
-
-			ed, commitment, rlcOrig, err := Encode(data, cfg)
-			if err != nil {
-				t.Fatalf("Encode: %v", err)
-			}
-
-			ctxScalar, _, err := CreateVerificationContext(rlcOrig, cfg)
-			if err != nil {
-				t.Fatalf("CreateVerificationContext: %v", err)
-			}
-			ctxBatched, _, err := CreateVerificationContext(rlcOrig, cfg)
-			if err != nil {
-				t.Fatalf("CreateVerificationContext: %v", err)
-			}
-
-			proofs := make([]*RowProof, nProofs)
-			for i := range proofs {
-				// Pick distinct indices in [0, K+N).
-				idx := (i * 3) % (cfg.K + cfg.N)
-				p, err := ed.GenerateRowProof(idx)
-				if err != nil {
-					t.Fatalf("GenerateRowProof(%d): %v", idx, err)
-				}
-				proofs[i] = p
-			}
-
-			// Scalar loop reference.
-			for _, p := range proofs {
-				if err := VerifyRowWithContext(p, commitment, ctxScalar); err != nil {
-					t.Fatalf("VerifyRowWithContext: %v", err)
-				}
-			}
-
-			// Batched path.
-			if err := VerifyRowsWithContext(proofs, commitment, ctxBatched); err != nil {
-				t.Fatalf("VerifyRowsWithContext: %v", err)
-			}
-		})
-	}
-}
-
 // TestVerifyRowsWithContextDetectsTamperedRow verifies that corrupting any row
 // in a batch makes the batched verify return an error. Ensures SIMD path does
 // not hide tampering.

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -82,7 +82,7 @@ func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 
-	for tamperedIdx := 0; tamperedIdx < 16; tamperedIdx++ {
+	for tamperedIdx := range 16 {
 		ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
 		if err != nil {
 			t.Fatalf("CreateVerificationContext: %v", err)
@@ -102,6 +102,49 @@ func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
 		proofs[tamperedIdx].Row[0] ^= 0xFF
 		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
 			t.Fatalf("tampered row %d was accepted", tamperedIdx)
+		}
+	}
+}
+
+// TestVerifyRowsWithContextNilProof covers the edge case where a caller passes
+// a nil proof element. The nil-first case is specifically tested with a
+// context whose config.RowSize == 0 — that path dereferences proofs[0] to
+// derive the expected row size, and would panic without the nil pre-check.
+func TestVerifyRowsWithContextNilProof(t *testing.T) {
+	encodeCfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+	data := make([][]byte, encodeCfg.K)
+	r := rand.New(rand.NewPCG(11, 11))
+	for i := range data {
+		data[i] = make([]byte, encodeCfg.RowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	ed, commitment, rlcOrig, err := Encode(data, encodeCfg)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Verify context with RowSize==0 exercises the proofs[0].Row dereference
+	// path inside VerifyRowsWithContext.
+	verifyCfg := &Config{K: encodeCfg.K, N: encodeCfg.N, WorkerCount: 1}
+
+	for _, nilPos := range []int{0, minBatchedVerifyK / 2, minBatchedVerifyK} {
+		ctx, _, err := CreateVerificationContext(rlcOrig, verifyCfg)
+		if err != nil {
+			t.Fatalf("CreateVerificationContext: %v", err)
+		}
+		proofs := make([]*RowProof, minBatchedVerifyK+4)
+		for i := range proofs {
+			p, err := ed.GenerateRowProof(i)
+			if err != nil {
+				t.Fatalf("GenerateRowProof: %v", err)
+			}
+			proofs[i] = p
+		}
+		proofs[nilPos] = nil
+		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
+			t.Fatalf("nil proof at position %d was accepted", nilPos)
 		}
 	}
 }

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -1,0 +1,130 @@
+package rsema1d
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+// TestVerifyRowsWithContextMatchesScalar locks in that batched verify accepts
+// valid row proofs that the scalar path accepts — across the K values that
+// matter in production (≥ minBatchedVerifyK plus some small ones to exercise
+// the scalar fallback).
+func TestVerifyRowsWithContextMatchesScalar(t *testing.T) {
+	for _, nProofs := range []int{1, 4, 8, 16, 32, 64} {
+		t.Run("N="+itoa(nProofs), func(t *testing.T) {
+			// Build a realistic extended data set: K=64 rows of 1024 bytes,
+			// then sample nProofs rows out of the K+N total.
+			cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+			data := make([][]byte, cfg.K)
+			r := rand.New(rand.NewPCG(uint64(nProofs), 1))
+			for i := range data {
+				data[i] = make([]byte, cfg.RowSize)
+				for j := range data[i] {
+					data[i][j] = byte(r.IntN(256))
+				}
+			}
+
+			ed, commitment, rlcOrig, err := Encode(data, cfg)
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+
+			ctxScalar, _, err := CreateVerificationContext(rlcOrig, cfg)
+			if err != nil {
+				t.Fatalf("CreateVerificationContext: %v", err)
+			}
+			ctxBatched, _, err := CreateVerificationContext(rlcOrig, cfg)
+			if err != nil {
+				t.Fatalf("CreateVerificationContext: %v", err)
+			}
+
+			proofs := make([]*RowProof, nProofs)
+			for i := range proofs {
+				// Pick distinct indices in [0, K+N).
+				idx := (i * 3) % (cfg.K + cfg.N)
+				p, err := ed.GenerateRowProof(idx)
+				if err != nil {
+					t.Fatalf("GenerateRowProof(%d): %v", idx, err)
+				}
+				proofs[i] = p
+			}
+
+			// Scalar loop reference.
+			for _, p := range proofs {
+				if err := VerifyRowWithContext(p, commitment, ctxScalar); err != nil {
+					t.Fatalf("VerifyRowWithContext: %v", err)
+				}
+			}
+
+			// Batched path.
+			if err := VerifyRowsWithContext(proofs, commitment, ctxBatched); err != nil {
+				t.Fatalf("VerifyRowsWithContext: %v", err)
+			}
+		})
+	}
+}
+
+// TestVerifyRowsWithContextDetectsTamperedRow verifies that corrupting any row
+// in a batch makes the batched verify return an error. Ensures SIMD path does
+// not hide tampering.
+func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
+	cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+	data := make([][]byte, cfg.K)
+	r := rand.New(rand.NewPCG(7, 7))
+	for i := range data {
+		data[i] = make([]byte, cfg.RowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	ed, commitment, rlcOrig, err := Encode(data, cfg)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	for tamperedIdx := 0; tamperedIdx < 16; tamperedIdx++ {
+		ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+		if err != nil {
+			t.Fatalf("CreateVerificationContext: %v", err)
+		}
+		proofs := make([]*RowProof, 16)
+		for i := range proofs {
+			p, err := ed.GenerateRowProof(i)
+			if err != nil {
+				t.Fatalf("GenerateRowProof: %v", err)
+			}
+			// deep-copy Row to avoid mutating ed state
+			rowCopy := append([]byte(nil), p.Row...)
+			p.Row = rowCopy
+			proofs[i] = p
+		}
+		// Tamper with one byte of one row.
+		proofs[tamperedIdx].Row[0] ^= 0xFF
+		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
+			t.Fatalf("tampered row %d was accepted", tamperedIdx)
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -2,6 +2,7 @@ package rsema1d
 
 import (
 	"math/rand/v2"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -10,7 +11,7 @@ import (
 // valid row proofs that the scalar path accepts.
 func TestVerifyRowsWithContextMatchesScalar(t *testing.T) {
 	for _, nProofs := range []int{1, 4, 8, 16, 32, 64} {
-		t.Run("N="+itoa(nProofs), func(t *testing.T) {
+		t.Run("N="+strconv.Itoa(nProofs), func(t *testing.T) {
 			// Build a realistic extended data set: K=64 rows of 1024 bytes,
 			// then sample nProofs rows out of the K+N total.
 			cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
@@ -195,33 +196,10 @@ func TestVerifyRowsWithContextErrorIncludesRow(t *testing.T) {
 			if err == nil {
 				t.Fatalf("expected error, got nil")
 			}
-			want := "row " + itoa(bad.Index)
+			want := "row " + strconv.Itoa(bad.Index)
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("error missing %q: %q", want, err.Error())
 			}
 		})
 	}
-}
-
-func itoa(n int) string {
-	if n == 0 {
-		return "0"
-	}
-	neg := false
-	if n < 0 {
-		neg = true
-		n = -n
-	}
-	var buf [20]byte
-	i := len(buf)
-	for n > 0 {
-		i--
-		buf[i] = byte('0' + n%10)
-		n /= 10
-	}
-	if neg {
-		i--
-		buf[i] = '-'
-	}
-	return string(buf[i:])
 }


### PR DESCRIPTION
## Summary

Replace `verifyShard`'s per-row `VerifyRowWithContext` loop with a single `VerifyRowsWithContext` call so the SIMD GF(2^16) kernel is set up once per shard instead of N times. All rows in a shard share the same `verificationCtx` and RLC coefficients, which is the precondition `computeRLCVectorized` needs.

## Numbers

`BenchmarkShardVerify` on c6id.8xlarge, AVX-512 + GFNI, taskset -c 0:

| Shard shape | main | this PR | Δ |
|---|---:|---:|---:|
| k=64, 16 rows × 1 KiB | 547 µs | 166 µs | 3.29× |
| k=256, 64 rows × 1 KiB | 2,069 µs | 413 µs | 5.01× |
| k=4096, 128 rows × 32 KiB (128 MiB blob, fibre default) | 115.07 ms | 10.96 ms | 10.50× |

Per-shard verify CPU drops ~10× at `MinRowsPerValidator=147` (default).

## Test plan

- [x] `./pkg/rsema1d/...` and `./fibre/...` (`-tags fibre`) pass.
- [ ] End-to-end validator deploy + pyroscope re-verification (separate ops task).

Closes: https://linear.app/celestia/issue/PROTOCO-1566/perffibre-batched-rlc-verify-for-shard-uploads