### PR TITLE
fix(test): reduce TestSyncToTipMocha nightly flakiness

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -55,12 +55,19 @@ jobs:
   test-nightly:
     needs: build-e2e-image
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Generous budget so the retried sync test (up to 3 attempts) has headroom
+    # without prematurely killing the long-running upgrade/tx tests.
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         include:
+          # TestSyncToTipMocha syncs against the live mocha testnet and can
+          # intermittently stall when no connected peer is serving a usable
+          # state-sync snapshot. Retry it before failing the nightly. Other
+          # tests default to a single attempt so real failures aren't masked.
           - test: TestSyncToTipMocha
+            max-attempts: 3
           - test: TestAllUpgrades
           - test: TestTxSubmission
             extra-image: true
@@ -92,7 +99,13 @@ jobs:
           -f docker/latency-monitor/Dockerfile .
 
       - name: Run ${{ matrix.test }}
-        run: make test-docker-e2e test=${{ matrix.test }}
+        uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
+        with:
+          # Per-attempt cap; comfortably above a single run of any nightly test.
+          timeout_minutes: 30
+          # Defaults to 1 attempt (no retry) for tests that don't opt in.
+          max_attempts: ${{ matrix.max-attempts || 1 }}
+          command: make test-docker-e2e test=${{ matrix.test }}
         env:
           CELESTIA_IMAGE: ghcr.io/celestiaorg/celestia-app
           CELESTIA_TAG: ${{ needs.build-e2e-image.outputs.tag }}

--- a/test/docker-e2e/networks/config.go
+++ b/test/docker-e2e/networks/config.go
@@ -16,7 +16,15 @@ func NewMochaConfig() *Config {
 	return &Config{
 		Name:    "mocha",
 		ChainID: appconsts.MochaChainID,
-		RPCs:    []string{"https://celestia-testnet-rpc.itrocket.net:443", "https://celestia-testnet-rpc.itrocket.net:443"},
+		// State sync requires >= 2 RPC servers to cross-verify the app hash
+		// header. These must be distinct providers: listing one host twice
+		// gives no redundancy, so a single slow/unavailable provider stalls
+		// state sync. Keep these in sync with the live mocha-4 testnet.
+		RPCs: []string{
+			"https://celestia-testnet-rpc.itrocket.net:443",
+			"https://rpc-mocha.pops.one:443",
+			"https://full.consensus.mocha-4.celestia-mocha.com:443",
+		},
 		Seeds:   "b402fe40f3474e9e208840702e1b7aa37f2edc4b@celestia-testnet-seed.itrocket.net:14656,ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@seed-mocha.pops.one:26656",
 		Peers:   "daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656,96b2761729cea90ee7c61206433fc0ba40c245bf@57.128.141.126:11656,f4f75a55bfc5f302ef34435ef096a4551ecb6804@152.53.33.96:12056,31bb1c9c1be7743d1115a8270bd1c83d01a9120a@148.72.141.31:26676,3e30bcfc55e7d351f18144aab4b0973e9e9bf987@65.108.226.183:11656,7a0d5818c0e5b0d4fbd86a9921f413f5e4e4ac1e@65.109.83.40:28656,43e9da043318a4ea0141259c17fcb06ecff816af@164.132.247.253:43656,5a7566aa030f7e5e7114dc9764f944b2b1324bcd@65.109.23.114:11656,c17c0cbf05e98656fee5f60fad469fc528f6d6de@65.109.25.113:11656,fb5e0b9efacc11916c58bbcd3606cbaa7d43c99f@65.108.234.84:28656,45504fb31eb97ea8778c920701fc8076e568a9cd@188.214.133.100:26656,edafdf47c443344fb940a32ab9d2067c482e59df@84.32.71.47:26656,ae7d00d6d70d9b9118c31ac0913e0808f2613a75@177.54.156.69:26656,7c841f59c35d70d9f1472d7d2a76a11eefb7f51f@136.243.69.100:43656",
 	}

--- a/test/docker-e2e/networks/config_test.go
+++ b/test/docker-e2e/networks/config_test.go
@@ -42,3 +42,28 @@ func TestMochaConfigUpdate(t *testing.T) {
 	
 	t.Logf("Mocha config updated successfully with %d peers and correct seeds", len(peerList))
 }
+
+// TestMochaConfigRPCsAreDistinct verifies that the mocha RPC list contains at
+// least two distinct endpoints. CometBFT state sync requires >= 2 RPC servers
+// to cross-verify the app hash header; listing the same host twice satisfies
+// the count but provides no redundancy, so a single slow or unavailable
+// provider stalls state sync (see flaky TestSyncToTipMocha nightly failures).
+func TestMochaConfigRPCsAreDistinct(t *testing.T) {
+	config := NewMochaConfig()
+
+	if len(config.RPCs) < 2 {
+		t.Fatalf("Expected at least 2 RPC servers for state sync, got %d", len(config.RPCs))
+	}
+
+	seen := make(map[string]bool)
+	for _, rpc := range config.RPCs {
+		if seen[rpc] {
+			t.Errorf("Duplicate RPC endpoint %q: state sync needs distinct servers for redundancy", rpc)
+		}
+		seen[rpc] = true
+	}
+
+	if len(seen) < 2 {
+		t.Errorf("Expected at least 2 distinct RPC endpoints, got %d distinct out of %d", len(seen), len(config.RPCs))
+	}
+}


### PR DESCRIPTION
## Overview

`TestSyncToTipMocha` state-syncs a fresh node against the **live mocha testnet** under a 10-minute deadline. It fails intermittently (~3 of the last 12 nightlies: 5/29, 5/28, 5/23). In every failure the node's statesync reactor spins in the `sync any` snapshot-discovery loop and never applies a snapshot, so Phase 1's `WaitForSync(LatestBlockHeight >= trustHeight)` times out at ~625s. This is an external-dependency flake (no usable snapshot from connected peers at `trustHeight = latest − 2000`), not a code regression.

Example failed run: https://github.com/celestiaorg/celestia-app/actions/runs/26615593432

## Changes

- **Diversify state-sync RPC servers.** The list was a single host listed twice (`itrocket`), padded to satisfy CometBFT's ≥2 RPC server requirement but giving zero redundancy for trust-height bootstrap and light-block verification. Replaced with three distinct, verified mocha-4 providers (itrocket, `rpc-mocha.pops.one`, `full.consensus.mocha-4.celestia-mocha.com`). Added `TestMochaConfigRPCsAreDistinct` asserting the endpoints are distinct.
- **Retry the sync test in CI.** Wrapped the nightly run step in `nick-fields/retry`, scoped via the matrix so only `TestSyncToTipMocha` opts into 3 attempts; the other e2e tests default to a single attempt so their real failures aren't masked. Bumped the job timeout to 90m for headroom.

## Testing

- New `TestMochaConfigRPCsAreDistinct`: red against the duplicated list, green after the fix.
- Verified all three RPC endpoints serve mocha-4 `/status` and historical `/commit`.
- `go build` / `go vet` clean on the `test/docker-e2e` module; `make lint` clean for Go (pre-existing markdownlint MD060 errors in unrelated files are out of scope).

Closes PROTOCO-1828