### PR TITLE
fix: buf release workflows should trigger on release published

### DIFF
--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -1,23 +1,23 @@
 name: Buf Release
 
 on:
-    release:
-        types: [ published ]
+  release:
+    types: [ published ]
 
 permissions:
-    contents: read
+  contents: read
 
 jobs:
-    push:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v6
-              with:
-                  ref: ${{ github.event.release.tag_name }}
-            - uses: bufbuild/buf-setup-action@v1.50.0
-              with:
-                  github_token: ${{ secrets.GITHUB_TOKEN }}
-            - name: Push tagged Protobuf schema release
-              env:
-                  BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-              run: buf push proto --label "${{ github.event.release.tag_name }}"
+  push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+      - uses: bufbuild/buf-setup-action@v1.50.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push tagged Protobuf schema release
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+        run: buf push proto --label "${{ github.event.release.tag_name }}"

--- a/.github/workflows/buf-release.yml
+++ b/.github/workflows/buf-release.yml
@@ -1,22 +1,23 @@
 name: Buf Release
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+    release:
+        types: [ published ]
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  push:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: bufbuild/buf-setup-action@v1.50.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Push tagged Protobuf schema release
-        env:
-          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
-        run: buf push proto --label "${GITHUB_REF_NAME}"
+    push:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.release.tag_name }}
+            - uses: bufbuild/buf-setup-action@v1.50.0
+              with:
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Push tagged Protobuf schema release
+              env:
+                  BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
+              run: buf push proto --label "${{ github.event.release.tag_name }}"


### PR DESCRIPTION
## Overview

Updates the `buf-release` workflow to run on releases published, rather than on tags pushed.

The workflow doesn't seem to have run on any of the recent v8.x releases. See https://github.com/celestiaorg/celestia-app/actions/workflows/buf-release.yml

I believe this is possibly due to tags being created via the GitHub releases page. i.e. tags created on the remote, and not tags created and pushed to the remote from origin, triggering the workflow.

I think this should cover it.

closes #7169
