### PR TITLE
fix: preserve network suffix (e.g. -mocha) in celestia-appd version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,4 @@
-VERSION := $(shell \
-	if [ $$(git tag --points-at HEAD | wc -l) -gt 1 ]; then \
-		git describe --tags --always --match "v*" | cut -d'-' -f1 | sed 's/^v//'; \
-	else \
-		git describe --tags --always --match "v*" | sed 's/^v//'; \
-	fi \
-)
+VERSION := $(shell ./scripts/version.sh)
 COMMIT := $(shell git rev-parse --short HEAD)
 CELESTIA_TAG := $(shell git rev-parse --short=8 HEAD)
 export CELESTIA_TAG

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+#
+# Resolves the semantic version of the current git checkout. The result is
+# embedded into the celestia-appd binary via the VERSION variable in the
+# Makefile (and the cosmos-sdk version ldflags).
+#
+# A single release commit is usually tagged once per network, e.g. v3.8.1,
+# v3.8.1-mocha and v3.8.1-arabica all point at the same commit. When several
+# tags point at HEAD we must choose deterministically:
+#
+#   1. the base mainnet tag (vX.Y.Z) if present, so mainnet builds report a
+#      clean version (preserves the behavior of #5894), otherwise
+#   2. the network / pre-release tag, preferring mocha > arabica > rc > beta >
+#      alpha, so a build from e.g. v7.0.2-mocha reports 7.0.2-mocha instead of
+#      an arbitrary sibling tag (fixes #4631).
+#
+# `git describe` and `git name-rev` cannot be relied on here: their tie-breaking
+# between tags on the same commit depends on tag type, creation order and tagger
+# date, so they non-deterministically return the wrong network suffix (the old
+# `cut -d'-' -f1` workaround instead dropped the suffix entirely).
+#
+# When HEAD is not exactly at a tag (e.g. a development build on main) we fall
+# back to `git describe`, which yields the usual vX.Y.Z-<n>-g<hash> dev version.
+set -u
+
+# semver core: vX.Y.Z
+core='^v[0-9]+\.[0-9]+\.[0-9]+'
+
+tags=$(git tag --points-at HEAD --sort=-v:refname 2>/dev/null)
+
+pick() {
+	printf '%s\n' "$tags" | grep -E "$1" | head -n 1
+}
+
+version=""
+if [ -n "$tags" ]; then
+	for pattern in \
+		"${core}\$" \
+		"${core}-mocha\$" \
+		"${core}-arabica\$" \
+		"${core}-rc[0-9]*\$" \
+		"${core}-beta\$" \
+		"${core}-alpha\$"; do
+		version=$(pick "$pattern")
+		[ -n "$version" ] && break
+	done
+fi
+
+# Fall back to git describe for development builds or unrecognized tag formats.
+if [ -z "$version" ]; then
+	version=$(git describe --tags --always --match "v*" 2>/dev/null)
+fi
+
+# Strip the leading v for the embedded version string.
+printf '%s\n' "$version" | sed 's/^v//'

--- a/tools/version/doc.go
+++ b/tools/version/doc.go
@@ -1,0 +1,6 @@
+// Package version contains a regression test for scripts/version.sh, the shell
+// helper that the Makefile uses to resolve the semantic version embedded into
+// the celestia-appd binary. There is no production Go code here; the test
+// guards the version-resolution logic, which has regressed several times (see
+// issues #3977, #4631 and PR #5894).
+package version

