### PR TITLE
feat(fibre): validator-endorsed gRPC TLS

### DIFF
--- a/fibre/client.go
+++ b/fibre/client.go
@@ -69,7 +69,7 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 	}
 
 	if cfg.NewClientFn == nil {
-		cfg.NewClientFn = fibregrpc.DefaultNewClientFn(stateClient, cfg.MaxMessageSize, cfg.Log)
+		cfg.NewClientFn = fibregrpc.DefaultNewClientFn(stateClient, stateClient.ChainID, cfg.MaxMessageSize, cfg.Log)
 	}
 
 	metrics, err := newClientMetrics(cfg.Meter)

--- a/fibre/client.go
+++ b/fibre/client.go
@@ -69,7 +69,7 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 	}
 
 	if cfg.NewClientFn == nil {
-		cfg.NewClientFn = fibregrpc.DefaultNewClientFn(stateClient, stateClient.ChainID, cfg.MaxMessageSize)
+		cfg.NewClientFn = fibregrpc.DefaultNewClientFn(stateClient, cfg.MaxMessageSize, cfg.Log)
 	}
 
 	metrics, err := newClientMetrics(cfg.Meter)

--- a/fibre/client.go
+++ b/fibre/client.go
@@ -69,7 +69,7 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 	}
 
 	if cfg.NewClientFn == nil {
-		cfg.NewClientFn = fibregrpc.DefaultNewClientFn(stateClient, cfg.MaxMessageSize)
+		cfg.NewClientFn = fibregrpc.DefaultNewClientFn(stateClient, stateClient.ChainID, cfg.MaxMessageSize)
 	}
 
 	metrics, err := newClientMetrics(cfg.Meter)

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -15,6 +15,7 @@ import (
 	grpcfibre "github.com/celestiaorg/celestia-app/v9/fibre/internal/grpc"
 	"github.com/celestiaorg/celestia-app/v9/fibre/state"
 	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
+	fibretypes "github.com/celestiaorg/celestia-app/v9/x/fibre/types"
 	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
@@ -295,7 +296,11 @@ func makeTestEnv(
 		if modifyClientConfig != nil {
 			modifyClientConfig(&clientCfg)
 		}
-		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(&testHostRegistry{addresses: addresses}, clientCfg.MaxMessageSize)
+		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
+			&testHostRegistry{addresses: addresses},
+			func() string { return "celestia" },
+			clientCfg.MaxMessageSize,
+		)
 		clientCfg.StateClientFn = func() (state.Client, error) {
 			return &mockStateClient{SetGetter: valSetGetter, chainID: "celestia"}, nil
 		}
@@ -422,4 +427,47 @@ func (g *shufflingValidatorSetGetter) setForHeight(height uint64) validator.Set 
 		ValidatorSet: core.NewValidatorSet(shuffled),
 		Height:       height,
 	}
