### PR TITLE
refactor(rsema1d): rename rlc.Derive to DeriveCoefficients to match spec

### DIFF
--- a/pkg/rsema1d/README.md
+++ b/pkg/rsema1d/README.md
@@ -169,7 +169,7 @@ Row size is not in Config — every operation (Encode, Verify, VerifyStandaloneP
 ### Core Components
 
 - **Field Arithmetic** (`field/`): GF(2^16) and GF(2^128) primitives plus Leopard byte-layout codec
-- **Random Linear Combination** (`rlc/`): Fiat-Shamir coefficient derivation (`rlc.Derive`), batched vectorized RLC compute (`rlc.Compute`), single-row scalar (`rlc.ComputeRow`), and RLC vector serialization (`rlc.Marshal` / `Unmarshal` and the `rlc.Vector` type)
+- **Random Linear Combination** (`rlc/`): Fiat-Shamir coefficient derivation (`rlc.DeriveCoefficients`), batched vectorized RLC compute (`rlc.Compute`), single-row scalar (`rlc.ComputeRow`), and RLC vector serialization (`rlc.Marshal` / `Unmarshal` and the `rlc.Vector` type)
 - **Merkle Trees** (`merkle/`): Binary trees with RFC 6962-compatible formatting; `merkle.Root` is the canonical 32-byte hash type
 - **Coder** (`coder.go`): Producer-side encoding and reconstruction with a cached Reed-Solomon encoder
 - **Verifier** (`verifier.go`): Batched proof verification with reusable scratch and a concurrent-safe `VerifyShared` path

--- a/pkg/rsema1d/coder.go
+++ b/pkg/rsema1d/coder.go
@@ -78,7 +78,7 @@ func (c *Coder) commit(extendedRows [][]byte, buf []byte) *ExtendedData {
 	rowRoot := rowTree.Root()
 
 	// derive RLC coefficients and compute RLC results for original rows.
-	coeffs := rlc.Derive(rowRoot, c.config.K, c.config.N, len(extendedRows[0]), c.config.WorkerCount)
+	coeffs := rlc.DeriveCoefficients(rowRoot, c.config.K, c.config.N, len(extendedRows[0]), c.config.WorkerCount)
 	rlcVec := rlc.Compute(extendedRows[:c.config.K], coeffs, c.config.WorkerCount)
 
 	// build Merkle tree over the RLC values from the buffer's tail

--- a/pkg/rsema1d/rlc/compute_test.go
+++ b/pkg/rsema1d/rlc/compute_test.go
@@ -41,7 +41,7 @@ func TestComputeMatchesScalar(t *testing.T) {
 		for i := range rowRoot {
 			rowRoot[i] = byte(r.IntN(256))
 		}
-		coeffs := rlc.Derive(rowRoot, tc.k, tc.k, tc.rowSize, 1)
+		coeffs := rlc.DeriveCoefficients(rowRoot, tc.k, tc.k, tc.rowSize, 1)
 
 		want := make(rlc.Vector, tc.k)
 		for i, row := range rows {
@@ -88,7 +88,7 @@ func TestComputeLinearity(t *testing.T) {
 	for i := range rowRoot {
 		rowRoot[i] = byte(r.IntN(256))
 	}
-	coeffs := rlc.Derive(rowRoot, k, k, rowSize, 1)
+	coeffs := rlc.DeriveCoefficients(rowRoot, k, k, rowSize, 1)
 
 	rlcA := rlc.Compute(a, coeffs, 1)
 	rlcB := rlc.Compute(b, coeffs, 1)
@@ -121,7 +121,7 @@ func BenchmarkCompute(b *testing.B) {
 		b.Run(cfg.name, func(b *testing.B) {
 			rowSize := cfg.bytes / cfg.k
 			rowRoot := [32]byte{1, 2, 3, 4}
-			coeffs := rlc.Derive(rowRoot, cfg.k, cfg.n, rowSize, cfg.workers)
+			coeffs := rlc.DeriveCoefficients(rowRoot, cfg.k, cfg.n, rowSize, cfg.workers)
 
 			data := make([][]byte, cfg.k)
 			r := rand.New(rand.NewPCG(uint64(cfg.k), uint64(rowSize)))

--- a/pkg/rsema1d/rlc/derive.go
+++ b/pkg/rsema1d/rlc/derive.go
@@ -9,12 +9,13 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/pkg/rsema1d/merkle"
 )
 
-// Derive generates Fiat-Shamir RLC coefficients bound to (rowRoot, k, n, rowSize).
-// k, n, and rowSize are mixed into the seed so coefficients are unique per
-// (rowRoot, k, n, rowSize) tuple. Producer paths bind rowSize to the configured
-// row length; consumer paths bind it to the actual data length. workers <= 0
-// is treated as 1; the parallel path only kicks in above minParallelSymbols.
-func Derive(rowRoot merkle.Root, k, n, rowSize, workers int) Vector {
+// DeriveCoefficients generates Fiat-Shamir RLC coefficients bound to
+// (rowRoot, k, n, rowSize). k, n, and rowSize are mixed into the seed so
+// coefficients are unique per (rowRoot, k, n, rowSize) tuple. Producer paths
+// bind rowSize to the configured row length; consumer paths bind it to the
+// actual data length. workers <= 0 is treated as 1; the parallel path only
+// kicks in above minParallelSymbols.
+func DeriveCoefficients(rowRoot merkle.Root, k, n, rowSize, workers int) Vector {
 	h := sha256.New()
 	h.Write(rowRoot[:])
 	var params [12]byte

--- a/pkg/rsema1d/rlc/derive_test.go
+++ b/pkg/rsema1d/rlc/derive_test.go
@@ -22,9 +22,9 @@ func TestDeriveDeterministic(t *testing.T) {
 		{1024, 1024, 8192}, // 4096 symbols — parallel
 	}
 	for _, tc := range cases {
-		serial := rlc.Derive(rowRoot, tc.k, tc.n, tc.rowSize, 1)
-		again := rlc.Derive(rowRoot, tc.k, tc.n, tc.rowSize, 1)
-		parallel := rlc.Derive(rowRoot, tc.k, tc.n, tc.rowSize, 4)
+		serial := rlc.DeriveCoefficients(rowRoot, tc.k, tc.n, tc.rowSize, 1)
+		again := rlc.DeriveCoefficients(rowRoot, tc.k, tc.n, tc.rowSize, 1)
+		parallel := rlc.DeriveCoefficients(rowRoot, tc.k, tc.n, tc.rowSize, 4)
 		if got, want := len(serial), tc.rowSize/2; got != want {
 			t.Errorf("k=%d n=%d rs=%d: len got %d want %d", tc.k, tc.n, tc.rowSize, got, want)
 			continue
@@ -44,21 +44,21 @@ func TestDeriveDeterministic(t *testing.T) {
 // mixed into the Fiat-Shamir seed: changing any of them changes the
 // coefficients.
 func TestDeriveSensitivity(t *testing.T) {
-	base := rlc.Derive([32]byte{1}, 100, 200, 256, 1)
+	base := rlc.DeriveCoefficients([32]byte{1}, 100, 200, 256, 1)
 
-	if equal128s(base, rlc.Derive([32]byte{2}, 100, 200, 256, 1)) {
+	if equal128s(base, rlc.DeriveCoefficients([32]byte{2}, 100, 200, 256, 1)) {
 		t.Error("changing rowRoot did not change coefficients")
 	}
-	if equal128s(base, rlc.Derive([32]byte{1}, 101, 200, 256, 1)) {
+	if equal128s(base, rlc.DeriveCoefficients([32]byte{1}, 101, 200, 256, 1)) {
 		t.Error("changing k did not change coefficients")
 	}
-	if equal128s(base, rlc.Derive([32]byte{1}, 100, 201, 256, 1)) {
+	if equal128s(base, rlc.DeriveCoefficients([32]byte{1}, 100, 201, 256, 1)) {
 		t.Error("changing n did not change coefficients")
 	}
 	// Changing rowSize also changes the slice length, so compare the leading
 	// len(base) coefficients of a longer rowSize derivation — they must differ
 	// from base if rowSize is properly bound into the seed.
-	other := rlc.Derive([32]byte{1}, 100, 200, 258, 1)
+	other := rlc.DeriveCoefficients([32]byte{1}, 100, 200, 258, 1)
 	if len(other) <= len(base) {
 		t.Fatalf("expected longer derivation: len=%d base=%d", len(other), len(base))
 	}
@@ -67,10 +67,10 @@ func TestDeriveSensitivity(t *testing.T) {
 	}
 }
 
-// TestDeriveEmptyRowSize verifies Derive(_, _, _, 0) returns an empty slice
+// TestDeriveEmptyRowSize verifies DeriveCoefficients(_, _, _, 0) returns an empty slice
 // rather than panicking on the runtime.GOMAXPROCS / chunk-size math.
 func TestDeriveEmptyRowSize(t *testing.T) {
-	got := rlc.Derive([32]byte{}, 1, 1, 0, 1)
+	got := rlc.DeriveCoefficients([32]byte{}, 1, 1, 0, 1)
 	if len(got) != 0 {
 		t.Errorf("expected empty slice, got len %d", len(got))
 	}
@@ -112,7 +112,7 @@ func BenchmarkDerive(b *testing.B) {
 			b.SetBytes(int64(tc.rowSize))
 			b.ResetTimer()
 			for range b.N {
-				_ = rlc.Derive(rowRoot, tc.k, tc.n, tc.rowSize, ws)
+				_ = rlc.DeriveCoefficients(rowRoot, tc.k, tc.n, tc.rowSize, ws)
 			}
 		})
 	}

--- a/pkg/rsema1d/rlc/doc.go
+++ b/pkg/rsema1d/rlc/doc.go
@@ -3,7 +3,7 @@
 //
 // Public surface:
 //
-//   - [Derive]: Fiat-Shamir derivation of per-symbol coefficients from a
+//   - [DeriveCoefficients]: Fiat-Shamir derivation of per-symbol coefficients from a
 //     row Merkle root and the codec parameters.
 //   - [Compute]: vectorized GF(2^16) SIMD computation of the RLC of every
 //     row against the derived coefficients.

--- a/pkg/rsema1d/standalone_proof.go
+++ b/pkg/rsema1d/standalone_proof.go
@@ -45,7 +45,7 @@ func VerifyStandaloneProof(proof *StandaloneProof, commitment Commitment, config
 	}
 
 	// 2. Derive coefficients and recompute the row's RLC scalar-wise.
-	coeffs := rlc.Derive(rowRoot, config.K, config.N, len(proof.Row), config.WorkerCount)
+	coeffs := rlc.DeriveCoefficients(rowRoot, config.K, config.N, len(proof.Row), config.WorkerCount)
 	rlcValue := rlc.ComputeRow(proof.Row, coeffs)
 
 	// 3. Recover rlcOrigRoot from the RLC's Merkle proof.

--- a/pkg/rsema1d/verifier.go
+++ b/pkg/rsema1d/verifier.go
@@ -201,7 +201,7 @@ func (v *Verifier) verify(commitment Commitment, proofs []*RowProof, rowSize int
 // coefficients lazily computes Fiat-Shamir coefficients for the current matrix.
 func (v *Verifier) coefficients(rowRoot merkle.Root, rowSize int) rlc.Vector {
 	if v.rlcCoeffs == nil {
-		v.rlcCoeffs = rlc.Derive(rowRoot, v.config.K, v.config.N, rowSize, v.config.WorkerCount)
+		v.rlcCoeffs = rlc.DeriveCoefficients(rowRoot, v.config.K, v.config.N, rowSize, v.config.WorkerCount)
 	}
 	return v.rlcCoeffs
 }


### PR DESCRIPTION
## Overview

[`SPEC.md`](https://github.com/celestiaorg/celestia-app/blob/main/pkg/rsema1d/SPEC.md) (section 3.3) names the Fiat-Shamir coefficient-derivation function `DeriveCoefficients`, but the Go code exported it as `rlc.Derive`. This renames it (and updates call sites, doc comments, and the README) so the implementation matches the spec name.

## Audit of other spec-named functions

Per the issue's follow-up question, I checked the other functions named in the spec against the code. `Derive` was the only exported function whose name diverged from a spec-named function. The rest either match or are idiomatic-Go equivalents:

| Spec name | Code | Status |
|---|---|---|
| `DeriveCoefficients` | `rlc.Derive` | ❌ renamed in this PR |
| `RootFromProof` | `merkle.RootFromProof` | ✅ matches |
| `HashToGF128` | `field.HashToGF128` | ✅ matches |
| `PackGF128ToLeopard` / `UnpackGF128FromLeopard` | `field.GF128ToLeopard` / `field.GF128FromLeopard` | semantically equivalent; the `To`/`From` form is idiomatic Go and the spec notes implementers may choose alternatives |
| `BuildRowTree` / `BuildRLCTree` / `ExtractSymbols` / `ExtendRLCResults` | inlined or unexported helpers (`buildRowTree`, `setRLC`, etc.) | not part of the exported surface; left as-is |

If reviewers want the `Pack`/`Unpack` field functions renamed too, happy to do that in this PR.

## Testing

- `go build ./pkg/rsema1d/...`
- `go test ./pkg/rsema1d/...` — all pass
- `go tool golangci-lint run ./pkg/rsema1d/...` — 0 issues

Closes https://github.com/celestiaorg/celestia-app/issues/7378
Closes https://linear.app/celestia/issue/PROTOCO-1901

🤖 Generated with [Claude Code](https://claude.com/claude-code)