### PR TITLE
feat(rsema1d): `Reconstructor`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/hashicorp/go-metrics v0.5.4
 	github.com/joho/godotenv v1.5.1
-	github.com/klauspost/reedsolomon v1.14.0
+	github.com/klauspost/reedsolomon v1.14.1-0.20260518132338-1166fa573ff0
 	github.com/pelletier/go-toml/v2 v2.3.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/rs/zerolog v1.35.1

--- a/go.sum
+++ b/go.sum
@@ -847,8 +847,8 @@ github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXD
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/klauspost/reedsolomon v1.14.0 h1:5YSZeclzSYg5nl349+GDG/agDtQ6MZiwUYXvVKN1Jx0=
-github.com/klauspost/reedsolomon v1.14.0/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
+github.com/klauspost/reedsolomon v1.14.1-0.20260518132338-1166fa573ff0 h1:95EZGl+eRFug+REA3ido0G9WsJ3Gbt8/rwb2WIpqya8=
+github.com/klauspost/reedsolomon v1.14.1-0.20260518132338-1166fa573ff0/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=

--- a/pkg/rsema1d/reconstructor.go
+++ b/pkg/rsema1d/reconstructor.go
@@ -1,0 +1,153 @@
+package rsema1d
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/field"
+)
+
+// ErrNotEnoughRows is returned when reconstruction is attempted before K
+// unique rows have been added to a Reconstructor.
+var ErrNotEnoughRows = errors.New("not enough rows to reconstruct")
+
+// Reconstructor is the download-path counterpart to [Coder.Reconstruct]: it
+// collects RLC-verified row proofs from many sources and recovers the K
+// original rows once enough unique indices have arrived. Because every
+// contributing row is RLC-verified against the target commitment as it lands,
+// [Reconstructor.Reconstruct] runs only Reed-Solomon data-shard recovery and
+// skips the merkle/commitment rebuild that [Coder.Reconstruct] performs.
+//
+// Reconstructor does not own row storage. The caller supplies a row buffer to
+// [Reconstructor.Reconstruct]; dedup happens internally via a per-index seen
+// bitset.
+//
+// Concurrency:
+//
+//   - [Reconstructor.Add] is safe to call from many goroutines. The first
+//     successful Add installs the cached RLC under verifierMu; subsequent Adds
+//     take the lock-free fast path through VerifyShared. Dedup and the
+//     have-count update run under seenMu.
+//   - Concurrent Add calls return disjoint Index sets, so callers may store
+//     the returned novel proofs into their row buffer without further
+//     synchronization.
+//   - [Reconstructor.Reconstruct] must not race with Add. Drain in-flight Adds
+//     before calling it.
+type Reconstructor struct {
+	coder *Coder
+
+	commitment Commitment
+
+	verifierMu  sync.Mutex
+	verifierRLC atomic.Bool
+	verifier    *Verifier
+
+	seenMu sync.Mutex
+	seen   []bool
+	have   int
+}
+
+// NewReconstructor builds a Reconstructor bound to this Coder's config and the
+// target commitment.
+func (c *Coder) NewReconstructor(commitment Commitment) (*Reconstructor, error) {
+	verifier, err := NewVerifier(c.config)
+	if err != nil {
+		return nil, err
+	}
+	return &Reconstructor{
+		coder:      c,
+		commitment: commitment,
+		verifier:   verifier,
+		seen:       make([]bool, c.config.K+c.config.N),
+	}, nil
+}
+
+// Add verifies a batch of row proofs against the commitment using the given
+// RLC, marks newly-unique indices as seen, and returns the novel proofs (those
+// whose Index had not been seen before).
+//
+// Dedup compacts in place: the returned slice shares the input's backing
+// array — Add overwrites proofs[0:n] with the novel ones, where n is the
+// returned length. Any caller-held reference to the original slice is
+// invalidated; iterate the returned slice exclusively.
+//
+// Safe to call concurrently. Concurrent Add calls return disjoint Index sets,
+// so callers can store novel proofs into their own buffer without locking.
+func (r *Reconstructor) Add(proofs []*RowProof, rlc []field.GF128) ([]*RowProof, error) {
+	if err := r.verify(rlc, proofs); err != nil {
+		return nil, err
+	}
+	return r.addVerified(proofs), nil
+}
+
+func (r *Reconstructor) addVerified(proofs []*RowProof) []*RowProof {
+	r.seenMu.Lock()
+	defer r.seenMu.Unlock()
+	n := 0
+	for _, p := range proofs {
+		if r.seen[p.Index] {
+			continue
+		}
+		r.seen[p.Index] = true
+		proofs[n] = p
+		n++
+		r.have++
+	}
+	return proofs[:n]
+}
+
+// Have returns the number of unique rows seen so far.
+func (r *Reconstructor) Have() int {
+	r.seenMu.Lock()
+	defer r.seenMu.Unlock()
+	return r.have
+}
+
+// Want returns the number of additional unique rows needed before
+// [Reconstructor.Reconstruct] can run. Returns 0 when ready.
+func (r *Reconstructor) Want() int {
+	r.seenMu.Lock()
+	defer r.seenMu.Unlock()
+	if r.have >= r.coder.config.K {
+		return 0
+	}
+	return r.coder.config.K - r.have
+}
+
+// Reconstruct fills any missing original rows in place via Reed-Solomon
+// data-shard recovery. rows must have length K+N, with previously-Added rows
+// placed at their reported indices and missing entries set to nil. Caller
+// must ensure no Add is in flight.
+func (r *Reconstructor) Reconstruct(rows [][]byte) error {
+	if want := r.Want(); want > 0 {
+		return fmt.Errorf("%w: need %d more rows", ErrNotEnoughRows, want)
+	}
+	if err := r.coder.enc.ReconstructData(rows); err != nil {
+		return fmt.Errorf("reconstructing original rows: %w", err)
+	}
+	return nil
+}
+
+// verify checks proofs against r.commitment. Fast path: one atomic load and a
+// concurrent-safe VerifyShared against the cached RLC. Slow path: serialize on
+// verifierMu and install this caller's RLC, but only mark it cached if Verify
+// validates it against the commitment.
+func (r *Reconstructor) verify(rlc []field.GF128, proofs []*RowProof) error {
+	if r.verifierRLC.Load() {
+		return r.verifier.VerifyShared(r.commitment, proofs)
+	}
+
+	r.verifierMu.Lock()
+	defer r.verifierMu.Unlock()
+	if r.verifierRLC.Load() {
+		// another caller installed a validated RLC while we waited for the lock
+		return r.verifier.VerifyShared(r.commitment, proofs)
+	}
+	if _, err := r.verifier.Verify(r.commitment, proofs, rlc); err != nil {
+		return err
+	}
+	r.verifierRLC.Store(true)
+	return nil
+}

