### PR TITLE
test(app): right-size account count in TestProcessProposalCappingNumberOfMessages

### DIFF
--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -378,7 +378,7 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 	}
 
 	// Create enough accounts so each sends exactly one tx (avoids sequence collisions).
-	numberOfAccounts := 2000
+	numberOfAccounts := (appconsts.MaxSDKMessages + 1) + (appconsts.MaxPFBMessages + 1)
 	accounts := testfactory.GenerateAccounts(numberOfAccounts)
 	consensusParams := app.DefaultConsensusParams()
 	testApp, kr := testutil.SetupTestAppWithGenesisValSetAndMaxSquareSize(consensusParams, 128, accounts...)


### PR DESCRIPTION
## Summary

`TestProcessProposalCappingNumberOfMessages` allocates 2000 funded genesis accounts but only consumes `MaxSDKMessages+1 + MaxPFBMessages+1 = 802`. Under `-race`, genesis init for 1198 unused accounts is wasted work, and on slow GHA runners it pushed the test past Go's default 15m timeout (failures: 4/19, 4/22, 4/25, 4/26 nightlies).

## Investigation

Local timings under `-race` for this test alone:

| accounts | total | sub-tests | setup |
|---|---|---|---|
| 2000 | 84.1s | 4.9s | ~79s |
| 802 | 32.0s | 4.7s | ~27s |

Setup is ~94% of runtime; reducing 2000 → 802 cuts setup ~65%. Sub-tests are unchanged. Extrapolating to CI (last passing nightly: 515s), expected drop is ~515s → ~195s, taking margin under the 15m timeout from ~1.7x to ~4.6x.

## Is this the root cause?

It's *a* root cause, not the only one. The 8.6m → 15m+ variance between healthy and failing runs also has runner-side contributors (GHA host load, GC, race-detector lock contention). This change removes objectively wasteful work and shrinks the variance window, but doesn't address why some GHA runners are slower. If nightlies fail again, the next steps would be raising `-timeout` for `make test-race`, or splitting this test into its own job with a longer cap.

## Test plan

- [x] `go test -race -run TestProcessProposalCappingNumberOfMessages ./app/test/` passes locally (32s vs 84s before)
- [ ] Watch the nightly `test-race` job after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)