### PR TITLE
feat: add duplicate row indices check to Verify() in Fibre

### DIFF
--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -94,6 +94,22 @@ func TestServerUploadShard(t *testing.T) {
 			},
 		},
 		{
+			name: "DuplicateRows",
+			requestModifier: func(req *types.UploadShardRequest) {
+				// repeat the first assigned row across every slot: the count and
+				// membership checks pass, but the rows are not unique
+				require.Greater(t, len(req.Shard.Rows), 1, "need >1 assigned row to duplicate")
+				for i := range req.Shard.Rows {
+					req.Shard.Rows[i] = req.Shard.Rows[0]
+				}
+			},
+			check: func(t *testing.T, resp *types.UploadShardResponse, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "shard assignment verification failed")
+				require.Contains(t, err.Error(), "duplicate row")
+			},
+		},
+		{
 			name: "InvalidRowProof",
 			requestModifier: func(req *types.UploadShardRequest) {
 				// corrupt the proof

--- a/fibre/validator/set.go
+++ b/fibre/validator/set.go
@@ -175,8 +175,10 @@ func shuffleByStake(selected []SelectedValidator, rng *rand.Rand) {
 }
 
 // Verify checks if all given row indices are assigned to [core.Validator].
-// Returns error if validator is not in the map, count doesn't match, or any row is not assigned.
-// This method builds a temporary set for O(r + n) complexity instead of O(n × r).
+// Returns error if validator is not in the map, count doesn't match, any
+//
+//	row is not assigned or row indices are duplicate. This method builds
+//	a temporary set for O(r + n) complexity instead of O(n × r).
 func (sm ShardMap) Verify(val *core.Validator, rowIndices []uint32) error {
 	rows, ok := sm[val]
 	if !ok {
@@ -193,10 +195,16 @@ func (sm ShardMap) Verify(val *core.Validator, rowIndices []uint32) error {
 		assignedSet[idx] = struct{}{}
 	}
 
+	// Reject duplicate submitted indices so a repeated valid row can't stand in for a missing assigned one.
+	seen := make(map[uint32]struct{}, len(rowIndices))
 	for _, rowIdx := range rowIndices {
 		if _, ok := assignedSet[int(rowIdx)]; !ok {
 			return fmt.Errorf("row %d not assigned to validator", rowIdx)
 		}
+		if _, dup := seen[rowIdx]; dup {
+			return fmt.Errorf("duplicate row %d", rowIdx)
+		}
+		seen[rowIdx] = struct{}{}
 	}
 	return nil
 }

--- a/fibre/validator/set.go
+++ b/fibre/validator/set.go
@@ -190,21 +190,21 @@ func (sm ShardMap) Verify(val *core.Validator, rowIndices []uint32) error {
 		return fmt.Errorf("expected %d rows, got %d", len(rows), len(rowIndices))
 	}
 
-	assignedSet := make(map[int]struct{}, len(rows))
+	// Map each assigned row to whether it has been seen, reject duplicates.
+	assigned := make(map[uint32]bool, len(rows))
 	for _, idx := range rows {
-		assignedSet[idx] = struct{}{}
+		assigned[uint32(idx)] = false
 	}
 
-	// Reject duplicate submitted indices so a repeated valid row can't stand in for a missing assigned one.
-	seen := make(map[uint32]struct{}, len(rowIndices))
 	for _, rowIdx := range rowIndices {
-		if _, ok := assignedSet[int(rowIdx)]; !ok {
+		seen, ok := assigned[rowIdx]
+		if !ok {
 			return fmt.Errorf("row %d not assigned to validator", rowIdx)
 		}
-		if _, dup := seen[rowIdx]; dup {
+		if seen {
 			return fmt.Errorf("duplicate row %d", rowIdx)
 		}
-		seen[rowIdx] = struct{}{}
+		assigned[rowIdx] = true
 	}
 	return nil
 }

--- a/fibre/validator/set_test.go
+++ b/fibre/validator/set_test.go
@@ -153,6 +153,20 @@ func TestShardMap_Verify(t *testing.T) {
 			break
 		}
 	})
+
+	t.Run("duplicate rows", func(t *testing.T) {
+		for val, rows := range shardMap {
+			if len(rows) < 2 {
+				continue
+			}
+			indices := make([]uint32, len(rows))
+			for i := range indices {
+				indices[i] = uint32(rows[0])
+			}
+			require.ErrorContains(t, shardMap.Verify(val, indices), "duplicate row")
+			break
+		}
+	})
 }
 
 func TestSet_Select(t *testing.T) {


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-1866/fibre-validators-sign-payment-promises-for-duplicate-row-shards
