### PR TITLE
fix: bound input size in proof querier handlers

### DIFF
--- a/pkg/proof/querier.go
+++ b/pkg/proof/querier.go
@@ -17,6 +17,13 @@ import (
 
 const TxInclusionQueryPath = "txInclusionProof"
 
+// maxQueryDataSize is the upper bound on the size of req.Data accepted by the
+// inclusion proof query handlers. It mirrors the governance upper bound on the
+// block MaxBytes parameter so any legitimate block payload fits, while
+// preventing callers from triggering an unbounded square.Construct invocation
+// (and the associated heap amplification) via /abci_query.
+const maxQueryDataSize = appconsts.DefaultUpperBoundMaxBytes
+
 // QueryTxInclusionProof defines the logic performed when the ABCI client uses the Query
 // method with the custom query path. The index of the transaction being
 // proved must be appended to the path. The marshalled bytes of the transaction
@@ -25,6 +32,11 @@ const TxInclusionQueryPath = "txInclusionProof"
 // example path for proving the third transaction in that block:
 // custom/txInclusionProof/3
 func QueryTxInclusionProof(_ sdk.Context, path []string, req *abci.RequestQuery) ([]byte, error) {
+	// reject oversized inputs before doing any allocation-heavy work
+	if len(req.Data) > maxQueryDataSize {
+		return nil, fmt.Errorf("request data too large: %d bytes exceeds maximum of %d bytes", len(req.Data), maxQueryDataSize)
+	}
+
 	// parse the index from the path
 	if len(path) != 1 {
 		return nil, fmt.Errorf("expected query path length: 1 actual: %d ", len(path))
@@ -69,6 +81,11 @@ const ShareInclusionQueryPath = "shareInclusionProof"
 // be appended to the path. Example path for proving the set of shares [3, 5]:
 // custom/shareInclusionProof/3/5
 func QueryShareInclusionProof(_ sdk.Context, path []string, req *abci.RequestQuery) ([]byte, error) {
+	// reject oversized inputs before doing any allocation-heavy work
+	if len(req.Data) > maxQueryDataSize {
+		return nil, fmt.Errorf("request data too large: %d bytes exceeds maximum of %d bytes", len(req.Data), maxQueryDataSize)
+	}
+
 	// parse the share range from the path
 	if len(path) != 2 {
 		return nil, fmt.Errorf("expected query path length: 2 actual: %d ", len(path))

--- a/pkg/proof/querier_test.go
+++ b/pkg/proof/querier_test.go
@@ -1,0 +1,46 @@
+package proof_test
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v9/pkg/proof"
+	abci "github.com/cometbft/cometbft/abci/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestQueryShareInclusionProofRejectsOversizedRequest verifies that
+// QueryShareInclusionProof rejects req.Data larger than the maximum legitimate
+// block payload so that callers cannot trigger an unbounded square.Construct
+// invocation via /abci_query.
+func TestQueryShareInclusionProofRejectsOversizedRequest(t *testing.T) {
+	// One byte over the upper bound on max bytes a legitimate block can carry.
+	oversized := make([]byte, appconsts.DefaultUpperBoundMaxBytes+1)
+
+	rawProof, err := proof.QueryShareInclusionProof(
+		sdk.Context{},
+		[]string{"0", "1"},
+		&abci.RequestQuery{Data: oversized},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too large")
+	require.Empty(t, rawProof)
+}
+
+// TestQueryTxInclusionProofRejectsOversizedRequest verifies that
+// QueryTxInclusionProof rejects req.Data larger than the maximum legitimate
+// block payload so that callers cannot trigger an unbounded square.Construct
+// invocation via /abci_query.
+func TestQueryTxInclusionProofRejectsOversizedRequest(t *testing.T) {
+	oversized := make([]byte, appconsts.DefaultUpperBoundMaxBytes+1)
+
+	rawProof, err := proof.QueryTxInclusionProof(
+		sdk.Context{},
+		[]string{"0"},
+		&abci.RequestQuery{Data: oversized},
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "too large")
+	require.Empty(t, rawProof)
+}


### PR DESCRIPTION
## Summary

Adds a size guard on `req.Data` in `QueryShareInclusionProof` and `QueryTxInclusionProof` (`pkg/proof/querier.go`) to prevent unbounded `square.Construct` invocation from large RPC inputs reaching the ABCI custom-query handlers via `/abci_query`. The bound is chosen to fit the maximum legitimate ODS payload: `appconsts.DefaultUpperBoundMaxBytes` (32 MiB), which is the governance upper bound on the block `MaxBytes` parameter, so any legitimate block payload still fits while obviously-oversized inputs are rejected before any heavy allocation.

Closes [PROTOCO-1742](https://linear.app/celestia/issue/PROTOCO-1742).

## Test plan

- [x] `TestQueryShareInclusionProofRejectsOversizedRequest` and `TestQueryTxInclusionProofRejectsOversizedRequest` fail on `main` and pass with the fix
- [x] `go test ./pkg/proof/...` passes
- [x] `make build` succeeds
- [x] `go tool golangci-lint run ./pkg/proof/...` reports no issues