### PR TITLE
fix: retry tx query to avoid flaky "tx not found" in integration tests

### DIFF
--- a/test/util/testnode/comet_node_test.go
+++ b/test/util/testnode/comet_node_test.go
@@ -1,6 +1,7 @@
 package testnode
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -67,10 +68,9 @@ func (s *IntegrationTestSuite) TestFillBlock() {
 		resp, err := s.cctx.FillBlock(squareSize, s.accounts[1], flags.BroadcastSync)
 		require.NoError(err)
 
-		err = s.cctx.WaitForBlocks(3)
-		require.NoError(err, squareSize)
-
-		res, err := QueryWithoutProof(s.cctx.Context, resp.TxHash)
+		queryCtx, queryCancel := context.WithTimeout(s.cctx.GoContext(), 15*time.Second)
+		defer queryCancel()
+		res, err := QueryWithoutProofWithRetry(queryCtx, s.cctx.Context, resp.TxHash)
 		require.NoError(err, squareSize)
 		require.Equal(abci.CodeTypeOK, res.TxResult.Code, squareSize)
 

--- a/test/util/testnode/utils.go
+++ b/test/util/testnode/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 	"sync/atomic"
+	"time"
 
 	"cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v9/app"
@@ -57,6 +58,34 @@ func QueryWithoutProof(clientCtx client.Context, hashHexStr string) (*rpctypes.R
 	}
 
 	return node.Tx(context.Background(), hash, false)
+}
+
+// QueryWithoutProofWithRetry polls for a tx by hash until it is indexed
+// or the context is cancelled.
+func QueryWithoutProofWithRetry(ctx context.Context, clientCtx client.Context, hashHexStr string) (*rpctypes.ResultTx, error) {
+	hash, err := hex.DecodeString(hashHexStr)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := clientCtx.GetNode()
+	if err != nil {
+		return nil, err
+	}
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("tx %s not found: %w", hashHexStr, ctx.Err())
+		case <-ticker.C:
+			res, err := node.Tx(ctx, hash, false)
+			if err == nil {
+				return res, nil
+			}
+		}
+	}
 }
 
 func NewKeyring(accounts ...string) (keyring.Keyring, []sdk.AccAddress) {

--- a/x/blob/client/testutil/integration_test.go
+++ b/x/blob/client/testutil/integration_test.go
@@ -1,11 +1,13 @@
 package testutil
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
@@ -156,11 +158,10 @@ func (s *IntegrationTestSuite) TestSubmitPayForBlob() {
 			require.Equal(tc.expectedCode, txResp.Code,
 				"test: %s, output\n:", tc.name, out.String())
 
-			// wait for the tx to be indexed
-			s.Require().NoError(s.ctx.WaitForNextBlock())
-
-			// attempt to query for the transaction using the tx's hash
-			res, err := testnode.QueryWithoutProof(s.ctx.Context, txResp.TxHash)
+			// poll until the tx is indexed
+			queryCtx, queryCancel := context.WithTimeout(s.ctx.GoContext(), 5*time.Second)
+			defer queryCancel()
+			res, err := testnode.QueryWithoutProofWithRetry(queryCtx, s.ctx.Context, txResp.TxHash)
 			require.NoError(err)
 			require.Equal(abci.CodeTypeOK, res.TxResult.Code)
 


### PR DESCRIPTION
Closes #7262

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Add a short polling to wait for tx inclusion, `BroadcastSync` does not guarantee block inclusion, just that the tx has entered the mempool.

The existing `WaitForNextBlock` does not seem to sufficiently handle this case.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
