### PR TITLE
fix(multiplexer): provide default minimum-gas-prices to embedded v4/v5

### DIFF
--- a/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
+++ b/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
@@ -3,11 +3,14 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/celestiaorg/celestia-app/v9/app"
 	embedding "github.com/celestiaorg/celestia-app/v9/internal/embedding"
 	"github.com/celestiaorg/celestia-app/v9/multiplexer/abci"
 	"github.com/celestiaorg/celestia-app/v9/multiplexer/appd"
 	multiplexer "github.com/celestiaorg/celestia-app/v9/multiplexer/cmd"
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
 	"github.com/cosmos/cosmos-sdk/server"
 	"github.com/spf13/cobra"
 )
@@ -91,6 +94,16 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 		v3Args = append(v3Args, "--v2-upgrade-height="+v2UpgradeHeight)
 	}
 
+	// v4 and v5 hard-fail on startup if minimum-gas-prices is empty (their
+	// cosmos-sdk fork requires it), unlike v3 (allowed empty) and v6+ (fall
+	// back to a hardcoded default). Pin the era's default so nodes syncing
+	// from genesis with an old app.toml don't get stuck at the v3->v4
+	// upgrade height. The value only affects local mempool filtering while
+	// replaying historical blocks, so overriding is harmless.
+	legacyMinGasPricesArgs := append([]string{
+		fmt.Sprintf("--minimum-gas-prices=%v%s", appconsts.LegacyDefaultMinGasPrice, appconsts.BondDenom),
+	}, defaultArgs...)
+
 	versions, err := abci.NewVersions(
 		abci.Version{
 			Appd:        appdV3,
@@ -101,12 +114,12 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 			Appd:        appdV4,
 			ABCIVersion: abci.ABCIClientVersion2,
 			AppVersion:  4,
-			StartArgs:   defaultArgs,
+			StartArgs:   legacyMinGasPricesArgs,
 		}, abci.Version{
 			Appd:        appdV5,
 			ABCIVersion: abci.ABCIClientVersion2,
 			AppVersion:  5,
-			StartArgs:   defaultArgs,
+			StartArgs:   legacyMinGasPricesArgs,
 		}, abci.Version{
 			Appd:        appdV6,
 			ABCIVersion: abci.ABCIClientVersion2,


### PR DESCRIPTION
## Overview

Nodes syncing from genesis with a v3-era app.toml (empty minimum-gas-prices) get stuck at the v3->v4 upgrade height because the embedded v4 binary refuses to start. Pin the era's default (0.002utia) in the v4/v5 embedded start args so no operator intervention is needed.

Closes #7403 and PROTOCO-1952