### PR TITLE
fix(multiplexer): exit when an embedded binary exits unexpectedly

### DIFF
--- a/multiplexer/abci/multiplexer.go
+++ b/multiplexer/abci/multiplexer.go
@@ -87,6 +87,15 @@ type Multiplexer struct {
 	// Prometheus collector registration when enableGRPCAndAPIServers is
 	// called more than once (e.g. during a version switch).
 	metrics *telemetry.Metrics
+	// fatalCh is closed when an embedded app exits unexpectedly. It unblocks
+	// Start so the process can exit instead of hanging silently.
+	fatalCh chan struct{}
+	// fatalErr describes why fatalCh was closed. It is only valid to read after
+	// fatalCh has been closed.
+	fatalErr error
+	// fatalOnce ensures fatalCh is closed at most once even if multiple embedded
+	// apps report a failure.
+	fatalOnce sync.Once
 }
 
 // NewMultiplexer creates a new Multiplexer.
@@ -127,6 +136,7 @@ func (m *Multiplexer) isGrpcOnly() bool {
 
 func (m *Multiplexer) Start() error {
 	m.g, m.ctx = getCtx(m.svrCtx, true)
+	m.fatalCh = make(chan struct{})
 
 	emitServerInfoMetrics()
 
@@ -147,7 +157,7 @@ func (m *Multiplexer) Start() error {
 
 	if m.isEmbeddedApp() {
 		m.logger.Debug("using embedded app, not continuing with grpc or api servers")
-		return m.g.Wait()
+		return m.waitForEmbeddedApp()
 	}
 
 	if err := m.enableGRPCAndAPIServers(m.nativeApp); err != nil {
@@ -233,6 +243,7 @@ func (m *Multiplexer) startApp() error {
 
 		m.started = true
 		m.activeVersion = currentVersion
+		m.monitorEmbeddedApp(currentVersion)
 	}
 
 	return m.initRemoteGrpcConn()
@@ -508,6 +519,7 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 
 		m.activeVersion = version
 		m.started = true
+		m.monitorEmbeddedApp(version)
 	}
 	return nil
 }
@@ -515,6 +527,43 @@ func (m *Multiplexer) startEmbeddedApp(version Version) error {
 // embeddedVersionRunning returns true if there is an active version specified which is running.
 func (m *Multiplexer) embeddedVersionRunning() bool {
 	return m.activeVersion.Appd != nil && m.activeVersion.Appd.IsRunning()
+}
+
+// waitForEmbeddedApp blocks until either a quit signal arrives (handled by the
+// errgroup) or the embedded app exits unexpectedly. The signal handler in m.g
+// only returns on an OS signal, so g.Wait alone would hang forever if the
+// embedded binary died on its own. fatalCh covers that case so the process
+// exits with an error instead.
+func (m *Multiplexer) waitForEmbeddedApp() error {
+	gDone := make(chan error, 1)
+	go func() {
+		gDone <- m.g.Wait()
+	}()
+
+	select {
+	case <-m.fatalCh:
+		return m.fatalErr
+	case err := <-gDone:
+		return err
+	}
+}
+
+// monitorEmbeddedApp watches an embedded app process and records a fatal error
+// if it exits unexpectedly (i.e. not via Stop). Intentional shutdowns, such as
+// the one performed during a version switch, report no error and are ignored.
+func (m *Multiplexer) monitorEmbeddedApp(version Version) {
+	appd := version.Appd
+	if appd == nil {
+		return
+	}
+	go func() {
+		if err := appd.Wait(); err != nil {
+			m.fatalOnce.Do(func() {
+				m.fatalErr = fmt.Errorf("embedded app for version %d exited unexpectedly: %w", version.AppVersion, err)
+				close(m.fatalCh)
+			})
+		}
+	}()
 }
 
 // startCmtNode initializes and starts a CometBFT node, sets up cleanup tasks, and assigns it to the Multiplexer instance.

--- a/multiplexer/abci/wait_test.go
+++ b/multiplexer/abci/wait_test.go
@@ -1,0 +1,57 @@
+package abci
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+)
+
+// TestWaitForEmbeddedApp verifies that the multiplexer returns when the embedded
+// app exits unexpectedly, rather than blocking forever on the signal handler.
+func TestWaitForEmbeddedApp(t *testing.T) {
+	t.Run("returns the fatal error when an embedded app exits unexpectedly", func(t *testing.T) {
+		// g mimics the real errgroup whose signal-handler goroutine blocks until
+		// an OS signal that never arrives in this test.
+		g := &errgroup.Group{}
+		g.Go(func() error {
+			select {} // block forever
+		})
+
+		m := &Multiplexer{g: g, fatalCh: make(chan struct{})}
+
+		fatal := errors.New("embedded app for version 5 exited unexpectedly")
+		m.fatalErr = fatal
+		close(m.fatalCh)
+
+		done := make(chan error, 1)
+		go func() { done <- m.waitForEmbeddedApp() }()
+
+		select {
+		case err := <-done:
+			require.ErrorIs(t, err, fatal)
+		case <-time.After(5 * time.Second):
+			t.Fatal("waitForEmbeddedApp did not return after a fatal embedded app exit")
+		}
+	})
+
+	t.Run("returns the errgroup result on graceful shutdown", func(t *testing.T) {
+		g := &errgroup.Group{}
+		// Simulate the signal handler returning nil after a quit signal.
+		g.Go(func() error { return nil })
+
+		m := &Multiplexer{g: g, fatalCh: make(chan struct{})}
+
+		done := make(chan error, 1)
+		go func() { done <- m.waitForEmbeddedApp() }()
+
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Fatal("waitForEmbeddedApp did not return on graceful shutdown")
+		}
+	})
+}

--- a/multiplexer/appd/lifecycle_test.go
+++ b/multiplexer/appd/lifecycle_test.go
@@ -1,0 +1,105 @@
+package appd
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestWait verifies that Wait reports unexpected process exits but stays quiet
+// for intentional shutdowns. This is what lets the multiplexer notice that an
+// embedded binary died and exit instead of hanging silently.
+func TestWait(t *testing.T) {
+	t.Run("returns nil if the process was never started", func(t *testing.T) {
+		appdInstance := &Appd{
+			path:   "/non/existent/binary",
+			stdin:  os.Stdin,
+			stdout: os.Stdout,
+			stderr: os.Stderr,
+		}
+
+		require.NoError(t, appdInstance.Wait())
+	})
+
+	t.Run("returns an error when the process exits unexpectedly with a non-zero code", func(t *testing.T) {
+		mockBinary := createMockBinary(t, "exit 1")
+
+		appdInstance := newTestAppd(mockBinary)
+		require.NoError(t, appdInstance.Start())
+
+		err := appdInstance.Wait()
+		require.Error(t, err)
+		require.True(t, appdInstance.IsStopped())
+	})
+
+	t.Run("returns an error when the process exits unexpectedly with a zero code", func(t *testing.T) {
+		mockBinary := createMockBinary(t, "exit 0")
+
+		appdInstance := newTestAppd(mockBinary)
+		require.NoError(t, appdInstance.Start())
+
+		err := appdInstance.Wait()
+		require.Error(t, err)
+		require.True(t, appdInstance.IsStopped())
+	})
+
+	t.Run("returns nil when the process is stopped intentionally", func(t *testing.T) {
+		mockBinary := createMockBinary(t, "sleep 10")
+
+		appdInstance := newTestAppd(mockBinary)
+		require.NoError(t, appdInstance.Start())
+		require.True(t, appdInstance.IsRunning())
+
+		require.NoError(t, appdInstance.Stop())
+
+		require.NoError(t, appdInstance.Wait())
+		require.True(t, appdInstance.IsStopped())
+	})
+}
+
+// TestWaitUnblocksOnCrash ensures Wait returns promptly once the process dies
+// rather than blocking forever.
+func TestWaitUnblocksOnCrash(t *testing.T) {
+	mockBinary := createMockBinary(t, "exit 1")
+
+	appdInstance := newTestAppd(mockBinary)
+	require.NoError(t, appdInstance.Start())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- appdInstance.Wait()
+	}()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait did not return after the process exited")
+	}
+}
+
+func newTestAppd(path string) *Appd {
+	return &Appd{
+		path:   path,
+		stdin:  os.Stdin,
+		stdout: os.Stdout,
+		stderr: os.Stderr,
+	}
+}
+
+// createMockBinary creates a temporary executable shell script for tests.
+func createMockBinary(t *testing.T, bashCommand string) string {
+	t.Helper()
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "mock-binary-*")
+	require.NoError(t, err)
+
+	_, err = tmpFile.WriteString("#!/bin/sh\n" + bashCommand + "\n")
+	require.NoError(t, err)
+	require.NoError(t, tmpFile.Close())
+	require.NoError(t, os.Chmod(tmpFile.Name(), 0o755))
+
+	return tmpFile.Name()
+}

