### PR TITLE
fix(blob)!: cap GovMaxSquareSize at SquareSizeUpperBound

### DIFF
--- a/x/blob/types/params.go
+++ b/x/blob/types/params.go
@@ -93,5 +93,15 @@ func validateGovMaxSquareSize(v any) error {
 		)
 	}
 
+	// Cap at the consensus-critical upper bound. Without this guard,
+	// downstream uint64 multiplications (e.g. App.getGovMaxSquareBytes which
+	// computes maxSquareSize*maxSquareSize*share.ShareSize) silently wrap.
+	if govMaxSquareSize > uint64(appconsts.SquareSizeUpperBound) {
+		return fmt.Errorf(
+			"gov max square size %d exceeds the upper bound %d",
+			govMaxSquareSize, appconsts.SquareSizeUpperBound,
+		)
+	}
+
 	return nil
 }

--- a/x/blob/types/params_test.go
+++ b/x/blob/types/params_test.go
@@ -34,11 +34,25 @@ func Test_validateGovMaxSquareSize(t *testing.T) {
 			input:     uint64(0),
 			expectErr: true,
 		},
+		{
+			// Without the upper-bound guard, downstream uint64 multiplications
+			// (governMaxSquareSize^2 * share.ShareSize) silently wrap.
+			name:      "exceeds upper bound",
+			input:     uint64(appconsts.SquareSizeUpperBound) * 2,
+			expectErr: true,
+		},
+		{
+			name:      "exactly at upper bound",
+			input:     uint64(appconsts.SquareSizeUpperBound),
+			expectErr: false,
+		},
 	}
 	for _, tt := range tests {
 		err := validateGovMaxSquareSize(tt.input)
 		if tt.expectErr {
 			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Add upper-bound guard in `validateGovMaxSquareSize` so values above the consensus-critical `SquareSizeUpperBound` are rejected.
- Without the guard, downstream `uint64` multiplications (`maxSquareSize * maxSquareSize * share.ShareSize` in `App.getGovMaxSquareBytes`) silently wrap for values ≥ 2^28.
- Add regression test cases for "exceeds upper bound" and "exactly at upper bound".

Closes https://linear.app/celestia/issue/PROTOCO-1670

## Test plan

- [x] `go test -v -run Test_validateGovMaxSquareSize ./x/blob/types/` passes
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)