### PR TITLE
fix(talis): strip DNS suffix when parsing hostname for per-validator dir

### DIFF
--- a/tools/talis/scripts/validator_init.sh
+++ b/tools/talis/scripts/validator_init.sh
@@ -124,8 +124,13 @@ cd $HOME
 # Get the hostname
 hostname=$(hostname)
 
-# Parse the first part of the hostname
-parsed_hostname=$(echo $hostname | awk -F'-' '{print $1 "-" $2}')
+# Parse the first part of the hostname. Strip any DNS suffix first so that
+# GCP hostnames like `validator-85.us-east1-c.<project>.internal` don't end
+# up parsed as `validator-85.us` — which then makes every per-validator
+# `mv`/`cp` below fail, leaving the node with the default priv_validator_key
+# from `celestia-appd init` (not in any gentx), so CometBFT logs "node is
+# not a validator" and the network never reaches quorum.
+parsed_hostname=$(echo $hostname | cut -d. -f1 | awk -F'-' '{print $1 "-" $2}')
 
 cp payload/build/celestia-appd /bin/celestia-appd
 cp payload/build/txsim /bin/txsim


### PR DESCRIPTION
## Summary

- `scripts/validator_init.sh` parses the node hostname by splitting on `-`, but GCP hostnames contain `-` inside the region tag (e.g. `validator-47.asia-east1-c.c.<project>.internal`). The parse produces `validator-47.asia` instead of `validator-47`, so every per-validator `mv`/`cp` fails silently and the node ends up running with the default `priv_validator_key.json` written by `celestia-appd init`. That key is not in any gentx, so CometBFT logs `node is not a validator` on every box and the cluster never reaches quorum.
- Fix: strip the DNS suffix with `cut -d. -f1` before the `awk` split. Added a comment above the line so the next person doesn't innocently "simplify" the pipeline.

## Test plan

- [ ] `talis up` against a multi-region GCP cluster (regions whose tags contain `-`, e.g. `us-east1`, `asia-east1`, `europe-west1`).
- [ ] `talis genesis` + `talis deploy`.
- [ ] On a validator box, `/root/logs` no longer contains `mv: cannot stat 'payload/validator-N.<region-prefix>/...'`.
- [ ] `$HOME/.celestia-app/config/priv_validator_key.json` matches the corresponding `payload/validator-N/priv_validator_key.json` (same `address`/`pub_key`).
- [ ] Validators stop logging `node is not a validator` and blocks start producing.

Closes #7288
PROTOCO-1792