### PR TITLE
perf(rsema1d): parallelize deriveCoefficients

### DIFF
--- a/pkg/rsema1d/commitment.go
+++ b/pkg/rsema1d/commitment.go
@@ -3,32 +3,56 @@ package rsema1d
 import (
 	"crypto/sha256"
 	"encoding/binary"
+	"runtime"
+	"sync"
 
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
 )
 
-// deriveCoefficients generates RLC coefficients via Fiat-Shamir (internal)
+// deriveCoefficients generates RLC coefficients via Fiat-Shamir, fanning
+// the SHA256 loop out across GOMAXPROCS via static chunking above the
+// parallel break-even. Below the threshold goroutine startup would dwarf
+// the per-iteration SHA256.
 func deriveCoefficients(rowRoot [32]byte, rowSize int) []field.GF128 {
-	seed := sha256.Sum256(rowRoot[:])
-	numSymbols := rowSize / 2 // Each GF16 symbol is 2 bytes
+	numSymbols := rowSize / 2
 	coeffs := make([]field.GF128, numSymbols)
+	workers := min(runtime.GOMAXPROCS(0), numSymbols)
+	if workers <= 1 || numSymbols < minParallelDeriveSymbols {
+		deriveCoefficientsRange(rowRoot, coeffs, 0, numSymbols)
+		return coeffs
+	}
+	chunk := (numSymbols + workers - 1) / workers
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := range workers {
+		start := w * chunk
+		end := min(start+chunk, numSymbols)
+		go func(start, end int) {
+			defer wg.Done()
+			deriveCoefficientsRange(rowRoot, coeffs, start, end)
+		}(start, end)
+	}
+	wg.Wait()
+	return coeffs
+}
 
+// minParallelDeriveSymbols is the empirical break-even on a 24-thread Ryzen:
+// parallel is slower below ~256 and 1.3-7× faster from 512 upward.
+const minParallelDeriveSymbols = 512
+
+func deriveCoefficientsRange(rowRoot [32]byte, coeffs []field.GF128, start, end int) {
+	seed := sha256.Sum256(rowRoot[:])
 	var input [32 + 4]byte
 	copy(input[:32], seed[:])
-
-	// Reuse a single SHA256 hasher with Reset() between iterations.
-	// This avoids re-initializing the digest state from scratch on each call
-	// to sha256.Sum256, saving ~12% on coefficient derivation.
 	h := sha256.New()
 	var digest [32]byte
-	for i := range numSymbols {
+	for i := start; i < end; i++ {
 		binary.LittleEndian.PutUint32(input[32:], uint32(i))
 		h.Reset()
 		h.Write(input[:])
 		h.Sum(digest[:0])
 		coeffs[i] = field.HashToGF128(digest[:])
 	}
-	return coeffs
 }
 
 // computeRLC computes random linear combination for a row (internal)


### PR DESCRIPTION
Fan the Fiat-Shamir SHA256 loop out across GOMAXPROCS via static index chunking. Each iteration is independent — input is (seed || u32(i)) — so the work parallelizes cleanly with no shared state across goroutines.

Empirical break-even on a 24-thread Ryzen: parallel is slower than sequential below numSymbols=256 (dispatch overhead dominates SHA256 work), ties around 256, and is 1.3–7× faster from 512 upward. Threshold pinned at 512 — production rowSize=32768 (numSymbols=16384) hits the 7.4× speedup, smaller blobs below 16 MiB stay sequential.

For the rsema1d.Verifier upload-path bench at production v0 settings: single-call latency drops 17% at the 5 MB shard and 10% at the 51 MB shard without affecting the bounded-pool concurrent throughput design.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/celestiaorg/celestia-app/pull/7198" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