--- a/multiplexer/appd/run.go
+++ b/multiplexer/appd/run.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
@@ -26,8 +27,21 @@ type Appd struct {
 	stdin  io.Reader
 	stderr io.Writer
 	stdout io.Writer
+
+	// mu guards the fields below which are accessed by both the caller and the
+	// goroutine that waits on the running process.
+	mu sync.Mutex
 	// cmd is the started celestia-appd binary.
 	cmd *exec.Cmd
+	// waitCh is closed when the process started by the most recent call to
+	// Start exits. It is nil until Start is called.
+	waitCh chan struct{}
+	// waitErr is the error returned by cmd.Wait. It is only valid to read after
+	// waitCh has been closed.
+	waitErr error
+	// stopping is set to true when Stop is called so that the process exit is
+	// recognised as intentional rather than a crash.
+	stopping bool
 }
 
 // New returns a new Appd instance.
@@ -96,7 +110,26 @@ func (a *Appd) Start(args ...string) error {
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start %s: %w", a.path, err)
 	}
+
+	// Wait on the process from a single goroutine. Centralizing the cmd.Wait
+	// call here means both Stop and Wait can observe the exit via waitCh without
+	// racing on a second cmd.Wait call.
+	waitCh := make(chan struct{})
+	a.mu.Lock()
 	a.cmd = cmd
