### PR TITLE
fix: retry transient failures when downloading embedded binaries

### DIFF
--- a/scripts/download_binary.sh
+++ b/scripts/download_binary.sh
@@ -23,5 +23,15 @@ else
     echo "Binary $out not found, downloading"
 fi
 
-wget -q "https://github.com/celestiaorg/celestia-app/releases/download/$version/$url" -O internal/embedding/$out
+# Retry on transient failures (connection refused, host errors, and transient
+# HTTP status codes such as 429 rate limiting and 5xx server errors). A genuine
+# 404 (missing asset) is not in the retry list, so it still fails fast.
+wget -q \
+    --tries=5 \
+    --waitretry=5 \
+    --retry-connrefused \
+    --retry-on-host-error \
+    --retry-on-http-error=429,500,502,503,504 \
+    "https://github.com/celestiaorg/celestia-app/releases/download/$version/$url" \
+    -O internal/embedding/$out
 echo "$version" > internal/embedding/.embed_version_$out


### PR DESCRIPTION
## Motivation

The `build / build` job failed on `main` in a recent post-merge CI run while downloading the embedded `celestia-app v8.0.8` binary (`make download-v8-binaries`, exit code 8). The asset exists in the release, and the same commit built successfully in the merge queue — so the failure was a transient GitHub error (429/5xx).

`scripts/download_binary.sh` used `wget -q` with no retries, so any transient HTTP/connection error fails the whole build.

## Change

Add wget retry flags to `download_binary.sh`:
- `--tries=5 --waitretry=5 --retry-connrefused --retry-on-host-error`
- `--retry-on-http-error=429,500,502,503,504`

Transient errors are retried with backoff; a genuine 404 (missing asset) is **not** in the retry list, so it still fails fast. Verified locally: real asset downloads succeed, and a 404 fails in <0.5s without retrying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)