### PR TITLE
fix(cmd): strip color codes when logging to a file

### DIFF
--- a/cmd/celestia-appd/cmd/root.go
+++ b/cmd/celestia-appd/cmd/root.go
@@ -181,6 +181,10 @@ func replaceLogger(cmd *cobra.Command) error {
 	}
 
 	sctx := server.GetServerContextFromCmd(cmd)
+	// Disable colored output when logging to a file so that the log file does
+	// not contain ANSI color escape codes (e.g. [90m). See
+	// https://github.com/celestiaorg/celestia-app/issues/4966
+	sctx.Viper.Set(flags.FlagLogNoColor, true)
 	sctx.Logger, err = server.CreateSDKLogger(sctx, kitlog.NewSyncWriter(file))
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)

--- a/cmd/celestia-appd/cmd/root_test.go
+++ b/cmd/celestia-appd/cmd/root_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cosmos/cosmos-sdk/server"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/require"
+)
+
+// TestReplaceLoggerStripsColorCodes verifies that logs written to a file do not
+// contain ANSI color escape codes. See https://github.com/celestiaorg/celestia-app/issues/4966
+func TestReplaceLoggerStripsColorCodes(t *testing.T) {
+	logFilePath := filepath.Join(t.TempDir(), "test.log")
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String(FlagLogToFile, "", "")
+	require.NoError(t, cmd.Flags().Set(FlagLogToFile, logFilePath))
+
+	// Use a default server context which enables colored output by default.
+	sctx := server.NewDefaultContext()
+	sctx.Viper = viper.New()
+	ctx := context.WithValue(context.Background(), server.ServerContextKey, sctx)
+	cmd.SetContext(ctx)
+
+	require.NoError(t, replaceLogger(cmd))
+
+	sctx = server.GetServerContextFromCmd(cmd)
+	sctx.Logger.Info("received complete proposal block", "height", 6562871, "module", "consensus")
+
+	contents, err := os.ReadFile(logFilePath)
+	require.NoError(t, err)
+	require.NotEmpty(t, contents)
+
+	// The ANSI escape character (0x1b) should not appear in the log file.
+	require.NotContains(t, string(contents), "\x1b", "log file should not contain ANSI color escape codes")
+}


### PR DESCRIPTION
## Motivation

When logs are directed to a file via `celestia-appd start --log-to-file foo.log`, the file contains ANSI color escape codes (e.g. `[90m`), making it hard to read.

## Change

Disable colored output when logging to a file. Colored output is preserved when logging to the terminal, matching the behavior requested in the issue.

Closes #4966

## Testing

Added `TestReplaceLoggerStripsColorCodes`, which asserts the log file contains no ANSI escape characters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)