### PR TITLE
fix: replace MustGetFreePort with deterministic port allocation

### DIFF
--- a/test/util/testnode/config.go
+++ b/test/util/testnode/config.go
@@ -166,10 +166,10 @@ func DefaultTendermintConfig() *tmconfig.Config {
 	tmCfg := app.DefaultConsensusConfig()
 
 	// Set all the ports to random open ones.
-	tmCfg.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-	tmCfg.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-	tmCfg.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-	tmCfg.PrivValidatorGRPCListenAddr = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
+	tmCfg.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
+	tmCfg.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
+	tmCfg.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
+	tmCfg.PrivValidatorGRPCListenAddr = fmt.Sprintf("127.0.0.1:%d", GetDeterministicPort())
 
 	tmCfg.TxIndex.Indexer = "kv"
 
@@ -231,8 +231,8 @@ func CustomAppCreator(appOptions ...func(*baseapp.BaseApp)) srvtypes.AppCreator 
 func DefaultAppConfig() *srvconfig.Config {
 	appCfg := app.DefaultAppConfig()
 	appCfg.GRPC.Enable = true
-	appCfg.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
+	appCfg.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", GetDeterministicPort())
 	appCfg.API.Enable = true
-	appCfg.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
+	appCfg.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
 	return appCfg
 }

--- a/test/util/testnode/network.go
+++ b/test/util/testnode/network.go
@@ -124,13 +124,13 @@ func tryStartNetwork(t testing.TB, config *Config) (cctx Context, rpcAddr, grpcA
 // and DefaultAppConfig; missing any one of them makes the retry loop in
 // NewNetworkWithRetry re-use a stale port on every attempt (see #7137).
 func reassignListenPorts(config *Config) {
-	config.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-	config.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-	config.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
-	config.TmConfig.PrivValidatorGRPCListenAddr = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
-	config.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", MustGetFreePort())
+	config.TmConfig.RPC.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
+	config.TmConfig.P2P.ListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
+	config.TmConfig.RPC.GRPCListenAddress = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
+	config.TmConfig.PrivValidatorGRPCListenAddr = fmt.Sprintf("127.0.0.1:%d", GetDeterministicPort())
+	config.AppConfig.GRPC.Address = fmt.Sprintf("127.0.0.1:%d", GetDeterministicPort())
 	config.AppConfig.API.Enable = true
-	config.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", MustGetFreePort())
+	config.AppConfig.API.Address = fmt.Sprintf("tcp://127.0.0.1:%d", GetDeterministicPort())
 }
 
 // isPortBindingError checks if an error is related to port binding failures

--- a/test/util/testnode/utils.go
+++ b/test/util/testnode/utils.go
@@ -29,6 +29,10 @@ import (
 // We use a larger increment on macOS to account for port release delays
 var portCounter atomic.Int64
 
+// portWrapOffset shifts the port sequence by 1 each time we wrap past 65535,
+// so repeated cycles land on different ports.
+var portWrapOffset atomic.Int64
+
 // portIncrement defines how much to increment between port allocations
 // Mimic cicaidas by using a prime number to avoid patterns and conflicts with other allocation schemes
 const portIncrement = 11
@@ -115,15 +119,6 @@ func GetFreePort() (int, error) {
 	return l.LocalAddr().(*net.UDPAddr).Port, nil
 }
 
-// MustGetFreePort returns a free port and panics in case of an error.
-func MustGetFreePort() int {
-	port, err := GetFreePort()
-	if err != nil {
-		panic(err)
-	}
-	return port
-}
-
 // isPortAvailable checks if a port is available by attempting to listen on it.
 // It checks both TCP and UDP to ensure the port is truly available across platforms.
 func isPortAvailable(port int) bool {
@@ -157,9 +152,13 @@ func isPortAvailable(port int) bool {
 // Uses larger increments to avoid conflicts from delayed port releases on macOS.
 func GetDeterministicPort() int {
 	for {
-		port := int(portCounter.Add(portIncrement))
-		if isPortAvailable(port) {
-			return port
+		raw := int(portCounter.Add(portIncrement))
+		if raw > 65535 {
+			portCounter.Store(20000 + portWrapOffset.Add(1))
+			raw = int(portCounter.Add(portIncrement))
+		}
+		if isPortAvailable(raw) {
+			return raw
 		}
 		// On macOS, ports may not be immediately available after closing
 		// Continue with next increment if port is still bound


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Marked R4R to run all the tests, will re-run them a few times to make sure we don't see the error mentioned in #7074 

The `MustGetFreePort` function was still able to return the same port for tests running in parallel, the existing `GetDeterministicPort` should fix these issues.

Ref #7074 (can close issue if fix is confirmed to work)

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
