### PR TITLE
docs: document supported operating systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,11 @@ celestia-app's GitHub Actions workflows run all unit, integration, and lint jobs
 |--------------------------|---------------------------------|--------------|
 | Ubuntu (`ubuntu-latest`) | Ubuntu 24.04 LTS (Noble Numbat) | x86_64       |
 
+GitHub may advance `ubuntu-latest` to a newer LTS over time; see [actions/runner-images](https://github.com/actions/runner-images) for the current alias mapping.
+
 Other OS / version combinations may work but are not exercised by CI and are not officially supported.
+
+Note that arm64 binaries are cross-compiled via goreleaser but are not executed in CI; only the x86_64 build is exercised end-to-end.
 
 ### Prebuilt binaries
 
@@ -103,14 +107,11 @@ Linux binaries built with the multiplexer require **glibc >= 2.38** (Ubuntu 24.0
 
 ### Known incompatibilities
 
-- **Windows**: the `celestia-appd` binary does not support signing with Ledger hardware wallets on Windows.
-- **OpenBSD**: the `celestia-appd` binary does not support signing with Ledger hardware wallets on OpenBSD.
+- **Windows**: the `celestia-appd` binary does not support signing with Ledger hardware wallets.
+- **OpenBSD**: the `celestia-appd` binary does not support signing with Ledger hardware wallets.
 - **Ubuntu 22.04 and older**: incompatible with multiplexer builds (glibc < 2.38).
 
 ## Usage
-
-> [!WARNING]
-> The celestia-appd binary doesn't support signing with Ledger hardware wallets on Windows and OpenBSD.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,37 @@ If you'd rather not install from source, you can download a prebuilt binary from
 
 See <https://docs.celestia.org/operate/consensus-validators/install-celestia-app/> for more information.
 
+## Supported operating systems
+
+This is the canonical matrix of operating systems that celestia-app is built for and tested against. For the OS versions a *specific* release was tested on, see the per-release entries in [docs/release-notes/release-notes.md](docs/release-notes/release-notes.md).
+
+### Tested in CI
+
+celestia-app's GitHub Actions workflows run all unit, integration, and lint jobs on:
+
+| OS                       | Version                         | Architecture |
+|--------------------------|---------------------------------|--------------|
+| Ubuntu (`ubuntu-latest`) | Ubuntu 24.04 LTS (Noble Numbat) | x86_64       |
+
+Other OS / version combinations may work but are not exercised by CI and are not officially supported.
+
+### Prebuilt binaries
+
+The [GitHub Releases](https://github.com/celestiaorg/celestia-app/releases) page provides prebuilt binaries for:
+
+| OS    | Architectures    |
+|-------|------------------|
+| Linux | `amd64`, `arm64` |
+| macOS | `amd64`, `arm64` |
+
+Linux binaries built with the multiplexer require **glibc >= 2.38** (Ubuntu 24.04 or equivalent). See [Prerequisites](#prerequisites) for details.
+
+### Known incompatibilities
+
+- **Windows**: the `celestia-appd` binary does not support signing with Ledger hardware wallets on Windows.
+- **OpenBSD**: the `celestia-appd` binary does not support signing with Ledger hardware wallets on OpenBSD.
+- **Ubuntu 22.04 and older**: incompatible with multiplexer builds (glibc < 2.38).
+
 ## Usage
 
 > [!WARNING]

--- a/docs/maintainers/release-guide.md
+++ b/docs/maintainers/release-guide.md
@@ -74,6 +74,7 @@ Follow the [creating a release candidate](#creating-a-release-candidate) section
 - The version tag should not include the `-rc` suffix. Instead append the release with `-arabica` or `-mocha` depending on the target network.
 - The release notes should contain an **Upgrade Notice** section with notable changes for node operators or library consumers.
 - The release notes section should contain a link to <https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md> where we capture breaking changes
+- The release notes should contain a **Supported operating systems** section per the [Release notes content](#release-notes-content) guide.
 
 ### After creating the release
 
@@ -87,3 +88,4 @@ Follow the [creating a release candidate](#creating-a-release-candidate) section
 - The version tag should not include the `-rc`, `-arabica`, or `-mocha` suffix.
 - Toggle off the **Set as a pre-release** checkbox.
 - Toggle on the **Set as the latest release** checkbox.
+- The release notes should contain a **Supported operating systems** section per the [Release notes content](#release-notes-content) guide.

--- a/docs/maintainers/release-guide.md
+++ b/docs/maintainers/release-guide.md
@@ -29,6 +29,32 @@ The versions of previous binaries are hard-coded at multiple places in celestia-
 1. Toggle on the **Set as a pre-release** checkbox.
 1. **Publish release**.
 
+### Release notes content
+
+After GitHub generates the auto-generated commit list, edit the release notes to add the following sections at the top, before the auto-generated content:
+
+1. **Upgrade Notice** — notable changes for node operators or library consumers (existing convention).
+2. **Supported operating systems** — required for every release. Use this template:
+
+   ```markdown
+   ## Supported operating systems
+
+   See the [canonical matrix in the README](https://github.com/celestiaorg/celestia-app/blob/<release-tag>/README.md#supported-operating-systems).
+
+   - **Tested in CI**: <e.g., Ubuntu 24.04 LTS (Noble Numbat) on x86_64>
+   - **Prebuilt binaries provided**: Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`)
+   - **Changes since the previous release**: <list any matrix changes, or "none">
+   ```
+
+   Pin the README link to the release tag (not `main`) so the matrix users read matches what was tested for *this* release.
+
+3. **Link to** [docs/release-notes/release-notes.md](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md) for breaking changes (existing convention).
+
+If the CI OS matrix in `.github/workflows/*.yml` has changed since the previous release, you must also:
+
+- Update the matrix in `README.md` under `## Supported operating systems`.
+- Update the `#### Supported operating systems` subsection under the new version's `### Node Operators` heading in `docs/release-notes/release-notes.md`.
+
 ### After creating the release candidate
 
 1. Wait until CI passes on the release and verify that prebuilt binaries were attached to the release.

--- a/docs/maintainers/release-guide.md
+++ b/docs/maintainers/release-guide.md
@@ -42,18 +42,21 @@ After GitHub generates the auto-generated commit list, edit the release notes to
    See the [canonical matrix in the README](https://github.com/celestiaorg/celestia-app/blob/<release-tag>/README.md#supported-operating-systems).
 
    - **Tested in CI**: <e.g., Ubuntu 24.04 LTS (Noble Numbat) on x86_64>
-   - **Prebuilt binaries provided**: Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`)
+   - **Prebuilt binaries provided**: Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`). arm64 binaries are cross-compiled and are not executed in CI.
+   - **Minimum glibc**: <version, e.g., 2.38>. <List incompatible distros, e.g., "Ubuntu 22.04 and older are not supported for multiplexer builds and will fail to start with a glibc version mismatch error.">
    - **Changes since the previous release**: <list any matrix changes, or "none">
    ```
 
    Pin the README link to the release tag (not `main`) so the matrix users read matches what was tested for *this* release.
 
-3. **Link to** [docs/release-notes/release-notes.md](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md) for breaking changes (existing convention).
+3. **Link to** [docs/release-notes/release-notes.md](https://github.com/celestiaorg/celestia-app/blob/main/docs/release-notes/release-notes.md) for breaking changes (existing convention). Unlike the README link in item 2, this URL stays pinned to `main` because the release-notes file grows with each release, and `main` always reflects the most complete history.
 
 If the CI OS matrix in `.github/workflows/*.yml` has changed since the previous release, you must also:
 
-- Update the matrix in `README.md` under `## Supported operating systems`.
+- Update the supported-OS content in `README.md` under `## Supported operating systems` (CI table, prebuilt-binaries section, glibc constraint, known incompatibilities — whichever changed).
 - Update the `#### Supported operating systems` subsection under the new version's `### Node Operators` heading in `docs/release-notes/release-notes.md`.
+
+These requirements apply to release candidates, testnet releases, and mainnet releases. The Testnet Release and Mainnet Release sections below reuse this content.
 
 ### After creating the release candidate
 

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -6,6 +6,15 @@ This guide provides notes for major version releases. These notes may be helpful
 
 ### Node Operators (v9.0.0)
 
+#### Supported operating systems
+
+The canonical matrix of supported operating systems lives in the [README](../../README.md#supported-operating-systems). For v9.0.0 specifically:
+
+- **Tested in CI**: Ubuntu 24.04 LTS (Noble Numbat) on x86_64.
+- **Prebuilt binaries provided**: Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`).
+- **Minimum glibc**: 2.38. Ubuntu 22.04 and older are **not supported** for multiplexer builds and will fail to start with a glibc version mismatch error.
+- **Changes since v8.0.0**: none — same matrix as v8.
+
 #### `update-config` Command Deprecated
 
 The `celestia-appd update-config` command is deprecated. The config values it used to apply are now enforced by the binary at startup, so running it when initialising a new node is no longer necessary. The command still works for now but prints a deprecation warning and will be removed in a future release.

--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -11,9 +11,9 @@ This guide provides notes for major version releases. These notes may be helpful
 The canonical matrix of supported operating systems lives in the [README](../../README.md#supported-operating-systems). For v9.0.0 specifically:
 
 - **Tested in CI**: Ubuntu 24.04 LTS (Noble Numbat) on x86_64.
-- **Prebuilt binaries provided**: Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`).
+- **Prebuilt binaries provided**: Linux (`amd64`, `arm64`), macOS (`amd64`, `arm64`). arm64 binaries are cross-compiled and are not executed in CI.
 - **Minimum glibc**: 2.38. Ubuntu 22.04 and older are **not supported** for multiplexer builds and will fail to start with a glibc version mismatch error.
-- **Changes since v8.0.0**: none — same matrix as v8.
+- **Changes since v8.0.0**: none. (v9 is the first release to record the matrix explicitly; the underlying CI and binary-target configuration is unchanged from v8.)
 
 #### `update-config` Command Deprecated
 


### PR DESCRIPTION
## Summary

- Add a canonical `## Supported operating systems` section to `README.md` (CI-tested OSes + prebuilt-binary targets + glibc constraint + known incompatibilities). Removes a now-redundant `> [!WARNING]` block under `## Usage` that duplicated the Ledger/Windows/OpenBSD content.
- Backfill `docs/release-notes/release-notes.md` v9.0.0 with a `#### Supported operating systems` subsection that links to the README and notes the diff vs v8.
- Update `docs/maintainers/release-guide.md` so every future release includes the section, with a copy-paste template, drift-update instructions, and cross-references from the Testnet Release / Mainnet Release sections so the requirement isn't missed.

Motivated by the Apr 22, 2026 Protocol ↔ DevOps incident review: ambiguity about supported OS contributed to the Arabica archival data-loss incident (Ubuntu 22 / glibc < 2.38 mismatch). The README is now the canonical matrix; release notes link to it; the release runbook keeps everything in sync.

celestia-node has parallel work tracked under the same Linear issue and will be a separate PR.

Closes https://linear.app/celestia/issue/PROTOCO-1565/add-currently-supported-os-to-readme-and-release-notes

## Test plan

- [x] `make lint` passes (no new errors in the three changed files)
- [x] All relative links resolve (`docs/release-notes/release-notes.md` from README; `../../README.md#supported-operating-systems` from release notes)
- [x] Anchor `#prerequisites` still resolves to the existing `### Prerequisites` heading
- [x] CI matrix claim verified against `.github/workflows/*.yml` (`ubuntu-latest` only)
- [x] Prebuilt-binary claim verified against `.goreleaser.yaml` (linux/darwin × amd64/arm64)
- [ ] Reviewer spot-checks rendered README on the PR diff
- [ ] Reviewer confirms v9.0.0 release-notes entry matches the README matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7194" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
