### PR TITLE
chore(deps): bump celestia-core to include comet refactor backport

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -459,7 +459,7 @@ replace (
 	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
-	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.40.2
+	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17.0.20260601234605-ab7b303ac203
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.6
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"

--- a/go.sum
+++ b/go.sum
@@ -255,8 +255,8 @@ github.com/catenacyber/perfsprint v0.10.1 h1:u7Riei30bk46XsG8nknMhKLXG9BcXz3+3tl
 github.com/catenacyber/perfsprint v0.10.1/go.mod h1:DJTGsi/Zufpuus6XPGJyKOTMELe347o6akPvWG9Zcsc=
 github.com/ccojocar/zxcvbn-go v1.0.4 h1:FWnCIRMXPj43ukfX000kvBZvV6raSxakYr1nzyNrUcc=
 github.com/ccojocar/zxcvbn-go v1.0.4/go.mod h1:3GxGX+rHmueTUMvm5ium7irpyjmm7ikxYFOSJB21Das=
-github.com/celestiaorg/celestia-core v0.40.2 h1:+8D3anWx0mn0Wyp/Hahml/1ZiyDc5yGbIR/k4iFtqms=
-github.com/celestiaorg/celestia-core v0.40.2/go.mod h1:ZCrmRE1UQzgZfho4Og6tAHtH1KY6s8Jpri5+EKobV5c=
+github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17.0.20260601234605-ab7b303ac203 h1:IigSR9oMPT+6rjs7ffkSV4TFYemzMbG9s+w+J+2/VTQ=
+github.com/celestiaorg/celestia-core v1.54.0-tm-v0.38.17.0.20260601234605-ab7b303ac203/go.mod h1:ZCrmRE1UQzgZfho4Og6tAHtH1KY6s8Jpri5+EKobV5c=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
 github.com/celestiaorg/cosmos-sdk v0.52.6 h1:8dNW6ONrOokGh25MMnh4uQhQKTRDYvM5Rv1hf3ApbW4=


### PR DESCRIPTION
Draft. Bumps the `celestia-core` replacement to include the comet refactor backport ([celestiaorg/celestia-core#3078](https://github.com/celestiaorg/celestia-core/pull/3078), backport of [cometbft/cometbft#5718](https://github.com/cometbft/cometbft/pull/5718)).

Currently pinned to a placeholder pseudo-version of the `v0.40.x` backport commit so CI can build against the fix now. **Once the next `v0.40.x` tag is cut, swap this for the tag and mark ready.**