### PR TITLE
fix(proof): use signed arithmetic in RowProof.Validate

### DIFF
--- a/pkg/proof/row_proof.go
+++ b/pkg/proof/row_proof.go
@@ -11,9 +11,15 @@ import (
 // the proof fails validation. If the proof passes validation, this function
 // attempts to verify the proof. It returns nil if the proof is valid.
 func (rp RowProof) Validate(root []byte) error {
-	// HACKHACK performing subtraction with unsigned integers is unsafe.
-	if int(rp.EndRow-rp.StartRow+1) != len(rp.RowRoots) {
-		return fmt.Errorf("the number of rows %d must equal the number of row roots %d", int(rp.EndRow-rp.StartRow+1), len(rp.RowRoots))
+	if rp.EndRow < rp.StartRow {
+		return fmt.Errorf("end row %d must be greater than or equal to start row %d", rp.EndRow, rp.StartRow)
+	}
+	expectedRows := int64(rp.EndRow) - int64(rp.StartRow) + 1
+	if expectedRows != int64(len(rp.RowRoots)) {
+		return fmt.Errorf("the number of rows %d must equal the number of row roots %d", expectedRows, len(rp.RowRoots))
+	}
+	if len(rp.RowRoots) == 0 {
+		return errors.New("row proof must contain at least one row root")
 	}
 	if len(rp.Proofs) != len(rp.RowRoots) {
 		return fmt.Errorf("the number of proofs %d must equal the number of row roots %d", len(rp.Proofs), len(rp.RowRoots))

--- a/pkg/proof/row_proof_test.go
+++ b/pkg/proof/row_proof_test.go
@@ -88,6 +88,22 @@ func validRowProof() RowProof {
 	}
 }
 
+// TestRowProofValidate_RejectsVacuousProof ensures Validate rejects a
+// constructed RowProof where EndRow < StartRow with empty RowRoots/Proofs.
+// Previously the uint32 subtraction `EndRow-StartRow+1` underflowed, the
+// arity check passed, and Validate returned nil for a proof that proved
+// nothing.
+func TestRowProofValidate_RejectsVacuousProof(t *testing.T) {
+	rp := RowProof{
+		StartRow: 5,
+		EndRow:   4,
+		RowRoots: nil,
+		Proofs:   nil,
+	}
+	err := rp.Validate(root)
+	assert.Error(t, err)
+}
+
 func mismatchedRowRoots() RowProof {
 	rp := validRowProof()
 	rp.RowRoots = [][]byte{}


### PR DESCRIPTION
## Summary

- Replace the underflow-prone `int(rp.EndRow-rp.StartRow+1)` in `RowProof.Validate` with a signed `int64` row count and an explicit `EndRow >= StartRow` precondition.
- Reject empty `RowRoots` outright so a proof with zero rows can't be returned as "valid".
- Add a regression test that constructs a vacuous proof (`StartRow=5, EndRow=4`, empty `RowRoots`/`Proofs`) and asserts it is rejected.

Closes https://linear.app/celestia/issue/PROTOCO-1673

## Test plan

- [x] `go test -v -run TestRowProof ./pkg/proof/` passes (existing + new case)
- [x] `go test ./pkg/proof/` passes
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)