### PR TITLE
fix(talis): mount local NVMe instance store at fibre's data dir

### DIFF
--- a/tools/talis/scripts/validator_init.sh
+++ b/tools/talis/scripts/validator_init.sh
@@ -64,6 +64,50 @@ fi
 
 echo "Script completed successfully."
 
+# === Mount local NVMe instance store (if any) at fibre's data dir ===
+#
+# c6id / i3en / i4i / i7i and similar instance families ship one or more
+# unmounted ephemeral NVMe disks. They are 10–20× faster than the EBS
+# root volume (gp3 baseline ~125 MB/s, instance NVMe is multi-GB/s).
+# Without this block, fibre's `store.Put` writes to the EBS root and
+# becomes the upload-path bottleneck — the disk saturates around 125
+# MB/s while the instance store sits idle.
+#
+# This is a no-op when:
+#   - the instance type has no second NVMe (DigitalOcean droplets,
+#     non-c6id EC2 types, Google Cloud)
+#   - the disk is already formatted+mounted from a previous run
+#     (idempotent on talis re-deploy)
+mount_instance_nvme() {
+  local fibre_dir="/root/.celestia-fibre"
+  local label="celestia-fibre"
+  local dev=""
+  # Pick the largest unmounted whole-disk NVMe that has no partitions.
+  # Sort by size desc, take the first.
+  while read -r name size mp; do
+    [ "$mp" = "" ] || continue
+    [ -n "$(ls /sys/block/${name}/${name}p* 2>/dev/null)" ] && continue
+    dev="/dev/${name}"
+    break
+  done < <(lsblk -bdno NAME,SIZE,MOUNTPOINT 2>/dev/null \
+    | awk '$1 ~ /^nvme/ {print}' | sort -k2 -nr)
+  if [ -z "$dev" ]; then
+    echo "no spare NVMe instance store found — fibre will run on the root volume"
+    return 0
+  fi
+  if ! blkid "$dev" >/dev/null 2>&1; then
+    echo "Formatting $dev (ephemeral NVMe instance store) as ext4..."
+    mkfs.ext4 -F -E lazy_itable_init=1,lazy_journal_init=1 -L "$label" "$dev"
+  fi
+  mkdir -p "$fibre_dir"
+  if ! mountpoint -q "$fibre_dir"; then
+    mount -o noatime,nodiratime "$dev" "$fibre_dir"
+  fi
+  chown root:root "$fibre_dir"
+  echo "Mounted $dev at $fibre_dir ($(df -h "$fibre_dir" | tail -1))"
+}
+mount_instance_nvme
+
 tar -xzf /root/$ARCHIVE_NAME -C /root/
 
 source ./vars.sh


### PR DESCRIPTION
## Summary

On AWS instance types that ship a local NVMe instance store (c6id, i3en, i4i, i7i, etc.) talis never mounts the second NVMe. fibre `store.Put` ends up writing to the EBS gp3 root volume which is throttled at ~125 MB/s baseline — the multi-GB/s ephemeral NVMe sits idle right next to it.

Adds an idempotent `mount_instance_nvme` block to `validator_init.sh` that:
- finds the largest unmounted whole-disk NVMe with no partitions,
- formats ext4 if not already (with lazy init for fast first-mount),
- mounts it at `/root/.celestia-fibre` (fibre's default home) with `noatime,nodiratime`.

No-op on instance types without a second NVMe (DigitalOcean droplets, non-`c6id*` EC2, Google Cloud).

## Measured impact

9v × 10e × c=2 talis cluster (c6id.8xlarge, us-east-1b, 128 MiB-5 blobs, `--upload-only`):

| Metric | EBS root (before) | Local NVMe (after) | Δ |
|---|---|---|---|
| `fibre_server_store_put_duration` avg | **12.26 s** | **0.34 s** | **36× faster** |
| `fibre_client_upload_duration` avg | 13.26 s | 1.45 s | 9.1× faster |
| aggregate upload data | 213 MB/s | **1.1 GB/s** | 5.2× |
| validator nvme0n1 (root) %util | 92% | low | — |

Closes: https://linear.app/celestia/issue/PROTOCO-1609/talis-validators-run-fibre-storeput-on-ebs-root-ignoring-local-nvme

## Test plan

- [x] Live experiment on 9v×10e c6id.8xlarge cluster — confirmed 5× aggregate throughput jump after manually applying the same mount logic.
- [x] `bash -n validator_init.sh` syntax check.
- [ ] Talis re-deploy on the same cluster to confirm the script block runs end-to-end (idempotent re-mount path).
- [ ] Talis deploy on a DigitalOcean droplet (or non-NVMe EC2) to confirm the no-op path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7187" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
