### PR TITLE
fix(signal)!: guard VersionFromBytes against malformed store values

### DIFF
--- a/x/signal/keeper.go
+++ b/x/signal/keeper.go
@@ -330,6 +330,13 @@ func VersionToBytes(version uint64) []byte {
 }
 
 func VersionFromBytes(version []byte) uint64 {
+	// Guard against malformed values that could land in the per-validator
+	// store via a future migration or hand-edited state. The canonical encoding
+	// (VersionToBytes) always produces 8 bytes; anything else is treated as
+	// "no recognised version".
+	if len(version) != 8 {
+		return 0
+	}
 	return binary.BigEndian.Uint64(version)
 }
 

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -28,6 +28,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestVersionFromBytes ensures the helper is total over arbitrary inputs.
+// `binary.BigEndian.Uint64` panics on inputs shorter than 8 bytes; the helper
+// must guard against that to avoid panicking inside store-iteration paths.
+func TestVersionFromBytes(t *testing.T) {
+	tests := []struct {
+		name  string
+		input []byte
+		want  uint64
+	}{
+		{"nil", nil, 0},
+		{"empty", []byte{}, 0},
+		{"one byte", []byte{0x01}, 0},
+		{"seven bytes", []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}, 0},
+		{"canonical 8 bytes", []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07}, 7},
+		{"nine bytes is rejected", []byte{0, 0, 0, 0, 0, 0, 0, 7, 0}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				assert.Equal(t, tt.want, signal.VersionFromBytes(tt.input))
+			})
+		})
+	}
+}
+
 func TestGetVotingPowerThreshold(t *testing.T) {
 	bigInt := big.NewInt(0)
 	bigInt.SetString("23058430092136939509", 10)


### PR DESCRIPTION
## Summary

- Add a length guard in `VersionFromBytes` so non-canonical store values are treated as "no recognised version" rather than panicking.
- Add a regression test covering nil, empty, sub-8-byte, canonical 8-byte, and over-8-byte inputs.

Closes https://linear.app/celestia/issue/PROTOCO-1669

## Test plan

- [x] `go test -v -run TestVersionFromBytes ./x/signal/` passes
- [x] `go build ./x/signal/... ./app/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)