### PR TITLE
fix(multiplexer): exit when an embedded binary fails

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -14,6 +14,7 @@ import (
 
 	"cosmossdk.io/log"
 	"github.com/celestiaorg/celestia-app/v9/app/observability"
+	"github.com/celestiaorg/celestia-app/v9/multiplexer/appd"
 	"github.com/celestiaorg/celestia-app/v9/multiplexer/internal"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	"github.com/cometbft/cometbft/node"
@@ -147,7 +148,7 @@ func (m *Multiplexer) Start() error {
 
 	if m.isEmbeddedApp() {
 		m.logger.Debug("using embedded app, not continuing with grpc or api servers")
-		return m.g.Wait()
+		return m.waitForEmbeddedApp()
 	}
 
 	if err := m.enableGRPCAndAPIServers(m.nativeApp); err != nil {
@@ -515,6 +516,61 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 // embeddedVersionRunning returns true if there is an active version specified which is running.
 func (m *Multiplexer) embeddedVersionRunning() bool {
 	return m.activeVersion.Appd != nil && m.activeVersion.Appd.IsRunning()
+}
+
+// waitForEmbeddedApp blocks until either a quit signal cancels the context or
+// the running embedded app exits. If the embedded app exits unexpectedly (i.e.
+// not as part of a planned version switch or graceful shutdown) it returns an
+// error so the parent celestia-appd process exits non-zero instead of hanging
+// silently. See https://github.com/celestiaorg/celestia-app/issues/7405.
+func (m *Multiplexer) waitForEmbeddedApp() error {
+	for {
+		// Snapshot the currently active embedded app under the lock so we watch
+		// the right process across version switches.
+		m.mu.Lock()
+		watched := m.activeVersion.Appd
+		appVersion := m.activeVersion.AppVersion
+		m.mu.Unlock()
+
+		if watched == nil {
+			// No embedded app is running (e.g. we switched to the native app).
+			// Fall back to waiting on the errgroup, which blocks until a quit
+			// signal is received.
+			return m.g.Wait()
+		}
+
+		select {
+		case <-m.ctx.Done():
+			// A quit signal cancelled the context; shut down gracefully.
+			return m.g.Wait()
+		case <-watched.WaitCh():
+			if !m.embeddedExitIsFatal(watched) {
+				// The exit was planned (graceful shutdown or version switch).
+				// Loop to watch the new active app, if any.
+				continue
+			}
+			return fmt.Errorf("embedded app for version %d exited unexpectedly: %w", appVersion, watched.ExitError())
+		}
+	}
+}
+
+// embeddedExitIsFatal reports whether the exit of the watched embedded app
+// should be treated as a fatal error. An exit is fatal only when it was not
+// initiated by the multiplexer: the context is still live (no quit signal) and
+// the watched app is still the active version (it was not replaced by a version
+// switch).
+func (m *Multiplexer) embeddedExitIsFatal(watched *appd.Appd) bool {
+	// A cancelled context means a quit signal was received: this is a graceful
+	// shutdown, not a failure.
+	if m.ctx.Err() != nil {
+		return false
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// If the watched app is no longer the active version it was intentionally
+	// stopped as part of a version switch.
+	return m.activeVersion.Appd == watched
 }
 
 // startCmtNode initializes and starts a CometBFT node, sets up cleanup tasks, and assigns it to the Multiplexer instance.

--- a/multiplexer/abci/multiplexer_test.go
+++ b/multiplexer/abci/multiplexer_test.go
@@ -1,12 +1,42 @@
 package abci
 
 import (
+	"context"
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/v9/multiplexer/appd"
 	serverconfig "github.com/cosmos/cosmos-sdk/server/config"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	"github.com/stretchr/testify/require"
 )
+
+// TestEmbeddedExitIsFatal verifies the multiplexer correctly classifies an
+// embedded app exit as fatal (unexpected) or not (planned shutdown / version
+// switch). See https://github.com/celestiaorg/celestia-app/issues/7405.
+func TestEmbeddedExitIsFatal(t *testing.T) {
+	running := &appd.Appd{}
+	other := &appd.Appd{}
+
+	t.Run("fatal when the exited app is still the active version", func(t *testing.T) {
+		m := &Multiplexer{ctx: context.Background()}
+		m.activeVersion = Version{AppVersion: 3, Appd: running}
+		require.True(t, m.embeddedExitIsFatal(running))
+	})
+
+	t.Run("not fatal when the context has been cancelled (shutdown)", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		m := &Multiplexer{ctx: ctx}
+		m.activeVersion = Version{AppVersion: 3, Appd: running}
+		require.False(t, m.embeddedExitIsFatal(running))
+	})
+
+	t.Run("not fatal when the app was replaced by a version switch", func(t *testing.T) {
+		m := &Multiplexer{ctx: context.Background()}
+		m.activeVersion = Version{AppVersion: 4, Appd: other}
+		require.False(t, m.embeddedExitIsFatal(running))
+	})
+}
 
 // TestInitTelemetryIsIdempotent verifies that initTelemetry is idempotent.
 //

--- a/multiplexer/appd/exec_command_test.go
+++ b/multiplexer/appd/exec_command_test.go
@@ -1,0 +1,51 @@
+//go:build multiplexer
+
+package appd
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v9/internal/embedding"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateExecCommand execs a command to an embedded binary.
+func TestCreateExecCommand(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test which expects an embedded binary")
+	}
+
+	binaryGenerators := []func() (string, []byte, error){
+		embedding.CelestiaAppV3,
+		embedding.CelestiaAppV4,
+		embedding.CelestiaAppV5,
+	}
+
+	for idx, binaryGenerator := range binaryGenerators {
+		t.Run(fmt.Sprintf("v%d", idx+3), func(t *testing.T) {
+			version, compressedBinary, err := binaryGenerator()
+			require.NoError(t, err)
+
+			appdInstance, err := New(version, compressedBinary)
+			require.NoError(t, err)
+			require.NotNil(t, appdInstance)
+
+			cmd := appdInstance.CreateExecCommand("version")
+			require.NotNil(t, cmd)
+
+			var outputBuffer bytes.Buffer
+			cmd.Stdout = &outputBuffer
+
+			require.NoError(t, cmd.Run())
+
+			want := strings.TrimPrefix(version, "v")
+			got := outputBuffer.String()
+			require.NotEmpty(t, got)
+			assert.Contains(t, got, want)
+		})
+	}
+}

--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -28,6 +28,12 @@ type Appd struct {
 	stdout io.Writer
 	// cmd is the started celestia-appd binary.
 	cmd *exec.Cmd
+	// exited is closed once the underlying process has exited and exitErr has
+	// been populated. It is created in Start.
+	exited chan struct{}
+	// exitErr is the result of the underlying cmd.Wait(). It is only valid to
+	// read after exited has been closed.
+	exitErr error
 }
 
 // New returns a new Appd instance.
@@ -97,6 +103,16 @@ func (a *Appd) Start(args ...string) error {
 		return fmt.Errorf("failed to start %s: %w", a.path, err)
 	}
 	a.cmd = cmd
+
+	// Reap the process in a single dedicated goroutine. cmd.Wait must only be
+	// called once, so it is centralized here. Both Stop and WaitCh observe the
+	// result via the exited channel rather than calling cmd.Wait themselves.
+	a.exited = make(chan struct{})
+	go func() {
+		err := cmd.Wait()
+		a.exitErr = err
+		close(a.exited)
+	}()
 	return nil
 }
 
@@ -106,28 +122,45 @@ func (a *Appd) IsRunning() bool {
 
 func (a *Appd) IsStopped() bool {
 	// Never started or failed to start
-	if a.cmd == nil || a.cmd.Process == nil {
+	if a.cmd == nil || a.cmd.Process == nil || a.exited == nil {
 		return true
 	}
 
-	// If ProcessState is not nil, it means Wait() was called and the process has finished
-	// (either by exiting normally or being terminated by a signal)
-	if a.cmd.ProcessState != nil {
+	// If the exited channel is closed, the process has finished (either by
+	// exiting normally or being terminated by a signal).
+	select {
+	case <-a.exited:
 		return true
+	default:
+		return false
 	}
+}
 
-	// ProcessState is nil, which means the process is still running
-	return false
+// WaitCh returns a channel that is closed once the underlying process has
+// exited. After it is closed, ExitError reports the exit result. The returned
+// channel is nil if the process was never started; receiving from a nil channel
+// blocks forever, so callers should only wait on it after a successful Start.
+func (a *Appd) WaitCh() <-chan struct{} {
+	return a.exited
+}
+
+// ExitError returns the error returned by the underlying cmd.Wait(). It is only
+// meaningful after the process has exited (i.e. after WaitCh has been closed).
+// A nil return means the process exited successfully.
+func (a *Appd) ExitError() error {
+	return a.exitErr
 }
 
 // Stop interrupts and then kills the running appd process if it exists and
 // waits for it to fully exit. If the process is not running, it returns nil.
 // The method will wait up to 6 seconds for graceful shutdown before force killing.
 func (a *Appd) Stop() error {
-	if a.cmd == nil {
+	if a.cmd == nil || a.cmd.Process == nil || a.exited == nil {
 		return nil
 	}
-	if a.cmd.Process == nil {
+
+	// If the process has already exited there is nothing to do.
+	if a.IsStopped() {
 		return nil
 	}
 
@@ -138,8 +171,9 @@ func (a *Appd) Stop() error {
 			return fmt.Errorf("failed to kill process with PID %d: %w", a.cmd.Process.Pid, err)
 		}
 
-		if err := a.cmd.Wait(); err != nil {
-			log.Printf("Process finished with error: %v\n", err)
+		<-a.exited
+		if a.exitErr != nil {
+			log.Printf("Process finished with error: %v\n", a.exitErr)
 		}
 		return nil
 	}
@@ -147,15 +181,10 @@ func (a *Appd) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 
-	done := make(chan error, 1)
-	go func() {
-		done <- a.cmd.Wait()
-	}()
-
 	select {
-	case err := <-done:
-		if err != nil {
-			log.Printf("Process finished with error: %v\n", err)
+	case <-a.exited:
+		if a.exitErr != nil {
+			log.Printf("Process finished with error: %v\n", a.exitErr)
 		} else {
 			log.Printf("Process finished with no error\n")
 		}
@@ -166,8 +195,9 @@ func (a *Appd) Stop() error {
 			return fmt.Errorf("failed to kill process with PID %d after timeout: %w", a.cmd.Process.Pid, err)
 		}
 
-		if err := <-done; err != nil {
-			log.Printf("Process finished with error after force kill: %v\n", err)
+		<-a.exited
+		if a.exitErr != nil {
+			log.Printf("Process finished with error after force kill: %v\n", a.exitErr)
 		} else {
 			log.Printf("Process finished after force kill\n")
 		}

--- a/multiplexer/appd/run_test.go
+++ b/multiplexer/appd/run_test.go
@@ -1,55 +1,12 @@
-//go:build multiplexer
-
 package appd
 
 import (
-	"bytes"
-	"fmt"
 	"os"
-	"strings"
 	"testing"
+	"time"
 
-	"github.com/celestiaorg/celestia-app/v9/internal/embedding"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-// TestCreateExecCommand execs a command to an embedded binary.
-func TestCreateExecCommand(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping test which expects an embedded binary")
-	}
-
-	binaryGenerators := []func() (string, []byte, error){
-		embedding.CelestiaAppV3,
-		embedding.CelestiaAppV4,
-		embedding.CelestiaAppV5,
-	}
-
-	for idx, binaryGenerator := range binaryGenerators {
-		t.Run(fmt.Sprintf("v%d", idx+3), func(t *testing.T) {
-			version, compressedBinary, err := binaryGenerator()
-			require.NoError(t, err)
-
-			appdInstance, err := New(version, compressedBinary)
-			require.NoError(t, err)
-			require.NotNil(t, appdInstance)
-
-			cmd := appdInstance.CreateExecCommand("version")
-			require.NotNil(t, cmd)
-
-			var outputBuffer bytes.Buffer
-			cmd.Stdout = &outputBuffer
-
-			require.NoError(t, cmd.Run())
-
-			want := strings.TrimPrefix(version, "v")
-			got := outputBuffer.String()
-			require.NotEmpty(t, got)
-			assert.Contains(t, got, want)
-		})
-	}
-}
 
 func TestStart(t *testing.T) {
 	t.Run("should start the process", func(t *testing.T) {
@@ -134,6 +91,54 @@ func TestStop(t *testing.T) {
 
 		require.True(t, appdInstance.IsStopped())
 		require.False(t, appdInstance.IsRunning())
+	})
+}
+
+func TestWaitCh(t *testing.T) {
+	t.Run("closes and reports no error when the process exits cleanly", func(t *testing.T) {
+		mockBinary := createMockExecutable(t, "exit 0")
+		defer os.Remove(mockBinary)
+
+		appdInstance := &Appd{
+			path:   mockBinary,
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
+
+		require.NoError(t, appdInstance.Start())
+
+		select {
+		case <-appdInstance.WaitCh():
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the process to exit")
+		}
+
+		require.NoError(t, appdInstance.ExitError())
+		require.True(t, appdInstance.IsStopped())
+	})
+
+	t.Run("closes and reports an error when the process fails", func(t *testing.T) {
+		mockBinary := createMockExecutable(t, "exit 3")
+		defer os.Remove(mockBinary)
+
+		appdInstance := &Appd{
+			path:   mockBinary,
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
+
+		require.NoError(t, appdInstance.Start())
+
+		select {
+		case <-appdInstance.WaitCh():
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for the process to exit")
+		}
+
+		require.Error(t, appdInstance.ExitError())
+		require.True(t, appdInstance.IsStopped())
 	})
 }
 


### PR DESCRIPTION
## Overview

When the multiplexer runs an embedded binary and that binary exits unexpectedly (e.g. an embedded v4 app that refuses to start), the parent `celestia-appd` process hangs silently instead of exiting. The embedded-app path blocks on `g.Wait()`, whose only remaining goroutine is the OS signal handler — it never returns without a real signal, so a dead child is never noticed.

## Changes

- `Appd`: centralize `cmd.Wait()` into a single goroutine started in `Start`, and expose `WaitCh()` / `ExitError()` so the process exit is observable. `Stop`/`IsStopped` now consume that channel instead of calling `cmd.Wait()` themselves.
- `Multiplexer`: replace the embedded-app branch of `Start` with `waitForEmbeddedApp`, which returns a non-zero error when the running embedded app exits **unexpectedly** — i.e. not during a planned version switch (`embeddedExitIsFatal` re-arms on the new active version) or graceful shutdown (context cancelled). The parent process then exits non-zero rather than hanging.

## Testing

- `appd`: new `TestWaitCh` covers clean/failed exit observation. The mock-based lifecycle tests (`TestStart`/`TestStop`) no longer require the `multiplexer` build tag (the embedded-binary `TestCreateExecCommand` moved to its own tagged file), so they run in CI without embedded binaries.
- `abci`: `TestEmbeddedExitIsFatal` covers the fatal/non-fatal classification (active version, shutdown, version switch).

Closes #7405

🤖 Generated with [Claude Code](https://claude.com/claude-code)