### PR TITLE
fix(user): retry worker account query after funding

### DIFF
--- a/pkg/user/parallel_tx_submission.go
+++ b/pkg/user/parallel_tx_submission.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
+	"time"
 
 	"cosmossdk.io/x/feegrant"
 	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
@@ -14,6 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	bank "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // SubmissionJob represents a transaction submission task for parallel processing
@@ -53,7 +57,47 @@ type txWorker struct {
 
 const (
 	defaultParallelQueueSize = 100
+
+	// workerAccountQueryRetries is the number of times to query a freshly
+	// funded worker account before giving up. ConfirmTx can report a funding
+	// transaction as committed before the committed account state is queryable,
+	// so the new account may briefly appear as "not found".
+	workerAccountQueryRetries = 8
+	// workerAccountQueryRetryDelay is the delay between worker account query
+	// attempts.
+	workerAccountQueryRetryDelay = 500 * time.Millisecond
 )
+
+// isAccountNotFound reports whether err indicates that an account does not (yet)
+// exist on chain.
+func isAccountNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if status.Code(err) == codes.NotFound {
+		return true
+	}
+	return strings.Contains(err.Error(), "not found")
+}
+
+// queryAccountWithRetry calls query, retrying while the account is reported as
+// not found. This tolerates the window after a funding transaction is confirmed
+// but before the committed account state is queryable. It returns immediately on
+// success or on any error that is not "account not found", and gives up after
+// attempts tries.
+func queryAccountWithRetry(ctx context.Context, attempts int, delay time.Duration, query func() (accNum, seqNum uint64, err error)) (accNum, seqNum uint64, err error) {
+	for attempt := 0; ; attempt++ {
+		accNum, seqNum, err = query()
+		if err == nil || !isAccountNotFound(err) || attempt >= attempts-1 {
+			return accNum, seqNum, err
+		}
+		select {
+		case <-ctx.Done():
+			return 0, 0, ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+}
 
 func newTxQueue(client *TxClient, numWorkers int) *txQueue {
 	pool := &txQueue{
@@ -461,8 +505,12 @@ func (client *TxClient) fundAndGrantWorkerAccounts(ctx context.Context, workers 
 			return fmt.Errorf("failed to get address for worker account %s: %w", worker.accountName, err)
 		}
 
-		// Query the account info from chain
-		accNum, seqNum, err := QueryAccount(ctx, client.conns[0], client.registry, workerAddress)
+		// Query the account info from chain. The funding transaction is
+		// confirmed at this point, but the committed account state can briefly
+		// lag behind, so retry while the account is reported as not found.
+		accNum, seqNum, err := queryAccountWithRetry(ctx, workerAccountQueryRetries, workerAccountQueryRetryDelay, func() (uint64, uint64, error) {
+			return QueryAccount(ctx, client.conns[0], client.registry, workerAddress)
+		})
 		if err != nil {
 			return fmt.Errorf("failed to query worker account %s on chain: %w", worker.accountName, err)
 		}

--- a/pkg/user/worker_account_retry_test.go
+++ b/pkg/user/worker_account_retry_test.go
@@ -1,0 +1,96 @@
+package user
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsAccountNotFound(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "grpc NotFound", err: status.Error(codes.NotFound, "account celestia1... not found"), want: true},
+		{name: "plain not found string", err: errors.New("account celestia1... not found"), want: true},
+		{name: "unrelated grpc error", err: status.Error(codes.Internal, "boom"), want: false},
+		{name: "unrelated error", err: errors.New("connection refused"), want: false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.want, isAccountNotFound(tc.err))
+		})
+	}
+}
+
+func TestQueryAccountWithRetry(t *testing.T) {
+	notFound := status.Error(codes.NotFound, "account not found")
+
+	t.Run("succeeds immediately", func(t *testing.T) {
+		calls := 0
+		accNum, seqNum, err := queryAccountWithRetry(context.Background(), 5, time.Millisecond, func() (uint64, uint64, error) {
+			calls++
+			return 7, 3, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, uint64(7), accNum)
+		require.Equal(t, uint64(3), seqNum)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("succeeds after transient not found", func(t *testing.T) {
+		calls := 0
+		accNum, seqNum, err := queryAccountWithRetry(context.Background(), 5, time.Millisecond, func() (uint64, uint64, error) {
+			calls++
+			if calls < 3 {
+				return 0, 0, notFound
+			}
+			return 9, 1, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, uint64(9), accNum)
+		require.Equal(t, uint64(1), seqNum)
+		require.Equal(t, 3, calls)
+	})
+
+	t.Run("gives up after exhausting attempts", func(t *testing.T) {
+		calls := 0
+		_, _, err := queryAccountWithRetry(context.Background(), 3, time.Millisecond, func() (uint64, uint64, error) {
+			calls++
+			return 0, 0, notFound
+		})
+		require.Error(t, err)
+		require.Equal(t, notFound, err)
+		require.Equal(t, 3, calls)
+	})
+
+	t.Run("does not retry on other errors", func(t *testing.T) {
+		calls := 0
+		other := errors.New("connection refused")
+		_, _, err := queryAccountWithRetry(context.Background(), 5, time.Millisecond, func() (uint64, uint64, error) {
+			calls++
+			return 0, 0, other
+		})
+		require.Equal(t, other, err)
+		require.Equal(t, 1, calls)
+	})
+
+	t.Run("respects context cancellation", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		calls := 0
+		_, _, err := queryAccountWithRetry(ctx, 5, time.Hour, func() (uint64, uint64, error) {
+			calls++
+			return 0, 0, notFound
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		require.Equal(t, 1, calls)
+	})
+}


### PR DESCRIPTION
## Motivation

`TestParallelTxSubmission` (in `pkg/user`) flakes in the nightly `test-race` job on `main` (e.g. 2026-06-24 and 2026-06-22). Initializing parallel worker accounts fails with:

```
failed to fund and grant worker accounts: failed to query worker account parallel-worker-1 on chain: rpc error: code = NotFound desc = account ... not found
```

`ConfirmTx` can report the funding transaction as committed before the committed account state is queryable, so the freshly funded worker account briefly appears as "not found" when queried immediately afterward.

## Change

- Retry the post-funding `QueryAccount` in `fundAndGrantWorkerAccounts` while the account is reported as not found; return immediately on success or any other error.
- Add a table-driven unit test for the new `isAccountNotFound` classifier and `queryAccountWithRetry` helper (immediate success, retry-then-success, give-up, no-retry on other errors, context cancellation).

No existing GitHub/Linear issue tracks this flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)