### PR TITLE
fix(fibre): enforce MaxRowSize on upload and download

### DIFF
--- a/fibre/blob.go
+++ b/fibre/blob.go
@@ -29,6 +29,10 @@ type BlobConfig struct {
 	RowSize func(dataLen int) int
 	// MaxDataSize is the maximum data size that can be passed to NewBlob.
 	MaxDataSize int
+	// MaxRowSize is the maximum allowed size of a single row in bytes. It bounds
+	// the DataPool/Assembler allocations, so rows larger than this must be
+	// rejected before they reach the pool (which would otherwise panic).
+	MaxRowSize int
 	// CodingWorkers is the number of workers to use for encoding and decoding rsema1d.
 	CodingWorkers int
 
@@ -100,6 +104,7 @@ func NewBlobConfigFromParams(blobVersion uint8, params ProtocolParams) (BlobConf
 			return params.RowSize(blobVersion, dataLen+blobHeaderLen)
 		},
 		MaxDataSize:   params.MaxBlobSize - blobHeaderLen,
+		MaxRowSize:    maxRowSize,
 		CodingWorkers: runtime.GOMAXPROCS(0),
 		Coder:         coder,
 		Assembler:     assembler,

--- a/fibre/download.go
+++ b/fibre/download.go
@@ -130,6 +130,13 @@ func (s *download) AddShard(from validator.SelectedValidator, proofs []*rsema1d.
 	}
 	if len(novel) > 0 {
 		rowLn := len(novel[0].Row)
+		// Reject rows larger than the reader's configured maximum before they
+		// reach the DataPool, which is sized for MaxRowSize and would otherwise
+		// panic. A malicious or custom uploader can serve an oversized row whose
+		// proof still verifies against the (attacker-chosen) commitment.
+		if s.cfg.MaxRowSize > 0 && rowLn > s.cfg.MaxRowSize {
+			return fmt.Errorf("row size %d exceeds maximum %d", rowLn, s.cfg.MaxRowSize)
+		}
 		s.acquireSlab(rowLn)
 		s.store(novel)
 	}

--- a/fibre/download_test.go
+++ b/fibre/download_test.go
@@ -79,6 +79,68 @@ func newTestDownload(t *testing.T, expected ...int) (*download, []*rsema1d.RowPr
 	return d, proofs, rlc
 }
 
+// A malicious/custom uploader can serve a shard whose row size exceeds the
+// reader's configured MaxRowSize. AddShard must reject it gracefully rather
+// than panicking inside the DataPool (which is sized for MaxRowSize).
+func TestDownload_OversizedRowReturnsError(t *testing.T) {
+	cfg := &rsema1d.Config{K: testK, N: testN, WorkerCount: 1}
+	coder, err := rsema1d.NewCoder(cfg)
+	require.NoError(t, err)
+
+	data := make([][]byte, testK)
+	r := rand.New(rand.NewPCG(1, 2))
+	for i := range data {
+		data[i] = make([]byte, testRowSize)
+		for j := range data[i] {
+			data[i][j] = byte(r.IntN(256))
+		}
+	}
+	hdr := newBlobHeaderV0(testK*testRowSize - blobHeaderLen)
+	hdr.marshalTo(data[0])
+	rows := make([][]byte, cfg.K+cfg.N)
+	copy(rows, data)
+	for i := cfg.K; i < cfg.K+cfg.N; i++ {
+		rows[i] = make([]byte, testRowSize)
+	}
+	ed, err := coder.Encode(rows)
+	require.NoError(t, err)
+	commitment, rlcVec := ed.Commitment(), ed.RLC()
+
+	proofs := make([]*rsema1d.RowProof, testK)
+	for i := range proofs {
+		p, err := ed.GenerateRowProof(i)
+		require.NoError(t, err)
+		proofs[i] = p
+	}
+
+	priv := cmted25519.GenPrivKey()
+	selected := []validator.SelectedValidator{{
+		Validator:    &core.Validator{Address: priv.PubKey().Address(), PubKey: priv.PubKey(), VotingPower: 1},
+		ExpectedRows: testK,
+	}}
+
+	// Reader is configured for a MaxRowSize smaller than the wire row size, as
+	// if the attacker's row exceeds the protocol maximum the reader pool backs.
+	const readerMaxRowSize = testRowSize / 2
+	blobCfg := BlobConfig{
+		OriginalRows: testK,
+		ParityRows:   testN,
+		MaxDataSize:  testK*testRowSize - blobHeaderLen,
+		MaxRowSize:   readerMaxRowSize,
+		Coder:        coder,
+		DataPool:     row.NewPool(readerMaxRowSize, testK),
+	}
+	d, err := newDownload(blobCfg, NewBlobID(0, commitment), selected)
+	require.NoError(t, err)
+	t.Cleanup(d.freeSlab)
+
+	from, ok := d.pick()
+	require.True(t, ok)
+	err = d.AddShard(from, proofs, rlcVec)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "row size")
+}
+
 // First validator's reservation overshoots K; the K-budget gate prevents
 // dispatching the second.
 func TestDownload_OverReservationGatesFurtherDispatch(t *testing.T) {

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -184,6 +184,12 @@ func (s *Server) verifyShard(ctx context.Context, blobCfg BlobConfig, promise *P
 		return err
 	}
 
+	// reject oversized rows: a row larger than MaxRowSize cannot be backed by
+	// the protocol's row pool on the read side and must never be signed/stored.
+	if blobCfg.MaxRowSize > 0 && rowSize > blobCfg.MaxRowSize {
+		return fmt.Errorf("row size %d exceeds maximum %d", rowSize, blobCfg.MaxRowSize)
+	}
+
 	// validate upload size matches the row size
 	expectedUploadSize := rowSize * blobCfg.OriginalRows
 	if int(promise.UploadSize) != expectedUploadSize {

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -141,6 +141,25 @@ func TestServerUploadShard(t *testing.T) {
 				require.Contains(t, err.Error(), "upload size mismatch")
 			},
 		},
+		{
+			name: "OversizedRow",
+			requestModifier: func(req *types.UploadShardRequest) {
+				// craft rows one chunk larger than the protocol maximum. The
+				// handler must reject these before they are signed/stored, since
+				// the read-side row pool is sized for MaxRowSize.
+				blobCfg, _ := fibre.BlobConfigForVersion(uint8(req.Promise.BlobVersion))
+				oversized := blobCfg.MaxRowSize + 64
+				for i := range req.Shard.Rows {
+					req.Shard.Rows[i].Data = make([]byte, oversized)
+				}
+				req.Promise.BlobSize = uint32(oversized * blobCfg.OriginalRows)
+			},
+			check: func(t *testing.T, resp *types.UploadShardResponse, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "exceeds maximum")
+				require.Nil(t, resp)
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

A funded custom Fibre uploader can craft a valid shard whose row size is one 64-byte chunk above the protocol maximum. `verifyShard` only checks `UploadSize == rowSize * OriginalRows`, not `rowSize <= MaxRowSize`, so the oversized shard is signed and stored. A Fibre reader that later fetches the commitment then panics in `download.AddShard → DataPool.GetRegion → row.Pool.acquire` (`fibre/internal/row/pool.go:150`), because the row pool is sized for `MaxRowSize` — crashing the reader/downloader process.

The official `NewBlob` client rejects oversized data, so the attacker path is a custom lower-level uploader hitting `UploadShard` directly. Fibre-only; not a consensus or default-binary issue.

## Fix

- Add `MaxRowSize` to `BlobConfig` (value already computed in the constructor).
- **Read-side (the actual crash):** `download.AddShard` rejects rows larger than `MaxRowSize` with a structured error before allocating a pool slab.
- **Write-side (reject at source):** `verifyShard` rejects oversized rows before the expensive proof verification, so honest validators never sign/store an oversized shard.

## Tests

- `TestDownload_OversizedRowReturnsError` — panicked before, returns a graceful error now.
- `TestServerUploadShard/OversizedRow` — previously slid through to proof verification; now rejected early with `row size N exceeds maximum`.

Closes PROTOCO-2005

🤖 Generated with [Claude Code](https://claude.com/claude-code)