### PR TITLE
fix(proof): widen ShareProof span accumulator to int64 and bounds-check slices

### DIFF
--- a/pkg/proof/share_proof.go
+++ b/pkg/proof/share_proof.go
@@ -18,26 +18,28 @@ func (sp ShareProof) Validate(root []byte) error {
 		return errors.New("empty share proof")
 	}
 
-	numberOfSharesInProofs := int32(0)
-	for _, proof := range sp.ShareProofs {
-		// the range is not inclusive from the left.
-		numberOfSharesInProofs += proof.End - proof.Start
-	}
-
 	if len(sp.ShareProofs) != len(sp.RowProof.RowRoots) {
 		return fmt.Errorf("the number of share proofs %d must equal the number of row roots %d", len(sp.ShareProofs), len(sp.RowProof.RowRoots))
 	}
-	if len(sp.Data) != int(numberOfSharesInProofs) {
-		return fmt.Errorf("the number of shares %d must equal the number of shares in share proofs %d", len(sp.Data), numberOfSharesInProofs)
-	}
 
+	// Sum into int64 so the running total does not wrap. Also check each
+	// per-proof span before adding so a single malformed entry is caught
+	// before it can poison the sum.
+	var numberOfSharesInProofs int64
 	for _, proof := range sp.ShareProofs {
 		if proof.Start < 0 {
 			return errors.New("proof index cannot be negative")
 		}
-		if (proof.End - proof.Start) <= 0 {
+		if proof.End <= proof.Start {
 			return errors.New("proof total must be positive")
 		}
+		numberOfSharesInProofs += int64(proof.End) - int64(proof.Start)
+		if numberOfSharesInProofs > int64(len(sp.Data)) {
+			return fmt.Errorf("the number of shares in share proofs exceeds the number of shares %d", len(sp.Data))
+		}
+	}
+	if int64(len(sp.Data)) != numberOfSharesInProofs {
+		return fmt.Errorf("the number of shares %d must equal the number of shares in share proofs %d", len(sp.Data), numberOfSharesInProofs)
 	}
 
 	if err := sp.RowProof.Validate(root); err != nil {
@@ -52,25 +54,32 @@ func (sp ShareProof) Validate(root []byte) error {
 }
 
 func (sp ShareProof) VerifyProof() bool {
-	cursor := int32(0)
+	if sp.NamespaceVersion > math.MaxUint8 {
+		return false
+	}
+	cursor := int64(0)
+	dataLen := int64(len(sp.Data))
 	for i, proof := range sp.ShareProofs {
+		if proof.Start < 0 || proof.End <= proof.Start {
+			return false
+		}
+		sharesUsed := int64(proof.End) - int64(proof.Start)
+		if cursor+sharesUsed > dataLen {
+			return false
+		}
 		nmtProof := nmt.NewInclusionProof(
 			int(proof.Start),
 			int(proof.End),
 			proof.Nodes,
 			true,
 		)
-		sharesUsed := proof.End - proof.Start
-		if sp.NamespaceVersion > math.MaxUint8 {
-			return false
-		}
 		// Consider extracting celestia-app's namespace package. We can't use it
 		// here because that would introduce a circular import.
 		namespace := append([]byte{uint8(sp.NamespaceVersion)}, sp.NamespaceId...)
 		valid := nmtProof.VerifyInclusion(
 			appconsts.NewBaseHashFunc(),
 			namespace,
-			sp.Data[cursor:sharesUsed+cursor],
+			sp.Data[cursor:cursor+sharesUsed],
 			sp.RowProof.RowRoots[i],
 		)
 		if !valid {

--- a/pkg/proof/share_proof_test.go
+++ b/pkg/proof/share_proof_test.go
@@ -59,6 +59,38 @@ func TestShareProofValidate(t *testing.T) {
 	}
 }
 
+// TestShareProof_NoInt32WrapPanic ensures a malformed proof whose per-proof
+// `End - Start` spans wrap an int32 accumulator no longer leads to either a
+// "valid" Validate or a slice-bounds panic in VerifyProof.
+//
+// Three spans of 0x40000001 + 0x40000001 + 0x7FFFFFFE = 0x100000000 wrap to
+// int32(0). Combined with empty Data, the previous int32-based length check
+// passed. VerifyProof then sliced sp.Data[0:0x40000001] and panicked.
+func TestShareProof_NoInt32WrapPanic(t *testing.T) {
+	sp := ShareProof{
+		Data: [][]byte{},
+		ShareProofs: []*NMTProof{
+			{Start: 0, End: 0x40000001},
+			{Start: 0, End: 0x40000001},
+			{Start: 0, End: 0x7FFFFFFE},
+		},
+		RowProof: &RowProof{
+			RowRoots: [][]byte{make([]byte, 32), make([]byte, 32), make([]byte, 32)},
+			StartRow: 0,
+			EndRow:   2,
+		},
+	}
+
+	// Validate must fail. The exact error message isn't important — the
+	// invariant is "no nil return, no panic".
+	assert.Error(t, sp.Validate(root))
+
+	// VerifyProof, if called directly, must not panic on the slice bounds.
+	assert.NotPanics(t, func() {
+		_ = sp.VerifyProof()
+	})
+}
+
 func mismatchedShareProofs() ShareProof {
 	sp := validShareProof()
 	sp.ShareProofs = []*NMTProof{}


### PR DESCRIPTION
## Summary

- Widen the per-proof share-count accumulator in `ShareProof.Validate` from `int32` to `int64` so spans summing to ≥ 2³¹ no longer wrap.
- Validate each per-proof span and the running total against `len(sp.Data)` *before* adding so a single malformed entry is caught before it can poison the sum.
- Mirror the bounds check inside `ShareProof.VerifyProof` as defense in depth so the slice expression `sp.Data[cursor:cursor+sharesUsed]` cannot panic on an out-of-range range.
- Add a regression test that constructs three spans whose `int32` sum wraps to 0 and asserts both `Validate` returns an error and `VerifyProof` does not panic.

Closes https://linear.app/celestia/issue/PROTOCO-1674

## Test plan

- [x] `go test -v -run TestShareProof ./pkg/proof/` passes (existing + new case)
- [x] `go test ./pkg/proof/` passes
- [x] `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)