### PR TITLE
fix(talis): genesis emits incomplete config (peers, RPC bind, priv-validator gRPC)

### DIFF
--- a/tools/talis/fibre_txsim.go
+++ b/tools/talis/fibre_txsim.go
@@ -122,9 +122,15 @@ func startFibreTxsimOnEncoders(cfg Config, sshKeyPath string, instances, concurr
 		encKeyPrefix := fmt.Sprintf("enc%d", encIndex)
 
 		remoteCmd := fmt.Sprintf(
-			"OTEL_METRICS_EXEMPLAR_FILTER=always_on fibre-txsim --chain-id %s --grpc-endpoint %s --keyring-dir .celestia-app --key-prefix %s --blob-size %d --concurrency %d --interval %s --duration %s --download=%t --upload-only=%t",
+			// Encoders keep their per-encoder keyring under
+			// /root/encoder-payload/<name>/keyring-test/, never copied to
+			// the default ~/.celestia-app/keyring-test by the deploy step;
+			// point fibre-txsim at the right directory directly so it can
+			// load enc<i>-* keys.
+			"OTEL_METRICS_EXEMPLAR_FILTER=always_on fibre-txsim --chain-id %s --grpc-endpoint %s --keyring-dir encoder-payload/%s --key-prefix %s --blob-size %d --concurrency %d --interval %s --duration %s --download=%t --upload-only=%t",
 			cfg.ChainID,
 			grpcEndpoint,
+			enc.Name,
 			encKeyPrefix,
 			blobSize,
 			concurrency,

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -62,14 +62,14 @@ func generateCmd() *cobra.Command {
 				log.Fatalf("Failed to create payload: %v", err)
 			}
 
-			srcCmtConfig := filepath.Join(rootDir, "config.toml")
 			srcAppConfig := filepath.Join(rootDir, "app.toml")
 
 			for _, v := range cfg.Validators {
 				valDir := filepath.Join(payloadDir, v.Name)
-				if err := copyFile(srcCmtConfig, filepath.Join(valDir, "config.toml"), 0o755); err != nil {
-					return fmt.Errorf("failed to copy config.toml: %w", err)
-				}
+				// Note: per-validator config.toml is written by Network.InitNodes
+				// with the correct persistent_peers list. Don't overwrite it
+				// here — that would clobber the peer list and the chain comes
+				// up with zero peers.
 
 				if err := copyFile(srcAppConfig, filepath.Join(valDir, "app.toml"), 0o755); err != nil {
 					return fmt.Errorf("failed to copy app.toml: %w", err)

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/hd"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
+	"github.com/spf13/viper"
 )
 
 // NodeInfo is a struct that contains the name, IP address, and network address
@@ -261,8 +262,23 @@ func (n *Network) InitNodes(rootDir string) error {
 	// config.toml with a populated persistent_peers list. Without this the
 	// chain has no bootstrap mechanism — addrbook alone is not enough — and
 	// validators come up with zero peers and never reach quorum.
-	for _, v := range vals {
-		selfInfo := n.validators[v.Name]
+	//
+	// Use the templated config.toml that `talis init` wrote one level up
+	// (built from app.DefaultConsensusConfig + DefaultConfigProfile, see
+	// init.go:137-139). That carries the celestia-specific overrides
+	// AND the talis profile bits (TracingTables, Prometheus enable/listen
+	// addr, RPC.GRPCListenAddress=0.0.0.0:9090). Falling back to
+	// app.DefaultConsensusConfig directly would silently drop the talis
+	// profile — observability would break on --with-observability runs.
+	baseCfgPath := filepath.Join(filepath.Dir(rootDir), "config.toml")
+	v := viper.New()
+	v.SetConfigFile(baseCfgPath)
+	if err := v.ReadInConfig(); err != nil {
+		return fmt.Errorf("failed to read base config %q: %w", baseCfgPath, err)
+	}
+
+	for _, val := range vals {
+		selfInfo := n.validators[val.Name]
 		selfID := selfInfo.NetworkAddress
 		var peers []string
 		for _, peer := range n.validators {
@@ -272,26 +288,25 @@ func (n *Network) InitNodes(rootDir string) error {
 			peers = append(peers, peer.PeerID())
 		}
 
-		// Start from app.DefaultConsensusConfig (not cmtconfig.DefaultConfig)
-		// so we keep celestia-specific overrides like P2P send/recv rates,
-		// CAT mempool, consensus timeouts, RPC timeout, "null" tx indexer,
-		// DiscardABCIResponses, BlockSync.VerifyData=false. Those land in
-		// app/default_overrides.go and apply to every talis cluster.
+		// Start from app.DefaultConsensusConfig so any field absent from the
+		// templated TOML still inherits celestia defaults, then layer the
+		// templated values on top.
 		cmtcfg := app.DefaultConsensusConfig()
+		if err := v.Unmarshal(cmtcfg); err != nil {
+			return fmt.Errorf("failed to unmarshal base config: %w", err)
+		}
+
 		// Without persistent_peers the chain has no bootstrap mechanism on
 		// a fresh testnet — addrbook alone is not enough — and validators
 		// come up with zero peers and never reach quorum.
 		cmtcfg.P2P.PersistentPeers = strings.Join(peers, ",")
-		// Bind RPC publicly so other instances (encoders, fibre-txsim) can
-		// submit transactions; the default 127.0.0.1 is unreachable cross-node.
-		cmtcfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
 		// Enable the priv-validator gRPC endpoint that fibre needs to fetch
 		// the validator's public key for shard-assignment verification.
 		cmtcfg.PrivValidatorGRPCListenAddr = "127.0.0.1:26659"
-		cmtconfig.WriteConfigFile(filepath.Join(rootDir, v.Name, "config.toml"), cmtcfg)
+		cmtconfig.WriteConfigFile(filepath.Join(rootDir, val.Name, "config.toml"), cmtcfg)
 
 		appcfg := app.DefaultAppConfig()
-		serverconfig.WriteConfigFile(filepath.Join(rootDir, v.Name, "app.toml"), appcfg)
+		serverconfig.WriteConfigFile(filepath.Join(rootDir, val.Name, "app.toml"), appcfg)
 	}
 
 	return nil

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v9/app"
@@ -218,6 +219,10 @@ func (n *Network) InitNodes(rootDir string) error {
 	fmt.Println("genesis file saved to", genesisPath, "with", len(n.validators), "validators")
 
 	vals := n.genesis.Validators()
+
+	// Pass 1: write per-validator node_key.json + priv_validator files, and
+	// stamp NetworkAddress into n.validators so pass 2 can build a complete
+	// persistent_peers list.
 	for _, v := range vals {
 		valPath := filepath.Join(rootDir, v.Name)
 		nodeKeyFile := filepath.Join(valPath, "node_key.json")
@@ -250,8 +255,34 @@ func (n *Network) InitNodes(rootDir string) error {
 		}
 		filePV := privval.NewFilePV(v.ConsensusKey, pvKeyFile, pvStateFile)
 		filePV.Save()
+	}
+
+	// Pass 2: now that every validator's NetworkAddress is known, write
+	// config.toml with a populated persistent_peers list. Without this the
+	// chain has no bootstrap mechanism — addrbook alone is not enough — and
+	// validators come up with zero peers and never reach quorum.
+	for _, v := range vals {
+		selfInfo := n.validators[v.Name]
+		selfID := selfInfo.NetworkAddress
+		var peers []string
+		for _, peer := range n.validators {
+			if peer.NetworkAddress == "" || peer.NetworkAddress == selfID || peer.IP == "" || peer.IP == "TBD" {
+				continue
+			}
+			peers = append(peers, peer.PeerID())
+		}
 
 		cmtcfg := cmtconfig.DefaultConfig()
+		// Without persistent_peers the chain has no bootstrap mechanism on
+		// a fresh testnet — addrbook alone is not enough — and validators
+		// come up with zero peers and never reach quorum.
+		cmtcfg.P2P.PersistentPeers = strings.Join(peers, ",")
+		// Bind RPC publicly so other instances (encoders, fibre-txsim) can
+		// submit transactions; the default 127.0.0.1 is unreachable cross-node.
+		cmtcfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
+		// Enable the priv-validator gRPC endpoint that fibre needs to fetch
+		// the validator's public key for shard-assignment verification.
+		cmtcfg.PrivValidatorGRPCListenAddr = "127.0.0.1:26659"
 		cmtconfig.WriteConfigFile(filepath.Join(rootDir, v.Name, "config.toml"), cmtcfg)
 
 		appcfg := app.DefaultAppConfig()

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -272,7 +272,12 @@ func (n *Network) InitNodes(rootDir string) error {
 			peers = append(peers, peer.PeerID())
 		}
 
-		cmtcfg := cmtconfig.DefaultConfig()
+		// Start from app.DefaultConsensusConfig (not cmtconfig.DefaultConfig)
+		// so we keep celestia-specific overrides like P2P send/recv rates,
+		// CAT mempool, consensus timeouts, RPC timeout, "null" tx indexer,
+		// DiscardABCIResponses, BlockSync.VerifyData=false. Those land in
+		// app/default_overrides.go and apply to every talis cluster.
+		cmtcfg := app.DefaultConsensusConfig()
 		// Without persistent_peers the chain has no bootstrap mechanism on
 		// a fresh testnet — addrbook alone is not enough — and validators
 		// come up with zero peers and never reach quorum.


### PR DESCRIPTION
## Problem

`talis genesis` writes per-validator `config.toml` via `cmtconfig.DefaultConfig()`, then `genesis.go` immediately overwrites the file with the workdir-level `config.toml`, leaving several settings blank that are required to bring a cluster up. Five blockers compound:

1. **`persistent_peers` empty** → validators come up with zero peers and never reach quorum on a fresh chain (addrbook alone is not enough at first boot).
2. **RPC binds to `127.0.0.1:26657`** → unreachable from encoders; `setup-fibre` and `fibre-txsim` cannot submit transactions: `dial tcp <ip>:26657: connect: connection refused`.
3. **`PrivValidatorGRPCListenAddr` unset** → fibre cannot fetch the validator's public key for shard-assignment verification: `getting validator public key: grpc GetPubKey: connection refused on 127.0.0.1:26659`.
4. **The post-`createPayload` `copyFile` of `config.toml`** clobbered any per-validator settings that did get written by `Network.InitNodes`.
5. **`fibre-txsim --keyring-dir .celestia-app`** points at the default keyring, but the encoder keys live under `/root/encoder-payload/<name>/keyring-test/`, never copied across by deploy. Result: `key not found in keyring: enc<n>-0` and the txsim exits before sending a single blob.

I had to manually patch all five on every redeploy to make a cluster usable.

## Fix

- `tools/talis/network.go` — `InitNodes` now runs in two passes:
  - Pass 1: write `node_key.json` + priv-validator files for every validator and stamp `NetworkAddress` into `n.validators`.
  - Pass 2: build the `persistent_peers` string from every validator's now-known node ID + IP (excluding self) and write `config.toml` with that, plus `RPC.ListenAddress = "tcp://0.0.0.0:26657"` and `PrivValidatorGRPCListenAddr = "127.0.0.1:26659"`.
- `tools/talis/genesis.go` — drop the `copyFile(srcCmtConfig, validator/config.toml)` that clobbered the per-validator file. The workdir-level `app.toml` is still copied (no per-validator overrides currently).
- `tools/talis/fibre_txsim.go` — `--keyring-dir encoder-payload/<name>` so it loads the encoder-payload keys directly.

## Test plan

- [x] Builds clean with `go build -tags=ledger,fibre ./tools/talis`.
- [x] `talis genesis` produces validator-N/config.toml with non-empty `persistent_peers` (verified across 10 validators).
- [x] Validators boot, peer up, and produce blocks on a fresh `talis up + genesis + deploy`. **Verified at h=25 within ~30s of deploy completion**, no manual fix-ups needed.
- [x] `setup-fibre` runs cleanly: validators register host addresses, encoders deposit escrow.
- [x] `fibre-txsim --on-encoders` sends transactions: 3874 blobs in 5 min from 1 encoder (avg upload latency 75 ms); 6800 in 5 min from 4 encoders × 1 concurrency (130 ms each); 6071 in 5 min from 4 encoders × 4 concurrency (~340 ms each).
- [ ] CI: `make lint`, `make test-short` (not run locally — quick rebuild only).

## Known follow-ups (not in this PR)

- Validator init script (`scripts/validator_init.sh`) does `mv payload/$parsed_hostname/priv_validator_key.json` but the move sometimes silently fails on re-deploy; works on a fresh cluster.
- `talis deploy` doesn't restart `app` tmux sessions; the script complains "duplicate session: app" and the validator keeps running with the old payload on re-deploy.
- S3 deploy uses public-read ACLs — fails on modern buckets unless `BlockPublicAcls=false` and `ObjectOwnership=BucketOwnerPreferred`. Worth either pre-flighting or switching to presigned URLs / SSE-only uploads.
- S3 client requires static creds in `s3_config` even when `AWS_PROFILE` is set; EC2 client uses the profile fine.
- `DIGITALOCEAN_TOKEN` env auto-detected even when `aws_region` is set in config, sending `talis up` down the DO path on AWS-only configs. Workaround is `env -u DIGITALOCEAN_TOKEN`.

Closes: https://linear.app/celestia/issue/PROTOCO-1571/fixtalis-genesis-emits-incomplete-config-peers-rpc-bind-priv-validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)