### PR TITLE
feat(valaddr)!: garbage-collect stale fibre provider entries

### DIFF
--- a/app/test/std_sdk_fibre_test.go
+++ b/app/test/std_sdk_fibre_test.go
@@ -45,7 +45,7 @@ func (s *StandardSDKIntegrationTestSuite) TestFibreProviderTxAndQuery() {
 		require.Equal(abci.CodeTypeOK, res.Code)
 
 		queryClient := valaddrtypes.NewQueryClient(s.cctx.GRPCClient)
-		allProvidersResp, err := queryClient.AllFibreProviders(s.cctx.GoContext(), &valaddrtypes.QueryAllFibreProvidersRequest{})
+		allProvidersResp, err := queryClient.AllBondedFibreProviders(s.cctx.GoContext(), &valaddrtypes.QueryAllBondedFibreProvidersRequest{})
 		require.NoError(err)
 		require.NotNil(allProvidersResp)
 		require.Equal(0, slices.IndexFunc(allProvidersResp.Providers, func(provider valaddrtypes.FibreProvider) bool {

--- a/fibre/internal/grpc/host_registry.go
+++ b/fibre/internal/grpc/host_registry.go
@@ -129,7 +129,7 @@ func (g *HostRegistry) getHost(ctx context.Context, val *core.Validator) (valida
 
 // PullAll pulls all active fibre providers from the query client and caches them, overwriting any existing cached hosts.
 func (g *HostRegistry) PullAll(ctx context.Context) error {
-	resp, err := g.queryClient.AllFibreProviders(ctx, &types.QueryAllFibreProvidersRequest{})
+	resp, err := g.queryClient.AllBondedFibreProviders(ctx, &types.QueryAllBondedFibreProvidersRequest{})
 	if err != nil {
 		return err
 	}

--- a/fibre/internal/grpc/host_registry_test.go
+++ b/fibre/internal/grpc/host_registry_test.go
@@ -23,7 +23,7 @@ import (
 
 type mockQueryClient struct {
 	fibreProviderInfoFn func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error)
-	allFibreProvidersFn func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error)
+	allFibreProvidersFn func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error)
 }
 
 func (m *mockQueryClient) FibreProviderInfo(ctx context.Context, in *types.QueryFibreProviderInfoRequest, opts ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
@@ -33,7 +33,7 @@ func (m *mockQueryClient) FibreProviderInfo(ctx context.Context, in *types.Query
 	return nil, errors.New("not implemented")
 }
 
-func (m *mockQueryClient) AllFibreProviders(ctx context.Context, in *types.QueryAllFibreProvidersRequest, opts ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
+func (m *mockQueryClient) AllBondedFibreProviders(ctx context.Context, in *types.QueryAllBondedFibreProvidersRequest, opts ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
 	if m.allFibreProvidersFn != nil {
 		return m.allFibreProvidersFn(ctx, in, opts...)
 	}
@@ -90,8 +90,8 @@ func TestGetHost(t *testing.T) {
 		{
 			name: "cached",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
+				allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+					return &types.QueryAllBondedFibreProvidersResponse{
 						Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: expectedHost}}},
 					}, nil
 				},
@@ -102,8 +102,8 @@ func TestGetHost(t *testing.T) {
 		{
 			name: "not cached pull success",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
+				allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+					return &types.QueryAllBondedFibreProvidersResponse{
 						Providers: []types.FibreProvider{{ValidatorConsensusAddress: "other", Info: types.FibreProviderInfo{Host: "other.com"}}},
 					}, nil
 				},
@@ -117,8 +117,8 @@ func TestGetHost(t *testing.T) {
 		{
 			name: "not cached pull fail",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
+				allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+					return &types.QueryAllBondedFibreProvidersResponse{
 						Providers: []types.FibreProvider{{ValidatorConsensusAddress: "other", Info: types.FibreProviderInfo{Host: "other.com"}}},
 					}, nil
 				},
@@ -212,8 +212,8 @@ func TestPullAll(t *testing.T) {
 		{
 			name: "success",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-					return &types.QueryAllFibreProvidersResponse{
+				allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+					return &types.QueryAllBondedFibreProvidersResponse{
 						Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: expectedHost}}},
 					}, nil
 				},
@@ -222,7 +222,7 @@ func TestPullAll(t *testing.T) {
 		{
 			name: "error",
 			mock: &mockQueryClient{
-				allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
+				allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
 					return nil, errors.New("grpc error")
 				},
 			},
@@ -305,8 +305,8 @@ func TestPullHost_OverwritesCache(t *testing.T) {
 	secondHost := "validator1.example.com:9091"
 
 	registry := grpc.NewHostRegistry(&mockQueryClient{
-		allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-			return &types.QueryAllFibreProvidersResponse{
+		allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+			return &types.QueryAllBondedFibreProvidersResponse{
 				Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: firstHost}}},
 			}, nil
 		},
@@ -335,11 +335,11 @@ func TestHostRegistry_ConcurrentAccess(t *testing.T) {
 	var callCount int
 	var mu sync.Mutex
 	registry := grpc.NewHostRegistry(&mockQueryClient{
-		allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
+		allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
 			mu.Lock()
 			callCount++
 			mu.Unlock()
-			return &types.QueryAllFibreProvidersResponse{
+			return &types.QueryAllBondedFibreProvidersResponse{
 				Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: expectedHost}}},
 			}, nil
 		},
@@ -375,8 +375,8 @@ func TestRefreshHost(t *testing.T) {
 	curHost := initialHost
 	infoCalls := 0
 	mock := &mockQueryClient{
-		allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-			return &types.QueryAllFibreProvidersResponse{
+		allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+			return &types.QueryAllBondedFibreProvidersResponse{
 				Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: initialHost}}},
 			}, nil
 		},
@@ -541,8 +541,8 @@ func TestGetHost_MultipleValidators(t *testing.T) {
 	}
 
 	registry := grpc.NewHostRegistry(&mockQueryClient{
-		allFibreProvidersFn: func(context.Context, *types.QueryAllFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllFibreProvidersResponse, error) {
-			return &types.QueryAllFibreProvidersResponse{Providers: providers}, nil
+		allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
+			return &types.QueryAllBondedFibreProvidersResponse{Providers: providers}, nil
 		},
 	}, slog.Default())
 	err := registry.Start(t.Context())

--- a/proto/celestia/valaddr/v1/query.proto
+++ b/proto/celestia/valaddr/v1/query.proto
@@ -13,9 +13,11 @@ service Query {
     option (google.api.http).get = "/valaddr/v1/fibre-provider-info/{validator_consensus_address}";
   }
 
-  // AllFibreProviders queries fibre provider information for all validators
-  rpc AllFibreProviders(QueryAllFibreProvidersRequest) returns (QueryAllFibreProvidersResponse) {
-    option (google.api.http).get = "/valaddr/v1/all-fibre-providers";
+  // AllBondedFibreProviders queries fibre provider information for all currently
+  // bonded validators. Providers whose validator has left the active set (e.g.
+  // unbonded or jailed) are omitted so callers never receive a stale host.
+  rpc AllBondedFibreProviders(QueryAllBondedFibreProvidersRequest) returns (QueryAllBondedFibreProvidersResponse) {
+    option (google.api.http).get = "/valaddr/v1/all-bonded-fibre-providers";
   }
 }
 
@@ -33,12 +35,12 @@ message QueryFibreProviderInfoResponse {
   bool found = 2;
 }
 
-// QueryAllFibreProvidersRequest is the request type for the Query/AllFibreProviders RPC method.
-message QueryAllFibreProvidersRequest {}
+// QueryAllBondedFibreProvidersRequest is the request type for the Query/AllBondedFibreProviders RPC method.
+message QueryAllBondedFibreProvidersRequest {}
 
-// QueryAllFibreProvidersResponse is the response type for the Query/AllFibreProviders RPC method.
-message QueryAllFibreProvidersResponse {
-  // providers contains all fibre providers with a host defined
+// QueryAllBondedFibreProvidersResponse is the response type for the Query/AllBondedFibreProviders RPC method.
+message QueryAllBondedFibreProvidersResponse {
+  // providers contains the fibre providers of all currently bonded validators
   repeated FibreProvider providers = 1 [(gogoproto.nullable) = false];
 }
 

--- a/x/valaddr/client/cli/query.go
+++ b/x/valaddr/client/cli/query.go
@@ -22,7 +22,7 @@ func GetQueryCmd() *cobra.Command {
 
 	cmd.AddCommand(
 		CmdQueryFibreProviderInfo(),
-		CmdQueryAllFibreProviders(),
+		CmdQueryAllBondedFibreProviders(),
 	)
 
 	return cmd
@@ -61,8 +61,8 @@ func CmdQueryFibreProviderInfo() *cobra.Command {
 	return cmd
 }
 
-// CmdQueryAllFibreProviders queries all fibre providers
-func CmdQueryAllFibreProviders() *cobra.Command {
+// CmdQueryAllBondedFibreProviders queries all fibre providers
+func CmdQueryAllBondedFibreProviders() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "providers",
 		Short: "Query all fibre providers",
@@ -75,9 +75,9 @@ func CmdQueryAllFibreProviders() *cobra.Command {
 
 			queryClient := types.NewQueryClient(clientCtx)
 
-			res, err := queryClient.AllFibreProviders(
+			res, err := queryClient.AllBondedFibreProviders(
 				context.Background(),
-				&types.QueryAllFibreProvidersRequest{},
+				&types.QueryAllBondedFibreProvidersRequest{},
 			)
 			if err != nil {
 				return err

--- a/x/valaddr/keeper/endblocker_test.go
+++ b/x/valaddr/keeper/endblocker_test.go
@@ -2,6 +2,7 @@ package keeper_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -24,6 +25,9 @@ type mockStakingKeeper struct {
 	// byCons maps consAddr.String() to the validator returned for it. A missing
 	// key models a validator that has been fully removed from staking state.
 	byCons map[string]stakingtypes.Validator
+	// errByCons maps consAddr.String() to an error returned for it, modeling a
+	// staking state-read failure. It takes precedence over byCons.
+	errByCons map[string]error
 }
 
 func (m mockStakingKeeper) GetValidator(context.Context, sdk.ValAddress) (stakingtypes.Validator, error) {
@@ -35,6 +39,9 @@ func (m mockStakingKeeper) GetBondedValidatorsByPower(context.Context) ([]stakin
 }
 
 func (m mockStakingKeeper) GetValidatorByConsAddr(_ context.Context, consAddr sdk.ConsAddress) (stakingtypes.Validator, error) {
+	if err, ok := m.errByCons[consAddr.String()]; ok {
+		return stakingtypes.Validator{}, err
+	}
 	v, ok := m.byCons[consAddr.String()]
 	if !ok {
 		return stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound
@@ -91,7 +98,7 @@ func TestRemoveFibreProviders(t *testing.T) {
 		require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, info))
 	}
 
-	require.NoError(t, k.RemoveFibreProviders(ctx))
+	require.NoError(t, k.RemoveStaleFibreProviders(ctx))
 
 	assertPresent := func(consAddr sdk.ConsAddress, want bool) {
 		_, found := k.GetFibreProviderInfo(ctx, consAddr)
@@ -120,7 +127,7 @@ func TestRemoveFibreProviders_GracePeriodBoundary(t *testing.T) {
 		// blockTime == UnbondingTime + grace; deletion requires strictly after.
 		k, ctx := newTestKeeper(t, jailedAt(blockTime.Add(-types.JailedGracePeriod)), blockTime)
 		require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, types.FibreProviderInfo{Host: "h:1"}))
-		require.NoError(t, k.RemoveFibreProviders(ctx))
+		require.NoError(t, k.RemoveStaleFibreProviders(ctx))
 		_, found := k.GetFibreProviderInfo(ctx, consAddr)
 		require.True(t, found)
 	})
@@ -128,8 +135,29 @@ func TestRemoveFibreProviders_GracePeriodBoundary(t *testing.T) {
 	t.Run("one second past threshold is deleted", func(t *testing.T) {
 		k, ctx := newTestKeeper(t, jailedAt(blockTime.Add(-types.JailedGracePeriod-time.Second)), blockTime)
 		require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, types.FibreProviderInfo{Host: "h:1"}))
-		require.NoError(t, k.RemoveFibreProviders(ctx))
+		require.NoError(t, k.RemoveStaleFibreProviders(ctx))
 		_, found := k.GetFibreProviderInfo(ctx, consAddr)
 		require.False(t, found)
 	})
+}
+
+// TestRemoveFibreProviders_AbortsOnLookupError verifies that a non-NotFound
+// validator lookup error (a staking state-read problem) aborts the sweep and is
+// returned, leaving the entry untouched rather than acting on partial state.
+func TestRemoveFibreProviders_AbortsOnLookupError(t *testing.T) {
+	blockTime := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	consAddr := sdk.ConsAddress("readerror_validator")
+
+	readErr := errors.New("kv store read failure")
+	staking := mockStakingKeeper{errByCons: map[string]error{consAddr.String(): readErr}}
+
+	k, ctx := newTestKeeper(t, staking, blockTime)
+	require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, types.FibreProviderInfo{Host: "h:1"}))
+
+	err := k.RemoveStaleFibreProviders(ctx)
+	require.ErrorIs(t, err, readErr)
+
+	// The entry must NOT have been deleted; the sweep aborted.
+	_, found := k.GetFibreProviderInfo(ctx, consAddr)
+	require.True(t, found)
 }

--- a/x/valaddr/keeper/endblocker_test.go
+++ b/x/valaddr/keeper/endblocker_test.go
@@ -1,0 +1,135 @@
+package keeper_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cosmossdk.io/log"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/celestiaorg/celestia-app/v9/x/valaddr/keeper"
+	"github.com/celestiaorg/celestia-app/v9/x/valaddr/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	"github.com/cosmos/cosmos-sdk/testutil"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/stretchr/testify/require"
+)
+
+// mockStakingKeeper implements types.StakingKeeper. Only GetValidatorByConsAddr
+// is exercised by the sweep; the others satisfy the interface.
+type mockStakingKeeper struct {
+	// byCons maps consAddr.String() to the validator returned for it. A missing
+	// key models a validator that has been fully removed from staking state.
+	byCons map[string]stakingtypes.Validator
+}
+
+func (m mockStakingKeeper) GetValidator(context.Context, sdk.ValAddress) (stakingtypes.Validator, error) {
+	return stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound
+}
+
+func (m mockStakingKeeper) GetBondedValidatorsByPower(context.Context) ([]stakingtypes.Validator, error) {
+	return nil, nil
+}
+
+func (m mockStakingKeeper) GetValidatorByConsAddr(_ context.Context, consAddr sdk.ConsAddress) (stakingtypes.Validator, error) {
+	v, ok := m.byCons[consAddr.String()]
+	if !ok {
+		return stakingtypes.Validator{}, stakingtypes.ErrNoValidatorFound
+	}
+	return v, nil
+}
+
+func newTestKeeper(t *testing.T, staking types.StakingKeeper, blockTime time.Time) (keeper.Keeper, sdk.Context) {
+	t.Helper()
+	storeKey := storetypes.NewKVStoreKey(types.StoreKey)
+	tStoreKey := storetypes.NewTransientStoreKey("transient_test")
+	testCtx := testutil.DefaultContextWithDB(t, storeKey, tStoreKey)
+	ctx := testCtx.Ctx.WithBlockTime(blockTime)
+
+	cdc := codec.NewProtoCodec(codectypes.NewInterfaceRegistry())
+	k := keeper.NewKeeper(cdc, runtime.NewKVStoreService(storeKey), log.NewNopLogger(), staking)
+	return k, ctx
+}
+
+// TestRemoveFibreProviders covers each branch of the validator-lifecycle
+// sweep: removed validators and long-jailed validators are deleted, while
+// bonded and briefly-jailed validators keep their registration.
+func TestRemoveFibreProviders(t *testing.T) {
+	blockTime := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+
+	bonded := sdk.ConsAddress("bonded_validator___")
+	shortJail := sdk.ConsAddress("short_jail_validator")
+	longJail := sdk.ConsAddress("long_jail_validator_")
+	removed := sdk.ConsAddress("removed_validator__")
+
+	staking := mockStakingKeeper{byCons: map[string]stakingtypes.Validator{
+		// Active validator -> kept.
+		bonded.String(): {Status: stakingtypes.Bonded, Jailed: false},
+		// Jailed but only recently unbonded (within grace) -> kept.
+		shortJail.String(): {
+			Status:        stakingtypes.Unbonded,
+			Jailed:        true,
+			UnbondingTime: blockTime.Add(-24 * time.Hour),
+		},
+		// Jailed and unbonded well past the grace period -> deleted.
+		longJail.String(): {
+			Status:        stakingtypes.Unbonded,
+			Jailed:        true,
+			UnbondingTime: blockTime.Add(-types.JailedGracePeriod - 24*time.Hour),
+		},
+		// `removed` is intentionally absent -> GetValidatorByConsAddr returns
+		// ErrNoValidatorFound -> deleted.
+	}}
+
+	k, ctx := newTestKeeper(t, staking, blockTime)
+
+	info := types.FibreProviderInfo{Host: "host.example.com:7980"}
+	for _, consAddr := range []sdk.ConsAddress{bonded, shortJail, longJail, removed} {
+		require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, info))
+	}
+
+	require.NoError(t, k.RemoveFibreProviders(ctx))
+
+	assertPresent := func(consAddr sdk.ConsAddress, want bool) {
+		_, found := k.GetFibreProviderInfo(ctx, consAddr)
+		require.Equal(t, want, found, "consAddr %s", consAddr)
+	}
+
+	assertPresent(bonded, true)    // still active
+	assertPresent(shortJail, true) // jailed within grace
+	assertPresent(longJail, false) // jailed past grace
+	assertPresent(removed, false)  // removed from staking
+}
+
+// TestRemoveFibreProviders_GracePeriodBoundary verifies the entry survives
+// right up to the grace threshold and is removed once it elapses.
+func TestRemoveFibreProviders_GracePeriodBoundary(t *testing.T) {
+	blockTime := time.Date(2026, 6, 23, 0, 0, 0, 0, time.UTC)
+	consAddr := sdk.ConsAddress("boundary_validator_")
+
+	jailedAt := func(unbondingTime time.Time) mockStakingKeeper {
+		return mockStakingKeeper{byCons: map[string]stakingtypes.Validator{
+			consAddr.String(): {Status: stakingtypes.Unbonded, Jailed: true, UnbondingTime: unbondingTime},
+		}}
+	}
+
+	t.Run("exactly at threshold is kept", func(t *testing.T) {
+		// blockTime == UnbondingTime + grace; deletion requires strictly after.
+		k, ctx := newTestKeeper(t, jailedAt(blockTime.Add(-types.JailedGracePeriod)), blockTime)
+		require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, types.FibreProviderInfo{Host: "h:1"}))
+		require.NoError(t, k.RemoveFibreProviders(ctx))
+		_, found := k.GetFibreProviderInfo(ctx, consAddr)
+		require.True(t, found)
+	})
+
+	t.Run("one second past threshold is deleted", func(t *testing.T) {
+		k, ctx := newTestKeeper(t, jailedAt(blockTime.Add(-types.JailedGracePeriod-time.Second)), blockTime)
+		require.NoError(t, k.SetFibreProviderInfo(ctx, consAddr, types.FibreProviderInfo{Host: "h:1"}))
+		require.NoError(t, k.RemoveFibreProviders(ctx))
+		_, found := k.GetFibreProviderInfo(ctx, consAddr)
+		require.False(t, found)
+	})
+}

--- a/x/valaddr/keeper/grpc_query.go
+++ b/x/valaddr/keeper/grpc_query.go
@@ -29,8 +29,12 @@ func (k Keeper) FibreProviderInfo(goCtx context.Context, req *types.QueryFibrePr
 	}, nil
 }
 
-// AllFibreProviders queries fibre provider information for all validators that have a host defined
-func (k Keeper) AllFibreProviders(goCtx context.Context, req *types.QueryAllFibreProvidersRequest) (*types.QueryAllFibreProvidersResponse, error) {
+// AllBondedFibreProviders returns the fibre provider info of every currently
+// bonded validator that has registered a host. Providers whose validator has
+// left the active set (unbonded, or jailed and no longer bonded) are omitted so
+// callers never dial a stale host; such entries are also garbage-collected by
+// the EndBlocker sweep (see keeper.RemoveStaleFibreProviders).
+func (k Keeper) AllBondedFibreProviders(goCtx context.Context, req *types.QueryAllBondedFibreProvidersRequest) (*types.QueryAllBondedFibreProvidersResponse, error) {
 	if req == nil {
 		return nil, errorsmod.Wrap(types.ErrInvalidValidator, "empty request")
 	}
@@ -51,7 +55,7 @@ func (k Keeper) AllFibreProviders(goCtx context.Context, req *types.QueryAllFibr
 		return nil, errorsmod.Wrap(err, "failed to iterate fibre provider info")
 	}
 
-	return &types.QueryAllFibreProvidersResponse{
+	return &types.QueryAllBondedFibreProvidersResponse{
 		Providers: providers,
 	}, nil
 }

--- a/x/valaddr/keeper/grpc_query.go
+++ b/x/valaddr/keeper/grpc_query.go
@@ -37,6 +37,10 @@ func (k Keeper) AllFibreProviders(goCtx context.Context, req *types.QueryAllFibr
 
 	var providers []types.FibreProvider
 	err := k.IterateFibreProviderInfo(goCtx, func(consAddr sdk.ConsAddress, info types.FibreProviderInfo) bool {
+		validator, err := k.stakingKeeper.GetValidatorByConsAddr(goCtx, consAddr)
+		if err != nil || !validator.IsBonded() {
+			return false
+		}
 		providers = append(providers, types.FibreProvider{
 			ValidatorConsensusAddress: consAddr.String(),
 			Info:                      info,

--- a/x/valaddr/keeper/grpc_query_test.go
+++ b/x/valaddr/keeper/grpc_query_test.go
@@ -58,22 +58,27 @@ func TestAllFibreProvidersQuery(t *testing.T) {
 	types.RegisterQueryServer(queryHelper, testApp.ValAddrKeeper)
 	queryClient := types.NewQueryClient(queryHelper)
 
-	consAddr1 := sdk.ConsAddress("validator1")
-	info1 := types.FibreProviderInfo{
-		Host: "validator1.fibre.example.com",
-	}
-	err := testApp.ValAddrKeeper.SetFibreProviderInfo(ctx, consAddr1, info1)
+	// Use the consensus address of a real bonded validator: AllFibreProviders
+	// only advertises providers whose validator is currently in the active set.
+	validators, err := testApp.StakingKeeper.GetBondedValidatorsByPower(ctx)
 	require.NoError(t, err)
+	require.NotEmpty(t, validators)
+	consPubKey, err := validators[0].ConsPubKey()
+	require.NoError(t, err)
+	bondedConsAddr := sdk.ConsAddress(consPubKey.Address())
 
-	consAddr2 := sdk.ConsAddress("validator2")
-	info2 := types.FibreProviderInfo{
-		Host: "validator2.fibre.example.com",
-	}
-	err = testApp.ValAddrKeeper.SetFibreProviderInfo(ctx, consAddr2, info2)
-	require.NoError(t, err)
+	bondedInfo := types.FibreProviderInfo{Host: "bonded.fibre.example.com:7980"}
+	require.NoError(t, testApp.ValAddrKeeper.SetFibreProviderInfo(ctx, bondedConsAddr, bondedInfo))
+
+	// A provider for an address that is not a bonded validator must be excluded
+	// from the response (it is a stale host).
+	staleConsAddr := sdk.ConsAddress("not_a_validator____")
+	require.NoError(t, testApp.ValAddrKeeper.SetFibreProviderInfo(ctx, staleConsAddr, types.FibreProviderInfo{Host: "stale.example.com:7980"}))
 
 	resp, err := queryClient.AllFibreProviders(gocontext.Background(), &types.QueryAllFibreProvidersRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
-	require.Len(t, resp.Providers, 2)
+	require.Len(t, resp.Providers, 1)
+	require.Equal(t, bondedConsAddr.String(), resp.Providers[0].ValidatorConsensusAddress)
+	require.Equal(t, bondedInfo.Host, resp.Providers[0].Info.Host)
 }

--- a/x/valaddr/keeper/grpc_query_test.go
+++ b/x/valaddr/keeper/grpc_query_test.go
@@ -50,7 +50,7 @@ func TestFibreProviderInfoQuery(t *testing.T) {
 	})
 }
 
-func TestAllFibreProvidersQuery(t *testing.T) {
+func TestAllBondedFibreProvidersQuery(t *testing.T) {
 	testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams())
 	ctx := testApp.NewContext(true)
 
@@ -58,7 +58,7 @@ func TestAllFibreProvidersQuery(t *testing.T) {
 	types.RegisterQueryServer(queryHelper, testApp.ValAddrKeeper)
 	queryClient := types.NewQueryClient(queryHelper)
 
-	// Use the consensus address of a real bonded validator: AllFibreProviders
+	// Use the consensus address of a real bonded validator: AllBondedFibreProviders
 	// only advertises providers whose validator is currently in the active set.
 	validators, err := testApp.StakingKeeper.GetBondedValidatorsByPower(ctx)
 	require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestAllFibreProvidersQuery(t *testing.T) {
 	staleConsAddr := sdk.ConsAddress("not_a_validator____")
 	require.NoError(t, testApp.ValAddrKeeper.SetFibreProviderInfo(ctx, staleConsAddr, types.FibreProviderInfo{Host: "stale.example.com:7980"}))
 
-	resp, err := queryClient.AllFibreProviders(gocontext.Background(), &types.QueryAllFibreProvidersRequest{})
+	resp, err := queryClient.AllBondedFibreProviders(gocontext.Background(), &types.QueryAllBondedFibreProvidersRequest{})
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Len(t, resp.Providers, 1)

--- a/x/valaddr/keeper/keeper.go
+++ b/x/valaddr/keeper/keeper.go
@@ -83,7 +83,7 @@ func (k Keeper) DeleteFibreProviderInfo(ctx context.Context, consAddr sdk.ConsAd
 // RemoveStaleFibreProviders garbage-collects FibreProviderInfo entries whose
 // validator has permanently left the active set: either fully removed from
 // staking state, or jailed and unbonded for longer than
-// JailedGracePeriod(1 month).
+// JailedGracePeriod (1 week).
 //
 // A validator lookup that fails with anything other than ErrNoValidatorFound
 // indicates a staking state-read problem; in that case the sweep aborts and

--- a/x/valaddr/keeper/keeper.go
+++ b/x/valaddr/keeper/keeper.go
@@ -3,6 +3,7 @@ package keeper
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/log"
@@ -79,24 +80,32 @@ func (k Keeper) DeleteFibreProviderInfo(ctx context.Context, consAddr sdk.ConsAd
 	return store.Delete(key)
 }
 
-// RemoveFibreProviders garbage-collects FibreProviderInfo entries whose
+// RemoveStaleFibreProviders garbage-collects FibreProviderInfo entries whose
 // validator has permanently left the active set: either fully removed from
 // staking state, or jailed and unbonded for longer than
 // JailedGracePeriod(1 month).
-func (k Keeper) RemoveFibreProviders(ctx context.Context) error {
+//
+// A validator lookup that fails with anything other than ErrNoValidatorFound
+// indicates a staking state-read problem; in that case the sweep aborts and
+// returns the error rather than acting on partial state.
+func (k Keeper) RemoveStaleFibreProviders(ctx context.Context) error {
 	blockTime := sdk.UnwrapSDKContext(ctx).BlockTime()
 
 	var stale []sdk.ConsAddress
+	var lookupErr error
 	err := k.IterateFibreProviderInfo(ctx, func(consAddr sdk.ConsAddress, _ types.FibreProviderInfo) bool {
 		validator, err := k.stakingKeeper.GetValidatorByConsAddr(ctx, consAddr)
 		if err != nil {
-			// Only a definitively-removed validator counts as stale; on any
-			// other (unexpected) lookup error keep the entry rather than risk
-			// deleting a live registration.
+			// A definitively-removed validator is stale and its entry is dropped.
 			if errors.Is(err, stakingtypes.ErrNoValidatorFound) {
 				stale = append(stale, copyConsAddr(consAddr))
+				return false
 			}
-			return false
+			// Any other error means staking state could not be read. Something
+			// is off, so abort the sweep instead of risking action on partial
+			// state.
+			lookupErr = fmt.Errorf("looking up validator %s: %w", consAddr, err)
+			return true
 		}
 
 		// A validator that has been jailed and has finished unbonding without
@@ -109,6 +118,9 @@ func (k Keeper) RemoveFibreProviders(ctx context.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+	if lookupErr != nil {
+		return lookupErr
 	}
 
 	for _, consAddr := range stale {

--- a/x/valaddr/keeper/keeper.go
+++ b/x/valaddr/keeper/keeper.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"context"
+	"errors"
 
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/log"
@@ -9,6 +10,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/x/valaddr/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
 // Keeper of the valaddr store
@@ -75,6 +77,55 @@ func (k Keeper) DeleteFibreProviderInfo(ctx context.Context, consAddr sdk.ConsAd
 	store := k.storeService.OpenKVStore(ctx)
 	key := types.GetFibreProviderInfoKey(consAddr)
 	return store.Delete(key)
+}
+
+// RemoveFibreProviders garbage-collects FibreProviderInfo entries whose
+// validator has permanently left the active set: either fully removed from
+// staking state, or jailed and unbonded for longer than
+// JailedGracePeriod(1 month).
+func (k Keeper) RemoveFibreProviders(ctx context.Context) error {
+	blockTime := sdk.UnwrapSDKContext(ctx).BlockTime()
+
+	var stale []sdk.ConsAddress
+	err := k.IterateFibreProviderInfo(ctx, func(consAddr sdk.ConsAddress, _ types.FibreProviderInfo) bool {
+		validator, err := k.stakingKeeper.GetValidatorByConsAddr(ctx, consAddr)
+		if err != nil {
+			// Only a definitively-removed validator counts as stale; on any
+			// other (unexpected) lookup error keep the entry rather than risk
+			// deleting a live registration.
+			if errors.Is(err, stakingtypes.ErrNoValidatorFound) {
+				stale = append(stale, copyConsAddr(consAddr))
+			}
+			return false
+		}
+
+		// A validator that has been jailed and has finished unbonding without
+		// recovering for longer than the grace period is treated as gone.
+		if validator.IsJailed() && !validator.IsBonded() &&
+			blockTime.After(validator.UnbondingTime.Add(types.JailedGracePeriod)) {
+			stale = append(stale, copyConsAddr(consAddr))
+		}
+		return false
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, consAddr := range stale {
+		if err := k.DeleteFibreProviderInfo(ctx, consAddr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// copyConsAddr returns a copy of the consensus address. The address handed to
+// the iterator callback aliases iterator-owned memory that is reused on the
+// next iteration, so it must be copied before being retained.
+func copyConsAddr(consAddr sdk.ConsAddress) sdk.ConsAddress {
+	out := make(sdk.ConsAddress, len(consAddr))
+	copy(out, consAddr)
+	return out
 }
 
 // IterateFibreProviderInfo iterates over all fibre provider info entries

--- a/x/valaddr/module.go
+++ b/x/valaddr/module.go
@@ -25,6 +25,7 @@ var (
 	_ module.HasServices         = AppModule{}
 	_ module.HasConsensusVersion = AppModule{}
 	_ appmodule.AppModule        = AppModule{}
+	_ appmodule.HasEndBlocker    = AppModule{}
 )
 
 // AppModule implements the AppModule interface for the valaddr module.
@@ -117,3 +118,9 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, _ codec.JSONCodec) json.RawMe
 
 // ConsensusVersion implements AppModule/ConsensusVersion.
 func (AppModule) ConsensusVersion() uint64 { return 1 }
+
+// EndBlock garbage-collects stale fibre provider entries for validators that
+// have left the active set. See keeper.RemoveFibreProviders.
+func (am AppModule) EndBlock(ctx context.Context) error {
+	return am.keeper.RemoveFibreProviders(ctx)
+}

--- a/x/valaddr/module.go
+++ b/x/valaddr/module.go
@@ -120,7 +120,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, _ codec.JSONCodec) json.RawMe
 func (AppModule) ConsensusVersion() uint64 { return 1 }
 
 // EndBlock garbage-collects stale fibre provider entries for validators that
-// have left the active set. See keeper.RemoveFibreProviders.
+// have left the active set. See keeper.RemoveStaleFibreProviders.
 func (am AppModule) EndBlock(ctx context.Context) error {
-	return am.keeper.RemoveFibreProviders(ctx)
+	return am.keeper.RemoveStaleFibreProviders(ctx)
 }

--- a/x/valaddr/types/expected_keepers.go
+++ b/x/valaddr/types/expected_keepers.go
@@ -11,6 +11,10 @@ import (
 type StakingKeeper interface {
 	// GetValidator returns a validator by operator address
 	GetValidator(ctx context.Context, addr sdk.ValAddress) (stakingtypes.Validator, error)
+	// GetValidatorByConsAddr returns a validator by consensus address. It
+	// returns stakingtypes.ErrNoValidatorFound once the validator has been
+	// removed from staking state.
+	GetValidatorByConsAddr(ctx context.Context, consAddr sdk.ConsAddress) (stakingtypes.Validator, error)
 	// GetBondedValidatorsByPower returns all bonded validators sorted by power
 	GetBondedValidatorsByPower(ctx context.Context) ([]stakingtypes.Validator, error)
 }

--- a/x/valaddr/types/keys.go
+++ b/x/valaddr/types/keys.go
@@ -21,8 +21,9 @@ const (
 // before the EndBlocker sweep garbage-collects its Info entry. A
 // validator that recovers before this elapses keeps its
 // registration. This is a cleanup threshold, not a consensus-critical value, so
-// the exact duration is intentionally approximate (~1 month).
-const JailedGracePeriod = 30 * 24 * time.Hour
+// the exact duration is intentionally approximate. A week is plenty: a healthy
+// validator unjails within hours to at most a few days.
+const JailedGracePeriod = 7 * 24 * time.Hour
 
 // Store key prefixes
 var (

--- a/x/valaddr/types/keys.go
+++ b/x/valaddr/types/keys.go
@@ -1,6 +1,10 @@
 package types
 
-import sdk "github.com/cosmos/cosmos-sdk/types"
+import (
+	"time"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
 
 const (
 	// ModuleName defines the module name
@@ -12,6 +16,13 @@ const (
 	// RouterKey defines the module's message routing key
 	RouterKey = ModuleName
 )
+
+// JailedGracePeriod is how long a validator may remain jailed and unbonded
+// before the EndBlocker sweep garbage-collects its Info entry. A
+// validator that recovers before this elapses keeps its
+// registration. This is a cleanup threshold, not a consensus-critical value, so
+// the exact duration is intentionally approximate (~1 month).
+const JailedGracePeriod = 30 * 24 * time.Hour
 
 // Store key prefixes
 var (

--- a/x/valaddr/types/query.pb.go
+++ b/x/valaddr/types/query.pb.go
@@ -130,22 +130,22 @@ func (m *QueryFibreProviderInfoResponse) GetFound() bool {
 	return false
 }
 
-// QueryAllFibreProvidersRequest is the request type for the Query/AllFibreProviders RPC method.
-type QueryAllFibreProvidersRequest struct {
+// QueryAllBondedFibreProvidersRequest is the request type for the Query/AllBondedFibreProviders RPC method.
+type QueryAllBondedFibreProvidersRequest struct {
 }
 
-func (m *QueryAllFibreProvidersRequest) Reset()         { *m = QueryAllFibreProvidersRequest{} }
-func (m *QueryAllFibreProvidersRequest) String() string { return proto.CompactTextString(m) }
-func (*QueryAllFibreProvidersRequest) ProtoMessage()    {}
-func (*QueryAllFibreProvidersRequest) Descriptor() ([]byte, []int) {
+func (m *QueryAllBondedFibreProvidersRequest) Reset()         { *m = QueryAllBondedFibreProvidersRequest{} }
+func (m *QueryAllBondedFibreProvidersRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryAllBondedFibreProvidersRequest) ProtoMessage()    {}
+func (*QueryAllBondedFibreProvidersRequest) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e66720a0aa696609, []int{2}
 }
-func (m *QueryAllFibreProvidersRequest) XXX_Unmarshal(b []byte) error {
+func (m *QueryAllBondedFibreProvidersRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *QueryAllFibreProvidersRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueryAllBondedFibreProvidersRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_QueryAllFibreProvidersRequest.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryAllBondedFibreProvidersRequest.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -155,36 +155,36 @@ func (m *QueryAllFibreProvidersRequest) XXX_Marshal(b []byte, deterministic bool
 		return b[:n], nil
 	}
 }
-func (m *QueryAllFibreProvidersRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryAllFibreProvidersRequest.Merge(m, src)
+func (m *QueryAllBondedFibreProvidersRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllBondedFibreProvidersRequest.Merge(m, src)
 }
-func (m *QueryAllFibreProvidersRequest) XXX_Size() int {
+func (m *QueryAllBondedFibreProvidersRequest) XXX_Size() int {
 	return m.Size()
 }
-func (m *QueryAllFibreProvidersRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryAllFibreProvidersRequest.DiscardUnknown(m)
+func (m *QueryAllBondedFibreProvidersRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllBondedFibreProvidersRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_QueryAllFibreProvidersRequest proto.InternalMessageInfo
+var xxx_messageInfo_QueryAllBondedFibreProvidersRequest proto.InternalMessageInfo
 
-// QueryAllFibreProvidersResponse is the response type for the Query/AllFibreProviders RPC method.
-type QueryAllFibreProvidersResponse struct {
-	// providers contains all fibre providers with a host defined
+// QueryAllBondedFibreProvidersResponse is the response type for the Query/AllBondedFibreProviders RPC method.
+type QueryAllBondedFibreProvidersResponse struct {
+	// providers contains the fibre providers of all currently bonded validators
 	Providers []FibreProvider `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers"`
 }
 
-func (m *QueryAllFibreProvidersResponse) Reset()         { *m = QueryAllFibreProvidersResponse{} }
-func (m *QueryAllFibreProvidersResponse) String() string { return proto.CompactTextString(m) }
-func (*QueryAllFibreProvidersResponse) ProtoMessage()    {}
-func (*QueryAllFibreProvidersResponse) Descriptor() ([]byte, []int) {
+func (m *QueryAllBondedFibreProvidersResponse) Reset()         { *m = QueryAllBondedFibreProvidersResponse{} }
+func (m *QueryAllBondedFibreProvidersResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryAllBondedFibreProvidersResponse) ProtoMessage()    {}
+func (*QueryAllBondedFibreProvidersResponse) Descriptor() ([]byte, []int) {
 	return fileDescriptor_e66720a0aa696609, []int{3}
 }
-func (m *QueryAllFibreProvidersResponse) XXX_Unmarshal(b []byte) error {
+func (m *QueryAllBondedFibreProvidersResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
 }
-func (m *QueryAllFibreProvidersResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+func (m *QueryAllBondedFibreProvidersResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 	if deterministic {
-		return xxx_messageInfo_QueryAllFibreProvidersResponse.Marshal(b, m, deterministic)
+		return xxx_messageInfo_QueryAllBondedFibreProvidersResponse.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
 		n, err := m.MarshalToSizedBuffer(b)
@@ -194,19 +194,19 @@ func (m *QueryAllFibreProvidersResponse) XXX_Marshal(b []byte, deterministic boo
 		return b[:n], nil
 	}
 }
-func (m *QueryAllFibreProvidersResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryAllFibreProvidersResponse.Merge(m, src)
+func (m *QueryAllBondedFibreProvidersResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryAllBondedFibreProvidersResponse.Merge(m, src)
 }
-func (m *QueryAllFibreProvidersResponse) XXX_Size() int {
+func (m *QueryAllBondedFibreProvidersResponse) XXX_Size() int {
 	return m.Size()
 }
-func (m *QueryAllFibreProvidersResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryAllFibreProvidersResponse.DiscardUnknown(m)
+func (m *QueryAllBondedFibreProvidersResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryAllBondedFibreProvidersResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_QueryAllFibreProvidersResponse proto.InternalMessageInfo
+var xxx_messageInfo_QueryAllBondedFibreProvidersResponse proto.InternalMessageInfo
 
-func (m *QueryAllFibreProvidersResponse) GetProviders() []FibreProvider {
+func (m *QueryAllBondedFibreProvidersResponse) GetProviders() []FibreProvider {
 	if m != nil {
 		return m.Providers
 	}
@@ -317,8 +317,8 @@ func (m *FibreProviderInfo) GetHost() string {
 func init() {
 	proto.RegisterType((*QueryFibreProviderInfoRequest)(nil), "celestia.valaddr.v1.QueryFibreProviderInfoRequest")
 	proto.RegisterType((*QueryFibreProviderInfoResponse)(nil), "celestia.valaddr.v1.QueryFibreProviderInfoResponse")
-	proto.RegisterType((*QueryAllFibreProvidersRequest)(nil), "celestia.valaddr.v1.QueryAllFibreProvidersRequest")
-	proto.RegisterType((*QueryAllFibreProvidersResponse)(nil), "celestia.valaddr.v1.QueryAllFibreProvidersResponse")
+	proto.RegisterType((*QueryAllBondedFibreProvidersRequest)(nil), "celestia.valaddr.v1.QueryAllBondedFibreProvidersRequest")
+	proto.RegisterType((*QueryAllBondedFibreProvidersResponse)(nil), "celestia.valaddr.v1.QueryAllBondedFibreProvidersResponse")
 	proto.RegisterType((*FibreProvider)(nil), "celestia.valaddr.v1.FibreProvider")
 	proto.RegisterType((*FibreProviderInfo)(nil), "celestia.valaddr.v1.FibreProviderInfo")
 }
@@ -326,37 +326,38 @@ func init() {
 func init() { proto.RegisterFile("celestia/valaddr/v1/query.proto", fileDescriptor_e66720a0aa696609) }
 
 var fileDescriptor_e66720a0aa696609 = []byte{
-	// 470 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x93, 0x3f, 0x6f, 0x13, 0x31,
-	0x18, 0xc6, 0xe3, 0x90, 0x22, 0xea, 0x8a, 0xa1, 0xa6, 0x43, 0x08, 0x70, 0x09, 0x1e, 0x68, 0x96,
-	0x9c, 0xd5, 0x64, 0x43, 0xe2, 0x4f, 0x8b, 0xa8, 0xc4, 0x80, 0x04, 0x19, 0x59, 0x22, 0x27, 0xe7,
-	0x5c, 0x4e, 0x3a, 0xfc, 0x5e, 0x6d, 0xdf, 0x89, 0x0a, 0xb1, 0xf0, 0x09, 0x40, 0x7c, 0x06, 0x3e,
-	0x09, 0x4b, 0xc7, 0x4a, 0x2c, 0x4c, 0x08, 0x25, 0x7c, 0x05, 0x76, 0x74, 0x3e, 0x5f, 0x68, 0x94,
-	0x3f, 0xa8, 0xea, 0xe6, 0x3b, 0xff, 0x1e, 0xbf, 0xef, 0xf3, 0xf8, 0x35, 0x6e, 0x8e, 0x44, 0x2c,
-	0xb4, 0x89, 0x38, 0xcb, 0x78, 0xcc, 0x83, 0x40, 0xb1, 0xec, 0x80, 0x9d, 0xa4, 0x42, 0x9d, 0xfa,
-	0x89, 0x02, 0x03, 0xe4, 0x56, 0x09, 0xf8, 0x0e, 0xf0, 0xb3, 0x83, 0xc6, 0x5e, 0x08, 0x21, 0xd8,
-	0x7d, 0x96, 0xaf, 0x0a, 0xb4, 0x71, 0x37, 0x04, 0x08, 0x63, 0xc1, 0x78, 0x12, 0x31, 0x2e, 0x25,
-	0x18, 0x6e, 0x22, 0x90, 0xba, 0xd8, 0xa5, 0x03, 0x7c, 0xef, 0x75, 0x7e, 0xee, 0x71, 0x34, 0x54,
-	0xe2, 0x95, 0x82, 0x2c, 0x0a, 0x84, 0x7a, 0x21, 0xc7, 0xd0, 0x17, 0x27, 0xa9, 0xd0, 0x86, 0x3c,
-	0xc6, 0x77, 0x32, 0x1e, 0x47, 0x01, 0x37, 0xa0, 0x06, 0x23, 0x90, 0x5a, 0x48, 0x9d, 0xea, 0x41,
-	0x5e, 0x53, 0x68, 0x5d, 0x47, 0x2d, 0xd4, 0xde, 0xee, 0xdf, 0x9e, 0x23, 0xcf, 0x4a, 0xe2, 0xb0,
-	0x00, 0xa8, 0xc2, 0xde, 0xba, 0x02, 0x3a, 0xc9, 0x61, 0xf2, 0x10, 0xd7, 0x22, 0x39, 0x06, 0x7b,
-	0xd4, 0x4e, 0xf7, 0x81, 0xbf, 0xc2, 0x9a, 0xbf, 0xac, 0xb6, 0x1a, 0xb2, 0x87, 0xb7, 0xc6, 0x90,
-	0xca, 0xa0, 0x5e, 0x6d, 0xa1, 0xf6, 0x8d, 0x7e, 0xf1, 0x41, 0x9b, 0xce, 0xd4, 0x61, 0x1c, 0x2f,
-	0x08, 0xb5, 0x33, 0x45, 0x27, 0xae, 0xa9, 0x15, 0x80, 0x6b, 0xea, 0x18, 0x6f, 0x27, 0xe5, 0xcf,
-	0x3a, 0x6a, 0x5d, 0x6b, 0xef, 0x74, 0xe9, 0xff, 0x3b, 0x3b, 0xaa, 0x9d, 0xfd, 0x6c, 0x56, 0xfa,
-	0xff, 0xa4, 0xf4, 0x33, 0xc2, 0x37, 0x17, 0x90, 0xab, 0x06, 0x4a, 0x9e, 0xba, 0xb8, 0xaa, 0x97,
-	0x89, 0xcb, 0x35, 0x66, 0x95, 0x74, 0x1f, 0xef, 0x2e, 0x01, 0x84, 0xe0, 0xda, 0x04, 0xb4, 0x71,
-	0xf5, 0xed, 0xba, 0xfb, 0xa7, 0x8a, 0xb7, 0x6c, 0x4e, 0xe4, 0x1b, 0x5a, 0xa5, 0xe9, 0xae, 0x2c,
-	0xbe, 0x71, 0x9e, 0x1a, 0xbd, 0x4b, 0x69, 0x8a, 0xdb, 0xa0, 0xcf, 0x3f, 0x7e, 0xff, 0xfd, 0xa5,
-	0xfa, 0x84, 0x3c, 0xba, 0xf8, 0x1e, 0xc6, 0x39, 0xde, 0x29, 0xa3, 0xee, 0xe4, 0xd6, 0xd8, 0xfb,
-	0x0d, 0xd1, 0x7e, 0x20, 0x5f, 0x11, 0xde, 0x5d, 0xba, 0xf2, 0x4d, 0x2e, 0xd6, 0x0d, 0xd0, 0x26,
-	0x17, 0x6b, 0x67, 0x8a, 0xee, 0x5b, 0x17, 0xf7, 0x49, 0xf3, 0xa2, 0x0b, 0x1e, 0xc7, 0x9d, 0x45,
-	0x27, 0xfa, 0xe8, 0xe5, 0xd9, 0xd4, 0x43, 0xe7, 0x53, 0x0f, 0xfd, 0x9a, 0x7a, 0xe8, 0xd3, 0xcc,
-	0xab, 0x9c, 0xcf, 0xbc, 0xca, 0x8f, 0x99, 0x57, 0x79, 0xd3, 0x0b, 0x23, 0x33, 0x49, 0x87, 0xfe,
-	0x08, 0xde, 0xb2, 0xb2, 0x03, 0x50, 0xe1, 0x7c, 0xdd, 0xe1, 0x49, 0xc2, 0xde, 0xcd, 0xcf, 0x37,
-	0xa7, 0x89, 0xd0, 0xc3, 0xeb, 0xf6, 0xa9, 0xf7, 0xfe, 0x06, 0x00, 0x00, 0xff, 0xff, 0x49, 0x17,
-	0x4f, 0x68, 0x56, 0x04, 0x00, 0x00,
+	// 482 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x94, 0x4f, 0x6f, 0xd3, 0x30,
+	0x18, 0xc6, 0xeb, 0xae, 0x43, 0xcc, 0x13, 0x07, 0xcc, 0x24, 0x4a, 0x81, 0xac, 0x0a, 0x30, 0x7a,
+	0x49, 0xac, 0xb5, 0x17, 0x40, 0xe2, 0xcf, 0x8a, 0x98, 0xc4, 0x01, 0x09, 0x7a, 0xe4, 0x52, 0xb9,
+	0x8d, 0x9b, 0x45, 0x32, 0x7e, 0x33, 0xdb, 0x89, 0x98, 0x10, 0x17, 0x3e, 0x00, 0x02, 0xf1, 0x7d,
+	0xb8, 0x70, 0xd9, 0x71, 0x12, 0x17, 0x4e, 0x08, 0xb5, 0x7c, 0x10, 0x14, 0x27, 0x29, 0xab, 0xd6,
+	0x16, 0x95, 0xdd, 0xde, 0xc4, 0xbf, 0xc7, 0xef, 0xfb, 0x3c, 0x76, 0x82, 0xb7, 0x87, 0x5c, 0x70,
+	0x6d, 0x22, 0x46, 0x53, 0x26, 0x58, 0x10, 0x28, 0x9a, 0xee, 0xd2, 0xc3, 0x84, 0xab, 0x23, 0x3f,
+	0x56, 0x60, 0x80, 0x5c, 0x29, 0x01, 0xbf, 0x00, 0xfc, 0x74, 0xb7, 0xb1, 0x15, 0x42, 0x08, 0x76,
+	0x9d, 0x66, 0x55, 0x8e, 0x36, 0x6e, 0x84, 0x00, 0xa1, 0xe0, 0x94, 0xc5, 0x11, 0x65, 0x52, 0x82,
+	0x61, 0x26, 0x02, 0xa9, 0xf3, 0x55, 0xb7, 0x8f, 0x6f, 0xbe, 0xca, 0xf6, 0xdd, 0x8f, 0x06, 0x8a,
+	0xbf, 0x54, 0x90, 0x46, 0x01, 0x57, 0xcf, 0xe5, 0x08, 0x7a, 0xfc, 0x30, 0xe1, 0xda, 0x90, 0x47,
+	0xf8, 0x7a, 0xca, 0x44, 0x14, 0x30, 0x03, 0xaa, 0x3f, 0x04, 0xa9, 0xb9, 0xd4, 0x89, 0xee, 0x67,
+	0x3d, 0xb9, 0xd6, 0x75, 0xd4, 0x44, 0xad, 0x8d, 0xde, 0xb5, 0x29, 0xf2, 0xb4, 0x24, 0xf6, 0x72,
+	0xc0, 0x55, 0xd8, 0x59, 0xd4, 0x40, 0xc7, 0x19, 0x4c, 0x1e, 0xe0, 0x5a, 0x24, 0x47, 0x60, 0xb7,
+	0xda, 0x6c, 0xef, 0xf8, 0x73, 0xac, 0xf9, 0x67, 0xd5, 0x56, 0x43, 0xb6, 0xf0, 0xfa, 0x08, 0x12,
+	0x19, 0xd4, 0xab, 0x4d, 0xd4, 0xba, 0xd8, 0xcb, 0x1f, 0xdc, 0x3b, 0xf8, 0x96, 0xed, 0xb9, 0x27,
+	0x44, 0x17, 0x64, 0xc0, 0x83, 0x19, 0xb9, 0x2e, 0xac, 0xb9, 0x12, 0xdf, 0x5e, 0x8e, 0x15, 0x03,
+	0xee, 0xe3, 0x8d, 0xb8, 0x7c, 0x59, 0x47, 0xcd, 0xb5, 0xd6, 0x66, 0xdb, 0xfd, 0xf7, 0x94, 0xdd,
+	0xda, 0xf1, 0xcf, 0xed, 0x4a, 0xef, 0xaf, 0xd4, 0xfd, 0x8c, 0xf0, 0xa5, 0x19, 0xe4, 0xbc, 0xe1,
+	0x92, 0x27, 0x45, 0x74, 0xd5, 0x55, 0xa2, 0x2b, 0x06, 0xb3, 0x4a, 0xf7, 0x2e, 0xbe, 0x7c, 0x06,
+	0x20, 0x04, 0xd7, 0x0e, 0x40, 0x9b, 0xa2, 0xbf, 0xad, 0xdb, 0x1f, 0xd7, 0xf0, 0xba, 0x4d, 0x8b,
+	0x7c, 0x43, 0xf3, 0x34, 0xed, 0xb9, 0xcd, 0x97, 0xde, 0xad, 0x46, 0x67, 0x25, 0x4d, 0x7e, 0x1a,
+	0xee, 0xb3, 0x0f, 0xdf, 0x7f, 0x7f, 0xa9, 0x3e, 0x26, 0x0f, 0x4f, 0x7f, 0x1b, 0xa3, 0x0c, 0xf7,
+	0xca, 0xa8, 0xbd, 0xcc, 0x1a, 0x7d, 0xb7, 0x24, 0xda, 0xf7, 0xe4, 0x2b, 0xc2, 0x57, 0x17, 0x1c,
+	0x3c, 0xb9, 0xb7, 0x78, 0xae, 0xe5, 0x57, 0xaa, 0x71, 0xff, 0x3f, 0x94, 0x85, 0x2f, 0xdf, 0xfa,
+	0x6a, 0x91, 0x9d, 0xd3, 0xbe, 0x98, 0x10, 0xde, 0xc0, 0xaa, 0xbc, 0x59, 0x8b, 0xba, 0xfb, 0xe2,
+	0x78, 0xec, 0xa0, 0x93, 0xb1, 0x83, 0x7e, 0x8d, 0x1d, 0xf4, 0x69, 0xe2, 0x54, 0x4e, 0x26, 0x4e,
+	0xe5, 0xc7, 0xc4, 0xa9, 0xbc, 0xee, 0x84, 0x91, 0x39, 0x48, 0x06, 0xfe, 0x10, 0xde, 0xd0, 0x72,
+	0x1c, 0x50, 0xe1, 0xb4, 0xf6, 0x58, 0x1c, 0xd3, 0xb7, 0xd3, 0x36, 0xe6, 0x28, 0xe6, 0x7a, 0x70,
+	0xc1, 0xfe, 0x0f, 0x3a, 0x7f, 0x02, 0x00, 0x00, 0xff, 0xff, 0xb0, 0x9a, 0x61, 0x51, 0x7b, 0x04,
+	0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -373,8 +374,10 @@ const _ = grpc.SupportPackageIsVersion4
 type QueryClient interface {
 	// FibreProviderInfo queries the fibre provider information for a specific validator
 	FibreProviderInfo(ctx context.Context, in *QueryFibreProviderInfoRequest, opts ...grpc.CallOption) (*QueryFibreProviderInfoResponse, error)
-	// AllFibreProviders queries fibre provider information for all validators
-	AllFibreProviders(ctx context.Context, in *QueryAllFibreProvidersRequest, opts ...grpc.CallOption) (*QueryAllFibreProvidersResponse, error)
+	// AllBondedFibreProviders queries fibre provider information for all currently
+	// bonded validators. Providers whose validator has left the active set (e.g.
+	// unbonded or jailed) are omitted so callers never receive a stale host.
+	AllBondedFibreProviders(ctx context.Context, in *QueryAllBondedFibreProvidersRequest, opts ...grpc.CallOption) (*QueryAllBondedFibreProvidersResponse, error)
 }
 
 type queryClient struct {
@@ -394,9 +397,9 @@ func (c *queryClient) FibreProviderInfo(ctx context.Context, in *QueryFibreProvi
 	return out, nil
 }
 
-func (c *queryClient) AllFibreProviders(ctx context.Context, in *QueryAllFibreProvidersRequest, opts ...grpc.CallOption) (*QueryAllFibreProvidersResponse, error) {
-	out := new(QueryAllFibreProvidersResponse)
-	err := c.cc.Invoke(ctx, "/celestia.valaddr.v1.Query/AllFibreProviders", in, out, opts...)
+func (c *queryClient) AllBondedFibreProviders(ctx context.Context, in *QueryAllBondedFibreProvidersRequest, opts ...grpc.CallOption) (*QueryAllBondedFibreProvidersResponse, error) {
+	out := new(QueryAllBondedFibreProvidersResponse)
+	err := c.cc.Invoke(ctx, "/celestia.valaddr.v1.Query/AllBondedFibreProviders", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -407,8 +410,10 @@ func (c *queryClient) AllFibreProviders(ctx context.Context, in *QueryAllFibrePr
 type QueryServer interface {
 	// FibreProviderInfo queries the fibre provider information for a specific validator
 	FibreProviderInfo(context.Context, *QueryFibreProviderInfoRequest) (*QueryFibreProviderInfoResponse, error)
-	// AllFibreProviders queries fibre provider information for all validators
-	AllFibreProviders(context.Context, *QueryAllFibreProvidersRequest) (*QueryAllFibreProvidersResponse, error)
+	// AllBondedFibreProviders queries fibre provider information for all currently
+	// bonded validators. Providers whose validator has left the active set (e.g.
+	// unbonded or jailed) are omitted so callers never receive a stale host.
+	AllBondedFibreProviders(context.Context, *QueryAllBondedFibreProvidersRequest) (*QueryAllBondedFibreProvidersResponse, error)
 }
 
 // UnimplementedQueryServer can be embedded to have forward compatible implementations.
@@ -418,8 +423,8 @@ type UnimplementedQueryServer struct {
 func (*UnimplementedQueryServer) FibreProviderInfo(ctx context.Context, req *QueryFibreProviderInfoRequest) (*QueryFibreProviderInfoResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method FibreProviderInfo not implemented")
 }
-func (*UnimplementedQueryServer) AllFibreProviders(ctx context.Context, req *QueryAllFibreProvidersRequest) (*QueryAllFibreProvidersResponse, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method AllFibreProviders not implemented")
+func (*UnimplementedQueryServer) AllBondedFibreProviders(ctx context.Context, req *QueryAllBondedFibreProvidersRequest) (*QueryAllBondedFibreProvidersResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method AllBondedFibreProviders not implemented")
 }
 
 func RegisterQueryServer(s grpc1.Server, srv QueryServer) {
@@ -444,20 +449,20 @@ func _Query_FibreProviderInfo_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Query_AllFibreProviders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(QueryAllFibreProvidersRequest)
+func _Query_AllBondedFibreProviders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryAllBondedFibreProvidersRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(QueryServer).AllFibreProviders(ctx, in)
+		return srv.(QueryServer).AllBondedFibreProviders(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/celestia.valaddr.v1.Query/AllFibreProviders",
+		FullMethod: "/celestia.valaddr.v1.Query/AllBondedFibreProviders",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(QueryServer).AllFibreProviders(ctx, req.(*QueryAllFibreProvidersRequest))
+		return srv.(QueryServer).AllBondedFibreProviders(ctx, req.(*QueryAllBondedFibreProvidersRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -472,8 +477,8 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 			Handler:    _Query_FibreProviderInfo_Handler,
 		},
 		{
-			MethodName: "AllFibreProviders",
-			Handler:    _Query_AllFibreProviders_Handler,
+			MethodName: "AllBondedFibreProviders",
+			Handler:    _Query_AllBondedFibreProviders_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
@@ -555,7 +560,7 @@ func (m *QueryFibreProviderInfoResponse) MarshalToSizedBuffer(dAtA []byte) (int,
 	return len(dAtA) - i, nil
 }
 
-func (m *QueryAllFibreProvidersRequest) Marshal() (dAtA []byte, err error) {
+func (m *QueryAllBondedFibreProvidersRequest) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -565,12 +570,12 @@ func (m *QueryAllFibreProvidersRequest) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *QueryAllFibreProvidersRequest) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryAllBondedFibreProvidersRequest) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *QueryAllFibreProvidersRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryAllBondedFibreProvidersRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -578,7 +583,7 @@ func (m *QueryAllFibreProvidersRequest) MarshalToSizedBuffer(dAtA []byte) (int, 
 	return len(dAtA) - i, nil
 }
 
-func (m *QueryAllFibreProvidersResponse) Marshal() (dAtA []byte, err error) {
+func (m *QueryAllBondedFibreProvidersResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
 	n, err := m.MarshalToSizedBuffer(dAtA[:size])
@@ -588,12 +593,12 @@ func (m *QueryAllFibreProvidersResponse) Marshal() (dAtA []byte, err error) {
 	return dAtA[:n], nil
 }
 
-func (m *QueryAllFibreProvidersResponse) MarshalTo(dAtA []byte) (int, error) {
+func (m *QueryAllBondedFibreProvidersResponse) MarshalTo(dAtA []byte) (int, error) {
 	size := m.Size()
 	return m.MarshalToSizedBuffer(dAtA[:size])
 }
 
-func (m *QueryAllFibreProvidersResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+func (m *QueryAllBondedFibreProvidersResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	i := len(dAtA)
 	_ = i
 	var l int
@@ -725,7 +730,7 @@ func (m *QueryFibreProviderInfoResponse) Size() (n int) {
 	return n
 }
 
-func (m *QueryAllFibreProvidersRequest) Size() (n int) {
+func (m *QueryAllBondedFibreProvidersRequest) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -734,7 +739,7 @@ func (m *QueryAllFibreProvidersRequest) Size() (n int) {
 	return n
 }
 
-func (m *QueryAllFibreProvidersResponse) Size() (n int) {
+func (m *QueryAllBondedFibreProvidersResponse) Size() (n int) {
 	if m == nil {
 		return 0
 	}
@@ -971,7 +976,7 @@ func (m *QueryFibreProviderInfoResponse) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *QueryAllFibreProvidersRequest) Unmarshal(dAtA []byte) error {
+func (m *QueryAllBondedFibreProvidersRequest) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -994,10 +999,10 @@ func (m *QueryAllFibreProvidersRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: QueryAllFibreProvidersRequest: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryAllBondedFibreProvidersRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryAllFibreProvidersRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryAllBondedFibreProvidersRequest: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		default:
@@ -1021,7 +1026,7 @@ func (m *QueryAllFibreProvidersRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *QueryAllFibreProvidersResponse) Unmarshal(dAtA []byte) error {
+func (m *QueryAllBondedFibreProvidersResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
 	for iNdEx < l {
@@ -1044,10 +1049,10 @@ func (m *QueryAllFibreProvidersResponse) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: QueryAllFibreProvidersResponse: wiretype end group for non-group")
+			return fmt.Errorf("proto: QueryAllBondedFibreProvidersResponse: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryAllFibreProvidersResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+			return fmt.Errorf("proto: QueryAllBondedFibreProvidersResponse: illegal tag %d (wire type %d)", fieldNum, wire)
 		}
 		switch fieldNum {
 		case 1:

--- a/x/valaddr/types/query.pb.gw.go
+++ b/x/valaddr/types/query.pb.gw.go
@@ -87,20 +87,20 @@ func local_request_Query_FibreProviderInfo_0(ctx context.Context, marshaler runt
 
 }
 
-func request_Query_AllFibreProviders_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq QueryAllFibreProvidersRequest
+func request_Query_AllBondedFibreProviders_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryAllBondedFibreProvidersRequest
 	var metadata runtime.ServerMetadata
 
-	msg, err := client.AllFibreProviders(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.AllBondedFibreProviders(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
 
-func local_request_Query_AllFibreProviders_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq QueryAllFibreProvidersRequest
+func local_request_Query_AllBondedFibreProviders_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryAllBondedFibreProvidersRequest
 	var metadata runtime.ServerMetadata
 
-	msg, err := server.AllFibreProviders(ctx, &protoReq)
+	msg, err := server.AllBondedFibreProviders(ctx, &protoReq)
 	return msg, metadata, err
 
 }
@@ -134,7 +134,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 
 	})
 
-	mux.Handle("GET", pattern_Query_AllFibreProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("GET", pattern_Query_AllBondedFibreProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		var stream runtime.ServerTransportStream
@@ -145,7 +145,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := local_request_Query_AllFibreProviders_0(rctx, inboundMarshaler, server, req, pathParams)
+		resp, md, err := local_request_Query_AllBondedFibreProviders_0(rctx, inboundMarshaler, server, req, pathParams)
 		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
@@ -153,7 +153,7 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 			return
 		}
 
-		forward_Query_AllFibreProviders_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_Query_AllBondedFibreProviders_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -218,7 +218,7 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
-	mux.Handle("GET", pattern_Query_AllFibreProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("GET", pattern_Query_AllBondedFibreProviders_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
@@ -227,14 +227,14 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_Query_AllFibreProviders_0(rctx, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_Query_AllBondedFibreProviders_0(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_Query_AllFibreProviders_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_Query_AllBondedFibreProviders_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -244,11 +244,11 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 var (
 	pattern_Query_FibreProviderInfo_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"valaddr", "v1", "fibre-provider-info", "validator_consensus_address"}, "", runtime.AssumeColonVerbOpt(false)))
 
-	pattern_Query_AllFibreProviders_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"valaddr", "v1", "all-fibre-providers"}, "", runtime.AssumeColonVerbOpt(false)))
+	pattern_Query_AllBondedFibreProviders_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"valaddr", "v1", "all-bonded-fibre-providers"}, "", runtime.AssumeColonVerbOpt(false)))
 )
 
 var (
 	forward_Query_FibreProviderInfo_0 = runtime.ForwardResponseMessage
 
-	forward_Query_AllFibreProviders_0 = runtime.ForwardResponseMessage
+	forward_Query_AllBondedFibreProviders_0 = runtime.ForwardResponseMessage
 )


### PR DESCRIPTION
What was done:
1. Added an `EndBlocker`(`RemoveFibreProviders`) that deletes an entry when its validator is removed from staking, or has been jailed and unbonded longer than JailedGracePeriod (~1 month). Short-lived jails are preserved so a recovering validator keeps its registration. 
2. Filtered `AllFibreProviders` to bonded validators so callers never get a stale host even before the sweep runs.
3.  Wired valaddr into the `EndBlock` phase (AppModule now implements `HasEndBlocker`) and extended the StakingKeeper interface with `GetValidatorByConsAddr`.

Resolves https://linear.app/celestia/issue/PROTOCO-1975