### PR TITLE
perf(rsema1d): chunked dispatch in parallelizeHashing

### DIFF
--- a/pkg/rsema1d/merkle/merkle.go
+++ b/pkg/rsema1d/merkle/merkle.go
@@ -69,29 +69,21 @@ func parallelizeHashing(count int, workerCount int, hashFunc func(i int)) {
 		return
 	}
 
-	// Use worker pool pattern for larger trees
 	workers := min(workerCount, count)
+	chunk := (count + workers - 1) / workers
 
 	var wg sync.WaitGroup
-	ch := make(chan int, count)
-
-	// Start workers
 	wg.Add(workers)
-	for range workers {
-		go func() {
+	for w := range workers {
+		start := w * chunk
+		end := min(start+chunk, count)
+		go func(start, end int) {
 			defer wg.Done()
-			for i := range ch {
+			for i := start; i < end; i++ {
 				hashFunc(i)
 			}
-		}()
+		}(start, end)
 	}
-
-	// Send work
-	for i := range count {
-		ch <- i
-	}
-	close(ch)
-
 	wg.Wait()
 }
 


### PR DESCRIPTION
Replace per-item channel send/receive with static index-range chunking. Per-item dispatch overhead (~500 ns send + ~500 ns receive) was dwarfing SHA256 work (~150 ns) on small leaves like the 16-byte GF128 RLC tree leaves: at K=4096 leaves the channel coordination alone burned ~4 ms per tree build, making the parallel path 3.5x slower than sequential. With chunked dispatch each goroutine pulls a contiguous range and runs a tight hash loop — same goroutine count, no per-item synchronization, and better cache locality from contiguous leaf access.

For uniform-cost work (every SHA256 is identical), static chunking gives up nothing vs work-stealing dispatch. Larger leaves like the row tree at encode time were already dispatch-amortized; this just removes the overhead at smaller scales without affecting them.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7197" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
