### PR TITLE
ci: notify #protocol-ci Slack channel on CI failures

### DIFF
--- a/.github/workflows/notify-protocol-ci.yml
+++ b/.github/workflows/notify-protocol-ci.yml
@@ -1,0 +1,38 @@
+name: Notify protocol-ci on failure
+
+# Posts a message to the #protocol-ci Slack channel when a CI workflow fails on
+# main (post-merge) or on a scheduled run. A single workflow_run-triggered file
+# watches several workflows so we don't have to add a notify job to each one.
+# The repo name is included in the message so #protocol-ci can aggregate
+# failures from celestia-app, celestia-core, and celestia-node.
+on:
+  workflow_run:
+    workflows:
+      - "Post-merge CI"
+      - "test-coverage"
+      - "docker-build-publish"
+      - "Nightly Tests"
+    types:
+      - completed
+    branches:
+      - main
+
+# The notifier only calls an external Slack webhook; it needs no GITHUB_TOKEN
+# scopes.
+permissions: {}
+
+jobs:
+  notify:
+    name: Notify Slack
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - name: Slack Notification
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+        with:
+          webhook: ${{ secrets.PROTOCOL_CI_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "${{ github.repository }} | ${{ github.event.workflow_run.name }} failed on ${{ github.event.workflow_run.head_branch }}: ${{ github.event.workflow_run.html_url }}"
+            }


### PR DESCRIPTION
## Overview

Routes celestia-app CI failures into the **#protocol-ci** Slack channel so failures from celestia-app, celestia-core, and celestia-node can be monitored in one place (celestia-core got this in celestiaorg/celestia-core#3101, celestia-node in celestiaorg/celestia-node#5040). Each message is prefixed with the repo name, e.g.:

> `celestiaorg/celestia-app | Post-merge CI failed on main: <link>`

## Changes

- Add `.github/workflows/notify-protocol-ci.yml`: a single `workflow_run`-triggered notifier that watches `Post-merge CI`, `test-coverage`, `docker-build-publish`, and the scheduled `Nightly Tests`, and posts to #protocol-ci when any fails on `main` (post-merge) or on a scheduled run.

## Notes

- In this repo, PR/merge-queue CI runs via reusable `workflow_call` workflows under `ci-release.yml`, so the post-merge signal on `main` is `Post-merge CI` (plus `test-coverage` and `docker-build-publish`, which trigger directly on push to `main`).
- Uses the repo secret `PROTOCOL_CI_SLACK_WEBHOOK_URL` (incoming webhook for #protocol-ci), so existing notifications to other channels are untouched. The secret is already configured in this repo.

## Security hardening

Matches the hardening from the celestia-core/celestia-node PRs:
- Pinned `slackapi/slack-github-action` to its v3.0.3 commit SHA (`45a88b9`).
- Set an empty `permissions: {}` block (the notifier only calls an external Slack webhook).

Closes [PROTOCO-1891](https://linear.app/celestia/issue/PROTOCO-1891/route-ci-failures-from-celestia-appcorenode-to-protocol-ci-slack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)