### PR TITLE
feat: cap sdk msg count in CheckTx

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -48,6 +48,11 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 		}
 	}
 
+	if msgCount := len(sdkTx.GetMsgs()); msgCount > appconsts.MaxSDKMessages {
+		err := errors.Wrapf(apperr.ErrTxExceedsMaxSDKMessages, "tx contains %d messages, limit is %d", msgCount, appconsts.MaxSDKMessages)
+		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), nil
+	}
+
 	return app.forwardCheckTx(req, sdkTx)
 }
 

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -12,4 +12,7 @@ const AppErrorsCodespace = "app"
 var (
 	// ErrTxExceedsMaxSize is returned when a transaction size exceeds the maximum allowed limit
 	ErrTxExceedsMaxSize = errors.Register(AppErrorsCodespace, 11142, "transaction size exceeds maximum allowed limit")
+
+	// ErrTxExceedsMaxSDKMessages is returned when an SDK tx contains more messages than a single block may ever include.
+	ErrTxExceedsMaxSDKMessages = errors.Register(AppErrorsCodespace, 11143, "transaction exceeds maximum allowed SDK message count")
 )

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -264,6 +265,22 @@ func TestCheckTx(t *testing.T) {
 				return tx
 			},
 			expectedABCICode: abci.CodeTypeOK,
+		},
+		{
+			name:      "normal transaction exceeding max SDK messages, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				signer := signers[9]
+				addr := signer.Account(accounts[9]).Address()
+				msgs := make([]sdk.Msg, appconsts.MaxSDKMessages+1)
+				for i := range msgs {
+					msgs[i] = banktypes.NewMsgSend(addr, addr, sdk.NewCoins(sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(1))))
+				}
+				tx, _, err := signer.CreateTx(msgs, user.SetGasLimitAndGasPrice(1e6, appconsts.DefaultMinGasPrice))
+				require.NoError(t, err)
+				return tx
+			},
+			expectedABCICode: apperr.ErrTxExceedsMaxSDKMessages.ABCICode(),
 		},
 	}
 


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-1940/medium-checktx-admits-over-message-limit-transactions-that-honest
