### PR TITLE
docs: update dependency forks table for v0.40.x and v9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,8 @@ All branches use forked cosmos-sdk and celestia-core:
 
 | celestia-app | celestia-core      | cosmos-sdk                 |
 |--------------|--------------------|----------------------------|
-| `main`       | `main`             | `release/v0.52.x-celestia` |
+| `main`       | `v0.40.x`          | `release/v0.52.x-celestia` |
+| `v9.x`       | `v0.40.x`          | `release/v0.52.x-celestia` |
 | `v8.x`       | `v0.39.x-celestia` | `release/v0.52.x-celestia` |
 | `v7.x`       | `v0.39.x-celestia` | `release/v0.52.x-celestia` |
 | `v6.x`       | `v0.39.x-celestia` | `release/v0.51.x-celestia` |


### PR DESCRIPTION
## Overview

Updates the dependency forks table in `CLAUDE.md` to reflect the current state of the `main` branch and adds a row for the celestia-app `v9.x` release.

### Changes

- `main` now tracks celestia-core `v0.40.x` (was `main`), confirmed by `go.mod` pinning `celestia-core v0.40.2`.
- Added a row for `v9.x`, which pins the same `celestia-core v0.40.2` / `cosmos-sdk v0.52.6` as `main`.

Note: the new `v0.40.x` core branch drops the `-celestia` suffix used by older branches (e.g. `v0.39.x-celestia`); that matches the actual upstream branch name.

Docs-only change (no Go code), so no lint required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)