--- a/tools/version/version_test.go
+++ b/tools/version/version_test.go
@@ -1,0 +1,143 @@
+package version
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// scriptPath returns the absolute path to scripts/version.sh.
+func scriptPath(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not determine caller path")
+	}
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	return filepath.Join(repoRoot, "scripts", "version.sh")
+}
+
+// gitEnv isolates HOME (so the developer's global git config, e.g. one that
+// forces annotated tags, does not interfere) while preserving PATH so git and
+// bash resolve.
+func gitEnv(dir string) []string {
+	return []string{
+		"PATH=" + os.Getenv("PATH"),
+		"HOME=" + dir,
+		"GIT_CONFIG_NOSYSTEM=1",
+	}
+}
+
+func runIn(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = gitEnv(dir)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitRepo initializes a throwaway git repository with a single commit.
+func gitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runIn(t, dir, "git", "init", "-q")
+	runIn(t, dir, "git", "config", "user.email", "test@test.test")
+	runIn(t, dir, "git", "config", "user.name", "test")
+	runIn(t, dir, "git", "commit", "-q", "--allow-empty", "-m", "commit 1")
+	return dir
+}
+
+// tag creates a lightweight tag pointing at rev (HEAD if empty). Lightweight
+// tags mirror tags created by GitHub releases and never require a tag message
+// regardless of git config.
+func tag(t *testing.T, dir, name, rev string) {
+	t.Helper()
+	if rev == "" {
+		rev = "HEAD"
+	}
+	runIn(t, dir, "git", "update-ref", "refs/tags/"+name, rev)
+}
+
+// version runs scripts/version.sh inside dir and returns the trimmed output.
+func version(t *testing.T, dir string) string {
+	t.Helper()
+	return runIn(t, dir, "bash", scriptPath(t))
+}
+
+func TestVersion_SingleBaseTag(t *testing.T) {
+	dir := gitRepo(t)
+	tag(t, dir, "v8.0.8", "")
+	if got := version(t, dir); got != "8.0.8" {
+		t.Errorf("got %q, want %q", got, "8.0.8")
+	}
+}
+
+func TestVersion_SingleMochaTag(t *testing.T) {
+	dir := gitRepo(t)
+	tag(t, dir, "v7.0.2-mocha", "")
+	if got := version(t, dir); got != "7.0.2-mocha" {
+		t.Errorf("got %q, want %q", got, "7.0.2-mocha")
+	}
+}
+
+// When the base mainnet tag is present alongside network tags the clean base
+// version wins (this preserves the behavior added in PR #5894).
+func TestVersion_BaseAndNetworkTags(t *testing.T) {
+	dir := gitRepo(t)
+	tag(t, dir, "v3.8.1-mocha", "")
+	tag(t, dir, "v3.8.1-arabica", "")
+	tag(t, dir, "v3.8.1", "")
+	if got := version(t, dir); got != "3.8.1" {
+		t.Errorf("got %q, want %q", got, "3.8.1")
+	}
+}
+
+// Regression test for issue #4631: a commit tagged for testnets only (no base
+// mainnet tag) must report the mocha suffix, not an arbitrary sibling tag or a
+// stripped base version.
+func TestVersion_MochaAndArabicaNoBase(t *testing.T) {
+	dir := gitRepo(t)
+	// Create in arabica-then-mocha order to prove ordering does not matter.
+	tag(t, dir, "v7.0.2-arabica", "")
+	tag(t, dir, "v7.0.2-mocha", "")
+	if got := version(t, dir); got != "7.0.2-mocha" {
+		t.Errorf("got %q, want %q", got, "7.0.2-mocha")
+	}
+}
+
+// mocha is preferred over a release-candidate tag on the same commit.
+func TestVersion_RcAndMocha(t *testing.T) {
+	dir := gitRepo(t)
+	tag(t, dir, "v9.0.0-rc1", "")
+	tag(t, dir, "v9.0.0-mocha", "")
+	if got := version(t, dir); got != "9.0.0-mocha" {
+		t.Errorf("got %q, want %q", got, "9.0.0-mocha")
+	}
+}
+
+func TestVersion_RcOnly(t *testing.T) {
+	dir := gitRepo(t)
+	tag(t, dir, "v9.0.0-rc1", "")
+	if got := version(t, dir); got != "9.0.0-rc1" {
+		t.Errorf("got %q, want %q", got, "9.0.0-rc1")
+	}
+}
+
+// When HEAD is ahead of the latest tag (a development build, e.g. on main) the
+// version falls back to git describe and includes the commit suffix.
+func TestVersion_DevBuildAheadOfTag(t *testing.T) {
+	dir := gitRepo(t)
+	tag(t, dir, "v8.0.8", "HEAD")
+	runIn(t, dir, "git", "commit", "-q", "--allow-empty", "-m", "commit 2")
+	got := version(t, dir)
+	if !strings.HasPrefix(got, "8.0.8-") || !strings.Contains(got, "-g") {
+		t.Errorf("got %q, want a dev version like 8.0.8-1-g<hash>", got)
+	}
+}


### PR DESCRIPTION
## Problem

`celestia-appd version` drops the network suffix when building from a tag like `v3.8.1-mocha`, reporting `3.8.1` instead of `3.8.1-mocha`.

Root cause: when multiple tags point at the same commit (common — one tag per network), the Makefile used `git describe ... | cut -d'-' -f1`, which strips the pre-release suffix entirely.

## Fix

Extract version resolution into `scripts/version.sh`, which selects deterministically by priority:

1. base mainnet tag (`vX.Y.Z`) if present — preserves the #5894 behavior (clean version for mainnet builds), otherwise
2. network / pre-release tag, preferring `mocha > arabica > rc > beta > alpha` — so a testnet-only commit reports the right suffix (fixes #4631), then
3. `git describe` fallback for development builds.

`git describe` / `git name-rev` (the celestia-node approach) are unreliable here: their tie-breaking between tags on one commit depends on tag type, creation order and tagger date, so on celestia-app's lightweight release tags they return an arbitrary sibling (e.g. `-arabica`). The explicit priority is order-independent.

Releases are unaffected — goreleaser computes its own `.Version` from the released tag.

## Test

Adds a `tools/version` regression test covering each tag layout (base+network, testnet-only, single, rc+mocha, dev build). Red without the fix, green with it.

Closes #4631