### PR TITLE
fix: relax flaky TestTxSubmission success-rate threshold to 99.5%

### DIFF
--- a/test/docker-e2e/e2e_tx_submission_test.go
+++ b/test/docker-e2e/e2e_tx_submission_test.go
@@ -14,8 +14,16 @@ const (
 	testDuration    = 15 * time.Minute       // 15 minutes
 	submissionDelay = 1 * time.Second
 
-	maxAvgLatency  = 8 * time.Second
-	minSuccessRate = 0.999 // 99.9%
+	maxAvgLatency = 8 * time.Second
+	// minSuccessRate is the minimum fraction of submitted transactions that
+	// must succeed. The run submits roughly one tx per second for 15 minutes
+	// (~900 txs), and the latency-monitor counts transient client-side errors
+	// (e.g. "context deadline exceeded") as failures. A 99.9% threshold
+	// tolerates zero failures at this volume (900 * 0.001 = 0.9), so a single
+	// transient failure fails the whole nightly. 99.5% leaves headroom for rare
+	// transient noise while still catching genuine reliability regressions,
+	// which manifest as far more than 0.5% failures.
+	minSuccessRate = 0.995 // 99.5%
 )
 
 func (s *CelestiaTestSuite) TestTxSubmission() {


### PR DESCRIPTION
## Overview

De-flakes the nightly `test-nightly (TestTxSubmission, true)` job.

[Nightly run 27250456804](https://github.com/celestiaorg/celestia-app/actions/runs/27250456804) (2026-06-10) failed:

```
Total Transactions: 894
Successful: 893 (99.89%)
Failed: 1
Avg Latency: 4.58787122s
Error: "0.9988814317673378" is not greater than or equal to "0.999"
Messages: Success rate 99.888% below threshold 99.900%
```

## Root cause

`TestTxSubmission` submits ~1 tx/sec for 15 minutes (~900 txs) and the latency-monitor counts transient client-side errors (e.g. `context deadline exceeded`) as failures. The `minSuccessRate` constant was `0.999` (99.9%), which at ~900 txs tolerates **zero** failures (`900 * 0.001 = 0.9`). So a single transient submission failure over a 15-minute real-network docker-in-CI run fails the entire nightly.

In the failing run, avg latency (4.59s) was well under the 8s threshold — only the success-rate assertion tripped, on a single failed tx out of 894.

## Fix

Relax `minSuccessRate` to `0.995` (99.5%). At ~900 txs this tolerates ~4 transient failures, leaving headroom for rare infra noise while still catching genuine reliability regressions, which manifest as far more than 0.5% failures. (If reviewers prefer a tolerance based on an absolute failure count rather than a rate, happy to switch.)

## Testing

- `gofmt`, `go vet`, and `golangci-lint` are clean on the changed file.
- The change is a constant + comment in an e2e test; behavior is exercised by the nightly job itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)