### PR TITLE
fix(talis): use app.DefaultConsensusConfig as base, not cmtconfig

### DIFF
--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -272,7 +272,12 @@ func (n *Network) InitNodes(rootDir string) error {
 			peers = append(peers, peer.PeerID())
 		}
 
-		cmtcfg := cmtconfig.DefaultConfig()
+		// Start from app.DefaultConsensusConfig (not cmtconfig.DefaultConfig)
+		// so we keep celestia-specific overrides like P2P send/recv rates,
+		// CAT mempool, consensus timeouts, RPC timeout, "null" tx indexer,
+		// DiscardABCIResponses, BlockSync.VerifyData=false. Those land in
+		// app/default_overrides.go and apply to every talis cluster.
+		cmtcfg := app.DefaultConsensusConfig()
 		// Without persistent_peers the chain has no bootstrap mechanism on
 		// a fresh testnet — addrbook alone is not enough — and validators
 		// come up with zero peers and never reach quorum.


### PR DESCRIPTION
## Summary

Pass 2 of `InitNodes` in `tools/talis/network.go` was starting from `cmtconfig.DefaultConfig()`, which silently dropped every celestia-specific consensus override that lives in `app/default_overrides.go::DefaultConsensusConfig`:

- P2P send/recv rates (100 MiB vs cometbft's ~5 MB defaults)
- `Mempool.Type=CAT` (vs `nop`)
- Consensus timeouts (`TimeoutPropose`, `TimeoutCommit`, etc.)
- RPC timeout 50s (vs 10s)
- `TxIndex.Indexer="null"` (we don't index)
- `Storage.DiscardABCIResponses=true`
- `BlockSync.VerifyData=false`

Switching to `app.DefaultConsensusConfig()` keeps those overrides while still letting us layer on `PersistentPeers`, public RPC bind, and the priv-validator gRPC listener.

Port of #7173 (now landed on `main`) onto `feat/fibre-payments`. Same buggy code reached this branch via the earlier merge of #7182.

Closes: https://linear.app/celestia/issue/PROTOCO-1604/talis-pass-2-of-initnodes-drops-celestia-consensus-overrides

## Test plan

- [ ] CI green
- [ ] Local build (`make build-fibre`) succeeds
- [ ] Re-run a talis cluster on `feat/fibre-payments` and confirm `config.toml` carries the celestia overrides (e.g. `mempool.type = "cat"`, RPC `timeout_broadcast_tx_commit = "50s"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7185" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
