### PR TITLE
fix: deflake TestTimeInPrepareProposalContext

### DIFF
--- a/app/test/prepare_proposal_context_test.go
+++ b/app/test/prepare_proposal_context_test.go
@@ -44,18 +44,28 @@ func TestTimeInPrepareProposalContext(t *testing.T) {
 	}
 	tests := []test{
 		{
-			name: "create continuous vesting account with a start time in the future",
+			name: "create continuous vesting account that has already started vesting",
 			msgFunc: func() (msgs []sdk.Msg, signer string) {
 				_, _, err := cctx.Keyring.NewMnemonic(vestAccName, keyring.English, "", "", hd.Secp256k1)
 				require.NoError(t, err)
 				sendingAccAddr := testfactory.GetAddress(cctx.Keyring, sendAccName)
 				vestAccAddr := testfactory.GetAddress(cctx.Keyring, vestAccName)
+				// Start vesting in the past so that some coins have already
+				// vested (and are therefore spendable) by the time the second
+				// transaction is included in a block. Continuous vesting
+				// returns zero vested coins while blockTime <= startTime, so
+				// using time.Now() as the start time made this test flaky: if
+				// the send tx landed in a block whose timestamp (truncated to
+				// whole seconds) equalled the start time, the vesting account
+				// had zero spendable balance and could not pay the fee.
+				startTime := time.Now().Add(-time.Minute)
+				endTime := time.Now().Add(time.Second * 100)
 				msg := vestingtypes.NewMsgCreateVestingAccount(
 					sendingAccAddr,
 					vestAccAddr,
 					sdk.NewCoins(sdk.NewCoin(params.BondDenom, math.NewInt(1000000))),
-					time.Now().Unix(),
-					time.Now().Add(time.Second*100).Unix(),
+					startTime.Unix(),
+					endTime.Unix(),
 					false,
 				)
 				return []sdk.Msg{msg}, sendAccName


### PR DESCRIPTION
## Overview

Deflakes `TestTimeInPrepareProposalContext`, which intermittently fails in the nightly `test-race` CI job (e.g. [run 26927926980](https://github.com/celestiaorg/celestia-app/actions/runs/26927926980)) with:

```
broadcast tx error: ... spendable balance 0utia is smaller than 4000utia: insufficient funds
```

## Root cause

The test creates a `ContinuousVestingAccount` with `StartTime = time.Now().Unix()`, then immediately sends funds from it (paying a 4000utia fee). Cosmos SDK's `ContinuousVestingAccount.GetVestedCoins` returns zero vested coins while `blockTime.Unix() <= cva.StartTime`:

```go
if blockTime.Unix() <= cva.StartTime {
    return vestedCoins // nil
}
```

Both the start time and block timestamps are truncated to whole seconds, and the test runs within ~1-2 seconds. When the send tx lands in a block whose timestamp (in whole seconds) equals the start-time second, zero coins have vested, so the vesting account has 0 spendable balance and cannot pay the fee.

## Fix

Set the vesting start time one minute in the past so a meaningful fraction of coins has reliably vested by the time the send tx is included in a block. This still exercises the original behaviour the test guards: that block time is present in the ante-handler context (otherwise the send tx would be filtered out entirely).

## Testing

- `go test -run TestTimeInPrepareProposalContext ./app/test/` passes consistently (ran 3×).
- `go test -race -run TestTimeInPrepareProposalContext ./app/test/` passes.

Closes https://github.com/celestiaorg/celestia-app/actions/runs/26927926980
Closes PROTOCO-1881

🤖 Generated with [Claude Code](https://claude.com/claude-code)
