### PR TITLE
fix(encoding): reject empty tx bytes in the tx decoder

### DIFF
--- a/app/encoding/encoding.go
+++ b/app/encoding/encoding.go
@@ -56,6 +56,7 @@ func MakeConfig(moduleBasics ...sdkmodule.AppModuleBasic) Config {
 	txDecoder := authtx.DefaultTxDecoder(protoCodec)
 	txDecoder = indexWrapperDecoder(txDecoder)
 	txDecoder = blobTxDecoder(txDecoder)
+	txDecoder = rejectEmptyTxDecoder(txDecoder)
 
 	txConfig, err := authtx.NewTxConfigWithOptions(protoCodec, authtx.ConfigOptions{
 		EnabledSignModes: authtx.DefaultSignModes,

--- a/app/encoding/encoding_test.go
+++ b/app/encoding/encoding_test.go
@@ -33,13 +33,13 @@ func TestMakeConfig(t *testing.T) {
 
 	t.Run("should return an error for an empty tx", func(t *testing.T) {
 		decodedTx, err := config.TxConfig.TxDecoder()([]byte{})
-		require.Error(t, err)
+		require.ErrorIs(t, err, encoding.ErrEmptyTx)
 		require.Nil(t, decodedTx)
 	})
 
 	t.Run("should return an error for a nil tx", func(t *testing.T) {
 		decodedTx, err := config.TxConfig.TxDecoder()(nil)
-		require.Error(t, err)
+		require.ErrorIs(t, err, encoding.ErrEmptyTx)
 		require.Nil(t, decodedTx)
 	})
 }

--- a/app/encoding/encoding_test.go
+++ b/app/encoding/encoding_test.go
@@ -30,6 +30,18 @@ func TestMakeConfig(t *testing.T) {
 		msgType := sdk.MsgTypeURL(msgs[0])
 		require.Equal(t, "/celestia.blob.v1.MsgPayForBlobs", msgType)
 	})
+
+	t.Run("should return an error for an empty tx", func(t *testing.T) {
+		decodedTx, err := config.TxConfig.TxDecoder()([]byte{})
+		require.Error(t, err)
+		require.Nil(t, decodedTx)
+	})
+
+	t.Run("should return an error for a nil tx", func(t *testing.T) {
+		decodedTx, err := config.TxConfig.TxDecoder()(nil)
+		require.Error(t, err)
+		require.Nil(t, decodedTx)
+	})
 }
 
 func createBlobTx(t *testing.T, testApp *app.App, config encoding.Config, kr keyring.Keyring, accounts []string) []byte {

--- a/app/encoding/reject_empty_tx_decoder.go
+++ b/app/encoding/reject_empty_tx_decoder.go
@@ -1,0 +1,24 @@
+package encoding
+
+import (
+	"errors"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// ErrEmptyTx is returned when an empty (zero-length or nil) transaction is
+// passed to the tx decoder. The default Cosmos SDK decoder returns a non-nil
+// tx and no error for empty bytes, which can cause the state machine to panic
+// downstream. See https://github.com/celestiaorg/celestia-app/issues/3175.
+var ErrEmptyTx = errors.New("tx bytes are empty")
+
+// rejectEmptyTxDecoder wraps a TxDecoder so that empty (zero-length or nil) tx
+// bytes are rejected with an error instead of being decoded into a non-nil tx.
+func rejectEmptyTxDecoder(decoder sdk.TxDecoder) sdk.TxDecoder {
+	return func(txBytes []byte) (sdk.Tx, error) {
+		if len(txBytes) == 0 {
+			return nil, ErrEmptyTx
+		}
+		return decoder(txBytes)
+	}
+}

--- a/app/filtered_square_builder_fibre_test.go
+++ b/app/filtered_square_builder_fibre_test.go
@@ -136,7 +136,10 @@ func TestFilteredSquareBuilderFillWithPayForFibre(t *testing.T) {
 	}
 
 	normalTx := newNormalTx(t, txConfig)
-	blobTx := blobfactory.UnsignedBlobTx(t)
+	// Use a blob tx with a real MsgPayForBlobs inner SDK tx (not the nil inner
+	// tx from blobfactory.UnsignedBlobTx) so it survives the inner-tx decode in
+	// Fill, where the decoder rejects empty tx bytes.
+	blobTx := newBlobTx(t, txConfig)
 	payForFibreTx := blobfactory.UnsignedPayForFibreTx(t, txConfig)
 
 	tests := []struct {


### PR DESCRIPTION
## Motivation

Closes #3175

The default Cosmos SDK tx decoder returns a **non-nil tx and no error** when given zero-length or `nil` tx bytes. An empty tx that slips past CometBFT/the mempool would then reach the state machine and panic, where an error should have been returned instead.

## Change

Wrap the tx decoder with `rejectEmptyTxDecoder`, which returns an explicit `ErrEmptyTx` for zero-length or `nil` input. Empty bytes are never a valid blob tx or index wrapper, so this is applied as the outermost decoder.

## Test

Added cases to `TestMakeConfig` asserting the decoder returns `ErrEmptyTx` (and a nil tx) for both empty and nil bytes. Verified the tests fail without the fix (red) and pass with it (green).

Also fixed `TestFilteredSquareBuilderFillWithPayForFibre`, which broke because it used `blobfactory.UnsignedBlobTx` (a blob tx with a `nil` inner SDK tx). `Fill` decodes the inner tx, which `rejectEmptyTxDecoder` now correctly rejects — so such invalid blob txs are dropped. Switched the test to `newBlobTx` (a real `MsgPayForBlobs` inner tx), matching the existing non-fibre `filtered_square_builder_test.go`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