+}
+
+// TestTLSIdentityMismatchIsRejected checks that the TLS verifier refuses to
+// accept a connection when the expected validator pubkey doesn't match the
+// one bound into the server's cert. We dial the real fibre server with a
+// fabricated *core.Validator whose Address points at the real validator but
+// whose PubKey belongs to a different identity.
+func TestTLSIdentityMismatchIsRejected(t *testing.T) {
+	validators, privKeys := makeTestValidators(t, 1)
+	valSetGetter := newShufflingValidatorSetGetter(validators, 1)
+	servers, _, addresses := makeTestServers(
+		t, validators, privKeys, fibre.DefaultProtocolParams, valSetGetter, nil,
+	)
+	t.Cleanup(func() {
+		for _, srv := range servers {
+			_ = srv.Stop(context.Background())
+		}
+	})
+
+	// Forge a validator that pretends to live at the real validator's address
+	// but carries a different consensus pubkey.
+	imposter := &core.Validator{
+		Address: validators[0].Address,
+		PubKey:  cmted25519.GenPrivKey().PubKey(),
+	}
+
+	newClient := grpcfibre.DefaultNewClientFn(
+		&testHostRegistry{addresses: addresses},
+		func() string { return "celestia" },
+		fibre.DefaultProtocolParams.MaxMessageSize(),
+	)
+
+	// Patch the host registry so the imposter resolves to the real server.
+	addresses[imposter.Address.String()] = servers[0].ListenAddress()
+
+	client, err := newClient(t.Context(), imposter)
+	require.NoError(t, err)
+	defer client.Close()
+
+	// gRPC dials lazily; the TLS handshake fires on the first RPC.
+	_, err = client.DownloadShard(t.Context(), &fibretypes.DownloadShardRequest{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "peer identity mismatch")
 }

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -298,8 +298,8 @@ func makeTestEnv(
 		}
 		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
 			&testHostRegistry{addresses: addresses},
-			func() string { return "celestia" },
 			clientCfg.MaxMessageSize,
+			nil,
 		)
 		clientCfg.StateClientFn = func() (state.Client, error) {
 			return &mockStateClient{SetGetter: valSetGetter, chainID: "celestia"}, nil
@@ -455,8 +455,8 @@ func TestTLSIdentityMismatchIsRejected(t *testing.T) {
 
 	newClient := grpcfibre.DefaultNewClientFn(
 		&testHostRegistry{addresses: addresses},
-		func() string { return "celestia" },
 		fibre.DefaultProtocolParams.MaxMessageSize(),
+		nil,
 	)
 
 	// Patch the host registry so the imposter resolves to the real server.
@@ -466,8 +466,10 @@ func TestTLSIdentityMismatchIsRejected(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
-	// gRPC dials lazily; the TLS handshake fires on the first RPC.
+	// gRPC dials lazily; the TLS handshake fires on the first RPC. The imposter
+	// supplies a different expected pubkey than the one that signed the real
+	// server's endorsement, so the endorsement signature fails to verify.
 	_, err = client.DownloadShard(t.Context(), &fibretypes.DownloadShardRequest{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "peer identity mismatch")
+	require.Contains(t, err.Error(), "peer cert signature is invalid")
 }

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -298,6 +298,7 @@ func makeTestEnv(
 		}
 		clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
 			&testHostRegistry{addresses: addresses},
+			func() string { return "celestia" },
 			clientCfg.MaxMessageSize,
 			nil,
 		)
@@ -455,6 +456,7 @@ func TestTLSIdentityMismatchIsRejected(t *testing.T) {
 
 	newClient := grpcfibre.DefaultNewClientFn(
 		&testHostRegistry{addresses: addresses},
+		func() string { return "celestia" },
 		fibre.DefaultProtocolParams.MaxMessageSize(),
 		nil,
 	)

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -70,6 +70,71 @@ To verify or override, check `config.toml`:
 priv_validator_grpc_laddr = "127.0.0.1:26659"
 ```
 
+## Transport security (TLS)
+
+The Fibre server↔client gRPC link is **TLS-only** (TLS 1.3, always on, no
+plaintext fallback). The server presents a self-signed certificate whose
+ephemeral TLS key is endorsed by the validator's **consensus key** (signed via
+`SignRawBytes` and embedded in a custom X.509 extension). The client verifies
+that the peer's certificate is endorsed by the exact validator it intended to
+dial, using the consensus pubkey from the current validator set.
+
+Properties and assumptions:
+
+- **Identity is the consensus key, not the network address.** Verification does
+  not inspect SNI/SAN/IP, so a validator may register either an **IP literal or
+  a DNS name** as its Fibre host — both work.
+- **Server-authenticated only.** There is no client certificate / mTLS.
+  `DownloadShard` is intentionally **public** (any reachable peer may read
+  shards); uploads remain gated by the payment-promise check. If reads must ever
+  be restricted, that requires adding client/app-layer authorization.
+- **The certificate is long-lived and re-minted on restart; there is no
+  in-process refresh or key rotation.** A Celestia validator's consensus key
+  does not rotate, and the TLS key is ephemeral (process memory only), so a
+  restart is the only re-issuance path needed.
+- **Loopback-only links.** The privval signer gRPC (`--signer-grpc-address`) and
+  the app-node gRPC (`--app-grpc-address`) are **not** TLS-protected and assume a
+  loopback/host-local endpoint. Do **not** point them at a remote host over an
+  untrusted network.
+
+### Rollout
+
+Because TLS is always on with no negotiation, a node on this build **cannot**
+speak Fibre gRPC with a plaintext (pre-TLS) peer. Roll out to all Fibre peers
+together (coordinated / greenfield cutover); a mixed-version Fibre mesh will
+partition. Plaintext tooling (`tools/fibre-txsim`, `tools/rust-fibre-txsim` /
+lumina) must be updated to the endorsed-TLS verifier before it can talk to a
+TLS-only server.
+
+### Design notes
+
+Why the scheme looks the way it does:
+
+- **Endorsement, not the consensus key as the TLS key.** TLS authentication
+  needs the private key to sign every handshake. The validator consensus key is
+  held in a separate signer (tmkms/HSM) and must not be in the TLS hot path — and
+  signers only expose `SignRawBytes`, not raw TLS signing. So the server uses a
+  disposable ephemeral TLS key and the consensus key signs it **once** (via
+  `SignRawBytes`) to authorize it. The consensus key is touched only at cert mint.
+- **Host-agnostic by design.** Verification pins the validator consensus key, not
+  the network location (no SNI/SAN/IP/DNS check). This is why the on-chain host
+  registry can use an IP literal *or* a DNS name (or `host:port`) — TLS imposes no
+  format constraint; the location is just a routing hint.
+- **Long-lived cert, re-minted on restart, no in-process refresh.** A Celestia
+  validator's consensus key cannot rotate, and the TLS key is ephemeral, so the
+  endorsed identity never changes while the server runs; a restart re-mints it.
+- **No chain-ID binding.** The endorsement does not bind the chain ID — the TLS
+  layer only proves "this peer is validator V". Chain and data correctness come
+  from the chain-bound, consensus-key-signed application messages (payment
+  promises, acknowledgements) and on-chain data-availability commitments, so a
+  chain binding here would be redundant. Decoupling from the runtime chain ID
+  also keeps the client free of a startup-ordering dependency.
+- **Endorsement carried in a custom DER X.509 extension.** The endorsement
+  signature must reach the client at handshake time, so it rides in the cert. DER
+  is canonical (friendly to non-Go verifiers like lumina). The extension OID will
+  live under a Celestia-owned IANA PEN; it is a documented placeholder until the
+  PEN is registered (PROTOCO-1808).
+
 ## Observability
 
 All observability flags are persistent and apply to every subcommand.

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -123,12 +123,11 @@ Why the scheme looks the way it does:
 - **Long-lived cert, re-minted on restart, no in-process refresh.** A Celestia
   validator's consensus key cannot rotate, and the TLS key is ephemeral, so the
   endorsed identity never changes while the server runs; a restart re-mints it.
-- **No chain-ID binding.** The endorsement does not bind the chain ID — the TLS
-  layer only proves "this peer is validator V". Chain and data correctness come
-  from the chain-bound, consensus-key-signed application messages (payment
-  promises, acknowledgements) and on-chain data-availability commitments, so a
-  chain binding here would be redundant. Decoupling from the runtime chain ID
-  also keeps the client free of a startup-ordering dependency.
+- **Payload is chain-ID-free; the signing envelope is not.** The certificate's
+  structured binding payload only contains the schema version, validity window,
+  and TLS public key, because the TLS layer proves "this peer is validator V".
+  The outer `SignRawBytes` envelope still uses the runtime chain ID so
+  chain-ID-enforcing remote signers and HSM policy remain compatible.
 - **Endorsement carried in a custom DER X.509 extension.** The endorsement
   signature must reach the client at handshake time, so it rides in the cert. DER
   is canonical (friendly to non-Go verifiers like lumina). The extension OID will

--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -101,8 +101,8 @@ func (s *FibreE2ETestSuite) SetupSuite() {
 	fibreAddr := s.fibreServer.ListenAddress()
 	clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
 		&fixedHostRegistry{addr: fibreAddr},
-		func() string { return s.fibreClient.ChainID() },
 		clientCfg.MaxMessageSize,
+		nil,
 	)
 
 	s.txClient = txClient

--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -101,6 +101,7 @@ func (s *FibreE2ETestSuite) SetupSuite() {
 	fibreAddr := s.fibreServer.ListenAddress()
 	clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
 		&fixedHostRegistry{addr: fibreAddr},
+		func() string { return s.fibreClient.ChainID() },
 		clientCfg.MaxMessageSize,
 	)
 

--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -101,6 +101,7 @@ func (s *FibreE2ETestSuite) SetupSuite() {
 	fibreAddr := s.fibreServer.ListenAddress()
 	clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
 		&fixedHostRegistry{addr: fibreAddr},
+		func() string { return s.fibreClient.ChainID() },
 		clientCfg.MaxMessageSize,
 		nil,
 	)

--- a/fibre/internal/grpc/fibre_client.go
+++ b/fibre/internal/grpc/fibre_client.go
@@ -46,9 +46,15 @@ func (f *fibreClientCloser) Close() error {
 // grpc.NewClient dials lazily, verification runs on the first RPC and a failure
 // otherwise surfaces upstream only as an aggregated quorum/unavailable error;
 // logging here preserves the underlying cause for operators.
-func DefaultNewClientFn(hostReg validator.HostRegistry, maxMsgSize int, log *slog.Logger) NewClientFn {
+//
+// chainID is evaluated lazily per dial because the state client resolves it
+// during Start, which can run after this constructor.
+func DefaultNewClientFn(hostReg validator.HostRegistry, chainID func() string, maxMsgSize int, log *slog.Logger) NewClientFn {
 	if log == nil {
 		log = slog.Default()
+	}
+	if chainID == nil {
+		chainID = func() string { return "" }
 	}
 	return func(ctx context.Context, val *core.Validator) (Client, error) {
 		host, err := hostReg.GetHost(ctx, val)
@@ -58,9 +64,16 @@ func DefaultNewClientFn(hostReg validator.HostRegistry, maxMsgSize int, log *slo
 		if val.PubKey == nil {
 			return nil, errors.New("validator has no consensus pubkey for TLS identity check")
 		}
+		cid := chainID()
+		if cid == "" {
+			return nil, errors.New("chain ID is empty; state client must be started before dialing")
+		}
 
-		verify := tlsid.VerifyConnection(val.PubKey)
+		verify := tlsid.VerifyConnection(val.PubKey, cid)
 		tlsCfg := &tls.Config{
+			// The peer certificate is self-signed; VerifyConnection below authenticates the
+			// validator consensus-key endorsement instead of a CA/SAN chain.
+			// codeql[go/disabled-certificate-check]
 			InsecureSkipVerify: true, //nolint:gosec // identity is verified via VerifyConnection
 			VerifyConnection: func(state tls.ConnectionState) error {
 				if err := verify(state); err != nil {

--- a/fibre/internal/grpc/fibre_client.go
+++ b/fibre/internal/grpc/fibre_client.go
@@ -2,14 +2,17 @@ package grpc
 
 import (
 	"context"
+	"crypto/tls"
+	"errors"
 	"io"
 
+	"github.com/celestiaorg/celestia-app/v9/fibre/internal/tlsid"
 	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v9/x/fibre/types"
 	core "github.com/cometbft/cometbft/types"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	grpclib "google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/credentials"
 )
 
 // Client combines [FibreClient] with [io.Closer] to manage the lifecycle
@@ -33,20 +36,35 @@ func (f *fibreClientCloser) Close() error {
 	return f.conn.Close()
 }
 
-// DefaultNewClientFn returns the default [NewClientFn] that uses the provided
-// [validator.HostRegistry] to resolve validator hosts and establishes insecure gRPC connections
-// with OpenTelemetry instrumentation for distributed tracing.
-// The maxMsgSize parameter sets the maximum gRPC message size for send and receive operations.
-func DefaultNewClientFn(hostReg validator.HostRegistry, maxMsgSize int) NewClientFn {
+// DefaultNewClientFn returns the default [NewClientFn]. It resolves the
+// validator's network host through hostReg, then dials over TLS with the
+// peer identity bound to the validator's consensus pubkey via
+// [tlsid.VerifyPeer].
+//
+// chainID is evaluated lazily per dial because the state client resolves it
+// during Start, which can run after this constructor.
+func DefaultNewClientFn(hostReg validator.HostRegistry, chainID func() string, maxMsgSize int) NewClientFn {
 	return func(ctx context.Context, val *core.Validator) (Client, error) {
 		host, err := hostReg.GetHost(ctx, val)
 		if err != nil {
 			return nil, err
 		}
+		if val.PubKey == nil {
+			return nil, errors.New("validator has no consensus pubkey for TLS identity check")
+		}
+		cid := chainID()
+		if cid == "" {
+			return nil, errors.New("chain ID is empty; state client must be started before dialing")
+		}
 
-		// TODO(@Wondertan): setup secure connection
+		tlsCfg := &tls.Config{
+			InsecureSkipVerify:    true, //nolint:gosec // identity is verified via VerifyPeerCertificate
+			VerifyPeerCertificate: tlsid.VerifyPeer(val.PubKey, cid),
+			MinVersion:            tls.VersionTLS13,
+		}
+
 		conn, err := grpclib.NewClient(host.String(),
-			grpclib.WithTransportCredentials(insecure.NewCredentials()),
+			grpclib.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
 			grpclib.WithStatsHandler(otelgrpc.NewClientHandler()),
 			grpclib.WithDefaultCallOptions(
 				grpclib.MaxCallRecvMsgSize(maxMsgSize),

--- a/fibre/internal/grpc/fibre_client.go
+++ b/fibre/internal/grpc/fibre_client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"io"
+	"log/slog"
 
 	"github.com/celestiaorg/celestia-app/v9/fibre/internal/tlsid"
 	"github.com/celestiaorg/celestia-app/v9/fibre/validator"
@@ -39,11 +40,16 @@ func (f *fibreClientCloser) Close() error {
 // DefaultNewClientFn returns the default [NewClientFn]. It resolves the
 // validator's network host through hostReg, then dials over TLS with the
 // peer identity bound to the validator's consensus pubkey via
-// [tlsid.VerifyPeer].
+// [tlsid.VerifyConnection].
 //
-// chainID is evaluated lazily per dial because the state client resolves it
-// during Start, which can run after this constructor.
-func DefaultNewClientFn(hostReg validator.HostRegistry, chainID func() string, maxMsgSize int) NewClientFn {
+// log records TLS identity-verification failures with peer context. Because
+// grpc.NewClient dials lazily, verification runs on the first RPC and a failure
+// otherwise surfaces upstream only as an aggregated quorum/unavailable error;
+// logging here preserves the underlying cause for operators.
+func DefaultNewClientFn(hostReg validator.HostRegistry, maxMsgSize int, log *slog.Logger) NewClientFn {
+	if log == nil {
+		log = slog.Default()
+	}
 	return func(ctx context.Context, val *core.Validator) (Client, error) {
 		host, err := hostReg.GetHost(ctx, val)
 		if err != nil {
@@ -52,15 +58,21 @@ func DefaultNewClientFn(hostReg validator.HostRegistry, chainID func() string, m
 		if val.PubKey == nil {
 			return nil, errors.New("validator has no consensus pubkey for TLS identity check")
 		}
-		cid := chainID()
-		if cid == "" {
-			return nil, errors.New("chain ID is empty; state client must be started before dialing")
-		}
 
+		verify := tlsid.VerifyConnection(val.PubKey)
 		tlsCfg := &tls.Config{
-			InsecureSkipVerify:    true, //nolint:gosec // identity is verified via VerifyPeerCertificate
-			VerifyPeerCertificate: tlsid.VerifyPeer(val.PubKey, cid),
-			MinVersion:            tls.VersionTLS13,
+			InsecureSkipVerify: true, //nolint:gosec // identity is verified via VerifyConnection
+			VerifyConnection: func(state tls.ConnectionState) error {
+				if err := verify(state); err != nil {
+					log.Warn("fibre TLS peer identity verification failed",
+						"validator", val.Address.String(),
+						"host", host.String(),
+						"err", err)
+					return err
+				}
+				return nil
+			},
+			MinVersion: tls.VersionTLS13,
 		}
 
 		conn, err := grpclib.NewClient(host.String(),

--- a/fibre/internal/grpc/server.go
+++ b/fibre/internal/grpc/server.go
@@ -59,6 +59,15 @@ func (s *Server) Stop(ctx context.Context) {
 		return
 	}
 
+	// Registered but never served: grpc-go only takes ownership of the listener
+	// in Serve, so GracefulStop/Stop would not close it. Close it ourselves to
+	// avoid leaking the file descriptor and port on a failed startup.
+	if s.done == nil {
+		s.server.Stop()
+		_ = s.listener.Close()
+		return
+	}
+
 	done := make(chan struct{})
 	go func() {
 		s.server.GracefulStop()
@@ -71,7 +80,5 @@ func (s *Server) Stop(ctx context.Context) {
 		s.server.Stop()
 	}
 
-	if s.done != nil {
-		<-s.done
-	}
+	<-s.done
 }

--- a/fibre/internal/grpc/server.go
+++ b/fibre/internal/grpc/server.go
@@ -16,19 +16,23 @@ type Server struct {
 	done     chan struct{}
 }
 
-// NewServer creates a Fibre gRPC [Server] that listens on the given address
-// and registers the provided [types.FibreServer] service.
-func NewServer(listenAddr string, service types.FibreServer, opts ...grpc.ServerOption) (*Server, error) {
+// Listen creates a [Server] bound to listenAddr. The underlying [grpc.Server]
+// is created lazily by [Server.Register] so callers can defer building
+// credentials until after the listener address is known (e.g., for TLS certs
+// that depend on a chain ID resolved at startup).
+func Listen(listenAddr string) (*Server, error) {
 	listener, err := net.Listen("tcp", listenAddr)
 	if err != nil {
 		return nil, fmt.Errorf("listen on %s: %w", listenAddr, err)
 	}
-	server := grpc.NewServer(opts...)
-	types.RegisterFibreServer(server, service)
-	return &Server{
-		server:   server,
-		listener: listener,
-	}, nil
+	return &Server{listener: listener}, nil
+}
+
+// Register builds the underlying [grpc.Server] with opts and registers the
+// fibre service. It must be called exactly once before [Server.Serve].
+func (s *Server) Register(service types.FibreServer, opts ...grpc.ServerOption) {
+	s.server = grpc.NewServer(opts...)
+	types.RegisterFibreServer(s.server, service)
 }
 
 // ListenAddress returns the actual address the server is listening on.
@@ -37,6 +41,7 @@ func (s *Server) ListenAddress() string {
 }
 
 // Serve starts serving gRPC requests in a background goroutine.
+// [Server.Register] must have been called first.
 func (s *Server) Serve() {
 	s.done = make(chan struct{})
 	go func() {
@@ -47,7 +52,13 @@ func (s *Server) Serve() {
 
 // Stop gracefully stops the gRPC server.
 // If the context is cancelled before draining completes, it forces an immediate stop.
+// If [Server.Register] was never called, Stop closes the listener and returns.
 func (s *Server) Stop(ctx context.Context) {
+	if s.server == nil {
+		_ = s.listener.Close()
+		return
+	}
+
 	done := make(chan struct{})
 	go func() {
 		s.server.GracefulStop()
@@ -60,5 +71,7 @@ func (s *Server) Stop(ctx context.Context) {
 		s.server.Stop()
 	}
 
-	<-s.done
+	if s.done != nil {
+		<-s.done
+	}
 }

--- a/fibre/internal/grpc/server_lifecycle_test.go
+++ b/fibre/internal/grpc/server_lifecycle_test.go
@@ -1,0 +1,32 @@
+package grpc_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	fibregrpc "github.com/celestiaorg/celestia-app/v9/fibre/internal/grpc"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServer_StopReleasesListenerWhenRegisteredButNotServed ensures that a
+// startup that registers the gRPC server but fails before Serve (e.g. the store
+// fails to open) does not leak the TCP listener. Previously GracefulStop did not
+// close a listener grpc-go never saw, leaking the fd/port.
+func TestServer_StopReleasesListenerWhenRegisteredButNotServed(t *testing.T) {
+	srv, err := fibregrpc.Listen("127.0.0.1:0")
+	require.NoError(t, err)
+
+	addr := srv.ListenAddress()
+	srv.Register(nil) // server created, but Serve is never called
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	srv.Stop(ctx)
+
+	// The port must be free again immediately after Stop.
+	ln, err := net.Listen("tcp", addr)
+	require.NoError(t, err, "Stop should have closed the listener and freed the port")
+	require.NoError(t, ln.Close())
+}

--- a/fibre/internal/tlsid/tlsid.go
+++ b/fibre/internal/tlsid/tlsid.go
@@ -33,12 +33,12 @@
 //     signed window;
 //   - the certificate carries the serverAuth extended key usage.
 //
-// The endorsement deliberately does NOT bind the chain ID. The TLS layer only
-// proves "this peer is validator V"; chain and data semantics are enforced by
-// the chain-bound, consensus-key-signed application messages (payment promises,
-// validator acknowledgements) and by on-chain data-availability commitments, so
-// a chain binding here would be redundant. This also keeps the client free of a
-// startup-ordering dependency on the resolved chain ID.
+// The BindingPayload deliberately does NOT include the chain ID. The TLS layer
+// only proves "this peer is validator V"; chain and data semantics are enforced
+// by the chain-bound, consensus-key-signed application messages (payment
+// promises, validator acknowledgements) and by on-chain data-availability
+// commitments. The outer SignRawBytes envelope still uses the runtime chain ID
+// so the endorsement is compatible with chain-ID-enforcing remote signers.
 //
 // This is a Celestia-specific identity scheme; it is NOT libp2p-TLS compatible
 // (different OID, signing prefix, sign-byte wrapper, and pubkey encoding), so a
@@ -60,6 +60,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"time"
 
 	"github.com/cometbft/cometbft/crypto"
@@ -75,16 +76,17 @@ const SignUniqueID = "celestia-fibre-tls-v1"
 // signature can never collide with another payload signed by the same key.
 const SignPrefix = "celestia-fibre-tls:"
 
-// signDomain is supplied in the chain-ID slot of SignRawBytes /
-// RawBytesMessageSignBytes. The endorsement deliberately does not bind the
-// runtime chain ID (see the package doc), but RawBytesMessageSignBytes rejects
-// an empty chain ID, so a fixed constant is used. Purpose-based domain
-// separation from votes/proposals/promises is provided by SignUniqueID.
-const signDomain = "celestia-fibre-tls"
-
 // bindingVersion is the schema version of the signed BindingPayload. Bumping it
 // is a protocol-level break.
 const bindingVersion = 1
+
+// MaxPayloadDERSize bounds the signed BindingPayload DER accepted from peer
+// certificates. Correctly generated payloads are small; this cap keeps malformed
+// certs from forcing unbounded parser/allocation work.
+const MaxPayloadDERSize = 4096
+
+// MaxIdentityExtensionSize bounds the custom certificate extension DER.
+const MaxIdentityExtensionSize = 8192
 
 // CertValidity is how long generated certificates remain valid. The cert is
 // re-minted on every server start (the TLS keypair is ephemeral and lives only
@@ -135,14 +137,18 @@ type bindingPayload struct {
 
 // BuildServerCert generates an ephemeral Ed25519 TLS keypair and a self-signed
 // certificate that binds it to the consensus identity exposed by signer.
-// The signer is invoked once via SignRawBytes.
-func BuildServerCert(signer core.PrivValidator) (tls.Certificate, error) {
-	return buildServerCert(signer, time.Now(), CertValidity)
+// The signer is invoked once via SignRawBytes using chainID in the CometBFT
+// signing envelope.
+func BuildServerCert(signer core.PrivValidator, chainID string) (tls.Certificate, error) {
+	return buildServerCert(signer, chainID, time.Now(), CertValidity)
 }
 
-func buildServerCert(signer core.PrivValidator, now time.Time, validity time.Duration) (tls.Certificate, error) {
+func buildServerCert(signer core.PrivValidator, chainID string, now time.Time, validity time.Duration) (tls.Certificate, error) {
 	if signer == nil {
 		return tls.Certificate{}, errors.New("signer must not be nil")
+	}
+	if chainID == "" {
+		return tls.Certificate{}, errors.New("chain ID must not be empty")
 	}
 
 	tlsPub, tlsPriv, err := ed25519.GenerateKey(rand.Reader)
@@ -170,7 +176,7 @@ func buildServerCert(signer core.PrivValidator, now time.Time, validity time.Dur
 		return tls.Certificate{}, fmt.Errorf("marshal binding payload: %w", err)
 	}
 
-	sig, err := signer.SignRawBytes(signDomain, SignUniqueID, signedBytes(payloadDER))
+	sig, err := signer.SignRawBytes(chainID, SignUniqueID, signedBytes(payloadDER))
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("sign TLS binding: %w", err)
 	}
@@ -212,7 +218,8 @@ func buildServerCert(signer core.PrivValidator, now time.Time, validity time.Dur
 // for expected. Prefer [VerifyConnection], which also runs on resumed TLS 1.3
 // sessions. Use only with tls.Config.InsecureSkipVerify=true; the custom
 // verifier replaces CA/hostname validation with validator consensus-key binding.
-func VerifyPeer(expected crypto.PubKey) func([][]byte, [][]*x509.Certificate) error {
+// chainID must match the chain ID used when the server endorsed the certificate.
+func VerifyPeer(expected crypto.PubKey, chainID string) func([][]byte, [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 		if len(rawCerts) == 0 {
 			return errors.New("peer presented no certificate")
@@ -221,25 +228,29 @@ func VerifyPeer(expected crypto.PubKey) func([][]byte, [][]*x509.Certificate) er
 		if err != nil {
 			return fmt.Errorf("parse peer cert: %w", err)
 		}
-		return verifyCert(cert, expected)
+		return verifyCert(cert, expected, chainID)
 	}
 }
 
 // VerifyConnection returns a [tls.Config.VerifyConnection] callback equivalent
 // to [VerifyPeer]. Unlike VerifyPeerCertificate it also runs for resumed TLS
 // 1.3 sessions, so identity is re-checked on every connection.
-func VerifyConnection(expected crypto.PubKey) func(tls.ConnectionState) error {
+// chainID must match the chain ID used when the server endorsed the certificate.
+func VerifyConnection(expected crypto.PubKey, chainID string) func(tls.ConnectionState) error {
 	return func(state tls.ConnectionState) error {
 		if len(state.PeerCertificates) == 0 {
 			return errors.New("peer presented no certificate")
 		}
-		return verifyCert(state.PeerCertificates[0], expected)
+		return verifyCert(state.PeerCertificates[0], expected, chainID)
 	}
 }
 
-func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
+func verifyCert(cert *x509.Certificate, expected crypto.PubKey, chainID string) error {
 	if expected == nil {
 		return errors.New("no expected validator pubkey")
+	}
+	if chainID == "" {
+		return errors.New("chain ID must not be empty")
 	}
 
 	var extBytes []byte
@@ -252,6 +263,9 @@ func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
 	if extBytes == nil {
 		return errors.New("peer cert is missing the fibre identity extension")
 	}
+	if len(extBytes) > MaxIdentityExtensionSize {
+		return fmt.Errorf("identity extension size %d exceeds maximum %d", len(extBytes), MaxIdentityExtensionSize)
+	}
 
 	var id signedIdentity
 	rest, err := asn1.Unmarshal(extBytes, &id)
@@ -263,6 +277,9 @@ func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
 	}
 	if len(id.Payload) == 0 {
 		return errors.New("empty identity payload")
+	}
+	if len(id.Payload) > MaxPayloadDERSize {
+		return fmt.Errorf("identity payload size %d exceeds maximum %d", len(id.Payload), MaxPayloadDERSize)
 	}
 	if len(id.Signature) == 0 {
 		return errors.New("empty identity signature")
@@ -284,7 +301,7 @@ func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
 	// using the expected validator's consensus pubkey (from the validator set).
 	// A signature that verifies under `expected` is the proof the validator
 	// authorized this TLS key, so no pubkey needs to be embedded in the cert.
-	signed, err := core.RawBytesMessageSignBytes(signDomain, SignUniqueID, signedBytes(id.Payload))
+	signed, err := core.RawBytesMessageSignBytes(chainID, SignUniqueID, signedBytes(id.Payload))
 	if err != nil {
 		return fmt.Errorf("compute signed bytes: %w", err)
 	}
@@ -323,14 +340,7 @@ func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
 	}
 
 	// Require the serverAuth EKU that BuildServerCert sets.
-	hasServerAuth := false
-	for _, eku := range cert.ExtKeyUsage {
-		if eku == x509.ExtKeyUsageServerAuth {
-			hasServerAuth = true
-			break
-		}
-	}
-	if !hasServerAuth {
+	if !slices.Contains(cert.ExtKeyUsage, x509.ExtKeyUsageServerAuth) {
 		return errors.New("peer cert missing serverAuth extended key usage")
 	}
 
@@ -338,7 +348,7 @@ func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
 }
 
 func signedBytes(payloadDER []byte) []byte {
-	out := make([]byte, 0, len(SignPrefix)+len(payloadDER))
+	out := make([]byte, 0, len(SignPrefix))
 	out = append(out, SignPrefix...)
 	out = append(out, payloadDER...)
 	return out

--- a/fibre/internal/tlsid/tlsid.go
+++ b/fibre/internal/tlsid/tlsid.go
@@ -1,0 +1,229 @@
+// Package tlsid produces and verifies fibre gRPC TLS certificates that bind
+// the ephemeral TLS keypair to a validator's consensus identity.
+//
+// A fibre server generates a fresh Ed25519 keypair on every start. The
+// self-signed certificate it presents carries a custom X.509 extension with
+// the layout (ASN.1 DER):
+//
+//	SignedIdentity ::= SEQUENCE {
+//	    pubKey    OCTET STRING,  -- proto-encoded cometbft consensus pubkey
+//	    signature OCTET STRING   -- consensus key signature
+//	}
+//
+// The signature is produced by [core.PrivValidator.SignRawBytes] over
+// [SignPrefix] concatenated with the DER-encoded TLS SubjectPublicKeyInfo,
+// using [SignUniqueID] for domain separation. The fibre client supplies the
+// expected consensus pubkey to [VerifyPeer] and rejects any peer whose
+// certificate does not contain a matching, validly-signed extension.
+//
+// The design follows the libp2p-TLS spec
+// (https://github.com/libp2p/specs/blob/master/tls/tls.md) so browser clients
+// (e.g. Lumina) can interoperate with the same machinery.
+package tlsid
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/cometbft/cometbft/crypto"
+	"github.com/cometbft/cometbft/crypto/encoding"
+	cryptoproto "github.com/cometbft/cometbft/proto/tendermint/crypto"
+	core "github.com/cometbft/cometbft/types"
+)
+
+// SignUniqueID is the privval domain-separation tag used when binding the TLS
+// keypair to a validator's consensus identity. Bumping this string is a
+// protocol-level break.
+const SignUniqueID = "celestia-fibre-tls-v1"
+
+// SignPrefix is mixed into the signed payload alongside SignUniqueID so the
+// signature can never collide with another payload signed by the same key.
+const SignPrefix = "celestia-fibre-tls:"
+
+// CertValidity is how long generated certificates remain valid. Certs are
+// regenerated on every server start so this only bounds the upper edge.
+const CertValidity = 365 * 24 * time.Hour
+
+// signedIDExtensionOID identifies the custom certificate extension. Bumping
+// this OID is a protocol-level break.
+var signedIDExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 56843, 1, 1}
+
+// signedIdentity is the ASN.1 payload of the custom extension.
+type signedIdentity struct {
+	PubKey    []byte
+	Signature []byte
+}
+
+// BuildServerCert generates an ephemeral Ed25519 TLS keypair and a self-signed
+// certificate that binds it to the consensus identity exposed by signer.
+// The signer is invoked once via SignRawBytes; chainID provides domain
+// separation against other chains using the same key.
+func BuildServerCert(signer core.PrivValidator, chainID string) (tls.Certificate, error) {
+	if signer == nil {
+		return tls.Certificate{}, errors.New("signer must not be nil")
+	}
+	if chainID == "" {
+		return tls.Certificate{}, errors.New("chainID must not be empty")
+	}
+
+	tlsPub, tlsPriv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate TLS keypair: %w", err)
+	}
+
+	tlsPubDER, err := x509.MarshalPKIXPublicKey(tlsPub)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("marshal TLS pubkey: %w", err)
+	}
+
+	payload := signedPayload(tlsPubDER)
+	sig, err := signer.SignRawBytes(chainID, SignUniqueID, payload)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("sign TLS binding: %w", err)
+	}
+
+	consPub, err := signer.GetPubKey()
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("get consensus pubkey: %w", err)
+	}
+	consPubBytes, err := marshalConsPubKey(consPub)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	extBytes, err := asn1.Marshal(signedIdentity{PubKey: consPubBytes, Signature: sig})
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("marshal identity extension: %w", err)
+	}
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("generate cert serial: %w", err)
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{CommonName: "celestia-fibre"},
+		NotBefore:    now.Add(-time.Hour),
+		NotAfter:     now.Add(CertValidity),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+		ExtraExtensions: []pkix.Extension{{
+			Id:    signedIDExtensionOID,
+			Value: extBytes,
+		}},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, tlsPub, tlsPriv)
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("create cert: %w", err)
+	}
+
+	return tls.Certificate{
+		Certificate: [][]byte{certDER},
+		PrivateKey:  tlsPriv,
+	}, nil
+}
+
+// VerifyPeer returns a [tls.Config.VerifyPeerCertificate] callback that
+// accepts a peer iff its leaf certificate carries a validly-signed identity
+// extension whose embedded consensus pubkey equals expected. Use only with
+// tls.Config.InsecureSkipVerify=true; we deliberately bypass CA/hostname
+// validation in favor of identity binding.
+//
+// chainID must match the chainID the server used when signing the extension,
+// otherwise the signature will not verify.
+func VerifyPeer(expected crypto.PubKey, chainID string) func([][]byte, [][]*x509.Certificate) error {
+	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+		if expected == nil {
+			return errors.New("no expected validator pubkey")
+		}
+		if len(rawCerts) == 0 {
+			return errors.New("peer presented no certificate")
+		}
+		cert, err := x509.ParseCertificate(rawCerts[0])
+		if err != nil {
+			return fmt.Errorf("parse peer cert: %w", err)
+		}
+
+		var extBytes []byte
+		for _, ext := range cert.Extensions {
+			if ext.Id.Equal(signedIDExtensionOID) {
+				extBytes = ext.Value
+				break
+			}
+		}
+		if extBytes == nil {
+			return errors.New("peer cert is missing the fibre identity extension")
+		}
+
+		var id signedIdentity
+		rest, err := asn1.Unmarshal(extBytes, &id)
+		if err != nil {
+			return fmt.Errorf("unmarshal identity extension: %w", err)
+		}
+		if len(rest) != 0 {
+			return errors.New("trailing bytes in identity extension")
+		}
+
+		peerPub, err := unmarshalConsPubKey(id.PubKey)
+		if err != nil {
+			return err
+		}
+		if !peerPub.Equals(expected) {
+			return fmt.Errorf("peer identity mismatch: expected %X got %X",
+				expected.Address(), peerPub.Address())
+		}
+
+		tlsPubDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+		if err != nil {
+			return fmt.Errorf("marshal peer TLS pubkey: %w", err)
+		}
+		signed, err := core.RawBytesMessageSignBytes(chainID, SignUniqueID, signedPayload(tlsPubDER))
+		if err != nil {
+			return fmt.Errorf("compute signed bytes: %w", err)
+		}
+		if !peerPub.VerifySignature(signed, id.Signature) {
+			return errors.New("peer cert signature is invalid")
+		}
+		return nil
+	}
+}
+
+func signedPayload(tlsPubDER []byte) []byte {
+	out := make([]byte, 0, len(SignPrefix)+len(tlsPubDER))
+	out = append(out, SignPrefix...)
+	out = append(out, tlsPubDER...)
+	return out
+}
+
+func marshalConsPubKey(pk crypto.PubKey) ([]byte, error) {
+	proto, err := encoding.PubKeyToProto(pk)
+	if err != nil {
+		return nil, fmt.Errorf("encode consensus pubkey to proto: %w", err)
+	}
+	b, err := proto.Marshal()
+	if err != nil {
+		return nil, fmt.Errorf("marshal consensus pubkey proto: %w", err)
+	}
+	return b, nil
+}
+
+func unmarshalConsPubKey(b []byte) (crypto.PubKey, error) {
+	var pkProto cryptoproto.PublicKey
+	if err := pkProto.Unmarshal(b); err != nil {
+		return nil, fmt.Errorf("unmarshal consensus pubkey proto: %w", err)
+	}
+	pk, err := encoding.PubKeyFromProto(pkProto)
+	if err != nil {
+		return nil, fmt.Errorf("decode consensus pubkey: %w", err)
+	}
+	return pk, nil
+}

--- a/fibre/internal/tlsid/tlsid.go
+++ b/fibre/internal/tlsid/tlsid.go
@@ -2,26 +2,55 @@
 // the ephemeral TLS keypair to a validator's consensus identity.
 //
 // A fibre server generates a fresh Ed25519 keypair on every start. The
-// self-signed certificate it presents carries a custom X.509 extension with
-// the layout (ASN.1 DER):
+// self-signed certificate it presents carries a custom, non-critical X.509
+// extension with the ASN.1 DER layout:
 //
 //	SignedIdentity ::= SEQUENCE {
-//	    pubKey    OCTET STRING,  -- proto-encoded cometbft consensus pubkey
-//	    signature OCTET STRING   -- consensus key signature
+//	    payload   OCTET STRING,  -- DER of BindingPayload (the exact signed bytes)
+//	    signature OCTET STRING   -- consensus-key signature over the payload
+//	}
+//
+//	BindingPayload ::= SEQUENCE {
+//	    version    INTEGER,      -- schema version
+//	    notBefore  INTEGER,      -- unix seconds; equals the cert NotBefore
+//	    notAfter   INTEGER,      -- unix seconds; equals the cert NotAfter
+//	    tlsPubKey  OCTET STRING  -- DER SubjectPublicKeyInfo of the TLS key
 //	}
 //
 // The signature is produced by [core.PrivValidator.SignRawBytes] over
-// [SignPrefix] concatenated with the DER-encoded TLS SubjectPublicKeyInfo,
-// using [SignUniqueID] for domain separation. The fibre client supplies the
-// expected consensus pubkey to [VerifyPeer] and rejects any peer whose
-// certificate does not contain a matching, validly-signed extension.
+// [SignPrefix] concatenated with the DER-encoded BindingPayload, using
+// [SignUniqueID] for domain separation. The verifier checks the embedded payload
+// bytes directly (it does not re-encode), then enforces that:
 //
-// The design follows the libp2p-TLS spec
-// (https://github.com/libp2p/specs/blob/master/tls/tls.md) so browser clients
-// (e.g. Lumina) can interoperate with the same machinery.
+//   - the endorsement signature verifies under the expected validator's
+//     consensus pubkey (taken from the validator set). A signature that
+//     verifies under that key *is* the proof the validator authorized this TLS
+//     key, so the consensus pubkey is not embedded in the certificate;
+//   - the presented TLS public key equals the signed tlsPubKey (TLS 1.3
+//     CertificateVerify proves possession of it, closing the binding);
+//   - now is within the signed validity window, the window does not exceed
+//     [MaxCertValidity], and the certificate's own NotBefore/NotAfter equal the
+//     signed window;
+//   - the certificate carries the serverAuth extended key usage.
+//
+// The endorsement deliberately does NOT bind the chain ID. The TLS layer only
+// proves "this peer is validator V"; chain and data semantics are enforced by
+// the chain-bound, consensus-key-signed application messages (payment promises,
+// validator acknowledgements) and by on-chain data-availability commitments, so
+// a chain binding here would be redundant. This also keeps the client free of a
+// startup-ordering dependency on the resolved chain ID.
+//
+// This is a Celestia-specific identity scheme; it is NOT libp2p-TLS compatible
+// (different OID, signing prefix, sign-byte wrapper, and pubkey encoding), so a
+// stock libp2p verifier will not accept these certificates. It is intentionally
+// host-agnostic: nothing about the network location (IP, DNS name, or SNI) is
+// bound, so a validator may be addressed by either an IP literal or a DNS name.
+// Identity is the validator consensus key; the network location is only a
+// routing hint resolved from the on-chain host registry.
 package tlsid
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/tls"
@@ -34,8 +63,6 @@ import (
 	"time"
 
 	"github.com/cometbft/cometbft/crypto"
-	"github.com/cometbft/cometbft/crypto/encoding"
-	cryptoproto "github.com/cometbft/cometbft/proto/tendermint/crypto"
 	core "github.com/cometbft/cometbft/types"
 )
 
@@ -48,30 +75,74 @@ const SignUniqueID = "celestia-fibre-tls-v1"
 // signature can never collide with another payload signed by the same key.
 const SignPrefix = "celestia-fibre-tls:"
 
-// CertValidity is how long generated certificates remain valid. Certs are
-// regenerated on every server start so this only bounds the upper edge.
+// signDomain is supplied in the chain-ID slot of SignRawBytes /
+// RawBytesMessageSignBytes. The endorsement deliberately does not bind the
+// runtime chain ID (see the package doc), but RawBytesMessageSignBytes rejects
+// an empty chain ID, so a fixed constant is used. Purpose-based domain
+// separation from votes/proposals/promises is provided by SignUniqueID.
+const signDomain = "celestia-fibre-tls"
+
+// bindingVersion is the schema version of the signed BindingPayload. Bumping it
+// is a protocol-level break.
+const bindingVersion = 1
+
+// CertValidity is how long generated certificates remain valid. The cert is
+// re-minted on every server start (the TLS keypair is ephemeral and lives only
+// in process memory), and there is deliberately no in-process refresh: a
+// Celestia validator's consensus key cannot rotate (the SDK exposes no
+// consensus-key rotation), so the endorsed identity never changes while the
+// server runs. The window is therefore set well beyond any realistic uptime so
+// a long-running server never presents an expired cert.
 const CertValidity = 365 * 24 * time.Hour
 
-// signedIDExtensionOID identifies the custom certificate extension. Bumping
-// this OID is a protocol-level break.
-var signedIDExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 56843, 1, 1}
+// clockSkew backdates NotBefore and is tolerated on both edges of the validity
+// window so modest clock differences between peers do not break handshakes.
+const clockSkew = 5 * time.Minute
+
+// MaxCertValidity is the largest validity window a client will accept. It is a
+// sanity ceiling just above [CertValidity]: a correctly signed endorsement is
+// still rejected if it claims a window longer than we would ever issue, so a
+// one-time signer misuse cannot mint an arbitrarily long-lived cert.
+const MaxCertValidity = CertValidity + 2*clockSkew
+
+// signedIDExtensionOID identifies the custom certificate extension carrying the
+// fibre identity endorsement.
+//
+// TODO(PROTOCO-1808): this is the placeholder IANA PEN 32473, which RFC 5612
+// reserves for documentation/example use (so it is unassigned to any real
+// organization, unlike the previous 56843 = KASSEX s.r.o.). Replace the
+// enterprise number with the Celestia-allocated PEN once registered
+// (https://linear.app/celestia/issue/PROTOCO-1808). Bumping this OID is a
+// protocol-level break.
+var signedIDExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 32473, 1, 1}
 
 // signedIdentity is the ASN.1 payload of the custom extension.
 type signedIdentity struct {
-	PubKey    []byte
+	Payload   []byte
 	Signature []byte
+}
+
+// bindingPayload is the structured, signed binding between the ephemeral TLS
+// key and its validity window. It is signed by the validator consensus key; the
+// signer's identity is established by verifying against the expected validator
+// pubkey, so the consensus pubkey itself is not part of the payload.
+type bindingPayload struct {
+	Version   int
+	NotBefore int64
+	NotAfter  int64
+	TLSPubKey []byte
 }
 
 // BuildServerCert generates an ephemeral Ed25519 TLS keypair and a self-signed
 // certificate that binds it to the consensus identity exposed by signer.
-// The signer is invoked once via SignRawBytes; chainID provides domain
-// separation against other chains using the same key.
-func BuildServerCert(signer core.PrivValidator, chainID string) (tls.Certificate, error) {
+// The signer is invoked once via SignRawBytes.
+func BuildServerCert(signer core.PrivValidator) (tls.Certificate, error) {
+	return buildServerCert(signer, time.Now(), CertValidity)
+}
+
+func buildServerCert(signer core.PrivValidator, now time.Time, validity time.Duration) (tls.Certificate, error) {
 	if signer == nil {
 		return tls.Certificate{}, errors.New("signer must not be nil")
-	}
-	if chainID == "" {
-		return tls.Certificate{}, errors.New("chainID must not be empty")
 	}
 
 	tlsPub, tlsPriv, err := ed25519.GenerateKey(rand.Reader)
@@ -84,22 +155,27 @@ func BuildServerCert(signer core.PrivValidator, chainID string) (tls.Certificate
 		return tls.Certificate{}, fmt.Errorf("marshal TLS pubkey: %w", err)
 	}
 
-	payload := signedPayload(tlsPubDER)
-	sig, err := signer.SignRawBytes(chainID, SignUniqueID, payload)
+	// Truncate to second precision so the cert's encoded NotBefore/NotAfter
+	// match the signed unix-second values exactly.
+	notBefore := now.Add(-clockSkew).Truncate(time.Second)
+	notAfter := now.Add(validity).Truncate(time.Second)
+
+	payloadDER, err := asn1.Marshal(bindingPayload{
+		Version:   bindingVersion,
+		NotBefore: notBefore.Unix(),
+		NotAfter:  notAfter.Unix(),
+		TLSPubKey: tlsPubDER,
+	})
+	if err != nil {
+		return tls.Certificate{}, fmt.Errorf("marshal binding payload: %w", err)
+	}
+
+	sig, err := signer.SignRawBytes(signDomain, SignUniqueID, signedBytes(payloadDER))
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("sign TLS binding: %w", err)
 	}
 
-	consPub, err := signer.GetPubKey()
-	if err != nil {
-		return tls.Certificate{}, fmt.Errorf("get consensus pubkey: %w", err)
-	}
-	consPubBytes, err := marshalConsPubKey(consPub)
-	if err != nil {
-		return tls.Certificate{}, err
-	}
-
-	extBytes, err := asn1.Marshal(signedIdentity{PubKey: consPubBytes, Signature: sig})
+	extBytes, err := asn1.Marshal(signedIdentity{Payload: payloadDER, Signature: sig})
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("marshal identity extension: %w", err)
 	}
@@ -108,12 +184,11 @@ func BuildServerCert(signer core.PrivValidator, chainID string) (tls.Certificate
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("generate cert serial: %w", err)
 	}
-	now := time.Now()
 	tmpl := &x509.Certificate{
 		SerialNumber: serial,
 		Subject:      pkix.Name{CommonName: "celestia-fibre"},
-		NotBefore:    now.Add(-time.Hour),
-		NotAfter:     now.Add(CertValidity),
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
 		KeyUsage:     x509.KeyUsageDigitalSignature,
 		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 		ExtraExtensions: []pkix.Extension{{
@@ -132,19 +207,13 @@ func BuildServerCert(signer core.PrivValidator, chainID string) (tls.Certificate
 	}, nil
 }
 
-// VerifyPeer returns a [tls.Config.VerifyPeerCertificate] callback that
-// accepts a peer iff its leaf certificate carries a validly-signed identity
-// extension whose embedded consensus pubkey equals expected. Use only with
-// tls.Config.InsecureSkipVerify=true; we deliberately bypass CA/hostname
-// validation in favor of identity binding.
-//
-// chainID must match the chainID the server used when signing the extension,
-// otherwise the signature will not verify.
-func VerifyPeer(expected crypto.PubKey, chainID string) func([][]byte, [][]*x509.Certificate) error {
+// VerifyPeer returns a [tls.Config.VerifyPeerCertificate] callback that accepts
+// a peer iff its leaf certificate carries a validly-signed identity extension
+// for expected. Prefer [VerifyConnection], which also runs on resumed TLS 1.3
+// sessions. Use only with tls.Config.InsecureSkipVerify=true; the custom
+// verifier replaces CA/hostname validation with validator consensus-key binding.
+func VerifyPeer(expected crypto.PubKey) func([][]byte, [][]*x509.Certificate) error {
 	return func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
-		if expected == nil {
-			return errors.New("no expected validator pubkey")
-		}
 		if len(rawCerts) == 0 {
 			return errors.New("peer presented no certificate")
 		}
@@ -152,78 +221,125 @@ func VerifyPeer(expected crypto.PubKey, chainID string) func([][]byte, [][]*x509
 		if err != nil {
 			return fmt.Errorf("parse peer cert: %w", err)
 		}
-
-		var extBytes []byte
-		for _, ext := range cert.Extensions {
-			if ext.Id.Equal(signedIDExtensionOID) {
-				extBytes = ext.Value
-				break
-			}
-		}
-		if extBytes == nil {
-			return errors.New("peer cert is missing the fibre identity extension")
-		}
-
-		var id signedIdentity
-		rest, err := asn1.Unmarshal(extBytes, &id)
-		if err != nil {
-			return fmt.Errorf("unmarshal identity extension: %w", err)
-		}
-		if len(rest) != 0 {
-			return errors.New("trailing bytes in identity extension")
-		}
-
-		peerPub, err := unmarshalConsPubKey(id.PubKey)
-		if err != nil {
-			return err
-		}
-		if !peerPub.Equals(expected) {
-			return fmt.Errorf("peer identity mismatch: expected %X got %X",
-				expected.Address(), peerPub.Address())
-		}
-
-		tlsPubDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
-		if err != nil {
-			return fmt.Errorf("marshal peer TLS pubkey: %w", err)
-		}
-		signed, err := core.RawBytesMessageSignBytes(chainID, SignUniqueID, signedPayload(tlsPubDER))
-		if err != nil {
-			return fmt.Errorf("compute signed bytes: %w", err)
-		}
-		if !peerPub.VerifySignature(signed, id.Signature) {
-			return errors.New("peer cert signature is invalid")
-		}
-		return nil
+		return verifyCert(cert, expected)
 	}
 }
 
-func signedPayload(tlsPubDER []byte) []byte {
-	out := make([]byte, 0, len(SignPrefix)+len(tlsPubDER))
+// VerifyConnection returns a [tls.Config.VerifyConnection] callback equivalent
+// to [VerifyPeer]. Unlike VerifyPeerCertificate it also runs for resumed TLS
+// 1.3 sessions, so identity is re-checked on every connection.
+func VerifyConnection(expected crypto.PubKey) func(tls.ConnectionState) error {
+	return func(state tls.ConnectionState) error {
+		if len(state.PeerCertificates) == 0 {
+			return errors.New("peer presented no certificate")
+		}
+		return verifyCert(state.PeerCertificates[0], expected)
+	}
+}
+
+func verifyCert(cert *x509.Certificate, expected crypto.PubKey) error {
+	if expected == nil {
+		return errors.New("no expected validator pubkey")
+	}
+
+	var extBytes []byte
+	for _, ext := range cert.Extensions {
+		if ext.Id.Equal(signedIDExtensionOID) {
+			extBytes = ext.Value
+			break
+		}
+	}
+	if extBytes == nil {
+		return errors.New("peer cert is missing the fibre identity extension")
+	}
+
+	var id signedIdentity
+	rest, err := asn1.Unmarshal(extBytes, &id)
+	if err != nil {
+		return fmt.Errorf("unmarshal identity extension: %w", err)
+	}
+	if len(rest) != 0 {
+		return errors.New("trailing bytes in identity extension")
+	}
+	if len(id.Payload) == 0 {
+		return errors.New("empty identity payload")
+	}
+	if len(id.Signature) == 0 {
+		return errors.New("empty identity signature")
+	}
+
+	var bp bindingPayload
+	rest, err = asn1.Unmarshal(id.Payload, &bp)
+	if err != nil {
+		return fmt.Errorf("unmarshal binding payload: %w", err)
+	}
+	if len(rest) != 0 {
+		return errors.New("trailing bytes in binding payload")
+	}
+	if bp.Version != bindingVersion {
+		return fmt.Errorf("unsupported fibre identity version %d", bp.Version)
+	}
+
+	// Verify the endorsement signature over the exact embedded payload bytes
+	// using the expected validator's consensus pubkey (from the validator set).
+	// A signature that verifies under `expected` is the proof the validator
+	// authorized this TLS key, so no pubkey needs to be embedded in the cert.
+	signed, err := core.RawBytesMessageSignBytes(signDomain, SignUniqueID, signedBytes(id.Payload))
+	if err != nil {
+		return fmt.Errorf("compute signed bytes: %w", err)
+	}
+	if !expected.VerifySignature(signed, id.Signature) {
+		return errors.New("peer cert signature is invalid")
+	}
+
+	// Bind the presented TLS key to the signed key; TLS 1.3 proves possession.
+	tlsPubDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
+	if err != nil {
+		return fmt.Errorf("marshal peer TLS pubkey: %w", err)
+	}
+	if !bytes.Equal(tlsPubDER, bp.TLSPubKey) {
+		return errors.New("peer cert public key does not match signed identity")
+	}
+
+	// Enforce the signed validity window and an upper bound on its length.
+	notBefore := time.Unix(bp.NotBefore, 0)
+	notAfter := time.Unix(bp.NotAfter, 0)
+	if !notAfter.After(notBefore) {
+		return errors.New("fibre identity validity window is empty")
+	}
+	if notAfter.Sub(notBefore) > MaxCertValidity {
+		return fmt.Errorf("fibre identity validity window %s exceeds maximum %s",
+			notAfter.Sub(notBefore), MaxCertValidity)
+	}
+	now := time.Now()
+	if now.Before(notBefore.Add(-clockSkew)) || now.After(notAfter.Add(clockSkew)) {
+		return fmt.Errorf("peer fibre identity not valid at %s", now.UTC().Format(time.RFC3339))
+	}
+
+	// Bind the certificate's own validity to the signed window so a reissued
+	// cert cannot widen it without invalidating the signature.
+	if cert.NotBefore.Unix() != bp.NotBefore || cert.NotAfter.Unix() != bp.NotAfter {
+		return errors.New("certificate validity does not match signed identity")
+	}
+
+	// Require the serverAuth EKU that BuildServerCert sets.
+	hasServerAuth := false
+	for _, eku := range cert.ExtKeyUsage {
+		if eku == x509.ExtKeyUsageServerAuth {
+			hasServerAuth = true
+			break
+		}
+	}
+	if !hasServerAuth {
+		return errors.New("peer cert missing serverAuth extended key usage")
+	}
+
+	return nil
+}
+
+func signedBytes(payloadDER []byte) []byte {
+	out := make([]byte, 0, len(SignPrefix)+len(payloadDER))
 	out = append(out, SignPrefix...)
-	out = append(out, tlsPubDER...)
+	out = append(out, payloadDER...)
 	return out
-}
-
-func marshalConsPubKey(pk crypto.PubKey) ([]byte, error) {
-	proto, err := encoding.PubKeyToProto(pk)
-	if err != nil {
-		return nil, fmt.Errorf("encode consensus pubkey to proto: %w", err)
-	}
-	b, err := proto.Marshal()
-	if err != nil {
-		return nil, fmt.Errorf("marshal consensus pubkey proto: %w", err)
-	}
-	return b, nil
-}
-
-func unmarshalConsPubKey(b []byte) (crypto.PubKey, error) {
-	var pkProto cryptoproto.PublicKey
-	if err := pkProto.Unmarshal(b); err != nil {
-		return nil, fmt.Errorf("unmarshal consensus pubkey proto: %w", err)
-	}
-	pk, err := encoding.PubKeyFromProto(pkProto)
-	if err != nil {
-		return nil, fmt.Errorf("decode consensus pubkey: %w", err)
-	}
-	return pk, nil
 }

--- a/fibre/internal/tlsid/tlsid_test.go
+++ b/fibre/internal/tlsid/tlsid_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"fmt"
 	"math/big"
 	"net"
 	"testing"
@@ -18,9 +19,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const testChainID = "test-chain"
+
 func TestBuildAndVerify_RoundTrip(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv)
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
 	require.NoError(t, err)
 	require.NotNil(t, cert.PrivateKey)
 	require.Len(t, cert.Certificate, 1)
@@ -28,13 +31,13 @@ func TestBuildAndVerify_RoundTrip(t *testing.T) {
 	expectedPub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	verify := tlsid.VerifyPeer(expectedPub)
+	verify := tlsid.VerifyPeer(expectedPub, testChainID)
 	require.NoError(t, verify(cert.Certificate, nil))
 }
 
 func TestVerify_RejectsWrongValidator(t *testing.T) {
 	server := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(server)
+	cert, err := tlsid.BuildServerCert(server, testChainID)
 	require.NoError(t, err)
 
 	other := core.NewMockPV()
@@ -44,9 +47,36 @@ func TestVerify_RejectsWrongValidator(t *testing.T) {
 	// The endorsement was signed by `server`, so verifying against `other`'s
 	// pubkey fails the signature check (identity is established by the signature
 	// verifying under the expected key, not by an embedded pubkey field).
-	err = tlsid.VerifyPeer(otherPub)(cert.Certificate, nil)
+	err = tlsid.VerifyPeer(otherPub, testChainID)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signature is invalid")
+}
+
+func TestVerify_RejectsWrongChainID(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(pub, "other-chain")(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature is invalid")
+}
+
+func TestBuildServerCert_UsesProvidedChainID(t *testing.T) {
+	pv := &chainIDEnforcingPV{
+		PrivValidator: core.NewMockPV(),
+		chainID:       testChainID,
+	}
+
+	_, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+
+	_, err = tlsid.BuildServerCert(pv, "other-chain")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected chain ID")
 }
 
 func TestVerify_RejectsMissingExtension(t *testing.T) {
@@ -57,7 +87,7 @@ func TestVerify_RejectsMissingExtension(t *testing.T) {
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(pub)([][]byte{rawCert}, nil)
+	err = tlsid.VerifyPeer(pub, testChainID)([][]byte{rawCert}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing the fibre identity extension")
 }
@@ -67,24 +97,24 @@ func TestVerify_RejectsEmptyChain(t *testing.T) {
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(pub)(nil, nil)
+	err = tlsid.VerifyPeer(pub, testChainID)(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no certificate")
 }
 
 func TestVerify_RejectsNilExpected(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv)
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(nil)(cert.Certificate, nil)
+	err = tlsid.VerifyPeer(nil, testChainID)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no expected validator pubkey")
 }
 
 func TestVerify_RejectsTamperedSignature(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv)
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
 	require.NoError(t, err)
 
 	parsed, err := x509.ParseCertificate(cert.Certificate[0])
@@ -96,19 +126,24 @@ func TestVerify_RejectsTamperedSignature(t *testing.T) {
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(pub)([][]byte{tampered}, nil)
+	err = tlsid.VerifyPeer(pub, testChainID)([][]byte{tampered}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signature is invalid")
 }
 
 func TestBuildServerCert_RejectsNilSigner(t *testing.T) {
-	_, err := tlsid.BuildServerCert(nil)
+	_, err := tlsid.BuildServerCert(nil, testChainID)
+	require.Error(t, err)
+}
+
+func TestBuildServerCert_RejectsEmptyChainID(t *testing.T) {
+	_, err := tlsid.BuildServerCert(core.NewMockPV(), "")
 	require.Error(t, err)
 }
 
 func TestTLSHandshake_EndToEnd(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv)
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
 	require.NoError(t, err)
 
 	serverCfg := &tls.Config{
@@ -120,7 +155,7 @@ func TestTLSHandshake_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	clientCfg := &tls.Config{
 		InsecureSkipVerify:    true, //nolint:gosec // identity is checked via VerifyPeerCertificate
-		VerifyPeerCertificate: tlsid.VerifyPeer(pub),
+		VerifyPeerCertificate: tlsid.VerifyPeer(pub, testChainID),
 		MinVersion:            tls.VersionTLS13,
 	}
 
@@ -145,6 +180,18 @@ func TestTLSHandshake_EndToEnd(t *testing.T) {
 	tlsClient := tls.Client(rawClient, clientCfg)
 	require.NoError(t, tlsClient.Handshake())
 	require.NoError(t, <-srvDone)
+}
+
+type chainIDEnforcingPV struct {
+	core.PrivValidator
+	chainID string
+}
+
+func (pv *chainIDEnforcingPV) SignRawBytes(chainID, uniqueID string, rawBytes []byte) ([]byte, error) {
+	if chainID != pv.chainID {
+		return nil, fmt.Errorf("unexpected chain ID %q", chainID)
+	}
+	return pv.PrivValidator.SignRawBytes(chainID, uniqueID, rawBytes)
 }
 
 // buildPlainSelfSignedCert returns DER bytes of a self-signed Ed25519 cert

--- a/fibre/internal/tlsid/tlsid_test.go
+++ b/fibre/internal/tlsid/tlsid_test.go
@@ -18,11 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const testChainID = "test-chain"
-
 func TestBuildAndVerify_RoundTrip(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	cert, err := tlsid.BuildServerCert(pv)
 	require.NoError(t, err)
 	require.NotNil(t, cert.PrivateKey)
 	require.Len(t, cert.Certificate, 1)
@@ -30,33 +28,23 @@ func TestBuildAndVerify_RoundTrip(t *testing.T) {
 	expectedPub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	verify := tlsid.VerifyPeer(expectedPub, testChainID)
+	verify := tlsid.VerifyPeer(expectedPub)
 	require.NoError(t, verify(cert.Certificate, nil))
 }
 
 func TestVerify_RejectsWrongValidator(t *testing.T) {
 	server := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(server, testChainID)
+	cert, err := tlsid.BuildServerCert(server)
 	require.NoError(t, err)
 
 	other := core.NewMockPV()
 	otherPub, err := other.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(otherPub, testChainID)(cert.Certificate, nil)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "peer identity mismatch")
-}
-
-func TestVerify_RejectsWrongChainID(t *testing.T) {
-	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv, testChainID)
-	require.NoError(t, err)
-
-	pub, err := pv.GetPubKey()
-	require.NoError(t, err)
-
-	err = tlsid.VerifyPeer(pub, "different-chain")(cert.Certificate, nil)
+	// The endorsement was signed by `server`, so verifying against `other`'s
+	// pubkey fails the signature check (identity is established by the signature
+	// verifying under the expected key, not by an embedded pubkey field).
+	err = tlsid.VerifyPeer(otherPub)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signature is invalid")
 }
@@ -69,7 +57,7 @@ func TestVerify_RejectsMissingExtension(t *testing.T) {
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(pub, testChainID)([][]byte{rawCert}, nil)
+	err = tlsid.VerifyPeer(pub)([][]byte{rawCert}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing the fibre identity extension")
 }
@@ -79,24 +67,24 @@ func TestVerify_RejectsEmptyChain(t *testing.T) {
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(pub, testChainID)(nil, nil)
+	err = tlsid.VerifyPeer(pub)(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no certificate")
 }
 
 func TestVerify_RejectsNilExpected(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	cert, err := tlsid.BuildServerCert(pv)
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(nil, testChainID)(cert.Certificate, nil)
+	err = tlsid.VerifyPeer(nil)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no expected validator pubkey")
 }
 
 func TestVerify_RejectsTamperedSignature(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	cert, err := tlsid.BuildServerCert(pv)
 	require.NoError(t, err)
 
 	parsed, err := x509.ParseCertificate(cert.Certificate[0])
@@ -108,25 +96,19 @@ func TestVerify_RejectsTamperedSignature(t *testing.T) {
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
 
-	err = tlsid.VerifyPeer(pub, testChainID)([][]byte{tampered}, nil)
+	err = tlsid.VerifyPeer(pub)([][]byte{tampered}, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signature is invalid")
 }
 
 func TestBuildServerCert_RejectsNilSigner(t *testing.T) {
-	_, err := tlsid.BuildServerCert(nil, testChainID)
-	require.Error(t, err)
-}
-
-func TestBuildServerCert_RejectsEmptyChainID(t *testing.T) {
-	pv := core.NewMockPV()
-	_, err := tlsid.BuildServerCert(pv, "")
+	_, err := tlsid.BuildServerCert(nil)
 	require.Error(t, err)
 }
 
 func TestTLSHandshake_EndToEnd(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	cert, err := tlsid.BuildServerCert(pv)
 	require.NoError(t, err)
 
 	serverCfg := &tls.Config{
@@ -138,7 +120,7 @@ func TestTLSHandshake_EndToEnd(t *testing.T) {
 	require.NoError(t, err)
 	clientCfg := &tls.Config{
 		InsecureSkipVerify:    true, //nolint:gosec // identity is checked via VerifyPeerCertificate
-		VerifyPeerCertificate: tlsid.VerifyPeer(pub, testChainID),
+		VerifyPeerCertificate: tlsid.VerifyPeer(pub),
 		MinVersion:            tls.VersionTLS13,
 	}
 
@@ -190,7 +172,7 @@ func tamperIdentityExtension(t *testing.T, src *x509.Certificate) []byte {
 	t.Helper()
 	var ext pkix.Extension
 	for _, e := range src.Extensions {
-		if e.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 56843, 1, 1}) {
+		if e.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 32473, 1, 1}) {
 			ext = e
 			break
 		}
@@ -198,7 +180,7 @@ func tamperIdentityExtension(t *testing.T, src *x509.Certificate) []byte {
 	require.NotEmpty(t, ext.Value)
 
 	type signedIdentity struct {
-		PubKey    []byte
+		Payload   []byte
 		Signature []byte
 	}
 	var id signedIdentity

--- a/fibre/internal/tlsid/tlsid_test.go
+++ b/fibre/internal/tlsid/tlsid_test.go
@@ -1,0 +1,228 @@
+package tlsid_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v9/fibre/internal/tlsid"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testChainID = "test-chain"
+
+func TestBuildAndVerify_RoundTrip(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+	require.NotNil(t, cert.PrivateKey)
+	require.Len(t, cert.Certificate, 1)
+
+	expectedPub, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	verify := tlsid.VerifyPeer(expectedPub, testChainID)
+	require.NoError(t, verify(cert.Certificate, nil))
+}
+
+func TestVerify_RejectsWrongValidator(t *testing.T) {
+	server := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(server, testChainID)
+	require.NoError(t, err)
+
+	other := core.NewMockPV()
+	otherPub, err := other.GetPubKey()
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(otherPub, testChainID)(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "peer identity mismatch")
+}
+
+func TestVerify_RejectsWrongChainID(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(pub, "different-chain")(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature is invalid")
+}
+
+func TestVerify_RejectsMissingExtension(t *testing.T) {
+	// Build a self-signed cert with no identity extension.
+	rawCert := buildPlainSelfSignedCert(t)
+
+	pv := core.NewMockPV()
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(pub, testChainID)([][]byte{rawCert}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "missing the fibre identity extension")
+}
+
+func TestVerify_RejectsEmptyChain(t *testing.T) {
+	pv := core.NewMockPV()
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(pub, testChainID)(nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no certificate")
+}
+
+func TestVerify_RejectsNilExpected(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(nil, testChainID)(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no expected validator pubkey")
+}
+
+func TestVerify_RejectsTamperedSignature(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+
+	// Locate the extension and flip a bit inside its signature octet string.
+	tampered := tamperIdentityExtension(t, parsed)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+
+	err = tlsid.VerifyPeer(pub, testChainID)([][]byte{tampered}, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature is invalid")
+}
+
+func TestBuildServerCert_RejectsNilSigner(t *testing.T) {
+	_, err := tlsid.BuildServerCert(nil, testChainID)
+	require.Error(t, err)
+}
+
+func TestBuildServerCert_RejectsEmptyChainID(t *testing.T) {
+	pv := core.NewMockPV()
+	_, err := tlsid.BuildServerCert(pv, "")
+	require.Error(t, err)
+}
+
+func TestTLSHandshake_EndToEnd(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := tlsid.BuildServerCert(pv, testChainID)
+	require.NoError(t, err)
+
+	serverCfg := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	}
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	clientCfg := &tls.Config{
+		InsecureSkipVerify:    true, //nolint:gosec // identity is checked via VerifyPeerCertificate
+		VerifyPeerCertificate: tlsid.VerifyPeer(pub, testChainID),
+		MinVersion:            tls.VersionTLS13,
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+
+	srvDone := make(chan error, 1)
+	go func() {
+		raw, acceptErr := ln.Accept()
+		if acceptErr != nil {
+			srvDone <- acceptErr
+			return
+		}
+		srvDone <- tls.Server(raw, serverCfg).Handshake()
+	}()
+
+	rawClient, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	defer rawClient.Close()
+
+	tlsClient := tls.Client(rawClient, clientCfg)
+	require.NoError(t, tlsClient.Handshake())
+	require.NoError(t, <-srvDone)
+}
+
+// buildPlainSelfSignedCert returns DER bytes of a self-signed Ed25519 cert
+// with no custom extension.
+func buildPlainSelfSignedCert(t *testing.T) []byte {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "no-extension"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	require.NoError(t, err)
+	return der
+}
+
+// tamperIdentityExtension rebuilds a fresh self-signed cert that carries an
+// extension whose signature octet string has been bit-flipped. We can't simply
+// edit the original DER because x509.CreateCertificate is the only path that
+// produces a valid DER body without a custom encoder.
+func tamperIdentityExtension(t *testing.T, src *x509.Certificate) []byte {
+	t.Helper()
+	var ext pkix.Extension
+	for _, e := range src.Extensions {
+		if e.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 56843, 1, 1}) {
+			ext = e
+			break
+		}
+	}
+	require.NotEmpty(t, ext.Value)
+
+	type signedIdentity struct {
+		PubKey    []byte
+		Signature []byte
+	}
+	var id signedIdentity
+	_, err := asn1.Unmarshal(ext.Value, &id)
+	require.NoError(t, err)
+	require.NotEmpty(t, id.Signature)
+	id.Signature[0] ^= 0xFF
+
+	repacked, err := asn1.Marshal(id)
+	require.NoError(t, err)
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "tampered"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		ExtraExtensions: []pkix.Extension{{
+			Id:    ext.Id,
+			Value: repacked,
+		}},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, priv)
+	require.NoError(t, err)
+	return der
+}

--- a/fibre/internal/tlsid/tlsid_validity_test.go
+++ b/fibre/internal/tlsid/tlsid_validity_test.go
@@ -1,0 +1,165 @@
+package tlsid
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These are white-box tests (package tlsid) that exercise the validity-window
+// enforcement: they mint certificates with controlled validity via the
+// unexported buildServerCert and forgeCert helpers.
+
+func TestVerify_AcceptsWithinWindow(t *testing.T) {
+	pv := core.NewMockPV()
+	cert, err := buildServerCert(pv, time.Now(), CertValidity)
+	require.NoError(t, err)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	require.NoError(t, VerifyPeer(pub)(cert.Certificate, nil))
+}
+
+func TestVerify_RejectsExpiredCert(t *testing.T) {
+	pv := core.NewMockPV()
+	// Issued 48h ago with a 24h window: long expired by now.
+	cert, err := buildServerCert(pv, time.Now().Add(-48*time.Hour), 24*time.Hour)
+	require.NoError(t, err)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	err = VerifyPeer(pub)(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid at")
+}
+
+func TestVerify_RejectsNotYetValidCert(t *testing.T) {
+	pv := core.NewMockPV()
+	// Issued as if 48h in the future: not yet valid.
+	cert, err := buildServerCert(pv, time.Now().Add(48*time.Hour), 24*time.Hour)
+	require.NoError(t, err)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	err = VerifyPeer(pub)(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid at")
+}
+
+func TestVerify_RejectsOverLongCert(t *testing.T) {
+	pv := core.NewMockPV()
+	// Currently valid, but with a window that exceeds MaxCertValidity.
+	cert, err := buildServerCert(pv, time.Now(), MaxCertValidity+time.Hour)
+	require.NoError(t, err)
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	err = VerifyPeer(pub)(cert.Certificate, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestVerify_RejectsCertValidityDifferentFromSigned(t *testing.T) {
+	pv := core.NewMockPV()
+	now := time.Now().Truncate(time.Second)
+	signedNotBefore := now.Add(-clockSkew)
+	signedNotAfter := now.Add(CertValidity)
+
+	// Cert claims a NotAfter far beyond the signed window.
+	cert := forgeCert(t, pv, forgeOpts{
+		signedNotBefore: signedNotBefore,
+		signedNotAfter:  signedNotAfter,
+		certNotBefore:   signedNotBefore,
+		certNotAfter:    now.Add(72 * time.Hour),
+		eku:             []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	})
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	err = verifyCert(cert, pub)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "certificate validity does not match signed identity")
+}
+
+func TestVerify_RejectsMissingServerAuthEKU(t *testing.T) {
+	pv := core.NewMockPV()
+	now := time.Now().Truncate(time.Second)
+	signedNotBefore := now.Add(-clockSkew)
+	signedNotAfter := now.Add(CertValidity)
+
+	cert := forgeCert(t, pv, forgeOpts{
+		signedNotBefore: signedNotBefore,
+		signedNotAfter:  signedNotAfter,
+		certNotBefore:   signedNotBefore,
+		certNotAfter:    signedNotAfter,
+		eku:             []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, // no serverAuth
+	})
+
+	pub, err := pv.GetPubKey()
+	require.NoError(t, err)
+	err = verifyCert(cert, pub)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "serverAuth")
+}
+
+type forgeOpts struct {
+	signedNotBefore time.Time
+	signedNotAfter  time.Time
+	certNotBefore   time.Time
+	certNotAfter    time.Time
+	eku             []x509.ExtKeyUsage
+}
+
+// forgeCert mints a self-signed certificate whose embedded identity is validly
+// signed by signer, but whose certificate template fields (validity, EKU) can
+// diverge from the signed binding. The cert's TLS key matches the signed
+// tlsPubKey so verification reaches the field-consistency checks.
+func forgeCert(t *testing.T, signer core.PrivValidator, o forgeOpts) *x509.Certificate {
+	t.Helper()
+
+	tlsPub, tlsPriv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	tlsPubDER, err := x509.MarshalPKIXPublicKey(tlsPub)
+	require.NoError(t, err)
+
+	payloadDER, err := asn1.Marshal(bindingPayload{
+		Version:   bindingVersion,
+		NotBefore: o.signedNotBefore.Unix(),
+		NotAfter:  o.signedNotAfter.Unix(),
+		TLSPubKey: tlsPubDER,
+	})
+	require.NoError(t, err)
+
+	sig, err := signer.SignRawBytes(signDomain, SignUniqueID, signedBytes(payloadDER))
+	require.NoError(t, err)
+
+	extBytes, err := asn1.Marshal(signedIdentity{Payload: payloadDER, Signature: sig})
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(99),
+		Subject:      pkix.Name{CommonName: "forged-fibre"},
+		NotBefore:    o.certNotBefore,
+		NotAfter:     o.certNotAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  o.eku,
+		ExtraExtensions: []pkix.Extension{{
+			Id:    signedIDExtensionOID,
+			Value: extBytes,
+		}},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, tlsPub, tlsPriv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(certDER)
+	require.NoError(t, err)
+	return cert
+}

--- a/fibre/internal/tlsid/tlsid_validity_test.go
+++ b/fibre/internal/tlsid/tlsid_validity_test.go
@@ -19,25 +19,27 @@ import (
 // enforcement: they mint certificates with controlled validity via the
 // unexported buildServerCert and forgeCert helpers.
 
+const validityTestChainID = "test-chain"
+
 func TestVerify_AcceptsWithinWindow(t *testing.T) {
 	pv := core.NewMockPV()
-	cert, err := buildServerCert(pv, time.Now(), CertValidity)
+	cert, err := buildServerCert(pv, validityTestChainID, time.Now(), CertValidity)
 	require.NoError(t, err)
 
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
-	require.NoError(t, VerifyPeer(pub)(cert.Certificate, nil))
+	require.NoError(t, VerifyPeer(pub, validityTestChainID)(cert.Certificate, nil))
 }
 
 func TestVerify_RejectsExpiredCert(t *testing.T) {
 	pv := core.NewMockPV()
 	// Issued 48h ago with a 24h window: long expired by now.
-	cert, err := buildServerCert(pv, time.Now().Add(-48*time.Hour), 24*time.Hour)
+	cert, err := buildServerCert(pv, validityTestChainID, time.Now().Add(-48*time.Hour), 24*time.Hour)
 	require.NoError(t, err)
 
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
-	err = VerifyPeer(pub)(cert.Certificate, nil)
+	err = VerifyPeer(pub, validityTestChainID)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not valid at")
 }
@@ -45,12 +47,12 @@ func TestVerify_RejectsExpiredCert(t *testing.T) {
 func TestVerify_RejectsNotYetValidCert(t *testing.T) {
 	pv := core.NewMockPV()
 	// Issued as if 48h in the future: not yet valid.
-	cert, err := buildServerCert(pv, time.Now().Add(48*time.Hour), 24*time.Hour)
+	cert, err := buildServerCert(pv, validityTestChainID, time.Now().Add(48*time.Hour), 24*time.Hour)
 	require.NoError(t, err)
 
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
-	err = VerifyPeer(pub)(cert.Certificate, nil)
+	err = VerifyPeer(pub, validityTestChainID)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not valid at")
 }
@@ -58,12 +60,12 @@ func TestVerify_RejectsNotYetValidCert(t *testing.T) {
 func TestVerify_RejectsOverLongCert(t *testing.T) {
 	pv := core.NewMockPV()
 	// Currently valid, but with a window that exceeds MaxCertValidity.
-	cert, err := buildServerCert(pv, time.Now(), MaxCertValidity+time.Hour)
+	cert, err := buildServerCert(pv, validityTestChainID, time.Now(), MaxCertValidity+time.Hour)
 	require.NoError(t, err)
 
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
-	err = VerifyPeer(pub)(cert.Certificate, nil)
+	err = VerifyPeer(pub, validityTestChainID)(cert.Certificate, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "exceeds maximum")
 }
@@ -85,7 +87,7 @@ func TestVerify_RejectsCertValidityDifferentFromSigned(t *testing.T) {
 
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
-	err = verifyCert(cert, pub)
+	err = verifyCert(cert, pub, validityTestChainID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "certificate validity does not match signed identity")
 }
@@ -106,7 +108,7 @@ func TestVerify_RejectsMissingServerAuthEKU(t *testing.T) {
 
 	pub, err := pv.GetPubKey()
 	require.NoError(t, err)
-	err = verifyCert(cert, pub)
+	err = verifyCert(cert, pub, validityTestChainID)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "serverAuth")
 }
@@ -139,7 +141,7 @@ func forgeCert(t *testing.T, signer core.PrivValidator, o forgeOpts) *x509.Certi
 	})
 	require.NoError(t, err)
 
-	sig, err := signer.SignRawBytes(signDomain, SignUniqueID, signedBytes(payloadDER))
+	sig, err := signer.SignRawBytes(validityTestChainID, SignUniqueID, signedBytes(payloadDER))
 	require.NoError(t, err)
 
 	extBytes, err := asn1.Marshal(signedIdentity{Payload: payloadDER, Signature: sig})

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -98,7 +98,7 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	}
 	s.log.Info("signer ready")
 
-	cert, err := tlsid.BuildServerCert(s.signer, s.state.ChainID())
+	cert, err := tlsid.BuildServerCert(s.signer)
 	if err != nil {
 		return fmt.Errorf("building TLS cert: %w", err)
 	}

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -98,7 +98,7 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	}
 	s.log.Info("signer ready")
 
-	cert, err := tlsid.BuildServerCert(s.signer)
+	cert, err := tlsid.BuildServerCert(s.signer, s.state.ChainID())
 	if err != nil {
 		return fmt.Errorf("building TLS cert: %w", err)
 	}

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -2,16 +2,19 @@ package fibre
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 
 	fibregrpc "github.com/celestiaorg/celestia-app/v9/fibre/internal/grpc"
+	"github.com/celestiaorg/celestia-app/v9/fibre/internal/tlsid"
 	"github.com/celestiaorg/celestia-app/v9/fibre/state"
 	core "github.com/cometbft/cometbft/types"
 	"go.opentelemetry.io/otel/trace"
 	grpclib "google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Server implements the Fibre gRPC service for validators.
@@ -57,14 +60,9 @@ func NewServer(cfg ServerConfig) (*Server, error) {
 		metrics: metrics,
 	}
 
-	server.grpc, err = fibregrpc.NewServer(
-		cfg.ServerListenAddress,
-		server,
-		grpclib.MaxRecvMsgSize(cfg.MaxMessageSize),
-		grpclib.MaxSendMsgSize(cfg.MaxMessageSize),
-	)
+	server.grpc, err = fibregrpc.Listen(cfg.ServerListenAddress)
 	if err != nil {
-		return nil, fmt.Errorf("creating gRPC server: %w", err)
+		return nil, fmt.Errorf("opening gRPC listener: %w", err)
 	}
 
 	return server, nil
@@ -99,6 +97,20 @@ func (s *Server) Start(ctx context.Context) (err error) {
 		return fmt.Errorf("creating signer: %w", err)
 	}
 	s.log.Info("signer ready")
+
+	cert, err := tlsid.BuildServerCert(s.signer, s.state.ChainID())
+	if err != nil {
+		return fmt.Errorf("building TLS cert: %w", err)
+	}
+	creds := credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS13,
+	})
+	s.grpc.Register(s,
+		grpclib.MaxRecvMsgSize(s.Config.MaxMessageSize),
+		grpclib.MaxSendMsgSize(s.Config.MaxMessageSize),
+		grpclib.Creds(creds),
+	)
 
 	s.store, err = s.Config.StoreFn(s.Config.StoreConfig)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds validator-endorsed TLS to the Fibre server<->client gRPC link (built on Solution A's commit `9462be35e`), then hardens it per the cross-solution security review.

The server presents a self-signed cert whose **ephemeral** TLS key is endorsed **once** by the validator consensus key (via `SignRawBytes`); the client verifies that endorsement against the validator-set pubkey during the TLS handshake. The consensus key never enters the TLS hot path.

Closes: https://linear.app/celestia/issue/PROTOCO-1807/fibre-grpc-tls-validator-endorsed-transport-security

## What's included

- Signed, structured identity binding (version + validity window + TLS pubkey), enforced client-side: validity windows, a `MaxCertValidity` ceiling, cert==endorsement validity, and the serverAuth EKU.
- Consensus pubkey is **not** embedded - the endorsement signature is verified directly against the validator-set key.
- The structured binding payload is host-agnostic and chain-ID-free, while the outer `SignRawBytes` envelope uses the runtime chain ID for compatibility with chain-ID-enforcing remote signers.
- `VerifyConnection` (re-checks identity on resumed TLS 1.3 sessions); the dialer logs identity-verification failures with validator/host context.
- Endorsement carried in a canonical **DER X.509 extension**. The OID is a documented placeholder (PEN 32473, RFC 5612 example) pending a Celestia-owned PEN - tracked in #7382.
- Registered-but-not-served listener-leak fix in the gRPC server wrapper.
- TLS posture + design decisions + rollout docs in `fibre/cmd/README.md`.

## Design decisions (why)

- **Endorsement, not consensus-key-as-TLS-key:** the consensus key stays in the signer (tmkms/HSM) and is touched only once at cert mint via `SignRawBytes`; a disposable ephemeral key is on the TLS hot path. (Signers expose `SignRawBytes`, not raw TLS signing - so the consensus key can't be the TLS key.)
- **Host-agnostic:** identity is the consensus key, not the network location (no SNI/SAN/IP/DNS check) -> the on-chain host registry can use an IP literal **or** a DNS name; TLS imposes no host-format constraint.
- **Runtime chain ID in the signing envelope:** the certificate payload itself does not carry chain ID, but `SignRawBytes` still uses the runtime chain ID. This preserves compatibility with CometBFT remote signer/HSM policies that reject requests for unexpected chain IDs, while `SignUniqueID` provides purpose-based domain separation from votes/proposals/promises.
- **No embedded consensus pubkey:** the client already has it from the validator set, so the signature is verified directly against that key.
- **Long-lived cert, re-minted on restart, no refresh:** a Celestia validator consensus key cannot rotate and the TLS key is ephemeral. Operators are expected to restart well within the one-year validity window as part of normal release cadence.
- **DER extension under an owned OID:** the endorsement must reach the client at handshake time (so it rides in the cert); DER is canonical and friendly to non-Go verifiers (lumina). Reusing libp2p was considered and rejected - its in-process-key + bare-signature model is incompatible with the remote-signer `SignRawBytes` envelope.

## Not in this PR (tracked follow-ups)

Independent / pre-existing, intentionally deferred:

- Celestia-owned PEN / OID migration: #7382
- Versioned Fibre TLS identity spec + golden vectors: #7383
- Rust/lumina and Talis endorsed-TLS compatibility: #7384
- Go `fibre-txsim` endorsed-TLS client (blocks some e2e/talis paths)
- client-cache eviction + start race
- upload/download TLS-error aggregation
- valaddr `ValidateHost` + keeper write-boundary check
- `Serve`-error reporting

## Threat model / scope

Server-auth-only TLS; **downloads are public by design**; privval/app gRPC links are **loopback-only (out of scope)**; **greenfield** rollout - TLS is always-on with no plaintext fallback, so coordinate cutover.

## Testing

`go test ./fibre/internal/tlsid ./fibre/internal/grpc ./fibre`, `go test -tags=ledger,fibre ./fibre/internal/tlsid ./fibre/internal/grpc ./fibre`, `go tool golangci-lint run --timeout 10m`, and `go tool golangci-lint run --timeout 10m --build-tags fibre` pass locally.

## Notes for operators

The validator signer must support `SignRawBytes`; do **not** terminate Fibre TLS at a proxy/load-balancer (must be passthrough). See `fibre/cmd/README.md` -> Transport security (TLS).