--- a/pkg/rsema1d/reconstructor_bench_test.go
+++ b/pkg/rsema1d/reconstructor_bench_test.go
@@ -1,0 +1,145 @@
+package rsema1d
+
+import (
+	"math/rand/v2"
+	"testing"
+)
+
+// BenchmarkReconstructorFibreMaxReconstruct models the download flow at the
+// fibre v0 shape (K=4096, N=12288, rowSize=32KiB): proofs arrive in shard-sized
+// batches, so Add fires many times against the same commitment. The first Add
+// primes Verify; the rest go through VerifyShared and reuse the cached
+// coefficients. Each iteration ends with a full RS reconstruct.
+func BenchmarkReconstructorFibreMaxReconstruct(b *testing.B) {
+	const (
+		k       = 4096
+		n       = 12288
+		rowSize = 32768
+		// chunkSize=163 mirrors the 5MB shard batch from BenchmarkVerifier
+		// (128 MiB blob across ~100 validators), so the first Add primes
+		// Verify and the remaining ~24 chunks go through VerifyShared.
+		chunkSize = 163
+	)
+
+	cfg := &Config{K: k, N: n, RowSize: rowSize, WorkerCount: 1}
+	source := make([][]byte, k)
+	for i := range source {
+		source[i] = make([]byte, rowSize)
+		for j := range source[i] {
+			source[i][j] = byte(i + j)
+		}
+	}
+
+	extData, commitment, _, err := Encode(source, cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	coder, err := NewCoder(&Config{K: k, N: n, WorkerCount: 1})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	patterns := []struct {
+		name    string
+		present []bool
+	}{
+		{
+			name:    "first_quarter_originals_rest_parity",
+			present: fibreMaxPresentQuarterOriginals(k, n),
+		},
+		{
+			name:    "random_k_rows",
+			present: fibreMaxPresentRandom(k, n),
+		},
+	}
+
+	for _, pattern := range patterns {
+		b.Run(pattern.name, func(b *testing.B) {
+			b.SetBytes(k * rowSize)
+
+			rows := make([][]byte, k+n)
+			originalScratch := make([][]byte, k)
+			for i := range originalScratch {
+				originalScratch[i] = make([]byte, 0, rowSize)
+			}
+			resetRows := func() {
+				for i := range rows {
+					switch {
+					case pattern.present[i]:
+						rows[i] = extData.rows[i]
+					case i < k:
+						rows[i] = originalScratch[i][:0]
+					default:
+						rows[i] = nil
+					}
+				}
+			}
+
+			proofs := make([]*RowProof, 0, k)
+			for i, ok := range pattern.present {
+				if !ok {
+					continue
+				}
+				proof, err := extData.GenerateRowProof(i)
+				if err != nil {
+					b.Fatal(err)
+				}
+				proofs = append(proofs, proof)
+			}
+			if len(proofs) != k {
+				b.Fatalf("expected %d proofs, got %d", k, len(proofs))
+			}
+			rlc := extData.RLC()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for b.Loop() {
+				b.StopTimer()
+				rec, err := coder.NewReconstructor(commitment)
+				if err != nil {
+					b.Fatal(err)
+				}
+				resetRows()
+				b.StartTimer()
+				for i := 0; i < len(proofs); i += chunkSize {
+					end := min(i+chunkSize, len(proofs))
+					if _, err := rec.Add(proofs[i:end], rlc); err != nil {
+						b.Fatal(err)
+					}
+				}
+				if err := rec.Reconstruct(rows); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func fibreMaxPresentQuarterOriginals(k, n int) []bool {
+	present := make([]bool, k+n)
+	presentData := k / 4
+	for i := range presentData {
+		present[i] = true
+	}
+	for i := k; i < k+(k-presentData); i++ {
+		present[i] = true
+	}
+	return present
+}
+
+func fibreMaxPresentRandom(k, n int) []bool {
+	present := make([]bool, k+n)
+	indices := make([]int, k+n)
+	for i := range indices {
+		indices[i] = i
+	}
+	rng := rand.New(rand.NewPCG(1, 2))
+	rng.Shuffle(len(indices), func(i, j int) {
+		indices[i], indices[j] = indices[j], indices[i]
+	})
+	for _, idx := range indices[:k] {
+		present[idx] = true
+	}
+	return present
+}

--- a/pkg/rsema1d/reconstructor_test.go
+++ b/pkg/rsema1d/reconstructor_test.go
@@ -1,0 +1,69 @@
+package rsema1d
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestReconstructorReconstructRequiresEnoughRows(t *testing.T) {
+	const (
+		k       = 8
+		n       = 8
+		rowSize = 256
+	)
+
+	cfg := &Config{K: k, N: n, RowSize: rowSize, WorkerCount: 1}
+	source := make([][]byte, k)
+	for i := range source {
+		source[i] = make([]byte, rowSize)
+		for j := range source[i] {
+			source[i][j] = byte(i + j)
+		}
+	}
+
+	extData, commitment, _, err := Encode(source, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	coder, err := NewCoder(&Config{K: k, N: n, WorkerCount: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec, err := coder.NewReconstructor(commitment)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proofs := make([]*RowProof, k)
+	for i := range proofs {
+		proofs[i], err = extData.GenerateRowProof(i)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	rows := make([][]byte, k+n)
+	for i := range k - 1 {
+		rows[i] = extData.rows[i]
+	}
+	if _, err := rec.Add(proofs[:k-1], extData.RLC()); err != nil {
+		t.Fatal(err)
+	}
+
+	err = rec.Reconstruct(rows)
+	if !errors.Is(err, ErrNotEnoughRows) {
+		t.Fatalf("expected ErrNotEnoughRows, got %v", err)
+	}
+	if want := rec.Want(); want != 1 {
+		t.Fatalf("expected Want 1, got %d", want)
+	}
+
+	rows[k-1] = extData.rows[k-1]
+	if _, err := rec.Add(proofs[k-1:k], extData.RLC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := rec.Reconstruct(rows); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -192,7 +192,7 @@ require (
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/klauspost/compress v1.18.6 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
-	github.com/klauspost/reedsolomon v1.14.0 // indirect
+	github.com/klauspost/reedsolomon v1.14.1-0.20260518132338-1166fa573ff0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lib/pq v1.12.3 // indirect

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -639,8 +639,8 @@ github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXD
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
-github.com/klauspost/reedsolomon v1.14.0 h1:5YSZeclzSYg5nl349+GDG/agDtQ6MZiwUYXvVKN1Jx0=
-github.com/klauspost/reedsolomon v1.14.0/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
+github.com/klauspost/reedsolomon v1.14.1-0.20260518132338-1166fa573ff0 h1:95EZGl+eRFug+REA3ido0G9WsJ3Gbt8/rwb2WIpqya8=
+github.com/klauspost/reedsolomon v1.14.1-0.20260518132338-1166fa573ff0/go.mod h1:yjqqjgMTQkBUHSG97/rm4zipffCNbCiZcB3kTqr++sQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
The new `Reconstructor` encapsulates the logic for original data reconstruction with RLC verification using the new Verifier (#7214). It uses a specialized `ReconstructData`a call on the reedsolomon encoder, as opposed to Reconstruct, which avoids recomputing everything but the original data.. This is possible because we don't recommit `ExtendedData`. The RLC verification with merkle proofs is sufficient, and we don't need to recompute the entire commitment from the encoding path.

One insight here is that reads are always slower than the encoding (~3x slower), due to how reedsolomon reconstruction works. The `Reconstruct/Data` takes substantially more resources than the regular `Encode`, so original data -> parity is ~3x faster than parity -> original.

So this led me to look into the `ReconstructData` and find low-hanging yet tangible optimizations which this PR bumps to as well:
  - leopard: sparse FFT for data-only recovery (https://github.com/klauspost/reedsolomon/pull/340)
  - leopard: bound decoder IFFT input for reconstruction (https://github.com/klauspost/reedsolomon/pull/341)

Also, note that the `Reconstructor` does not support the happy/fallback path separation we have and strictly works with RLC. The future PR integrating the `Reconstructor` will propose removing the happy path as unworthy. Benchmarking showed that Reconstruct + commit has ~2x less throughput than verify RLC once + `ReconstructData.` On top of that, both code paths together made the code very complex, even after I spent efforts into simplifying it, and dropping it was a blessing. However, there is a tradeoff with a slightly higher bandwidth usage in ~2MiB since a single path now requests the RLC from everyone. This is noticeable compared with smaller blobs; however, if we recall that small blobs are economically inefficient, where the encoding itself and fee pricing incentivize bigger blobs, then the tradeoff becomes reasonable.

### Some numbers

`ReconstructData`   821ms   163.40 MB/s     <-- we use this now
`Reconstruct`        1.12s   119.85 MB/s

This is essentially the ceiling on the machine I tested for downloads/reads. Unfortunately, we can't improve this further without changing the protocol. For comparison, on the same machine, I can get ~330 MiB/s for encoding, including all the hashing and committing. 