### PR TITLE
fix: pre-pull busybox image to de-flake docker e2e tests

### DIFF
--- a/test/docker-e2e/e2e_hyperlane_test.go
+++ b/test/docker-e2e/e2e_hyperlane_test.go
@@ -82,6 +82,7 @@ func (s *HyperlaneTestSuite) SetupSuite() {
 	s.logger = zaptest.NewLogger(s.T())
 	s.logger.Info("Setting up Celestia test suite: " + s.T().Name())
 	s.client, s.network = tastoradockertypes.Setup(s.T())
+	s.prePullBusybox(context.Background())
 
 	tag, err := dockerchain.GetCelestiaTagStrict()
 	s.Require().NoError(err)

--- a/test/docker-e2e/e2e_test.go
+++ b/test/docker-e2e/e2e_test.go
@@ -47,6 +47,15 @@ func (s *CelestiaTestSuite) SetupSuite() {
 	s.logger = zaptest.NewLogger(s.T())
 	s.logger.Info("Setting up Celestia test suite: " + s.T().Name())
 	s.client, s.network = tastoradockertypes.Setup(s.T())
+	s.prePullBusybox(context.Background())
+}
+
+// prePullBusybox pre-pulls the busybox image (with retry) that tastora pulls
+// internally during chain-node initialization. Calling this from SetupSuite
+// turns tastora's otherwise-flaky 60s pull into a local cache hit, so transient
+// registry errors don't surface as test failures. Safe to call repeatedly.
+func (s *CelestiaTestSuite) prePullBusybox(ctx context.Context) {
+	s.Require().NoError(pullImageWithRetry(ctx, s.client, busyboxImage()), "failed to pre-pull busybox image")
 }
 
 // CreateTxSim deploys and starts a txsim container to simulate transactions against the given celestia chain in the test environment.

--- a/test/docker-e2e/image_pull_retry.go
+++ b/test/docker-e2e/image_pull_retry.go
@@ -35,6 +35,22 @@ func retryPull(ctx context.Context, maxAttempts int, baseDelay time.Duration, op
 	return fmt.Errorf("retryPull exhausted after %d attempts: %w", maxAttempts, lastErr)
 }
 
+// busybox{Repository,Version} mirror tastora's internal busybox image reference
+// (github.com/celestiaorg/tastora/framework/docker/internal.BusyboxRef =
+// "busybox:stable"). tastora pulls this image during chain-node initialization
+// to set volume ownership, and skips the pull when the image is already cached
+// locally. The internal package can't be imported, so the ref is duplicated
+// here; TestBusyboxImage_MatchesTastoraRef guards the two staying in sync.
+const (
+	busyboxRepository = "busybox"
+	busyboxVersion    = "stable"
+)
+
+// busyboxImage returns the busybox image that tastora pulls internally.
+func busyboxImage() tastoracontainertypes.Image {
+	return tastoracontainertypes.NewImage(busyboxRepository, busyboxVersion, "")
+}
+
 // pullImageWithRetry pulls the given image via tastora's idempotent PullImage,
 // retrying on transient registry errors (e.g. ghcr.io timeouts). Safe to call
 // on images that are already cached locally — PullImage is a no-op in that case.

--- a/test/docker-e2e/image_pull_retry_test.go
+++ b/test/docker-e2e/image_pull_retry_test.go
@@ -11,6 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestBusyboxImage_MatchesTastoraRef guards the busybox reference we pre-pull
+// against tastora's internal one. tastora pulls busybox:stable
+// (github.com/celestiaorg/tastora/framework/docker/internal.BusyboxRef) during
+// chain-node initialization and skips the pull when the image is already cached
+// locally. Pre-pulling must use the exact same ref for that cache hit to work;
+// the internal package can't be imported, so this test documents the coupling.
+func TestBusyboxImage_MatchesTastoraRef(t *testing.T) {
+	assert.Equal(t, "busybox:stable", busyboxImage().Ref())
+}
+
 func TestRetryPull_SucceedsOnFirstAttempt(t *testing.T) {
 	calls := 0
 	err := retryPull(context.Background(), 3, time.Millisecond, func() error {


### PR DESCRIPTION
## Motivation

`test-docker-e2e` jobs (e.g. `TestHyperlaneZKIsmStateTransition`) have intermittently failed on `main` with:

```
failed to initialize chain nodes: set volume owner: failed to pull busybox image: condition not met within 60.00 seconds: context deadline exceeded
```

tastora pulls `busybox:stable` during chain-node initialization (to set volume ownership) inside a single 60s no-backoff retry window, so a transient registry hiccup fails the whole test. tastora skips that pull entirely when the image is already cached locally.

## Change

Pre-pull `busybox:stable` in `SetupSuite` via the existing `pullImageWithRetry` helper (3 attempts, exponential backoff), turning tastora's flaky pull into a local cache hit. Applied to both `CelestiaTestSuite.SetupSuite` (covers IBC/PFM/etc.) and the overriding `HyperlaneTestSuite.SetupSuite`.

A unit test asserts our duplicated ref stays `busybox:stable` (the `internal` package that defines tastora's `BusyboxRef` can't be imported).

No issue tracker entry; this resolves a recurring CI flake observed in post-merge/merge-queue runs.