### PR TITLE
fix(valaddr,fibre): require host:port form (port of #7183 onto feat/fibre-payments)

### DIFF
--- a/fibre/internal/grpc/host_registry.go
+++ b/fibre/internal/grpc/host_registry.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"sync"
 
 	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
@@ -38,18 +37,22 @@ func (g *HostRegistry) Start(ctx context.Context) error {
 }
 
 // GetHost implements the HostRegistry interface.
+//
+// The same `host:port` validation that x/valaddr's MsgSetFibreProviderInfo
+// applies on registration is re-applied here so that legacy registrations
+// (or any future bug that lets a malformed host slip past the chain check)
+// surface a clear "got invalid host" error at the registry boundary
+// instead of failing later inside grpc.NewClient with a confusing
+// "too many colons in address".
 func (g *HostRegistry) GetHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
 	host, err := g.getHost(ctx, val)
 	if err != nil {
 		return "", err
 	}
 
-	// check if the host is a valid URL
-	_, err = url.Parse(host.String())
-	if err != nil {
+	if err := types.ValidateHost(host.String()); err != nil {
 		return "", fmt.Errorf("got invalid host %s: %w", host.String(), err)
 	}
-
 	return host, nil
 }
 

--- a/fibre/internal/grpc/host_registry_test.go
+++ b/fibre/internal/grpc/host_registry_test.go
@@ -127,13 +127,53 @@ func TestGetHost(t *testing.T) {
 			wantErr:  "host not found",
 		},
 		{
-			name: "invalid URL",
+			name: "garbage host",
 			mock: &mockQueryClient{
 				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
 					return &types.QueryFibreProviderInfoResponse{Found: true, Info: &types.FibreProviderInfo{Host: "ht!tp://bad"}}, nil
 				},
 			},
 			wantErr: "invalid host",
+		},
+		{
+			// Production failure mode #1: gRPC dialer treats the entire
+			// string as the host because it doesn't recognise `http` as
+			// a resolver and appends `:443`, yielding "too many colons".
+			// Catch it at the registry boundary instead.
+			name: "scheme prefix rejected",
+			mock: &mockQueryClient{
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+					return &types.QueryFibreProviderInfoResponse{Found: true, Info: &types.FibreProviderInfo{Host: "http://10.0.0.1:7980"}}, nil
+				},
+			},
+			wantErr: "invalid host",
+		},
+		{
+			name: "dns:/// prefix rejected",
+			mock: &mockQueryClient{
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+					return &types.QueryFibreProviderInfoResponse{Found: true, Info: &types.FibreProviderInfo{Host: "dns:///10.0.0.1:7980"}}, nil
+				},
+			},
+			wantErr: "invalid host",
+		},
+		{
+			name: "bare hostname without port rejected",
+			mock: &mockQueryClient{
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+					return &types.QueryFibreProviderInfoResponse{Found: true, Info: &types.FibreProviderInfo{Host: "validator.example.com"}}, nil
+				},
+			},
+			wantErr: "invalid host",
+		},
+		{
+			name: "host:port accepted",
+			mock: &mockQueryClient{
+				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+					return &types.QueryFibreProviderInfoResponse{Found: true, Info: &types.FibreProviderInfo{Host: "10.0.0.1:7980"}}, nil
+				},
+			},
+			want: "10.0.0.1:7980",
 		},
 	}
 

