### PR TITLE
fix: disable privval gRPC server in non-fibre builds

### DIFF
--- a/cmd/celestia-appd/cmd/fibre_disabled.go
+++ b/cmd/celestia-appd/cmd/fibre_disabled.go
@@ -1,0 +1,8 @@
+//go:build !fibre
+
+package cmd
+
+// isFibreEnabled reports whether the binary was built with the fibre build tag.
+func isFibreEnabled() bool {
+	return false
+}

--- a/cmd/celestia-appd/cmd/fibre_enabled.go
+++ b/cmd/celestia-appd/cmd/fibre_enabled.go
@@ -1,0 +1,8 @@
+//go:build fibre
+
+package cmd
+
+// isFibreEnabled reports whether the binary was built with the fibre build tag.
+func isFibreEnabled() bool {
+	return true
+}

--- a/cmd/celestia-appd/cmd/override_privval_grpc_config.go
+++ b/cmd/celestia-appd/cmd/override_privval_grpc_config.go
@@ -8,9 +8,7 @@ import (
 
 // overridePrivValidatorGRPCConfig disables the privval gRPC server in non-fibre
 // builds by clearing its listen address (core only starts the server when the
-// address is non-empty). Its default, 127.0.0.1:26659, conflicts with the
-// default TMKMS remote signing port. The fibre module needs this endpoint for
-// signing, so it is left untouched in fibre builds.
+// address is non-empty).
 func overridePrivValidatorGRPCConfig(cmd *cobra.Command, logger log.Logger) error {
 	if isFibreEnabled() {
 		return nil

--- a/cmd/celestia-appd/cmd/override_privval_grpc_config.go
+++ b/cmd/celestia-appd/cmd/override_privval_grpc_config.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"cosmossdk.io/log"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+)
+
+// overridePrivValidatorGRPCConfig disables the privval gRPC server in non-fibre
+// builds by clearing its listen address (core only starts the server when the
+// address is non-empty). Its default, 127.0.0.1:26659, conflicts with the
+// default TMKMS remote signing port. The fibre module needs this endpoint for
+// signing, so it is left untouched in fibre builds.
+func overridePrivValidatorGRPCConfig(cmd *cobra.Command, logger log.Logger) error {
+	if isFibreEnabled() {
+		return nil
+	}
+
+	sctx := server.GetServerContextFromCmd(cmd)
+	cfg := sctx.Config
+
+	if cfg.PrivValidatorGRPCListenAddr != "" {
+		logger.Info("Disabling privval gRPC server (PrivValidatorAPI)",
+			"configured", cfg.PrivValidatorGRPCListenAddr,
+		)
+		cfg.PrivValidatorGRPCListenAddr = ""
+	}
+
+	return nil
+}

--- a/cmd/celestia-appd/cmd/override_privval_grpc_config_test.go
+++ b/cmd/celestia-appd/cmd/override_privval_grpc_config_test.go
@@ -1,0 +1,34 @@
+//go:build !fibre
+
+package cmd
+
+import (
+	"context"
+	"testing"
+
+	"cosmossdk.io/log"
+	"github.com/celestiaorg/celestia-app/v9/app"
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOverridePrivValidatorGRPCConfig(t *testing.T) {
+	logger := log.NewNopLogger()
+	cmd := &cobra.Command{Use: "test"}
+
+	sctx := server.NewDefaultContext()
+	sctx.Config = app.DefaultConsensusConfig()
+	sctx.Config.PrivValidatorGRPCListenAddr = "127.0.0.1:26659"
+	sctx.Logger = logger
+
+	ctx := context.WithValue(context.Background(), server.ServerContextKey, sctx)
+	cmd.SetContext(ctx)
+
+	require.NoError(t, overridePrivValidatorGRPCConfig(cmd, logger))
+
+	// In non-fibre builds the privval gRPC server is disabled by clearing its
+	// listen address.
+	assert.Empty(t, server.GetServerContextFromCmd(cmd).Config.PrivValidatorGRPCListenAddr)
+}

--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -135,7 +135,7 @@ func initRootCommand(rootCommand *cobra.Command, capp *app.App) {
 	modifyRootCommand(rootCommand)
 
 	// Add hooks run prior to the start command
-	if err := addPreStartHooks(rootCommand, overrideConsensusTimeouts, overrideP2PConfig, checkBBR, overrideMinRetainBlocks, setupOTelMetrics); err != nil {
+	if err := addPreStartHooks(rootCommand, overrideConsensusTimeouts, overrideP2PConfig, overridePrivValidatorGRPCConfig, checkBBR, overrideMinRetainBlocks, setupOTelMetrics); err != nil {
 		panic(fmt.Errorf("failed to add pre-start hooks: %w", err))
 	}
 }


### PR DESCRIPTION
## Overview

Closes https://github.com/celestiaorg/celestia-app/issues/7348 and PROTOCO-1877