### PR TITLE
perf(rsema1d): parallelize per-row merkle in VerifyRowsWithContext

### DIFF
--- a/pkg/rsema1d/codec_bench_test.go
+++ b/pkg/rsema1d/codec_bench_test.go
@@ -519,34 +519,34 @@ func BenchmarkVerifyRowWithContext(b *testing.B) {
 	}
 }
 
-// BenchmarkVerifyMultipleRowsWithContext benchmarks verifying multiple rows
-// against the same VerificationContext. This demonstrates the benefit of
-// caching coefficients: deriveCoefficients is called once on the first row
-// and reused for all subsequent rows.
-func BenchmarkVerifyMultipleRowsWithContext(b *testing.B) {
-	// Use a fixed small config so this benchmark runs quickly and focuses
-	// on the caching effect rather than data size.
+// BenchmarkVerifyRowsWithContext exercises the batched VerifyRowsWithContext
+// path across the two production v0 shard shapes plus a small case for
+// quick local feedback. The per-row merkle phase fans out across
+// config.WorkerCount goroutines via merkle.ComputeRootsFromProofs.
+func BenchmarkVerifyRowsWithContext(b *testing.B) {
 	type benchCase struct {
-		k       int
-		n       int
+		name    string
+		k, n    int
 		rowSize int
-		rows    int // number of rows to verify per iteration
+		rows    int
 	}
 
 	cases := []benchCase{
-		{k: 64, n: 64, rowSize: 1024, rows: 16},
-		{k: 256, n: 256, rowSize: 1024, rows: 64},
-		{k: 1024, n: 1024, rowSize: 1024, rows: 128},
+		{"k=1024/n=1024/rows=128", 1024, 1024, 1024, 128},
+		// 128 MiB blob, ~100 validators (~163 rows each).
+		{"shard=5MB/k=4096/n=12288/batch=163", 4096, 12288, 32768, 163},
+		// 128 MiB blob, 10 validators (~1638 rows each, realistic worst
+		// case at MaxBlobSize with minimum-validator load).
+		{"shard=51MB/k=4096/n=12288/batch=1638", 4096, 12288, 32768, 1638},
 	}
 
 	for _, tc := range cases {
-		name := fmt.Sprintf("k=%d/n=%d/rows=%d", tc.k, tc.n, tc.rows)
-		b.Run(name, func(b *testing.B) {
+		b.Run(tc.name, func(b *testing.B) {
 			codecConfig := &Config{
 				K:           tc.k,
 				N:           tc.n,
 				RowSize:     tc.rowSize,
-				WorkerCount: 1,
+				WorkerCount: runtime.NumCPU(),
 			}
 
 			originalData := generateTestData(tc.k, tc.rowSize)
@@ -554,8 +554,10 @@ func BenchmarkVerifyMultipleRowsWithContext(b *testing.B) {
 			if err != nil {
 				b.Fatalf("Encode failed: %v", err)
 			}
-
-			// Pre-generate proofs for the rows we'll verify
+			ctx, _, err := CreateVerificationContext(extData.rlcOrig, codecConfig)
+			if err != nil {
+				b.Fatalf("CreateVerificationContext failed: %v", err)
+			}
 			proofs := make([]*RowProof, tc.rows)
 			for i := range tc.rows {
 				proofs[i], err = extData.GenerateRowProof(i)
@@ -566,16 +568,8 @@ func BenchmarkVerifyMultipleRowsWithContext(b *testing.B) {
 
 			b.ResetTimer()
 			for range b.N {
-				// Fresh context each iteration so sync.Once runs once per iteration
-				ctx, _, err := CreateVerificationContext(extData.rlcOrig, codecConfig)
-				if err != nil {
-					b.Fatalf("CreateVerificationContext failed: %v", err)
-				}
-
-				for _, proof := range proofs {
-					if err := VerifyRowWithContext(proof, commitment, ctx); err != nil {
-						b.Fatalf("VerifyRowWithContext failed: %v", err)
-					}
+				if err := VerifyRowsWithContext(proofs, commitment, ctx); err != nil {
+					b.Fatalf("VerifyRowsWithContext failed: %v", err)
 				}
 			}
 		})

--- a/pkg/rsema1d/merkle/proof.go
+++ b/pkg/rsema1d/merkle/proof.go
@@ -2,7 +2,74 @@ package merkle
 
 import (
 	"fmt"
+	"sync"
+	"sync/atomic"
 )
+
+// ProofInput bundles the inputs ComputeRootFromProof needs for a single
+// leaf. Used as the per-proof payload for ComputeRootsFromProofs.
+type ProofInput struct {
+	Leaf  []byte
+	Index int
+	Path  [][]byte
+}
+
+// ComputeRootsFromProofs verifies a batch of merkle proofs in parallel and
+// writes each computed root to dst[i]. dst must have at least len(inputs)
+// capacity.
+//
+// The work fans out across up to workers goroutines via static index-range
+// chunking; below the parallel break-even (len(inputs) <= 64 or workers <=
+// 1) the call stays sequential — goroutine startup would otherwise dwarf
+// per-proof SHA256 work. Returns the first error any worker observed.
+func ComputeRootsFromProofs(inputs []ProofInput, dst [][32]byte, workers int) error {
+	if len(dst) < len(inputs) {
+		return fmt.Errorf("dst has length %d, need at least %d", len(dst), len(inputs))
+	}
+	verify := func(i int) error {
+		root, err := ComputeRootFromProof(inputs[i].Leaf, inputs[i].Index, inputs[i].Path)
+		if err != nil {
+			return fmt.Errorf("input %d (tree index %d): %w", i, inputs[i].Index, err)
+		}
+		dst[i] = root
+		return nil
+	}
+
+	if workers <= 1 || len(inputs) <= 64 {
+		for i := range inputs {
+			if err := verify(i); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if workers > len(inputs) {
+		workers = len(inputs)
+	}
+
+	chunk := (len(inputs) + workers - 1) / workers
+	var firstErr atomic.Value
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for w := range workers {
+		start := w * chunk
+		end := min(start+chunk, len(inputs))
+		go func(start, end int) {
+			defer wg.Done()
+			for i := start; i < end; i++ {
+				if err := verify(i); err != nil {
+					firstErr.CompareAndSwap(nil, err)
+					return
+				}
+			}
+		}(start, end)
+	}
+	wg.Wait()
+	if v := firstErr.Load(); v != nil {
+		return v.(error)
+	}
+	return nil
+}
 
 // GenerateProof generates a Merkle proof for the leaf at the given index
 func (t *Tree) GenerateProof(index int) ([][]byte, error) {

--- a/pkg/rsema1d/proof_batch.go
+++ b/pkg/rsema1d/proof_batch.go
@@ -64,15 +64,20 @@ func VerifyRowsWithContext(proofs []*RowProof, commitment Commitment, context *V
 	}
 
 	// Verify each row's Merkle proof independently so tampering with any
-	// single row fails, even though all rowRoots are identical in a valid shard.
-	rowRoots := make([][32]byte, len(proofs))
+	// single row fails, even though all rowRoots are identical in a valid
+	// shard. Each ComputeRootFromProof is independent — fan out across
+	// context.config.WorkerCount goroutines via merkle.ComputeRootsFromProofs.
+	inputs := make([]merkle.ProofInput, len(proofs))
 	for i, p := range proofs {
-		treeIndex := mapIndexToTreePosition(p.Index, context.config)
-		rowRoot, err := merkle.ComputeRootFromProof(p.Row, treeIndex, p.RowProof)
-		if err != nil {
-			return fmt.Errorf("failed to compute row root for row %d: %w", p.Index, err)
+		inputs[i] = merkle.ProofInput{
+			Leaf:  p.Row,
+			Index: mapIndexToTreePosition(p.Index, context.config),
+			Path:  p.RowProof,
 		}
-		rowRoots[i] = rowRoot
+	}
+	rowRoots := make([][32]byte, len(proofs))
+	if err := merkle.ComputeRootsFromProofs(inputs, rowRoots, context.config.WorkerCount); err != nil {
+		return fmt.Errorf("failed to compute row roots: %w", err)
 	}
 
 	// Choice of rowRoots[0] is arbitrary — all are equal in a valid shard,


### PR DESCRIPTION
Each row's ComputeRootFromProof is independent, so the per-row merkle phase fans out cleanly. Add merkle.ComputeRootsFromProofs that takes a []ProofInput and writes computed roots to a destination slice in parallel chunks, with worker count supplied by the caller. Below the parallel break-even (len(inputs) <= 64 or workers <= 1) it stays sequential — goroutine startup would otherwise dwarf per-proof SHA256 work.

VerifyRowsWithContext now builds a []merkle.ProofInput once and dispatches across config.WorkerCount goroutines instead of looping sequentially.

Existing BenchmarkVerifyMultipleRowsWithContext is renamed to BenchmarkVerifyRowsWithContext and now actually exercises VerifyRowsWithContext (it previously looped the singular per-row variant despite the name) plus extends to the two production v0 shard shapes.

Bench numbers on a 24-thread Ryzen, before vs after:

  k=1024 / n=1024 / rows=128         0.37 ms → 0.17 ms (2.2× faster)
  shard=5MB / k=4096 / batch=163     4.39 ms → 1.20 ms (3.7× faster)
  shard=51MB / k=4096 / batch=1638  35.66 ms → 7.49 ms (4.8× faster)

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