--- a/tools/talis/fibre_setup.go
+++ b/tools/talis/fibre_setup.go
@@ -51,9 +51,11 @@ func setupFibreCmd() *cobra.Command {
 				// Build script: register host + deposit escrow for validator + all fibre accounts
 				var sb strings.Builder
 
-				// 1. Register fibre host address
+				// 1. Register fibre host address. Plain `host:port` form —
+				// x/valaddr requires it; the gRPC client dials it via the
+				// passthrough resolver. Don't prefix `dns:///` here.
 				sb.WriteString(fmt.Sprintf(
-					"celestia-appd tx valaddr set-host dns:///%s:%d "+
+					"celestia-appd tx valaddr set-host %s:%d "+
 						"--from validator --keyring-backend=test --home .celestia-app "+
 						"--chain-id %s --fees %s --yes\n",
 					val.PublicIP, fibrePort,

--- a/x/valaddr/keeper/msg_server_test.go
+++ b/x/valaddr/keeper/msg_server_test.go
@@ -27,10 +27,10 @@ func TestMsgSetFibreProviderInfo(t *testing.T) {
 	require.NoError(t, err)
 	consAddr := sdk.ConsAddress(consPubKey.Address())
 
-	t.Run("valid DNS hostname", func(t *testing.T) {
+	t.Run("valid DNS hostname with port", func(t *testing.T) {
 		msg := &types.MsgSetFibreProviderInfo{
 			Signer: valAddrStr,
-			Host:   "validator1.fibre.example.com",
+			Host:   "validator1.fibre.example.com:7980",
 		}
 
 		err = msg.ValidateBasic()
@@ -45,16 +45,100 @@ func TestMsgSetFibreProviderInfo(t *testing.T) {
 		require.Equal(t, msg.Host, retrievedInfo.Host)
 	})
 
-	t.Run("valid DNS with port", func(t *testing.T) {
+	t.Run("valid IP with port", func(t *testing.T) {
 		valAddr := sdk.ValAddress("validator1")
 
 		msg := &types.MsgSetFibreProviderInfo{
 			Signer: valAddr.String(),
-			Host:   "validator.example.com:8080",
+			Host:   "10.0.0.1:8080",
 		}
 
 		err := msg.ValidateBasic()
 		require.NoError(t, err)
+	})
+
+	t.Run("valid IPv6 with port", func(t *testing.T) {
+		valAddr := sdk.ValAddress("validator1")
+
+		// IPv6 literals must be square-bracketed in host:port form, per
+		// RFC 3986 / net.SplitHostPort.
+		msg := &types.MsgSetFibreProviderInfo{
+			Signer: valAddr.String(),
+			Host:   "[2001:db8::1]:8080",
+		}
+
+		err := msg.ValidateBasic()
+		require.NoError(t, err)
+	})
+
+	t.Run("rejects bare hostname without port", func(t *testing.T) {
+		valAddr := sdk.ValAddress("validator1")
+
+		msg := &types.MsgSetFibreProviderInfo{
+			Signer: valAddr.String(),
+			Host:   "validator.example.com",
+		}
+
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, types.ErrInvalidHostAddress))
+	})
+
+	t.Run("rejects scheme prefix", func(t *testing.T) {
+		valAddr := sdk.ValAddress("validator1")
+
+		// `http://host:port` is a real-world operator mistake. gRPC
+		// can't dial it, so the chain should refuse to record it.
+		msg := &types.MsgSetFibreProviderInfo{
+			Signer: valAddr.String(),
+			Host:   "http://10.0.0.1:7980",
+		}
+
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, types.ErrInvalidHostAddress))
+	})
+
+	t.Run("rejects dns:/// prefix", func(t *testing.T) {
+		valAddr := sdk.ValAddress("validator1")
+
+		// Historically registered form. gRPC happens to accept it as a
+		// resolver URI, but allowing it lets operators register other
+		// schemes that gRPC won't dial. Keep the chain to one form.
+		msg := &types.MsgSetFibreProviderInfo{
+			Signer: valAddr.String(),
+			Host:   "dns:///10.0.0.1:7980",
+		}
+
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, types.ErrInvalidHostAddress))
+	})
+
+	t.Run("rejects port zero", func(t *testing.T) {
+		valAddr := sdk.ValAddress("validator1")
+
+		msg := &types.MsgSetFibreProviderInfo{
+			Signer: valAddr.String(),
+			Host:   "10.0.0.1:0",
+		}
+
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, types.ErrInvalidHostAddress))
+	})
+
+	t.Run("rejects non-numeric port", func(t *testing.T) {
+		valAddr := sdk.ValAddress("validator1")
+
+		msg := &types.MsgSetFibreProviderInfo{
+			Signer: valAddr.String(),
+			Host:   "10.0.0.1:abc",
+		}
+
+		err := msg.ValidateBasic()
+		require.Error(t, err)
+		require.True(t, errors.Is(err, types.ErrInvalidHostAddress))
 	})
 
 	t.Run("empty host", func(t *testing.T) {
@@ -76,7 +160,7 @@ func TestMsgSetFibreProviderInfo(t *testing.T) {
 
 		msg := &types.MsgSetFibreProviderInfo{
 			Signer: arbitraryValAddr.String(),
-			Host:   "nonexistent.validator.com",
+			Host:   "nonexistent.validator.com:7980",
 		}
 
 		err := msg.ValidateBasic()

--- a/x/valaddr/types/msg.go
+++ b/x/valaddr/types/msg.go
@@ -1,6 +1,9 @@
 package types
 
 import (
+	"net"
+	"strconv"
+
 	errorsmod "cosmossdk.io/errors"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
@@ -16,28 +19,61 @@ const (
 
 	// MaxHostLen is the maximum length for the host field (IP address, DNS name, etc.)
 	MaxHostLen = 100
+
+	// minPort/maxPort define the valid TCP/UDP port range. Port 0 is excluded
+	// because it is not a valid listening port — clients connecting to it
+	// would fail at the dialer.
+	minPort = 1
+	maxPort = 65535
 )
 
 var _ sdk.Msg = &MsgSetFibreProviderInfo{}
 
-// ValidateBasic performs basic validation of the MsgSetFibreProviderInfo message
+// ValidateBasic performs basic validation of the MsgSetFibreProviderInfo message.
+//
+// Host must be in `host:port` form: a non-empty host (IP literal or DNS name)
+// followed by a numeric port in the range [1, 65535]. Schemes (http://,
+// dns:///, etc.) and URL paths are rejected — every fibre client uses the
+// same gRPC transport, so per-provider scheme variation has no use case and
+// historically led to operators registering hosts that could not be dialled.
 func (m *MsgSetFibreProviderInfo) ValidateBasic() error {
-	// Validate validator address
 	if m.Signer == "" {
 		return errorsmod.Wrap(ErrInvalidValidator, "validator address cannot be empty")
 	}
-	_, err := sdk.ValAddressFromBech32(m.Signer)
-	if err != nil {
+	if _, err := sdk.ValAddressFromBech32(m.Signer); err != nil {
 		return errorsmod.Wrapf(ErrInvalidValidator, "invalid validator address: %v", err)
 	}
+	return ValidateHost(m.Host)
+}
 
-	// Validate address length (supports IP addresses, DNS names, etc.)
-	if len(m.Host) > MaxHostLen {
-		return errorsmod.Wrapf(ErrInvalidHostAddress, "address must be less than 90 characters, got %d", len(m.Host))
+// ValidateHost enforces the canonical `host:port` form on a fibre provider
+// host string. It is exported so off-chain callers (CLI, host registry,
+// test helpers) can apply the exact same check the chain enforces.
+func ValidateHost(host string) error {
+	if host == "" {
+		return errorsmod.Wrap(ErrInvalidHostAddress, "host cannot be empty")
 	}
-	if len(m.Host) == 0 {
-		return errorsmod.Wrap(ErrInvalidHostAddress, "address cannot be empty")
+	if len(host) > MaxHostLen {
+		return errorsmod.Wrapf(ErrInvalidHostAddress,
+			"host must be at most %d characters, got %d", MaxHostLen, len(host))
 	}
 
+	hostPart, portPart, err := net.SplitHostPort(host)
+	if err != nil {
+		return errorsmod.Wrapf(ErrInvalidHostAddress,
+			"host must be in host:port form, got %q: %v", host, err)
+	}
+	if hostPart == "" {
+		return errorsmod.Wrapf(ErrInvalidHostAddress, "host part cannot be empty in %q", host)
+	}
+	port, err := strconv.Atoi(portPart)
+	if err != nil {
+		return errorsmod.Wrapf(ErrInvalidHostAddress,
+			"port must be numeric in %q: %v", host, err)
+	}
+	if port < minPort || port > maxPort {
+		return errorsmod.Wrapf(ErrInvalidHostAddress,
+			"port %d in %q out of range [%d, %d]", port, host, minPort, maxPort)
+	}
 	return nil
 }


### PR DESCRIPTION
Cherry-pick of [#7183](https://github.com/celestiaorg/celestia-app/pull/7183) (`fix(valaddr,fibre): require host:port form for fibre provider hosts`) onto `feat/fibre-payments`, so this branch contains the host:port validation fix alongside the other fibre work.

Cherry-picked clean from `bf9ddb7b56e6cc10ac6e67c3a51c75790f38a403` onto `feat/fibre-payments@5fd06e5fd`. Builds with `-tags=ledger,fibre`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7184" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