+	a.waitCh = waitCh
+	a.waitErr = nil
+	a.stopping = false
+	a.mu.Unlock()
+
+	go func() {
+		err := cmd.Wait()
+		a.mu.Lock()
+		a.waitErr = err
+		a.mu.Unlock()
+		close(waitCh)
+	}()
+
 	return nil
 }
 
@@ -105,40 +138,76 @@ func (a *Appd) IsRunning() bool {
 }
 
 func (a *Appd) IsStopped() bool {
-	// Never started or failed to start
-	if a.cmd == nil || a.cmd.Process == nil {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Never started or failed to start.
+	if a.cmd == nil || a.cmd.Process == nil || a.waitCh == nil {
 		return true
 	}
 
-	// If ProcessState is not nil, it means Wait() was called and the process has finished
-	// (either by exiting normally or being terminated by a signal)
-	if a.cmd.ProcessState != nil {
+	// If waitCh is closed, the process has exited.
+	select {
+	case <-a.waitCh:
 		return true
+	default:
+		return false
+	}
+}
+
+// Wait blocks until the running process exits and reports whether the exit was
+// unexpected. It returns:
+//   - nil if the process was never started or was stopped intentionally via
+//     Stop.
+//   - a non-nil error if the process exited on its own, regardless of the exit
+//     code, since the multiplexer never expects an embedded binary to exit
+//     while it is still running.
+func (a *Appd) Wait() error {
+	a.mu.Lock()
+	waitCh := a.waitCh
+	a.mu.Unlock()
+
+	if waitCh == nil {
+		return nil
 	}
 
-	// ProcessState is nil, which means the process is still running
-	return false
+	<-waitCh
+
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if a.stopping {
+		return nil
+	}
+	if a.waitErr != nil {
+		return fmt.Errorf("embedded app exited unexpectedly: %w", a.waitErr)
+	}
+	return fmt.Errorf("embedded app exited unexpectedly")
 }
 
 // Stop interrupts and then kills the running appd process if it exists and
 // waits for it to fully exit. If the process is not running, it returns nil.
 // The method will wait up to 6 seconds for graceful shutdown before force killing.
 func (a *Appd) Stop() error {
-	if a.cmd == nil {
+	a.mu.Lock()
+	if a.cmd == nil || a.cmd.Process == nil || a.waitCh == nil {
+		a.mu.Unlock()
 		return nil
 	}
-	if a.cmd.Process == nil {
-		return nil
-	}
+	// Mark the shutdown as intentional before signalling the process so that the
+	// Wait observer does not interpret the exit as a crash.
+	a.stopping = true
+	process := a.cmd.Process
+	waitCh := a.waitCh
+	a.mu.Unlock()
 
-	err := a.cmd.Process.Signal(os.Interrupt)
-	if err != nil {
+	if err := process.Signal(os.Interrupt); err != nil {
 		log.Printf("Failed to send interrupt signal, attempting to kill: %v", err)
-		if err := a.cmd.Process.Kill(); err != nil {
-			return fmt.Errorf("failed to kill process with PID %d: %w", a.cmd.Process.Pid, err)
+		if err := process.Kill(); err != nil {
+			return fmt.Errorf("failed to kill process with PID %d: %w", process.Pid, err)
 		}
 
-		if err := a.cmd.Wait(); err != nil {
+		<-waitCh
+		if err := a.exitErr(); err != nil {
 			log.Printf("Process finished with error: %v\n", err)
 		}
 		return nil
@@ -147,14 +216,9 @@ func (a *Appd) Stop() error {
 	ctx, cancel := context.WithTimeout(context.Background(), 6*time.Second)
 	defer cancel()
 
-	done := make(chan error, 1)
-	go func() {
-		done <- a.cmd.Wait()
-	}()
-
 	select {
-	case err := <-done:
-		if err != nil {
+	case <-waitCh:
+		if err := a.exitErr(); err != nil {
 			log.Printf("Process finished with error: %v\n", err)
 		} else {
 			log.Printf("Process finished with no error\n")
@@ -162,17 +226,26 @@ func (a *Appd) Stop() error {
 		return nil
 	case <-ctx.Done():
 		log.Printf("Process did not exit within 6 seconds, force killing")
-		if err := a.cmd.Process.Kill(); err != nil {
-			return fmt.Errorf("failed to kill process with PID %d after timeout: %w", a.cmd.Process.Pid, err)
+		if err := process.Kill(); err != nil {
+			return fmt.Errorf("failed to kill process with PID %d after timeout: %w", process.Pid, err)
 		}
 
-		if err := <-done; err != nil {
+		<-waitCh
+		if err := a.exitErr(); err != nil {
 			log.Printf("Process finished with error after force kill: %v\n", err)
 		} else {
 			log.Printf("Process finished after force kill\n")
 		}
 		return nil
 	}
+}
+
+// exitErr returns the error returned by the underlying process. It must only be
+// called after the process has exited (waitCh closed).
+func (a *Appd) exitErr() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.waitErr
 }
 
 // CreateExecCommand creates an exec.Cmd for the appd binary.


### PR DESCRIPTION
## Overview

If an embedded binary exited after being started — for any reason other than an intentional `Stop` — the multiplexer kept blocking on the signal-handler goroutine inside `g.Wait()`, so `celestia-appd` hung silently with no indication that the child had died. The minimum-gas-prices bug fixed in #7404 was just one trigger of this underlying failure mode.

## Change

- `Appd` now waits on the child process from a single goroutine and exposes `Wait()`, which returns an error when the process exits on its own (regardless of exit code). `Stop()` is coordinated through the same channel so there is no second `cmd.Wait()` race.
- The multiplexer monitors the active embedded app and, on an unexpected exit, unblocks `Start()` with a fatal error so the process exits non-zero. Intentional shutdowns (including version switches during upgrades) report no error and are ignored.

## Test

- `multiplexer/appd`: `Wait()` returns an error on unexpected exit (zero and non-zero codes), returns nil on intentional `Stop()`, and unblocks promptly on crash.
- `multiplexer/abci`: `waitForEmbeddedApp` returns the fatal error when an embedded app exits unexpectedly and the errgroup result on graceful shutdown.

Closes #7405