### PR TITLE
perf(fibre): batched RLC verify + LogTab on top of feat/fibre-payments

### DIFF
--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -207,15 +207,21 @@ func (s *Server) verifyShard(_ context.Context, blobCfg BlobConfig, promise *Pay
 		return fmt.Errorf("creating verification context: %w", err)
 	}
 
-	for _, rowPb := range shard.Rows {
+	// Batched verify: parse every row up-front, then run one vectorized RLC
+	// pass over the whole shard. All rows in a shard share the same
+	// verificationCtx and therefore the same RLC coefficients, which is the
+	// precondition computeRLCVectorized needs to amortize the SIMD kernel
+	// setup across the batch.
+	rows := make([]*rsema1d.RowProof, len(shard.Rows))
+	for i, rowPb := range shard.Rows {
 		row, err := parseRow(rowPb)
 		if err != nil {
 			return err
 		}
-
-		if err := rsema1d.VerifyRowWithContext(row, promise.Commitment, verificationCtx); err != nil {
-			return fmt.Errorf("verification failed for row %d: %w", row.Index, err)
-		}
+		rows[i] = row
+	}
+	if err := rsema1d.VerifyRowsWithContext(rows, promise.Commitment, verificationCtx); err != nil {
+		return fmt.Errorf("shard row verification failed: %w", err)
 	}
 
 	// set RLC root, keep coefficients as-is for storage

--- a/pkg/rsema1d/commitment_luttab.go
+++ b/pkg/rsema1d/commitment_luttab.go
@@ -1,0 +1,248 @@
+package rsema1d
+
+import (
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
+)
+
+// This file implements a per-row log/exp LUT fast path for computeRLC.
+//
+// Motivation
+// ----------
+// klauspost's reedsolomon.(LowLevel).GF16Mul is implemented as:
+//
+//	func (l LowLevel) GF16Mul(a, b uint16) uint16 {
+//	    initConstants()
+//	    if a == 0 || b == 0 { return 0 }
+//	    logSum := addMod(logLUT[ffe(a)], logLUT[ffe(b)])
+//	    if logSum >= modulus { logSum -= modulus }
+//	    return uint16(expLUT[logSum])
+//	}
+//
+// initConstants() takes a sync.Once load+branch on every call.  For the hot
+// RLC loop that's 8 Mul per symbol * 16384 symbols per row = ~131k calls, and
+// the once-load shows up at ~9% on fibre flame graphs.  Additionally the
+// per-call logLUT[a] lookup is redundant: all 8 component multiplies in the
+// inner loop share the same symbol `sym`, so logSym = logLUT[sym] can be
+// hoisted — 9 log lookups per symbol become 1.
+//
+// And because the coeffs for a given row are fixed, we can precompute
+// coeffLog[j*8+k] = logLUT[coeffs[j][k]] once per row.  The inner loop
+// then collapses to one logLUT lookup (for sym) plus 8 expLUT lookups,
+// with no function calls and no sync.Once probe.
+//
+// We replicate logLUT / expLUT locally because they are package-private
+// inside klauspost.  The tables are bit-for-bit identical to klauspost's —
+// `TestComputeRLCLogTabMatchesScalar` locks that in against the reference
+// path.
+
+const (
+	gf16Order      = 1 << 16
+	gf16Modulus    = gf16Order - 1
+	gf16Polynomial = 0x1002D
+)
+
+// localLogLUT[x] = discrete log (in the Cantor basis) of x.
+// localExpLUT[i] = element whose log is i.
+//
+// Both tables follow klauspost's Cantor-basis Leopard encoding so that
+// GF16Mul(a,b) == localExpLUT[addModLUT(localLogLUT[a], localLogLUT[b])]
+// for a,b != 0.
+var (
+	localLogLUT [gf16Order]uint16
+	localExpLUT [gf16Order]uint16
+)
+
+// coeffLogSentinel marks "this coefficient is zero", in which case we must
+// skip the addModLUT/expLUT lookup because there is no valid logarithm.
+// 0xFFFF (= gf16Modulus, the "infinity" code that klauspost already uses
+// for log-of-zero elsewhere in leopard.go) is a safe choice: it is never a
+// valid log (logLUT image is [0, gf16Modulus-1]).
+const coeffLogSentinel uint16 = 0xFFFF
+
+// cantorBasis matches klauspost's leopard.go exactly. Without this, the
+// tables would still be valid GF(2^16) log/exp tables, but they would not
+// agree with klauspost, so GF16Mul results would differ.
+var cantorBasis = [16]uint16{
+	0x0001, 0xACCA, 0x3C0E, 0x163E,
+	0xC582, 0xED2E, 0x914C, 0x4012,
+	0x6C98, 0x10D8, 0x6A72, 0xB900,
+	0xFDB8, 0xFB34, 0xFF38, 0x991E,
+}
+
+func init() {
+	initLocalLUTs()
+}
+
+// initLocalLUTs reproduces klauspost's initLUTs() bit-for-bit.
+func initLocalLUTs() {
+	// LFSR generation into expLUT. After this, expLUT is in the "LFSR" basis.
+	state := 1
+	for i := range gf16Modulus {
+		localExpLUT[state] = uint16(i)
+		state <<= 1
+		if state >= gf16Order {
+			state ^= gf16Polynomial
+		}
+	}
+	localExpLUT[0] = gf16Modulus
+
+	// logLUT in the Cantor basis: logLUT[j+width] = logLUT[j] ^ basis[i].
+	localLogLUT[0] = 0
+	for i := range 16 {
+		basis := cantorBasis[i]
+		width := 1 << i
+		for j := range width {
+			localLogLUT[j+width] = localLogLUT[j] ^ basis
+		}
+	}
+
+	// Translate through expLUT to rebuild logLUT in the final form.
+	for i := range gf16Order {
+		localLogLUT[i] = localExpLUT[localLogLUT[i]]
+	}
+
+	// Invert: expLUT[logLUT[i]] = i.
+	for i := range gf16Order {
+		localExpLUT[localLogLUT[i]] = uint16(i)
+	}
+
+	// Ensure expLUT[modulus] == expLUT[0] (no-op guard from klauspost).
+	localExpLUT[gf16Modulus] = localExpLUT[0]
+}
+
+// rlcCoeffLog is the per-row precomputed log of every coefficient.
+//
+// Layout: flat [len(coeffs)*8]uint16 in AoS order matching field.GF128 — so
+// entry (j*8 + k) == localLogLUT[uint16(coeffs[j][k])], with the sentinel
+// coeffLogSentinel when coeffs[j][k] == 0.
+//
+// Size for fibre's default row (16384 symbols): 16384 * 8 * 2 = 256 KiB,
+// which fits comfortably in a c6id.8xlarge's 1.25 MiB L2.
+type rlcCoeffLog struct {
+	log []uint16
+}
+
+// buildRLCCoeffLog runs once per row: converts every coefficient in coeffs
+// into its logarithm so the per-symbol loop can skip the sym-side log
+// lookup. Zero coefficients get a sentinel (coeffLogSentinel).
+//
+// Cost: 8*len(coeffs) table loads + a 256 KiB alloc. Dwarfed by a single
+// computeRLC pass.
+func buildRLCCoeffLog(coeffs []field.GF128) *rlcCoeffLog {
+	out := make([]uint16, len(coeffs)*8)
+	for j := range coeffs {
+		off := j * 8
+		c := &coeffs[j]
+		for k := range 8 {
+			v := uint16(c[k])
+			if v == 0 {
+				out[off+k] = coeffLogSentinel
+			} else {
+				out[off+k] = localLogLUT[v]
+			}
+		}
+	}
+	return &rlcCoeffLog{log: out}
+}
+
+// computeRLCLogTab is the fast RLC using precomputed coefficient logs.
+//
+// Outer loop walks the Leopard-packed row (64-byte chunks, 32 symbols per
+// chunk, low/high-byte split). Inner loop XORs into 8 register-held
+// accumulators using one logLUT probe per symbol plus 8 expLUT probes.
+//
+// A symbol whose value is 0 is skipped (XOR by 0 is a no-op).
+// A coefficient whose log is coeffLogSentinel (i.e. coeff == 0) is also
+// skipped because GF16Mul(x, 0) == 0.
+func computeRLCLogTab(row []byte, coeffLog *rlcCoeffLog) field.GF128 {
+	var r0, r1, r2, r3, r4, r5, r6, r7 uint16
+	numChunks := len(row) / chunkSize
+	cl := coeffLog.log
+	// Local aliases so the compiler keeps them in registers / stack.
+	logLUT := &localLogLUT
+	expLUT := &localExpLUT
+
+	for c := range numChunks {
+		chunkOff := c * chunkSize
+		coeffOff := c * 32 * 8 // 8-wide stride into coeffLog
+		for j := range 32 {
+			sym := uint16(row[chunkOff+32+j])<<8 | uint16(row[chunkOff+j])
+			if sym == 0 {
+				continue
+			}
+			logSym := uint32(logLUT[sym])
+			base := coeffOff + j*8
+			// Each slot: if coeff log is sentinel, XOR by 0 (no-op).
+			// Otherwise expLUT[(logSym + coeffLog[k]) mod modulus].
+			// addModLUT inlined; also hoist compare to short-circuit.
+			{
+				cv := cl[base]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r0 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+1]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r1 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+2]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r2 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+3]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r3 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+4]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r4 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+5]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r5 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+6]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r6 ^= expLUT[uint16(s)]
+				}
+			}
+			{
+				cv := cl[base+7]
+				if cv != coeffLogSentinel {
+					s := logSym + uint32(cv)
+					s += s >> 16
+					r7 ^= expLUT[uint16(s)]
+				}
+			}
+		}
+	}
+	return field.GF128{
+		field.GF16(r0), field.GF16(r1), field.GF16(r2), field.GF16(r3),
+		field.GF16(r4), field.GF16(r5), field.GF16(r6), field.GF16(r7),
+	}
+}

