### PR TITLE
fix(multiplexer): close gRPC client on startGRPCServer failure paths

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -292,8 +292,8 @@ func (m *Multiplexer) initRemoteGrpcConn() error {
 }
 
 // startGRPCServer initializes and starts a gRPC server if enabled in the configuration, returning the server and updated context.
-func (m *Multiplexer) startGRPCServer() (*grpc.Server, client.Context, error) {
-	_, _, err := net.SplitHostPort(m.svrCfg.GRPC.Address)
+func (m *Multiplexer) startGRPCServer() (_ *grpc.Server, _ client.Context, err error) {
+	_, _, err = net.SplitHostPort(m.svrCfg.GRPC.Address)
 	if err != nil {
 		return nil, m.clientContext, err
 	}
@@ -321,6 +321,11 @@ func (m *Multiplexer) startGRPCServer() (*grpc.Server, client.Context, error) {
 	if err != nil {
 		return nil, m.clientContext, err
 	}
+	defer func() {
+		if err != nil {
+			_ = grpcClient.Close()
+		}
+	}()
 
 	m.clientContext = m.clientContext.WithGRPCClient(grpcClient)
 	m.logger.Debug("gRPC client assigned to client context", "target", m.svrCfg.GRPC.Address)


### PR DESCRIPTION
noticed this in a startup-failure simulation — repeated retries left grpc resolver goroutines hanging around:
```
      goroutine 1287 [select, 6 minutes]:
      google.golang.org/grpc/internal/grpcsync.(*CallbackSerializer).run(...)
      google.golang.org/grpc/internal/resolver/passthrough.(*passthroughResolver).watcher(...)
```

`startGRPCServer` was creating `grpcClient` before `NewGRPCServer` / `ConfigureRPC` but returning without closing it on those error paths. Applied the standard named-return + `defer Close-on-err` idiom so the client gets released on any failure; the success path still hands the connection off to `m.conn` for `stopGRPCConnection` to manage.