### PR TITLE
fix: print trailing newline when CLI tools report errors

### DIFF
--- a/test/cmd/txsim/cli.go
+++ b/test/cmd/txsim/cli.go
@@ -55,7 +55,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Kill)
 	defer cancel()
 	if err := command().ExecuteContext(ctx); err != nil {
-		fmt.Print(err)
+		fmt.Println(err)
 	}
 }
 

--- a/tools/blocketa/main.go
+++ b/tools/blocketa/main.go
@@ -37,7 +37,7 @@ const (
 
 func main() {
 	if err := Run(); err != nil {
-		fmt.Printf("ERROR: %s", err.Error())
+		fmt.Printf("ERROR: %s\n", err.Error())
 	}
 }
 

--- a/tools/blockheight/main.go
+++ b/tools/blockheight/main.go
@@ -40,7 +40,7 @@ const (
 
 func main() {
 	if err := Run(); err != nil {
-		fmt.Printf("ERROR: %s", err.Error())
+		fmt.Printf("ERROR: %s\n", err.Error())
 	}
 }
 

--- a/tools/blocktime/main.go
+++ b/tools/blocktime/main.go
@@ -13,7 +13,7 @@ import (
 
 func main() {
 	if err := Run(); err != nil {
-		fmt.Printf("ERROR: %s", err.Error())
+		fmt.Printf("ERROR: %s\n", err.Error())
 	}
 }
 

--- a/tools/throughput/main.go
+++ b/tools/throughput/main.go
@@ -62,7 +62,7 @@ func (bm *BlockMetrics) CalculateMetrics() (float64, float64, float64) {
 
 func main() {
 	if err := Run(); err != nil {
-		fmt.Printf("ERROR: %s", err.Error())
+		fmt.Printf("ERROR: %s\n", err.Error())
 	}
 }
 
@@ -83,7 +83,7 @@ func Run() error {
 	defer func() {
 		err := client.Stop()
 		if err != nil {
-			fmt.Printf("error while stopping node: %s", err.Error())
+			fmt.Printf("error while stopping node: %s\n", err.Error())
 		}
 	}()
 
@@ -99,7 +99,7 @@ func Run() error {
 	defer func() {
 		err := client.Unsubscribe(ctx, "heights-watcher", "tm.event = 'NewBlockHeader'")
 		if err != nil {
-			fmt.Printf("error while unsubscribing: %s", err.Error())
+			fmt.Printf("error while unsubscribing: %s\n", err.Error())
 		}
 	}()
 


### PR DESCRIPTION
## Overview

`txsim`, `blocketa`, `blocktime`, `blockheight`, and `throughput` printed top-level errors without a trailing newline. The error message was left concatenated with the next shell prompt, forcing users to run `clear` to keep using their terminal.

This adds the missing newline to each tool's error output.

Closes #5106

## Testing

Built and ran `blocketa` against an unreachable endpoint; the error now ends with a newline and the next prompt appears on its own line. `make lint` passes on the affected packages.