### PR TITLE
fix(fibre): free input blob at all Client.Upload call sites

### DIFF
--- a/fibre/client_put.go
+++ b/fibre/client_put.go
@@ -51,6 +51,7 @@ func Put(ctx context.Context, c *Client, txClient *user.TxClient, ns share.Names
 		span.SetStatus(codes.Error, "failed to encode blob")
 		return result, err
 	}
+	defer blob.Free()
 
 	blobID := blob.ID()
 	span.AddEvent("blob_encoded", trace.WithAttributes(

--- a/fibre/client_test.go
+++ b/fibre/client_test.go
@@ -53,6 +53,11 @@ func makeTestBlobV0(t *testing.T, sizeBytes int) *fibre.Blob {
 
 	blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
 	require.NoError(t, err)
+	// Free the source blob when the test ends so it is released even when the
+	// caller does not free it explicitly. Free is idempotent, so callers that
+	// already `defer blob.Free()` (or free early, as the use-after-free test
+	// does) remain correct.
+	t.Cleanup(blob.Free)
 	return blob
 }
 

--- a/fibre/client_upload_bench_test.go
+++ b/fibre/client_upload_bench_test.go
@@ -98,6 +98,7 @@ func BenchmarkClient_Upload(b *testing.B) {
 				if err != nil {
 					return err
 				}
+				defer blob.Free()
 				result, err := client.Upload(ctx, namespace, blob)
 				if err != nil {
 					return err

--- a/tools/fibre-txsim/main.go
+++ b/tools/fibre-txsim/main.go
@@ -492,6 +492,7 @@ func submitBlob(ctx context.Context, w worker, blobSize int, uploadOnly bool, st
 			fmt.Printf("[%s] blob encode error: %v\n", w.keyName, err)
 			return
 		}
+		defer blob.Free()
 		_, err = w.fibreClient.Upload(ctx, ns, blob, fibre.WithKeyName(w.keyName))
 		lat := time.Since(t)
 		if err != nil {
@@ -515,6 +516,7 @@ func submitBlob(ctx context.Context, w worker, blobSize int, uploadOnly bool, st
 		fmt.Printf("[%s] blob encode error: %v\n", w.keyName, err)
 		return
 	}
+	defer blob.Free()
 
 	signedPromise, err := w.fibreClient.Upload(ctx, ns, blob, fibre.WithKeyName(w.keyName))
 	if err != nil {


### PR DESCRIPTION
`Client.Upload`'s input blob holds pool-backed storage the caller must release via Blob.Free. Several call sites never did: Put, fibre-txsim and the upload benchmark.

Bug from #7283: I asked the agent to add the missing Free calls, and it only added them for downloads, not uploads. This PR addresses that. 

