### PR TITLE
fix: use published goreleaser-cross tag v1.26.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ HTTPS_GIT := https://github.com/celestiaorg/celestia-app.git
 PACKAGE_NAME := github.com/celestiaorg/celestia-app/v9
 # Before upgrading the GOLANG_CROSS_VERSION, please verify that a Docker image exists with the new tag.
 # See https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross
-GOLANG_CROSS_VERSION  ?= v1.26.1
+GOLANG_CROSS_VERSION  ?= v1.26.2
 # Set this to override v2 upgrade height for the v3 embedded binaries
 V2_UPGRADE_HEIGHT ?= 0
 


### PR DESCRIPTION
## Problem

Recent releases (`v9.0.0-*`, `v9.0.1-*`, `v9.0.2-*`) shipped with **no goreleaser binaries** attached — only GitHub's auto-generated source archives show up. The release binaries (multiplexer + standalone for darwin/linux × amd64/arm64, plus `checksums.txt`) are missing.

## Root cause

The `goreleaser` CI job is gated on `needs: goreleaser-check`, and `goreleaser-check` was failing on every release with:

```
docker: Error response from daemon: manifest unknown
make: *** [Makefile:525: goreleaser-check] Error 125
```

`Makefile` pinned `GOLANG_CROSS_VERSION ?= v1.26.1` (set in #6872 to match the Go bump to 1.26.1), but **goreleaser-cross never published an image tagged `v1.26.1`** — it skipped the `.1` patch for the Go 1.26 line. Only `v1.26.0`, `v1.26.2`, and `v1.26.3` exist in `ghcr.io/goreleaser/goreleaser-cross`. So Docker fails with `manifest unknown`, the check job dies, and the dependent `goreleaser` job is skipped → no binaries uploaded.

This never blocked the release from being *created*, so it was a silent failure.

## Fix

Pin to `v1.26.2`, a published image whose Go version satisfies the `go.mod` requirement (`go 1.26.1`).

## Follow-up

Existing releases that shipped without binaries will need their `goreleaser` workflow re-run (or be re-published) once this lands so the assets get backfilled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)