### PR TITLE
test(app): tolerate GetTx race in TestStandardSDK assert messages

### DIFF
--- a/app/test/std_sdk_test.go
+++ b/app/test/std_sdk_test.go
@@ -1,6 +1,7 @@
 package app_test
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
@@ -349,21 +350,30 @@ func (s *StandardSDKIntegrationTestSuite) TestStandardSDK() {
 
 				switch txError := err.(type) {
 				case *user.ExecutionError:
-					txResp, err := serviceClient.GetTx(s.cctx.GoContext(), &sdktx.GetTxRequest{Hash: txError.TxHash})
-					require.NoError(t, err)
-					assert.Equal(t, tt.expectedCode, txError.Code, txResp.TxResponse.RawLog)
+					assert.Equal(t, tt.expectedCode, txError.Code, fetchRawLog(s.cctx.GoContext(), serviceClient, txError.TxHash))
 				case *user.BroadcastTxError:
 					assert.Equal(t, tt.expectedCode, txError.Code, txError.ErrorLog)
 				}
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, res)
-				getTxResp, err := serviceClient.GetTx(s.cctx.GoContext(), &sdktx.GetTxRequest{Hash: res.TxHash})
-				require.NoError(t, err)
-				assert.Equal(t, tt.expectedCode, res.Code, getTxResp.TxResponse.RawLog)
+				assert.Equal(t, tt.expectedCode, res.Code, fetchRawLog(s.cctx.GoContext(), serviceClient, res.TxHash))
 			}
 		})
 	}
+}
+
+// fetchRawLog returns the raw log for txHash on a best-effort basis. Used only
+// to enrich assert failure messages; it must not fail the test if the cosmos
+// tx indexer hasn't caught up yet (celestia's TxStatus reports COMMITTED via
+// BlockStore.SaveTxInfo before the async IndexerService populates the index
+// GetTx reads, so calls right after SubmitTx can race and return NotFound).
+func fetchRawLog(ctx context.Context, serviceClient sdktx.ServiceClient, txHash string) string {
+	resp, err := serviceClient.GetTx(ctx, &sdktx.GetTxRequest{Hash: txHash})
+	if err != nil || resp == nil || resp.TxResponse == nil {
+		return ""
+	}
+	return resp.TxResponse.RawLog
 }
 
 func (s *StandardSDKIntegrationTestSuite) TestGRPCQueries() {


### PR DESCRIPTION
## Summary

`TestStandardSDKIntegrationTestSuite/TestStandardSDK` flakes in CI with:

```
rpc error: code = NotFound desc = tx not found: <hash>
```

at `app/test/std_sdk_test.go:362`. The `GetTx` call right after `SubmitTx` returns success races with CometBFT's async tx indexer.

Evidence of the flake on a recent run (unrelated PR, same failure mode):
https://github.com/celestiaorg/celestia-app/actions/runs/26586501354/job/78344286662

Also tracked at https://github.com/celestiaorg/celestia-app/issues/7259.

## Root cause

Two tx indexes are populated in celestia-core at different points:

1. `BlockStore.SaveTxInfo` runs **synchronously** inside block commit (`state/execution.go:361`). Celestia's `TxStatus` RPC reads from this (`rpc/core/tx.go:232`).
2. CometBFT `TxIndexer` is populated **asynchronously** by `IndexerService` via event-bus subscription (`state/txindex/indexer_service.go:60`). Cosmos-sdk's `GetTx` reads from this.

`txClient.SubmitTx` (`pkg/user/tx_client.go:764`) returns the moment celestia's `TxStatus` reports `COMMITTED`. The test then calls `serviceClient.GetTx(hash)` immediately, before the `IndexerService` goroutine has drained `EventDataTx` events. Small window, lost in CI sometimes.

## Fix

`GetTx` here is only called to extract `RawLog` for the `assert.Equal` failure message — diagnostic, not assertive. Wrap it in a best-effort helper that returns an empty string when the indexer hasn't caught up. If a test fails, the assert still fires; we just lose the raw-log context in the rare race case.

If we later need the raw log to be reliable (e.g. for debugging a real assertion failure), we can swap the helper for a short retry loop. Keeping it simple here since the only consumer is the message arg.

## Test plan

- [x] `go test -timeout 600s -count=3 -run 'TestStandardSDKIntegrationTestSuite' ./app/test/` passes locally across iterations.
- [ ] CI green.

Closes https://github.com/celestiaorg/celestia-app/issues/7259.

Linear: https://linear.app/celestia/issue/PROTOCO-1818/de-flake-teststandardsdkintegrationtestsuite-by-tolerating-gettx-race