### PR TITLE
fix: bump celestiaorg/cosmos-sdk to v0.52.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -460,7 +460,7 @@ replace (
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.40.6
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.6
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.7
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/celestiaorg/celestia-core v0.40.6 h1:+mppLA+X+BwXc0U/ivOB7XGVf5N6cwox
 github.com/celestiaorg/celestia-core v0.40.6/go.mod h1:ZCrmRE1UQzgZfho4Og6tAHtH1KY6s8Jpri5+EKobV5c=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v0.52.6 h1:8dNW6ONrOokGh25MMnh4uQhQKTRDYvM5Rv1hf3ApbW4=
-github.com/celestiaorg/cosmos-sdk v0.52.6/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
+github.com/celestiaorg/cosmos-sdk v0.52.7 h1:cJ6jMIVAC5OweZVAXvhYDn+Ff/vtFeEsECgsIUyPQ6Y=
+github.com/celestiaorg/cosmos-sdk v0.52.7/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.3.0 h1:DfckA2UihWckeKHBQU3UXkF2G/qEmsPxd3LtGYB9HeM=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -296,7 +296,7 @@ replace (
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/celestiaorg/celestia-app/v9 => ../..
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.40.6
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.6
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.7
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -167,8 +167,8 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.40.6 h1:+mppLA+X+BwXc0U/ivOB7XGVf5N6cwoxfz8Y2XH1UwQ=
 github.com/celestiaorg/celestia-core v0.40.6/go.mod h1:ZCrmRE1UQzgZfho4Og6tAHtH1KY6s8Jpri5+EKobV5c=
-github.com/celestiaorg/cosmos-sdk v0.52.6 h1:8dNW6ONrOokGh25MMnh4uQhQKTRDYvM5Rv1hf3ApbW4=
-github.com/celestiaorg/cosmos-sdk v0.52.6/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
+github.com/celestiaorg/cosmos-sdk v0.52.7 h1:cJ6jMIVAC5OweZVAXvhYDn+Ff/vtFeEsECgsIUyPQ6Y=
+github.com/celestiaorg/cosmos-sdk v0.52.7/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.3.0 h1:DfckA2UihWckeKHBQU3UXkF2G/qEmsPxd3LtGYB9HeM=


### PR DESCRIPTION
## Overview

Bumps the celestiaorg/cosmos-sdk fork from v0.52.6 to [v0.52.7](https://github.com/celestiaorg/cosmos-sdk/releases/tag/v0.52.7) in the root module and `test/docker-e2e`.

v0.52.7 contains a single change: [celestiaorg/cosmos-sdk#740](https://github.com/celestiaorg/cosmos-sdk/pull/740), which fixes a data race between `workingHash` (FinalizeBlock) and `Simulate`. This should resolve some flaky CI failures caused by that race.

## Testing

- `make build` passes
- `go tool golangci-lint run` passes (0 issues)
- `make test-short` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)