### PR TITLE
fix(proof): return error instead of panicking on malformed query data

### DIFF
--- a/pkg/proof/proof_test.go
+++ b/pkg/proof/proof_test.go
@@ -15,6 +15,7 @@ import (
 	square "github.com/celestiaorg/go-square/v4"
 	"github.com/celestiaorg/go-square/v4/share"
 	abci "github.com/cometbft/cometbft/abci/types"
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -261,6 +262,26 @@ func TestAllSharesInclusionProof(t *testing.T) {
 	)
 	require.NoError(t, err)
 	assert.NoError(t, proof.Validate(dataRoot))
+}
+
+// TestQueryTxInclusionProof_DoesNotPanicOnMalformedData ensures the handler
+// returns errors (rather than panicking) when given inputs that look like a
+// proto-block but trigger error paths in downstream parsing.
+func TestQueryTxInclusionProof_DoesNotPanicOnMalformedData(t *testing.T) {
+	emptyBlockBytes, err := (&tmproto.Block{}).Marshal()
+	require.NoError(t, err)
+
+	cases := [][]byte{
+		nil,
+		{},
+		[]byte("not a proto block"),
+		emptyBlockBytes,
+	}
+	for _, data := range cases {
+		assert.NotPanics(t, func() {
+			_, _ = proof.QueryTxInclusionProof(sdk.Context{}, []string{"0"}, &abci.RequestQuery{Data: data})
+		})
+	}
 }
 
 // Ensure that we reject negative index values and avoid overflows.

--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -45,7 +45,7 @@ func QueryTxInclusionProof(_ sdk.Context, path []string, req *abci.RequestQuery)
 	}
 	data, err := types.DataFromProto(&pbb.Data)
 	if err != nil {
-		panic(fmt.Errorf("error from proto block: %w", err))
+		return nil, fmt.Errorf("error from proto block: %w", err)
 	}
 
 	// create and marshal the tx inclusion proof, which we return in the form of []byte


### PR DESCRIPTION
## Summary

- Replace the `panic` in `QueryTxInclusionProof` with an error return so deserialization failures of attacker-controlled query data are handled the same way the surrounding `pbb.Unmarshal` failure already is.
- Add a regression test that exercises `QueryTxInclusionProof` with nil, empty, garbage, and empty-block-proto inputs and asserts no panic.

Closes https://linear.app/celestia/issue/PROTOCO-1671

## Test plan

- [x] `go test -v -run TestQueryTxInclusionProof ./pkg/proof/` passes
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)