### PR TITLE
fix: poll for delegation rewards in TestClaimRewardsAfterFullUndelegation

### DIFF
--- a/app/test/claim_test.go
+++ b/app/test/claim_test.go
@@ -3,6 +3,7 @@ package app_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
@@ -97,14 +98,23 @@ func verifyDelegationExists(t *testing.T, cctx *testnode.Context, stakingClient 
 	assert.Equal(t, delegationAmount.String(), delegationResp.DelegationResponse.Balance.Amount.String())
 }
 
+// verifyRewardsExist polls until the delegation has accrued rewards. Rewards
+// only start accruing in the block after the delegation is created, so a
+// one-shot query can race with block production and observe zero rewards.
 func verifyRewardsExist(t *testing.T, cctx *testnode.Context, distributionClient distributiontypes.QueryClient, delegatorAddress, validatorAddress string) {
-	rewardsResp, err := distributionClient.DelegationRewards(cctx.GoContext(), &distributiontypes.QueryDelegationRewardsRequest{
-		DelegatorAddress: delegatorAddress,
-		ValidatorAddress: validatorAddress,
-	})
-	require.NoError(t, err)
-	require.Greater(t, len(rewardsResp.Rewards), 0)
-	t.Logf("Rewards before undelegation: %v", rewardsResp.Rewards)
+	var rewards types.DecCoins
+	require.Eventually(t, func() bool {
+		rewardsResp, err := distributionClient.DelegationRewards(cctx.GoContext(), &distributiontypes.QueryDelegationRewardsRequest{
+			DelegatorAddress: delegatorAddress,
+			ValidatorAddress: validatorAddress,
+		})
+		if err != nil {
+			return false
+		}
+		rewards = rewardsResp.Rewards
+		return len(rewards) > 0
+	}, 30*time.Second, 100*time.Millisecond, "delegation rewards did not accrue")
+	t.Logf("Rewards before undelegation: %v", rewards)
 }
 
 func undelegate(t *testing.T, cctx *testnode.Context, txClient *user.TxClient, delegatorAddress, validatorAddress string, amount types.Coin) {


### PR DESCRIPTION
## Summary

`TestClaimRewardsAfterFullUndelegation` flaked in `test / test-short` with `"0" is not greater than "0"` at `claim_test.go:106` ([failing run](https://github.com/celestiaorg/celestia-app/actions/runs/27374484851/job/80895072868?pr=7400)).

Root cause: rewards only start accruing in the block **after** the delegation is created, so a one-shot `DelegationRewards` query right after the delegate tx commits races with block production and can observe zero rewards on a slow runner. A previous fix (#7046) addressed the network-startup race in this test, but this query race remained.

Fix: replace the one-shot assertion in `verifyRewardsExist` with `require.Eventually` polling (30s timeout, 100ms tick), matching the condition-based-waiting pattern used in `test/txsim/run_test.go`.

No GitHub or Linear issue tracks this flake; the closed #7045 covered the earlier startup race only.

## Test plan

- [x] `go test -run TestClaimRewardsAfterFullUndelegation -count=3 ./app/test/` passes 3/3 locally
- [x] `go tool golangci-lint run ./app/test/...` — 0 issues
- [ ] `test / test-short` CI job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)