### PR TITLE
chore: set up sync kpi metrics

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -96,6 +96,10 @@ jobs:
         env:
           CELESTIA_IMAGE: ghcr.io/celestiaorg/celestia-app
           CELESTIA_TAG: ${{ needs.build-e2e-image.outputs.tag }}
+          CELESTIA_APP_VERSION: ${{ needs.build-e2e-image.outputs.tag }}
+          PUSHGATEWAY_URL: ${{ secrets.PUSHGATEWAY_URL }}
+          PUSHGATEWAY_USERNAME: ${{ secrets.PUSHGATEWAY_USERNAME }}
+          PUSHGATEWAY_PASSWORD: ${{ secrets.PUSHGATEWAY_PASSWORD }}
 
   test-race:
     runs-on: ubuntu-latest

--- a/test/docker-e2e/e2e_sync_to_tip_test.go
+++ b/test/docker-e2e/e2e_sync_to_tip_test.go
@@ -3,12 +3,15 @@ package docker_e2e
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/celestiaorg/tastora/framework/docker/cosmos"
 	tastoratypes "github.com/celestiaorg/tastora/framework/types"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/push"
 
 	"celestiaorg/celestia-app/test/docker-e2e/networks"
 )
@@ -28,6 +31,9 @@ func (s *CelestiaTestSuite) TestSyncToTipMocha() {
 	}
 
 	ctx := context.TODO()
+
+	metrics := newSyncMetrics("mocha")
+	defer metrics.push(t)
 
 	mochaConfig := networks.NewMochaConfig()
 	mochaClient, err := networks.NewClient(mochaConfig.RPCs[0])
@@ -100,6 +106,7 @@ func (s *CelestiaTestSuite) TestSyncToTipMocha() {
 	s.Require().NoError(err, "state sync did not reach trust height within timeout")
 
 	stateSyncDuration := time.Since(startTime)
+	metrics.recordPhase("state_sync", stateSyncDuration)
 	t.Logf("Phase 1 complete: state sync took %s", stateSyncDuration)
 
 	// Verify that state sync was used.
@@ -120,6 +127,8 @@ func (s *CelestiaTestSuite) TestSyncToTipMocha() {
 
 	blockSyncDuration := time.Since(blockSyncStart)
 	totalDuration := time.Since(startTime)
+	metrics.recordPhase("block_sync", blockSyncDuration)
+	metrics.recordPhase("total", totalDuration)
 
 	t.Logf("Block sync complete: took %s", blockSyncDuration)
 	t.Logf("Total sync duration: %s (state sync: %s, block sync: %s)", totalDuration, stateSyncDuration, blockSyncDuration)
@@ -127,4 +136,79 @@ func (s *CelestiaTestSuite) TestSyncToTipMocha() {
 	s.Require().Less(totalDuration, syncToTipTimeout,
 		"total sync duration %s exceeded KPI target of %s (state sync: %s, block sync: %s)",
 		totalDuration, syncToTipTimeout, stateSyncDuration, blockSyncDuration)
+
+	metrics.markSuccess()
+}
+
+const pushJobName = "celestia_e2e_sync_to_tip"
+
+type syncMetrics struct {
+	network string
+	phases  map[string]time.Duration
+	success bool
+}
+
+func newSyncMetrics(network string) *syncMetrics {
+	return &syncMetrics{network: network, phases: make(map[string]time.Duration)}
+}
+
+func (m *syncMetrics) recordPhase(phase string, d time.Duration) {
+	m.phases[phase] = d
+}
+
+func (m *syncMetrics) markSuccess() {
+	m.success = true
+}
+
+// push sends the recorded sync durations and success flag to the Prometheus
+// Pushgateway specified by PUSHGATEWAY_URL. If the env var is unset the push is
+// skipped so local runs and PR CI don't try to reach an external service. Push
+// failures are logged but do not fail the test — the test result reflects the
+// sync KPI, not observability health.
+func (m *syncMetrics) push(t *testing.T) {
+	t.Helper()
+	url := os.Getenv("PUSHGATEWAY_URL")
+	if url == "" {
+		t.Log("PUSHGATEWAY_URL not set; skipping metrics push")
+		return
+	}
+
+	labels := []string{"commit_sha", "github_run_id", "celestia_app_version"}
+	durationGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "celestia_e2e_sync_duration_seconds",
+		Help: "Time taken for each phase of the sync-to-tip e2e test.",
+	}, append([]string{"phase"}, labels...))
+	successGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "celestia_e2e_sync_success",
+		Help: "Whether the most recent sync-to-tip e2e run met its KPI (1 = success, 0 = failure).",
+	}, labels)
+
+	commitSHA := os.Getenv("GITHUB_SHA")
+	if len(commitSHA) > 8 {
+		commitSHA = commitSHA[:8]
+	}
+	labelVals := []string{commitSHA, os.Getenv("GITHUB_RUN_ID"), os.Getenv("CELESTIA_APP_VERSION")}
+
+	for phase, d := range m.phases {
+		durationGauge.WithLabelValues(append([]string{phase}, labelVals...)...).Set(d.Seconds())
+	}
+	var successVal float64
+	if m.success {
+		successVal = 1
+	}
+	successGauge.WithLabelValues(labelVals...).Set(successVal)
+
+	pusher := push.New(url, pushJobName).
+		Grouping("network", m.network).
+		Collector(durationGauge).
+		Collector(successGauge)
+	if user := os.Getenv("PUSHGATEWAY_USERNAME"); user != "" {
+		pusher = pusher.BasicAuth(user, os.Getenv("PUSHGATEWAY_PASSWORD"))
+	}
+
+	if err := pusher.Push(); err != nil {
+		t.Logf("failed to push metrics to Pushgateway: %v", err)
+		return
+	}
+	t.Logf("pushed sync metrics to Pushgateway at %s (success=%v)", url, m.success)
 }

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/cosmos/ibc-go/v8 v8.7.0
 	github.com/ethereum/go-ethereum v1.17.2
 	github.com/moby/moby/client v0.4.1
+	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.20.0
@@ -217,7 +218,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect


### PR DESCRIPTION
## Overview

First part of https://linear.app/celestia/issue/PROTOCO-1023/create-live-dashboard-for-the-sync-kpi-on-mocha

Tested it locally
```
➜  celestia-app git:(main) ✗   curl -s http://localhost:9091/metrics | grep celestia_e2e
# HELP celestia_e2e_sync_success Whether the most recent sync-to-tip e2e run met its KPI (1 = success, 0 = failure).
# TYPE celestia_e2e_sync_success gauge
celestia_e2e_sync_success{celestia_app_version="local-test",commit_sha="deadbeef",github_run_id="42",instance="",job="celestia_e2e_sync_to_tip",network="mocha"} 0
push_failure_time_seconds{instance="",job="celestia_e2e_sync_to_tip",network="mocha"} 0
push_time_seconds{instance="",job="celestia_e2e_sync_to_tip",network="mocha"} 1.7788540870024621e+09
```