### PR TITLE
fix(zkism)!: reject non-canonical StateMembershipValues encodings

### DIFF
--- a/x/zkism/types/public_values.go
+++ b/x/zkism/types/public_values.go
@@ -127,11 +127,14 @@ func (v *StateMembershipValues) Marshal() ([]byte, error) {
 func (v *StateMembershipValues) Unmarshal(data []byte) error {
 	buf := bytes.NewReader(data)
 
-	if _, err := buf.Read(v.StateRoot[:]); err != nil {
+	// Use io.ReadFull on fixed-size fields. bytes.Reader.Read returns (n, nil)
+	// on partial reads, which would silently zero-pad fields and admit
+	// non-canonical encodings.
+	if _, err := io.ReadFull(buf, v.StateRoot[:]); err != nil {
 		return fmt.Errorf("read StateRoot: %w", err)
 	}
 
-	if _, err := buf.Read(v.MerkleTreeAddress[:]); err != nil {
+	if _, err := io.ReadFull(buf, v.MerkleTreeAddress[:]); err != nil {
 		return fmt.Errorf("read MerkleTreeAddress: %w", err)
 	}
 
@@ -144,14 +147,14 @@ func (v *StateMembershipValues) Unmarshal(data []byte) error {
 		return fmt.Errorf("message ids count %d exceeds maximum allowed %d", count, MaxMessageIdsCount)
 	}
 
-	remaining := buf.Len()
-	if remaining < int(count*32) {
-		return fmt.Errorf("buffer too short: need %d, have %d", count*32, remaining)
+	// Use int64 to avoid uint64 wrap on count*32.
+	if int64(buf.Len()) != int64(count)*32 {
+		return fmt.Errorf("buffer length mismatch: need exactly %d, have %d", int64(count)*32, buf.Len())
 	}
 
 	v.MessageIds = make([][32]byte, count)
 	for i := 0; i < int(count); i++ {
-		if _, err := buf.Read(v.MessageIds[i][:]); err != nil {
+		if _, err := io.ReadFull(buf, v.MessageIds[i][:]); err != nil {
 			return fmt.Errorf("read message_id %d: %w", i, err)
 		}
 	}

--- a/x/zkism/types/public_values_test.go
+++ b/x/zkism/types/public_values_test.go
@@ -84,6 +84,29 @@ func TestStateMembershipPublicValuesEncoding(t *testing.T) {
 	require.Equal(t, expected.MessageIds, decoded.MessageIds)
 }
 
+// TestStateMembershipPublicValuesUnmarshalRejectsTrailingBytes ensures the
+// canonical-encoding contract holds: every byte string that successfully
+// parses is exactly the canonical encoding of the resulting struct. Without
+// this guarantee, two distinct payloads can decode to the same struct.
+func TestStateMembershipPublicValuesUnmarshalRejectsTrailingBytes(t *testing.T) {
+	canonical := make([]byte, 72) // StateRoot=0, MerkleTreeAddress=0, count=0
+	withTail := append(append([]byte{}, canonical...), 0xAA, 0xBB, 0xCC)
+
+	var canonicalDecoded types.StateMembershipValues
+	require.NoError(t, canonicalDecoded.Unmarshal(canonical))
+
+	var tailDecoded types.StateMembershipValues
+	require.Error(t, tailDecoded.Unmarshal(withTail), "trailing bytes must be rejected")
+}
+
+func TestStateMembershipPublicValuesUnmarshalRejectsShortInputs(t *testing.T) {
+	for _, n := range []int{1, 31, 32, 40, 64, 71} {
+		var v types.StateMembershipValues
+		err := v.Unmarshal(make([]byte, n))
+		require.Error(t, err, "expected error on %d-byte input", n)
+	}
+}
+
 func TestStateMembershipPublicValuesUnmarshalCountLimit(t *testing.T) {
 	// Create a crafted payload with count exceeding MaxMessageIdsCount
 	// Format: StateRoot (32 bytes) + MerkleTreeAddress (32 bytes) + count (8 bytes little-endian)


### PR DESCRIPTION
## Summary

- Replace `bytes.Reader.Read` with `io.ReadFull` on fixed-size fields in `StateMembershipValues.Unmarshal` so partial reads fail rather than silently zero-padding.
- Assert the remaining buffer length equals exactly `count * 32` so trailing bytes after the canonical payload are rejected.
- Widen the bounds check to `int64` to avoid `uint64` wrap on `count * 32`.
- Add regression tests for trailing-byte malleability and for short inputs.

Closes https://linear.app/celestia/issue/PROTOCO-1672

## Test plan

- [x] `go test -v -run TestStateMembership ./x/zkism/types/` passes
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)