### PR TITLE
fix(ci): retry go mod tidy -diff to avoid flaky tidy-check failures

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -72,10 +72,25 @@ jobs:
           go-version-file: "go.mod"
       - name: Check go mod tidy
         run: |
+          # `go mod tidy -diff` exits non-zero for ANY error, including transient
+          # module download failures from the Go proxy, not only when a genuine
+          # diff exists. Retry a few times before declaring a module dirty: a
+          # network blip succeeds on retry, while a genuine diff fails every
+          # attempt and is still caught. See #7380.
           DIRTY=""
+          MAX_ATTEMPTS=3
           for moddir in $(find . -name 'go.mod' -exec dirname {} \;); do
             echo "Checking $moddir"
-            (cd "$moddir" && go mod tidy -diff) || DIRTY="$DIRTY $moddir"
+            attempt=1
+            until (cd "$moddir" && go mod tidy -diff); do
+              if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+                DIRTY="$DIRTY $moddir"
+                break
+              fi
+              echo "go mod tidy -diff failed for $moddir (attempt $attempt/$MAX_ATTEMPTS); retrying after backoff..."
+              sleep $((attempt * 5))
+              attempt=$((attempt + 1))
+            done
           done
           if [ -n "$DIRTY" ]; then
             echo "ERROR: go mod tidy produced changes in:$DIRTY"


### PR DESCRIPTION
## Problem

The `lint / go-mod-tidy-check` job intermittently fails on `main` with:

```
ERROR: go mod tidy produced changes in: .
Run 'make mod' and commit the changes.
```

even when `go.mod`/`go.sum` are actually tidy.

## Root cause

`go mod tidy -diff` exits non-zero for **any** error — including transient module download failures from the Go proxy — not only when a genuine diff exists. So a network blip (e.g. `stream error: ... INTERNAL_ERROR` fetching a module zip) is misreported as "go mod tidy produced changes."

## Fix

Retry `go mod tidy -diff` up to 3 times (with linear backoff) before declaring a module dirty. A transient failure succeeds on retry; a genuine diff fails every attempt and is still caught.

The retry logic was validated in isolation against three cases:
- **clean** module → reported clean (no retries)
- **genuine diff** → reported dirty (after exhausting retries)
- **transient failure** (fails twice, then succeeds) → reported clean

Closes #7380

🤖 Generated with [Claude Code](https://claude.com/claude-code)