--- a/pkg/rsema1d/proof.go
+++ b/pkg/rsema1d/proof.go
@@ -79,7 +79,14 @@ func VerifyRowWithContext(proof *RowProof, commitment Commitment, context *Verif
 	if len(context.coeffs) != len(proof.Row)/2 {
 		return fmt.Errorf("row size mismatch: cached coefficients for %d bytes, got %d", len(context.coeffs)*2, len(proof.Row))
 	}
-	computedRLC := computeRLC(proof.Row, context.coeffs)
+	// Lazily build the per-row coeffLog once per context. The first scalar
+	// verify pays the ~128 µs precompute; every subsequent scalar verify
+	// hits the cached LogTab and is ~2–3x faster than the klauspost-based
+	// computeRLC path.
+	context.coeffLogOnce.Do(func() {
+		context.coeffLog = buildRLCCoeffLog(context.coeffs)
+	})
+	computedRLC := computeRLCLogTab(proof.Row, context.coeffLog)
 
 	// 3. Verify RLC matches the extended value at this index
 	if proof.Index >= len(context.rlcExtended) {
@@ -148,7 +155,11 @@ func VerifyStandaloneProof(proof *StandaloneProof, commitment Commitment, config
 
 	// 2. Compute RLC for the row
 	coeffs := deriveCoefficients(rowRoot, len(proof.Row))
-	computedRLC := computeRLC(proof.Row, coeffs)
+	// Build coeffLog once and use the LogTab fast path. The precompute cost
+	// (~128 µs) is amortized below by saving ~250–400 µs per row compared to
+	// the klauspost-based computeRLC, so a single-row standalone verify is
+	// still a net win.
+	computedRLC := computeRLCLogTab(proof.Row, buildRLCCoeffLog(coeffs))
 
 	// 3. Compute RLC root from proof
 	rlcBytes := field.ToBytes128(computedRLC)

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -1,0 +1,129 @@
+package rsema1d
+
+import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math/bits"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/merkle"
+)
+
+// minBatchedVerifyK is the smallest batch size where computeRLCVectorized is
+// faster per-row than the scalar Kernel. Measured on Intel c6id.8xlarge
+// (AVX-512 + GFNI). Below this threshold, fall back to scalar VerifyRowWithContext
+// which avoids the zero-row padding overhead of the vectorized path.
+const minBatchedVerifyK = 8
+
+// VerifyRowsWithContext verifies N row proofs against the same commitment in a
+// single batched RLC computation. When len(proofs) ≥ minBatchedVerifyK it
+// replaces N calls to computeRLC with one computeRLCVectorized call, amortizing
+// the SIMD GF(2^16) kernel setup across all rows.
+//
+// Per-row Merkle proof verification and RLC/commitment comparisons still happen
+// individually. Returns the first error encountered, matching the fail-fast
+// semantics of a loop over VerifyRowWithContext.
+func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *VerificationContext) error {
+	if context == nil {
+		return errors.New("received nil context in verifier")
+	}
+	if len(proofs) == 0 {
+		return nil
+	}
+
+	// Below the break-even, per-row SIMD would pad each batch up to K=32 and
+	// pay more than a scalar computeRLCKernel call. Fall back to the existing
+	// scalar loop which is alloc-free.
+	if len(proofs) < minBatchedVerifyK {
+		for _, p := range proofs {
+			if err := VerifyRowWithContext(p, commitment, context); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// 1. Validate every proof's shape up-front (index range, row sizes, proof
+	// depths) before doing any heavy compute. This matches the checks inside
+	// VerifyRowWithContext but lets us fail fast without ever running the RLC.
+	kPadded := nextPowerOfTwo(context.config.K)
+	totalPadded := nextPowerOfTwo(kPadded + context.config.N)
+	expectedProofDepth := bits.Len(uint(totalPadded)) - 1
+	rowSize := context.config.RowSize
+	if rowSize == 0 {
+		rowSize = len(proofs[0].Row)
+	}
+	for _, p := range proofs {
+		if p == nil {
+			return errors.New("received nil proof in verifier")
+		}
+		if p.Index < 0 || p.Index >= context.config.K+context.config.N {
+			return fmt.Errorf("index %d out of range [0, %d)", p.Index, context.config.K+context.config.N)
+		}
+		if context.config.RowSize > 0 && len(p.Row) != context.config.RowSize {
+			return fmt.Errorf("row size mismatch: expected %d, got %d", context.config.RowSize, len(p.Row))
+		}
+		if len(p.Row) != rowSize {
+			return fmt.Errorf("batched verify requires equal-sized rows: row %d has %d bytes, expected %d",
+				p.Index, len(p.Row), rowSize)
+		}
+		if len(p.RowProof) != expectedProofDepth {
+			return fmt.Errorf("row proof depth mismatch: expected %d, got %d", expectedProofDepth, len(p.RowProof))
+		}
+		if p.Index >= len(context.rlcExtended) {
+			return fmt.Errorf("index %d out of range", p.Index)
+		}
+	}
+
+	// 2. Verify every Merkle proof and collect the computed rowRoot per row. In
+	// a valid shard, every rowRoot is identical (they all come from the same
+	// row tree), but we check each independently so tampering with any single
+	// row still fails.
+	rowRoots := make([][32]byte, len(proofs))
+	for i, p := range proofs {
+		treeIndex := mapIndexToTreePosition(p.Index, context.config)
+		rowRoot, err := merkle.ComputeRootFromProof(p.Row, treeIndex, p.RowProof)
+		if err != nil {
+			return fmt.Errorf("failed to compute row root for row %d: %w", p.Index, err)
+		}
+		rowRoots[i] = rowRoot
+	}
+
+	// 3. Derive coefficients once, using the same sync.Once cache as the
+	// scalar path so subsequent verify calls on this context hit the cache.
+	context.coeffsOnce.Do(func() {
+		context.coeffs = deriveCoefficients(rowRoots[0], len(proofs[0].Row))
+	})
+	if len(context.coeffs) != len(proofs[0].Row)/2 {
+		return fmt.Errorf("row size mismatch: cached coefficients for %d bytes, got %d",
+			len(context.coeffs)*2, len(proofs[0].Row))
+	}
+
+	// 4. Batched RLC: one vectorized pass over all rows instead of len(proofs)
+	// scalar calls. This is where the per-row cost drops from ~540 µs to ~50
+	// µs at K≥32 on AVX-512 + GFNI.
+	rows := make([][]byte, len(proofs))
+	for i, p := range proofs {
+		rows[i] = p.Row
+	}
+	computedRLCs := computeRLCVectorized(rows, context.coeffs, context.config)
+
+	// 5. Per-row commitment + RLC checks (cheap, keep in a tight loop).
+	for i, p := range proofs {
+		if !field.Equal128(computedRLCs[i], context.rlcExtended[p.Index]) {
+			return fmt.Errorf("row %d: computed RLC does not match expected value", p.Index)
+		}
+
+		h := sha256.New()
+		h.Write(rowRoots[i][:])
+		h.Write(context.rlcOrigRoot[:])
+		var computedCommitment [32]byte
+		h.Sum(computedCommitment[:0])
+		if commitment != computedCommitment {
+			return fmt.Errorf("row %d: commitment verification failed", p.Index)
+		}
+	}
+
+	return nil
+}

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -47,16 +47,18 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 	// 1. Validate every proof's shape up-front (index range, row sizes, proof
 	// depths) before doing any heavy compute. This matches the checks inside
 	// VerifyRowWithContext but lets us fail fast without ever running the RLC.
+	// Nil-checks come before any proofs[0] dereference so a nil first element
+	// returns an error instead of panicking.
 	kPadded := nextPowerOfTwo(context.config.K)
 	totalPadded := nextPowerOfTwo(kPadded + context.config.N)
 	expectedProofDepth := bits.Len(uint(totalPadded)) - 1
 	rowSize := context.config.RowSize
-	if rowSize == 0 {
-		rowSize = len(proofs[0].Row)
-	}
-	for _, p := range proofs {
+	for i, p := range proofs {
 		if p == nil {
 			return errors.New("received nil proof in verifier")
+		}
+		if i == 0 && rowSize == 0 {
+			rowSize = len(p.Row)
 		}
 		if p.Index < 0 || p.Index >= context.config.K+context.config.N {
 			return fmt.Errorf("index %d out of range [0, %d)", p.Index, context.config.K+context.config.N)

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -82,7 +82,7 @@ func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
 		t.Fatalf("Encode: %v", err)
 	}
 
-	for tamperedIdx := 0; tamperedIdx < 16; tamperedIdx++ {
+	for tamperedIdx := range 16 {
 		ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
 		if err != nil {
 			t.Fatalf("CreateVerificationContext: %v", err)
@@ -102,6 +102,49 @@ func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
 		proofs[tamperedIdx].Row[0] ^= 0xFF
 		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
 			t.Fatalf("tampered row %d was accepted", tamperedIdx)
+		}
+	}
+}
+
+// TestVerifyRowsWithContextNilProof covers the edge case where a caller passes
+// a nil proof element. The nil-first case is specifically tested with a
+// context whose config.RowSize == 0 — that path dereferences proofs[0] to
+// derive the expected row size, and would panic without the nil pre-check.
+func TestVerifyRowsWithContextNilProof(t *testing.T) {
+	encodeCfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+	data := make([][]byte, encodeCfg.K)
+	r := rand.New(rand.NewPCG(11, 11))
+	for i := range data {
+		data[i] = make([]byte, encodeCfg.RowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	ed, commitment, rlcOrig, err := Encode(data, encodeCfg)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	// Verify context with RowSize==0 exercises the proofs[0].Row dereference
+	// path inside VerifyRowsWithContext.
+	verifyCfg := &Config{K: encodeCfg.K, N: encodeCfg.N, WorkerCount: 1}
+
+	for _, nilPos := range []int{0, minBatchedVerifyK / 2, minBatchedVerifyK} {
+		ctx, _, err := CreateVerificationContext(rlcOrig, verifyCfg)
+		if err != nil {
+			t.Fatalf("CreateVerificationContext: %v", err)
+		}
+		proofs := make([]*RowProof, minBatchedVerifyK+4)
+		for i := range proofs {
+			p, err := ed.GenerateRowProof(i)
+			if err != nil {
+				t.Fatalf("GenerateRowProof: %v", err)
+			}
+			proofs[i] = p
+		}
+		proofs[nilPos] = nil
+		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
+			t.Fatalf("nil proof at position %d was accepted", nilPos)
 		}
 	}
 }

--- a/pkg/rsema1d/proof_batch_test.go
+++ b/pkg/rsema1d/proof_batch_test.go
@@ -1,0 +1,130 @@
+package rsema1d
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+// TestVerifyRowsWithContextMatchesScalar locks in that batched verify accepts
+// valid row proofs that the scalar path accepts — across the K values that
+// matter in production (≥ minBatchedVerifyK plus some small ones to exercise
+// the scalar fallback).
+func TestVerifyRowsWithContextMatchesScalar(t *testing.T) {
+	for _, nProofs := range []int{1, 4, 8, 16, 32, 64} {
+		t.Run("N="+itoa(nProofs), func(t *testing.T) {
+			// Build a realistic extended data set: K=64 rows of 1024 bytes,
+			// then sample nProofs rows out of the K+N total.
+			cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+			data := make([][]byte, cfg.K)
+			r := rand.New(rand.NewPCG(uint64(nProofs), 1))
+			for i := range data {
+				data[i] = make([]byte, cfg.RowSize)
+				for j := range data[i] {
+					data[i][j] = byte(r.IntN(256))
+				}
+			}
+
+			ed, commitment, rlcOrig, err := Encode(data, cfg)
+			if err != nil {
+				t.Fatalf("Encode: %v", err)
+			}
+
+			ctxScalar, _, err := CreateVerificationContext(rlcOrig, cfg)
+			if err != nil {
+				t.Fatalf("CreateVerificationContext: %v", err)
+			}
+			ctxBatched, _, err := CreateVerificationContext(rlcOrig, cfg)
+			if err != nil {
+				t.Fatalf("CreateVerificationContext: %v", err)
+			}
+
+			proofs := make([]*RowProof, nProofs)
+			for i := range proofs {
+				// Pick distinct indices in [0, K+N).
+				idx := (i * 3) % (cfg.K + cfg.N)
+				p, err := ed.GenerateRowProof(idx)
+				if err != nil {
+					t.Fatalf("GenerateRowProof(%d): %v", idx, err)
+				}
+				proofs[i] = p
+			}
+
+			// Scalar loop reference.
+			for _, p := range proofs {
+				if err := VerifyRowWithContext(p, commitment, ctxScalar); err != nil {
+					t.Fatalf("VerifyRowWithContext: %v", err)
+				}
+			}
+
+			// Batched path.
+			if err := VerifyRowsWithContext(proofs, commitment, ctxBatched); err != nil {
+				t.Fatalf("VerifyRowsWithContext: %v", err)
+			}
+		})
+	}
+}
+
+// TestVerifyRowsWithContextDetectsTamperedRow verifies that corrupting any row
+// in a batch makes the batched verify return an error. Ensures SIMD path does
+// not hide tampering.
+func TestVerifyRowsWithContextDetectsTamperedRow(t *testing.T) {
+	cfg := &Config{K: 64, N: 64, RowSize: 1024, WorkerCount: 1}
+	data := make([][]byte, cfg.K)
+	r := rand.New(rand.NewPCG(7, 7))
+	for i := range data {
+		data[i] = make([]byte, cfg.RowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	ed, commitment, rlcOrig, err := Encode(data, cfg)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+
+	for tamperedIdx := 0; tamperedIdx < 16; tamperedIdx++ {
+		ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+		if err != nil {
+			t.Fatalf("CreateVerificationContext: %v", err)
+		}
+		proofs := make([]*RowProof, 16)
+		for i := range proofs {
+			p, err := ed.GenerateRowProof(i)
+			if err != nil {
+				t.Fatalf("GenerateRowProof: %v", err)
+			}
+			// deep-copy Row to avoid mutating ed state
+			rowCopy := append([]byte(nil), p.Row...)
+			p.Row = rowCopy
+			proofs[i] = p
+		}
+		// Tamper with one byte of one row.
+		proofs[tamperedIdx].Row[0] ^= 0xFF
+		if err := VerifyRowsWithContext(proofs, commitment, ctx); err == nil {
+			t.Fatalf("tampered row %d was accepted", tamperedIdx)
+		}
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	neg := false
+	if n < 0 {
+		neg = true
+		n = -n
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		buf[i] = '-'
+	}
+	return string(buf[i:])
+}

--- a/pkg/rsema1d/proof_luttab_bench_test.go
+++ b/pkg/rsema1d/proof_luttab_bench_test.go
@@ -1,0 +1,262 @@
+package rsema1d
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"math/rand/v2"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
+)
+
+// benchLogTabRowSize matches fibre's worst-case per-row size at K=4096 for a
+// 128 MiB shard — 32768 bytes. This is the dominant size hit by the UploadShard
+// verify path.
+const benchLogTabRowSize = 32768
+
+// makeLogTabBenchCase encodes a small K so we can feed real proofs through
+// VerifyRow[s]WithContext. The row payload is still the production-size 32 KiB.
+func makeLogTabBenchCase(tb testing.TB, nProofs int) (
+	*ExtendedData, Commitment, []*RowProof, *Config, []field.GF128,
+) {
+	tb.Helper()
+	cfg := &Config{K: 64, N: 64, RowSize: benchLogTabRowSize, WorkerCount: 1}
+	data := make([][]byte, cfg.K)
+	r := rand.New(rand.NewPCG(42, 42))
+	for i := range data {
+		data[i] = make([]byte, cfg.RowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	ed, commitment, rlcOrig, err := Encode(data, cfg)
+	if err != nil {
+		tb.Fatalf("Encode: %v", err)
+	}
+	proofs := make([]*RowProof, nProofs)
+	for i := range proofs {
+		idx := (i * 3) % (cfg.K + cfg.N)
+		p, err := ed.GenerateRowProof(idx)
+		if err != nil {
+			tb.Fatalf("GenerateRowProof(%d): %v", idx, err)
+		}
+		proofs[i] = p
+	}
+	return ed, commitment, proofs, cfg, rlcOrig
+}
+
+// BenchmarkVerifyRowWithContext_LogTab exercises the single-row scalar verify
+// path. The context is recreated each iteration so the first call pays the
+// LogTab precompute. This measures the end-to-end per-row cost that the
+// fallback inside VerifyRowsWithContext will see for the very first row.
+func BenchmarkVerifyRowWithContext_LogTab(b *testing.B) {
+	_, commitment, proofs, cfg, rlcOrig := makeLogTabBenchCase(b, 1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+		if err != nil {
+			b.Fatalf("CreateVerificationContext: %v", err)
+		}
+		if err := VerifyRowWithContext(proofs[0], commitment, ctx); err != nil {
+			b.Fatalf("VerifyRowWithContext: %v", err)
+		}
+	}
+}
+
+// BenchmarkVerifyRowWithContext_LogTab_Warm reuses the same context so each
+// iteration pays only the hot-path computeRLCLogTab cost (no LogTab build,
+// no deriveCoefficients). This is what subsequent scalar verifies in a
+// shared context look like after the first call.
+func BenchmarkVerifyRowWithContext_LogTab_Warm(b *testing.B) {
+	_, commitment, proofs, cfg, rlcOrig := makeLogTabBenchCase(b, 1)
+	ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+	if err != nil {
+		b.Fatalf("CreateVerificationContext: %v", err)
+	}
+	// Warm the coeffs+coeffLog caches outside the timed loop.
+	if err := VerifyRowWithContext(proofs[0], commitment, ctx); err != nil {
+		b.Fatalf("warmup VerifyRowWithContext: %v", err)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := VerifyRowWithContext(proofs[0], commitment, ctx); err != nil {
+			b.Fatalf("VerifyRowWithContext: %v", err)
+		}
+	}
+}
+
+// BenchmarkVerifyRowsWithContext_SmallBatch_LogTab measures the K<8 fallback
+// regime where VerifyRowsWithContext loops over VerifyRowWithContext. This is
+// the path the LogTab composition accelerates; K=16 and K=64 runs use the
+// SIMD vectorized kernel and are included here as controls that should
+// remain unchanged.
+func BenchmarkVerifyRowsWithContext_SmallBatch_LogTab(b *testing.B) {
+	for _, K := range []int{1, 4, 7, 8, 16, 64} {
+		b.Run(fmt.Sprintf("K=%d", K), func(b *testing.B) {
+			_, commitment, proofs, cfg, rlcOrig := makeLogTabBenchCase(b, K)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+				if err != nil {
+					b.Fatalf("CreateVerificationContext: %v", err)
+				}
+				if err := VerifyRowsWithContext(proofs, commitment, ctx); err != nil {
+					b.Fatalf("VerifyRowsWithContext: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkVerifyRowWithContext_ParallelLogTab mirrors the production load of
+// a validator running several concurrent UploadShard verifications.
+func BenchmarkVerifyRowWithContext_ParallelLogTab(b *testing.B) {
+	_, commitment, proofs, cfg, rlcOrig := makeLogTabBenchCase(b, 1)
+	b.ReportAllocs()
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			ctx, _, err := CreateVerificationContext(rlcOrig, cfg)
+			if err != nil {
+				b.Fatalf("CreateVerificationContext: %v", err)
+			}
+			if err := VerifyRowWithContext(proofs[0], commitment, ctx); err != nil {
+				b.Fatalf("VerifyRowWithContext: %v", err)
+			}
+		}
+	})
+}
+
+// BenchmarkComputeRLC_PreLogTabScalar measures the pre-LogTab scalar path
+// (computeRLC) on a production-size row. This is the apples-to-apples
+// baseline for BenchmarkComputeRLC_LogTab inside this same binary, letting
+// us compute the speedup without needing to cross-build a different commit.
+func BenchmarkComputeRLC_PreLogTabScalar(b *testing.B) {
+	row, coeffs := makePreLogTabRow(b)
+	b.SetBytes(int64(len(row)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink field.GF128
+	for i := 0; i < b.N; i++ {
+		sink = computeRLC(row, coeffs)
+	}
+	_ = sink
+}
+
+// BenchmarkComputeRLC_LogTabHot measures the hot-path computeRLCLogTab (with
+// the coeffLog precomputed). This isolates the per-row cost after the
+// sync.Once build cost is paid.
+func BenchmarkComputeRLC_LogTabHot(b *testing.B) {
+	row, coeffs := makePreLogTabRow(b)
+	cl := buildRLCCoeffLog(coeffs)
+	b.SetBytes(int64(len(row)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink field.GF128
+	for i := 0; i < b.N; i++ {
+		sink = computeRLCLogTab(row, cl)
+	}
+	_ = sink
+}
+
+// BenchmarkBuildRLCCoeffLog isolates the per-context LogTab precompute that
+// the scalar verify path pays on first call.
+func BenchmarkBuildRLCCoeffLog(b *testing.B) {
+	_, coeffs := makePreLogTabRow(b)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink *rlcCoeffLog
+	for i := 0; i < b.N; i++ {
+		sink = buildRLCCoeffLog(coeffs)
+	}
+	_ = sink
+}
+
+func makePreLogTabRow(tb testing.TB) ([]byte, []field.GF128) {
+	tb.Helper()
+	row := make([]byte, benchLogTabRowSize)
+	r := rand.New(rand.NewPCG(99, 7))
+	for i := range row {
+		row[i] = byte(r.IntN(256))
+	}
+	rowRoot := sha256.Sum256([]byte("bench-prelogtab"))
+	coeffs := deriveCoefficients(rowRoot, len(row))
+	return row, coeffs
+}
+
+// BenchmarkVerifyRowWithContext_Scalar replicates the pre-LogTab scalar path
+// by constructing a fresh VerificationContext and calling deriveCoefficients
+// + computeRLC (the functions used before this change). This isolates the
+// "fresh context + single row" cost against BenchmarkVerifyRowWithContext_LogTab
+// in the same binary.
+func BenchmarkVerifyRowWithContext_Scalar(b *testing.B) {
+	_, _, proofs, cfg, rlcOrig := makeLogTabBenchCase(b, 1)
+	// Pre-extract the row and simulate the work that VerifyRowWithContext does.
+	// Each iter: fresh context -> rebuild coeffs -> computeRLC -> compare.
+	proof := proofs[0]
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Simulated: rebuild context equivalent (deriveCoefficients), then
+		// scalar RLC. We do not re-run Merkle here because Merkle work is a
+		// small constant factor both before and after this change; isolating
+		// the RLC-related delta is the point.
+		var rowRoot [32]byte
+		copy(rowRoot[:], proof.Row[:32]) // stand-in; consistent across iters
+		coeffs := deriveCoefficients(rowRoot, len(proof.Row))
+		_ = cfg
+		_ = rlcOrig
+		sink := computeRLC(proof.Row, coeffs)
+		runtime_KeepAlive(sink)
+	}
+}
+
+// BenchmarkVerifyRowWithContext_Scalar_Warm: cached coeffs path with scalar
+// computeRLC — what the old steady-state VerifyRowWithContext looked like
+// once coeffs were cached in the context.
+func BenchmarkVerifyRowWithContext_Scalar_Warm(b *testing.B) {
+	_, _, proofs, _, _ := makeLogTabBenchCase(b, 1)
+	proof := proofs[0]
+	var rowRoot [32]byte
+	copy(rowRoot[:], proof.Row[:32])
+	coeffs := deriveCoefficients(rowRoot, len(proof.Row))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sink := computeRLC(proof.Row, coeffs)
+		runtime_KeepAlive(sink)
+	}
+}
+
+// runtime_KeepAlive prevents dead-code elimination of bench outputs without
+// pulling in the full runtime package import just for this bench file.
+func runtime_KeepAlive(x field.GF128) {
+	// Force x onto the stack for the compiler.
+	if x[0] == 0xDEAD && x[1] == 0xBEEF {
+		panic("unreachable sentinel")
+	}
+}
+
+// TestComputeRLCLogTabMatchesScalar locks in bit-for-bit equivalence with the
+// reference computeRLC on a realistic row. This is the single test that
+// guarantees the LUT bootstrap in commitment_luttab.go is wired up correctly
+// and that the hot path does not diverge from klauspost's GF16Mul.
+func TestComputeRLCLogTabMatchesScalar(t *testing.T) {
+	row := make([]byte, benchLogTabRowSize)
+	r := rand.New(rand.NewPCG(123, 456))
+	for i := range row {
+		row[i] = byte(r.IntN(256))
+	}
+	rowRoot := sha256.Sum256([]byte("lutTab-equiv"))
+	coeffs := deriveCoefficients(rowRoot, len(row))
+
+	want := computeRLC(row, coeffs)
+	got := computeRLCLogTab(row, buildRLCCoeffLog(coeffs))
+
+	if !field.Equal128(want, got) {
+		t.Fatalf("LogTab diverges from scalar computeRLC\n want=%v\n got =%v", want, got)
+	}
+}

--- a/pkg/rsema1d/types.go
+++ b/pkg/rsema1d/types.go
@@ -44,6 +44,13 @@ type VerificationContext struct {
 
 	coeffsOnce sync.Once
 	coeffs     []field.GF128
+
+	// coeffLogOnce gates a lazy build of the per-row LogTab precompute used
+	// by the scalar verify fast path. The first scalar verify in this
+	// context pays ~128 µs to populate coeffLog; subsequent scalar verifies
+	// hit the cache and pay only the computeRLCLogTab inner loop.
+	coeffLogOnce sync.Once
+	coeffLog     *rlcCoeffLog
 }
 
 // RowProof is a lightweight proof without RLC data


### PR DESCRIPTION
Brings the 3 RLC-hot-path optimisation commits (currently open against `main` as #7165 + #7172) onto `feat/fibre-payments`, so this branch contains everything we want before the next experiment cluster.

## Commits

- `1e0d86595` — perf(fibre): batched RLC verify for shard uploads (= #7165)
- `35982b05c` — fix: nil-check proofs before deriving row size in batched verify (review fix on #7165)
- `2b10c9908` — perf(rsema1d): per-context log/exp LUT for scalar RLC fast path (= #7172)

Stacked cleanly on `feat/fibre-payments@4202c0e20` (which already has the slab pool / mmap-backed allocator / upload memory budget / non-blocking fan-out work). Cherry-pick was conflict-free.

## Live-load verification

Built `celestia-appd` with `-tags=ledger,fibre` from this branch and ran on a fresh 10-validator (`c6i.4xlarge`) + 10-encoder (`c6in.2xlarge`) `talis-fixed` cluster in `us-east-1b`, single AZ, 128 MiB blobs, `--upload-only`:

| Run | Setup | Uploads (5 min) | Aggregate MB/s | E2E latency | Errors |
|---|---|---:|---:|---:|---:|
| A | 1 enc × 4 workers | 256 | **109.2** | 4.27 s | 0 |
| B | 5 enc × 2 workers | 335 | **142.9** | 8.5 s | 0 |
| C | 10 enc × 1 worker | 388 | **165.5** | 7.4 s | 0 |

Cluster saturation lands around 150 MB/s aggregate on this validator-set size. Pushing past ~10 in-flight uploads (5×4 or 10×4) saturates fibre RAM (~13.5 GB resident on validators) and trips DeadlineExceeded — the slab pool keeps memory bounded but consensus + RLC verify can't keep pace beyond that.

This PR is the same code as #7165 + #7172 just rebased onto `feat/fibre-payments`. If you'd rather land via the original PRs against `main` and merge `main` here later, close this — it's just a shortcut so the branch is usable for the next experiment cluster without manual cherry-picks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7181" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
