### PR TITLE
fix(talis): genesis incomplete config + fibre-txsim keyring (onto feat/fibre-payments)

### DIFF
--- a/tools/talis/fibre_txsim.go
+++ b/tools/talis/fibre_txsim.go
@@ -122,9 +122,15 @@ func startFibreTxsimOnEncoders(cfg Config, sshKeyPath string, instances, concurr
 		encKeyPrefix := fmt.Sprintf("enc%d", encIndex)
 
 		remoteCmd := fmt.Sprintf(
-			"OTEL_METRICS_EXEMPLAR_FILTER=always_on fibre-txsim --chain-id %s --grpc-endpoint %s --keyring-dir .celestia-app --key-prefix %s --blob-size %d --concurrency %d --interval %s --duration %s --download=%t --upload-only=%t",
+			// Encoders keep their per-encoder keyring under
+			// /root/encoder-payload/<name>/keyring-test/, never copied to
+			// the default ~/.celestia-app/keyring-test by the deploy step;
+			// point fibre-txsim at the right directory directly so it can
+			// load enc<i>-* keys.
+			"OTEL_METRICS_EXEMPLAR_FILTER=always_on fibre-txsim --chain-id %s --grpc-endpoint %s --keyring-dir encoder-payload/%s --key-prefix %s --blob-size %d --concurrency %d --interval %s --duration %s --download=%t --upload-only=%t",
 			cfg.ChainID,
 			grpcEndpoint,
+			enc.Name,
 			encKeyPrefix,
 			blobSize,
 			concurrency,

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -62,14 +62,14 @@ func generateCmd() *cobra.Command {
 				log.Fatalf("Failed to create payload: %v", err)
 			}
 
-			srcCmtConfig := filepath.Join(rootDir, "config.toml")
 			srcAppConfig := filepath.Join(rootDir, "app.toml")
 
 			for _, v := range cfg.Validators {
 				valDir := filepath.Join(payloadDir, v.Name)
-				if err := copyFile(srcCmtConfig, filepath.Join(valDir, "config.toml"), 0o755); err != nil {
-					return fmt.Errorf("failed to copy config.toml: %w", err)
-				}
+				// Note: per-validator config.toml is written by Network.InitNodes
+				// with the correct persistent_peers list. Don't overwrite it
+				// here — that would clobber the peer list and the chain comes
+				// up with zero peers.
 
 				if err := copyFile(srcAppConfig, filepath.Join(valDir, "app.toml"), 0o755); err != nil {
 					return fmt.Errorf("failed to copy app.toml: %w", err)

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v9/app"
@@ -218,6 +219,10 @@ func (n *Network) InitNodes(rootDir string) error {
 	fmt.Println("genesis file saved to", genesisPath, "with", len(n.validators), "validators")
 
 	vals := n.genesis.Validators()
+
+	// Pass 1: write per-validator node_key.json + priv_validator files, and
+	// stamp NetworkAddress into n.validators so pass 2 can build a complete
+	// persistent_peers list.
 	for _, v := range vals {
 		valPath := filepath.Join(rootDir, v.Name)
 		nodeKeyFile := filepath.Join(valPath, "node_key.json")
@@ -250,8 +255,34 @@ func (n *Network) InitNodes(rootDir string) error {
 		}
 		filePV := privval.NewFilePV(v.ConsensusKey, pvKeyFile, pvStateFile)
 		filePV.Save()
+	}
+
+	// Pass 2: now that every validator's NetworkAddress is known, write
+	// config.toml with a populated persistent_peers list. Without this the
+	// chain has no bootstrap mechanism — addrbook alone is not enough — and
+	// validators come up with zero peers and never reach quorum.
+	for _, v := range vals {
+		selfInfo := n.validators[v.Name]
+		selfID := selfInfo.NetworkAddress
+		var peers []string
+		for _, peer := range n.validators {
+			if peer.NetworkAddress == "" || peer.NetworkAddress == selfID || peer.IP == "" || peer.IP == "TBD" {
+				continue
+			}
+			peers = append(peers, peer.PeerID())
+		}
 
 		cmtcfg := cmtconfig.DefaultConfig()
+		// Without persistent_peers the chain has no bootstrap mechanism on
+		// a fresh testnet — addrbook alone is not enough — and validators
+		// come up with zero peers and never reach quorum.
+		cmtcfg.P2P.PersistentPeers = strings.Join(peers, ",")
+		// Bind RPC publicly so other instances (encoders, fibre-txsim) can
+		// submit transactions; the default 127.0.0.1 is unreachable cross-node.
+		cmtcfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
+		// Enable the priv-validator gRPC endpoint that fibre needs to fetch
+		// the validator's public key for shard-assignment verification.
+		cmtcfg.PrivValidatorGRPCListenAddr = "127.0.0.1:26659"
 		cmtconfig.WriteConfigFile(filepath.Join(rootDir, v.Name, "config.toml"), cmtcfg)
 
 		appcfg := app.DefaultAppConfig()


### PR DESCRIPTION
Brings the 2 talis fixes (currently open against `main` as #7173) onto `feat/fibre-payments` so the next experiment cluster doesn't need manual SSH workarounds.

## Commits

- `7afd432a6` — fix(talis): genesis emits incomplete config (persistent_peers, RPC bind, priv_validator_grpc, drop config.toml clobber)
- `57fe128dc` — fix(talis): point fibre-txsim at the encoder-payload keyring

Cherry-picked clean from #7173 onto `feat/fibre-payments@c3e5d98d0`. Verified end-to-end (used these to bring up the cluster for the live-load runs reported on #7181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7182" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
