### PR TITLE
chore(ci): mint GitHub App token for goreleaser

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -34,4 +34,5 @@ jobs:
     uses: ./.github/workflows/goreleaser.yml
     permissions: write-all
     secrets:
-      GORELEASER_ACCESS_TOKEN: ${{ secrets.GORELEASER_ACCESS_TOKEN }}
+      RELEASE_APP_ID: ${{ secrets.RELEASE_APP_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -2,7 +2,9 @@ name: goreleaser
 on:
   workflow_call:
     secrets:
-      GORELEASER_ACCESS_TOKEN:
+      RELEASE_APP_ID:
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
         required: true
 
 jobs:
@@ -19,9 +21,15 @@ jobs:
       - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 #v6.0.0
         with:
           go-version-file: 'go.mod'
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Create .release-env file
         run: |-
-          echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' >> .release-env
+          echo 'GITHUB_TOKEN=${{ steps.app-token.outputs.token }}' >> .release-env
       - name: Check the .goreleaser.yaml config file
         run: make goreleaser-check
         env:
@@ -52,9 +60,15 @@ jobs:
           echo "GOMODCACHE=$(mktemp -d)" >> $GITHUB_ENV
           echo "GOCACHE=$(mktemp -d)" >> $GITHUB_ENV
           echo "GOTMPDIR=$(mktemp -d)" >> $GITHUB_ENV
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 #v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - name: Create .release-env file
         run: |-
-          echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' >> .release-env
+          echo 'GITHUB_TOKEN=${{ steps.app-token.outputs.token }}' >> .release-env
       - name: Create prebuilt binaries and attach them to the GitHub release
         run: make prebuilt-binary
         env:


### PR DESCRIPTION
## Summary

- Replaces the long-lived `GORELEASER_ACCESS_TOKEN` classic PAT with a short-lived GitHub App installation token minted at workflow runtime via `actions/create-github-app-token`.
- Prevents releases from being attributed to whichever individual's PAT was previously configured (see #7260).

## ⚠️ Pre-merge actions required

Before merging, an org admin must:

1. Create a GitHub App in the `celestiaorg` org (e.g. `celestia-release-bot`) with **`Contents: write`** repo permission.
2. Install the App on `celestia-app` only.
3. Add the App's ID and private key as repo (or org) secrets named **`RELEASE_APP_ID`** and **`RELEASE_APP_PRIVATE_KEY`**.
4. After this PR merges and the next release succeeds, delete the now-unused `GORELEASER_ACCESS_TOKEN` secret.

If the secrets are not set when a release fires, the goreleaser job will fail at the "Mint GitHub App installation token" step and no binaries will be attached.

## Test plan

The goreleaser jobs are gated by `if: github.event_name == 'release'`, so this PR's CI run won't exercise them. Verification has to happen on the next real release:

- [ ] On the next release, confirm the goreleaser job succeeds and binaries are attached
- [ ] Confirm the release on GitHub is attributed to the App (e.g. `celestia-release-bot[bot]`), not to a contributor
- [ ] Delete the old `GORELEASER_ACCESS_TOKEN` secret

Closes #7260

🤖 Generated with [Claude Code](https://claude.com/claude-code)