### PR TITLE
chore(deps): bump core to v0.39.29

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -445,7 +445,7 @@ replace (
 	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
-	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.28
+	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.29
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.3
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"

--- a/go.sum
+++ b/go.sum
@@ -856,8 +856,8 @@ github.com/catenacyber/perfsprint v0.10.1 h1:u7Riei30bk46XsG8nknMhKLXG9BcXz3+3tl
 github.com/catenacyber/perfsprint v0.10.1/go.mod h1:DJTGsi/Zufpuus6XPGJyKOTMELe347o6akPvWG9Zcsc=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
-github.com/celestiaorg/celestia-core v0.39.28 h1:2IwjvszCL45pa1pppnvlKL3QFCm9Gf8Ss7VAHC5d+e4=
-github.com/celestiaorg/celestia-core v0.39.28/go.mod h1:pWRN2gpl+Yb6ioIAwhEx1G8lwROMnUUxJM8Q4YJDjVM=
+github.com/celestiaorg/celestia-core v0.39.29 h1:nekTYS3KPRXlM7++4aJ/bbhglpv6RhvVKODSt+lMMVM=
+github.com/celestiaorg/celestia-core v0.39.29/go.mod h1:pWRN2gpl+Yb6ioIAwhEx1G8lwROMnUUxJM8Q4YJDjVM=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
 github.com/celestiaorg/cosmos-sdk v0.52.3 h1:YPMFCycTw77P7tn+HQHTmmdBwXWNMDOrZ6/xVPK9nvM=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -296,7 +296,7 @@ replace (
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/celestiaorg/celestia-app/v8 => ../..
-	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.28
+	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.29
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.1
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -770,8 +770,8 @@ github.com/btcsuite/btcd/btcutil v1.1.6/go.mod h1:9dFymx8HpuLqBnsPELrImQeTQfKBQq
 github.com/bufbuild/protocompile v0.14.1 h1:iA73zAf/fyljNjQKwYzUHD6AD4R8KMasmwa/FBatYVw=
 github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU5DoEw9xY/FUi1c=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/celestia-core v0.39.28 h1:2IwjvszCL45pa1pppnvlKL3QFCm9Gf8Ss7VAHC5d+e4=
-github.com/celestiaorg/celestia-core v0.39.28/go.mod h1:pWRN2gpl+Yb6ioIAwhEx1G8lwROMnUUxJM8Q4YJDjVM=
+github.com/celestiaorg/celestia-core v0.39.29 h1:nekTYS3KPRXlM7++4aJ/bbhglpv6RhvVKODSt+lMMVM=
+github.com/celestiaorg/celestia-core v0.39.29/go.mod h1:pWRN2gpl+Yb6ioIAwhEx1G8lwROMnUUxJM8Q4YJDjVM=
 github.com/celestiaorg/cosmos-sdk v0.52.1 h1:sH49jz9Vo/RkJz24fjr0jo7pd9stvxoXQ1G2n3nG3Xc=
 github.com/celestiaorg/cosmos-sdk v0.52.1/go.mod h1:r2LYq9wdoYUiNITEGrIq635ZXf2xhAPmMzimq3uITRI=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=


### PR DESCRIPTION
## Summary

Bumps `celestia-core` from `v0.39.28` to `v0.39.29`.

### Changes in core

- feat: failed tx code to prometheus (celestiaorg/celestia-core#2966)
- refactor: only unmarshal a single page from the tx index (celestiaorg/celestia-core#2962)

## Test plan

- [ ] CI passes
- [ ] `make build` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)