### PR TITLE
chore(ci): bump celestiaorg/.github to v0.6.5

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@9ee03305d3cc6cf520b7895436429aa853b58e70 #v0.6.4
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@33bbeb98fdf8d910a236e365b5f013cdfb81c082 #v0.6.5
     with:
       dockerfile: docker/standalone.Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}
@@ -34,7 +34,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@9ee03305d3cc6cf520b7895436429aa853b58e70 #v0.6.4
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@33bbeb98fdf8d910a236e365b5f013cdfb81c082 #v0.6.5
     with:
       dockerfile: docker/multiplexer.Dockerfile
       checkout_ref: ${{ github.event.inputs.ref }}
@@ -45,7 +45,7 @@ jobs:
     permissions:
       contents: write
       packages: write
-    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@9ee03305d3cc6cf520b7895436429aa853b58e70 #v0.6.4
+    uses: celestiaorg/.github/.github/workflows/reusable_dockerfile_pipeline.yml@33bbeb98fdf8d910a236e365b5f013cdfb81c082 #v0.6.5
     with:
       dockerfile: docker/txsim/Dockerfile
       packageName: txsim

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -92,5 +92,5 @@ jobs:
           PATTERNS: |
             **/*.yml
             **/*.yaml
-      - uses: celestiaorg/.github/.github/actions/yamllint@9ee03305d3cc6cf520b7895436429aa853b58e70 #v0.6.4
+      - uses: celestiaorg/.github/.github/actions/yamllint@33bbeb98fdf8d910a236e365b5f013cdfb81c082 #v0.6.5
         if: env.GIT_DIFF


### PR DESCRIPTION
## Overview

Bumps the `celestiaorg/.github` reusable workflows and actions from `v0.6.4` to [`v0.6.5`](https://github.com/celestiaorg/.github/releases/tag/v0.6.5).

This is motivated by celestiaorg/.github#157, which should address some recent CI failures in celestia-app.

Updated references:
- `.github/workflows/lint.yml` (yamllint action)
- `.github/workflows/docker-build-publish.yml` (reusable dockerfile pipeline, 3 occurrences)

🤖 Generated with [Claude Code](https://claude.com/claude-code)