### PR TITLE
feat(talis): provision gp3 root volume to max IOPS/throughput

### DIFF
--- a/tools/talis/aws.go
+++ b/tools/talis/aws.go
@@ -29,6 +29,12 @@ const (
 	AWSDefaultEncoderInstanceType       = "c6in.2xlarge"
 	AWSDefaultObservabilityInstanceType = "t3.medium"
 	AWSDefaultRootVolumeGB              = int32(400)
+	// gp3's baseline (3000 IOPS / 125 MB/s) caps disk throughput far below
+	// what c6in nodes can drive over the network — fibre's shard store
+	// becomes the bottleneck. Provision IOPS and throughput to gp3's max
+	// (16k / 1000 MB/s) so the disk matches the 25–50 Gbps NIC budget.
+	AWSDefaultRootVolumeIops          = int32(16000)
+	AWSDefaultRootVolumeThroughputMBs = int32(1000)
 
 	// AWSSecurityGroupName is the name of the security group used by every
 	// talis instance. It is created per-region on demand and permits all
@@ -389,6 +395,8 @@ func createAWSInstance(ctx context.Context, inst Instance, sshKey, keyName strin
 			Ebs: &ec2types.EbsBlockDevice{
 				VolumeSize:          aws.Int32(AWSDefaultRootVolumeGB),
 				VolumeType:          ec2types.VolumeTypeGp3,
+				Iops:                aws.Int32(AWSDefaultRootVolumeIops),
+				Throughput:          aws.Int32(AWSDefaultRootVolumeThroughputMBs),
 				DeleteOnTermination: aws.Bool(true),
 			},
 		}},


### PR DESCRIPTION
## Summary

- Set `Iops=16000` and `Throughput=1000 MB/s` on the gp3 root volume in `tools/talis/aws.go` — gp3's max
- Default gp3 baseline is 3000 IOPS / 125 MB/s, which caps fibre's shard store far below what c6in NICs can drive
- 8-line change: two new constants + two struct fields on the existing `BlockDeviceMappings`

## Why

On a 9v×10e×c=2 talis cluster, with default-gp3 root the encoder `store.Put` averaged 12.26s and aggregate upload was 213 MB/s — disk-bound. Provisioned gp3 (or local NVMe) drops `store_put` to ~0.3s and upload to 1.1 GB/s. This patch makes provisioned-gp3 the default for every AWS instance talis launches, so the disk matches the NIC budget out of the box.

## Cost

Provisioned IOPS/throughput on gp3 is roughly +$50/month per volume at max settings. Talis instances are short-lived, so per-experiment cost is negligible.

## Test plan

- [x] `go build ./tools/talis/...`
- [ ] `talis up` on AWS — verify EBS volume in console shows IOPS=16000, Throughput=1000 MiB/s
- [ ] Confirm fibre encoder sustains its NIC budget on the default root volume

Closes: https://linear.app/celestia/issue/PROTOCO-1615/talis-provision-gp3-root-volume-to-max-iopsthroughput-on-aws

🤖 Generated with [Claude Code](https://claude.com/claude-code)