### PR TITLE
fix(fibre): route settled escrow payments to the fee collector

### DIFF
--- a/app/test/fibre_settlement_test.go
+++ b/app/test/fibre_settlement_test.go
@@ -1,0 +1,112 @@
+//go:build fibre
+
+package app_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v9/app"
+	"github.com/celestiaorg/celestia-app/v9/fibre"
+	"github.com/celestiaorg/celestia-app/v9/pkg/appconsts"
+	testutil "github.com/celestiaorg/celestia-app/v9/test/util"
+	"github.com/celestiaorg/celestia-app/v9/test/util/testfactory"
+	fibrekeeper "github.com/celestiaorg/celestia-app/v9/x/fibre/keeper"
+	fibretypes "github.com/celestiaorg/celestia-app/v9/x/fibre/types"
+	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFibreSettlementRoutesToFeeCollector is an app-level test exercising the
+// real bank and fibre keepers. It verifies that settling a payment via
+// MsgPaymentPromiseTimeout moves the charged coins out of the fibre module
+// account into the fee collector, and that the module-account invariant
+// (bank balance == sum of escrow balances) holds across the settlement.
+func TestFibreSettlementRoutesToFeeCollector(t *testing.T) {
+	funder := testfactory.GenerateAccounts(1)[0]
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), funder)
+
+	ctx := testApp.NewContext(true).WithBlockTime(time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC))
+
+	moduleAddr := testApp.AccountKeeper.GetModuleAddress(fibretypes.ModuleName)
+	feeCollectorAddr := testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)
+
+	// Escrow owner: a fresh key that signs the payment promise. It does not need
+	// on-chain funds because we seed the escrow state and module balance directly.
+	ownerPriv := secp256k1.GenPrivKey()
+	ownerPub := ownerPriv.PubKey().(*secp256k1.PubKey)
+	ownerAddr := sdk.AccAddress(ownerPub.Address()).String()
+
+	// Seed the post-deposit state: move real coins into the fibre module account
+	// (as DepositToEscrow would) and record a matching escrow balance.
+	deposit := sdk.NewInt64Coin(appconsts.BondDenom, 5_000_000)
+	funderAddr := testfactory.GetAddress(kr, funder)
+	require.NoError(t, testApp.BankKeeper.SendCoinsFromAccountToModule(ctx, funderAddr, fibretypes.ModuleName, sdk.NewCoins(deposit)))
+	testApp.FibreKeeper.SetEscrowAccount(ctx, fibretypes.EscrowAccount{
+		Signer:           ownerAddr,
+		Balance:          deposit,
+		AvailableBalance: deposit,
+	})
+
+	// Pre-condition: invariant holds (module balance == escrow balance).
+	require.Equal(t, deposit.Amount, testApp.BankKeeper.GetBalance(ctx, moduleAddr, appconsts.BondDenom).Amount)
+
+	// Build an expired, owner-signed payment promise so the timeout path accepts it.
+	params := testApp.FibreKeeper.GetParams(ctx)
+	creation := ctx.BlockTime().Add(-params.PaymentPromiseTimeout).Add(-time.Hour)
+	// Height must be positive for stateless validation; the timeout path does
+	// not enforce the height window, so any positive height works.
+	promise := buildSignedPromise(t, 1, creation, *ownerPub, ownerPriv)
+
+	payment := sdk.NewInt64Coin(appconsts.BondDenom, int64(fibrekeeper.EstimateGasForPayForFibre(promise.BlobSize)))
+	feeBefore := testApp.BankKeeper.GetBalance(ctx, feeCollectorAddr, appconsts.BondDenom)
+
+	// Anyone can submit the timeout settlement.
+	msgServer := fibrekeeper.NewMsgServerImpl(*testApp.FibreKeeper)
+	_, err := msgServer.PaymentPromiseTimeout(ctx, &fibretypes.MsgPaymentPromiseTimeout{
+		Signer:         ownerAddr,
+		PaymentPromise: promise,
+	})
+	require.NoError(t, err)
+
+	moduleAfter := testApp.BankKeeper.GetBalance(ctx, moduleAddr, appconsts.BondDenom)
+	feeAfter := testApp.BankKeeper.GetBalance(ctx, feeCollectorAddr, appconsts.BondDenom)
+	escrow, found := testApp.FibreKeeper.GetEscrowAccount(ctx, ownerAddr)
+	require.True(t, found)
+
+	// The payment left the module account and landed in the fee collector.
+	require.Equal(t, deposit.Amount.Sub(payment.Amount), moduleAfter.Amount, "module account should shrink by the payment")
+	require.Equal(t, feeBefore.Amount.Add(payment.Amount), feeAfter.Amount, "fee collector should grow by the payment")
+	// Invariant restored: module-account balance equals the sum of escrow balances.
+	require.Equal(t, escrow.Balance.Amount, moduleAfter.Amount, "module balance must equal escrow balance after settlement")
+}
+
+// buildSignedPromise constructs a PaymentPromise signed by the escrow owner,
+// mirroring the construction used by the keeper unit tests.
+func buildSignedPromise(t *testing.T, height int64, creation time.Time, ownerPub secp256k1.PubKey, ownerPriv *secp256k1.PrivKey) fibretypes.PaymentPromise {
+	t.Helper()
+	promise := fibretypes.PaymentPromise{
+		ChainId:           "test-chain",
+		Height:            height,
+		Namespace:         share.MustNewV0Namespace(bytes.Repeat([]byte{0x1}, share.NamespaceVersionZeroIDSize)).Bytes(),
+		BlobSize:          1000,
+		BlobVersion:       0,
+		Commitment:        make([]byte, 32),
+		CreationTimestamp: creation,
+		SignerPublicKey:   ownerPub,
+		Signature:         make([]byte, 64),
+	}
+
+	pp := fibre.PaymentPromise{}
+	require.NoError(t, pp.FromProto(&promise))
+	signBytes, err := pp.SignBytes()
+	require.NoError(t, err)
+	signature, err := ownerPriv.Sign(signBytes)
+	require.NoError(t, err)
+	promise.Signature = signature
+	return promise
+}

--- a/specs/src/fibre_module.md
+++ b/specs/src/fibre_module.md
@@ -257,6 +257,23 @@ message MsgPayForFibre {
 Validator signatures are interpreted as a slice indexed by the validator-set order at `payment_promise.height`. Empty signatures are skipped, non-empty signatures whose index exceeds the validator count are invalid, each non-empty signature must verify with the corresponding CometBFT ed25519 validator public key over the payment-promise sign bytes, and the only threshold enforced is collected voting power at least `floor(2/3 * total_voting_power)`. This means exactly two thirds can pass when the integer voting power calculation allows it, for example 2 of 3 total power. The implementation does not enforce a separate validator-count threshold. `EventPayForFibre.validator_count` is the length of the submitted signature slice.
 
 Payment deduction first requires total escrow `balance >= payment_amount`. It subtracts the full payment from total `balance`, subtracts `min(available_balance, payment_amount)` from `available_balance`, and if the payment uses funds that were locked in pending withdrawals, it calls `ReduceWithdrawalsForPayment` to delete or reduce the signer's pending withdrawals in signer-index iteration order.
+Stateful Processing:
+
+1. Validate PaymentPromise
+2. Verify validator ed25519 signatures represent 2/3+ threshold from validator set at `promise.height` (obtained via historical info query from staking module):
+   - Signatures must represent 2/3+ of total voting power AND 2/3+ of validator count
+   - Each signature is verified using the validator's ed25519 public key from the validator set
+3. Calculate gas cost (see [Payment Amount](#payment-amount) section) and deduct from both escrow balance and available_balance. The deducted amount is transferred from the fibre module account to the `fee_collector` module account, where it is distributed to validators and delegators by `x/distribution` like a regular data-availability fee (see [Payment Settlement Destination](#payment-settlement-destination)).
+4. Mark promise as processed by storing `ProcessedPayment` with `processed_at` timestamp in both indexes:
+   - `processed_payments_by_hash/{payment_promise_hash}` for replay protection
+   - `processed_payments_by_time/{processed_at}/{payment_promise_hash}` for time-ordered pruning
+5. Include commitment in data square
+6. Emit EventPayForFibre
+
+When processing a successful `MsgPayForFibre`, two pieces of metadata are written to the original data square:
+
+1. The tx containing the `MsgPayForFibre` is included in the reserved namespace for Fibre transactions.
+2. A system-level blob is generated with the namespace from the PaymentPromise and the blob data is the Fibre blob commitment.
 
 ### MsgPaymentPromiseTimeout
 
@@ -301,6 +318,23 @@ share.NewV2Blob(namespace, payment_promise.blob_version, payment_promise.commitm
 ```
 
 Therefore the synthesized system blob includes the promise namespace, blob version, commitment, and raw message signer bytes. The v2 blob payload represents the blob version and 32-byte commitment; it is not just the commitment by itself. The PayForFibre transaction bytes are encoded under the PayForFibre namespace while the synthesized system blob is appended as the associated Fibre system blob by the square builder.
+
+1. Validate PaymentPromise
+2. Verify `promise.creation_timestamp + payment_promise_timeout <= header_timestamp` (timeout has passed)
+3. Calculate gas cost (see [Payment Amount](#payment-amount) section) and deduct from both escrow balance and available_balance. As with `MsgPayForFibre`, the deducted amount is transferred from the fibre module account to the `fee_collector` module account (see [Payment Settlement Destination](#payment-settlement-destination)).
+4. Mark promise as processed by storing `ProcessedPayment` with `processed_at` timestamp in both indexes:
+   - `processed_payments_by_hash/{payment_promise_hash}` for replay protection
+   - `processed_payments_by_time/{processed_at}/{payment_promise_hash}` for time-ordered pruning
+5. DO NOT include commitment in data square (since no validator consensus was reached)
+6. Emit EventPaymentPromiseTimeout
+
+### Payment Settlement Destination
+
+Both settlement paths (`MsgPayForFibre` and `MsgPaymentPromiseTimeout`) charge the escrow owner the gas-based payment amount. This charge is distinct from the fee paid for the settlement transaction itself: the transaction fee is paid by the broadcaster and distributed via the ante handler, whereas the escrow charge is the data-availability fee owed by the escrow owner for the Fibre blob.
+
+The charged amount is transferred from the fibre module account to the `fee_collector` module account. From there it follows the standard fee pipeline in `x/distribution`, paying validators (proportional to stake) and their delegators, with the community tax applied. This mirrors how regular blob fees (`MsgPayForBlobs`) are settled, and keeps the funds from being stranded in the fibre module account.
+
+The destination is independent of which validators signed the PaymentPromise. This is required because the timeout path carries no validator signatures, so a signer-dependent destination could not settle both paths consistently.
 
 ## Automatic State Transitions
 

--- a/specs/src/fibre_module.md
+++ b/specs/src/fibre_module.md
@@ -261,7 +261,6 @@ Stateful Processing:
 
 1. Validate PaymentPromise
 2. Verify validator ed25519 signatures represent 2/3+ threshold from validator set at `promise.height` (obtained via historical info query from staking module):
-   - Signatures must represent 2/3+ of total voting power AND 2/3+ of validator count
    - Each signature is verified using the validator's ed25519 public key from the validator set
 3. Calculate gas cost (see [Payment Amount](#payment-amount) section) and deduct from both escrow balance and available_balance. The deducted amount is transferred from the fibre module account to the `fee_collector` module account, where it is distributed to validators and delegators by `x/distribution` like a regular data-availability fee (see [Payment Settlement Destination](#payment-settlement-destination)).
 4. Mark promise as processed by storing `ProcessedPayment` with `processed_at` timestamp in both indexes:

--- a/x/fibre/keeper/mocks_test.go
+++ b/x/fibre/keeper/mocks_test.go
@@ -11,6 +11,7 @@ import (
 // MockBankKeeper implements the expected BankKeeper interface for testing
 type MockBankKeeper struct {
 	SendCoinsFromAccountToModuleFn func(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToModuleFn  func(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }
 
 func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error {
@@ -21,6 +22,13 @@ func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, sende
 }
 
 func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error {
+	return nil
+}
+
+func (m *MockBankKeeper) SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error {
+	if m.SendCoinsFromModuleToModuleFn != nil {
+		return m.SendCoinsFromModuleToModuleFn(ctx, senderModule, recipientModule, amt)
+	}
 	return nil
 }
 

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -14,6 +14,7 @@ import (
 	core "github.com/cometbft/cometbft/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 )
 
 var _ types.MsgServer = msgServer{}
@@ -308,6 +309,16 @@ func (ms msgServer) deductPaymentFromEscrow(ctx sdk.Context, escrowAccount *type
 		if err := ms.ReduceWithdrawalsForPayment(ctx, escrowAccount.Signer, shortfall); err != nil {
 			return err
 		}
+	}
+
+	// Route the settled payment to the fee collector so it is distributed to
+	// validators and delegators like a regular data-availability fee. The
+	// escrow accounting above only shrinks Balance/AvailableBalance; without
+	// this transfer the coins would stay stranded in the module account and be
+	// paid to no one. The full payment leaves the module account regardless of
+	// how it was split between available balance and pending withdrawals.
+	if err := ms.bankKeeper.SendCoinsFromModuleToModule(ctx, types.ModuleName, authtypes.FeeCollectorName, sdk.NewCoins(paymentAmount)); err != nil {
+		return errorsmod.Wrap(err, "failed to send fibre payment to fee collector")
 	}
 
 	return nil

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -556,6 +556,146 @@ func (suite *MsgServerTestSuite) TestPaymentPromiseTimeout() {
 	})
 }
 
+// moduleTransfer records a SendCoinsFromModuleToModule call.
+type moduleTransfer struct {
+	from string
+	to   string
+	amt  sdk.Coins
+}
+
+// recordModuleTransfers wires the bank mock to capture module-to-module
+// transfers and returns a pointer to the captured slice.
+func (suite *MsgServerTestSuite) recordModuleTransfers() *[]moduleTransfer {
+	var transfers []moduleTransfer
+	suite.bankKeeper.SendCoinsFromModuleToModuleFn = func(_ context.Context, from, to string, amt sdk.Coins) error {
+		transfers = append(transfers, moduleTransfer{from: from, to: to, amt: amt})
+		return nil
+	}
+	return &transfers
+}
+
+// TestSettlementRoutesPaymentToFeeCollector verifies that settling a payment
+// moves the charged amount out of the fibre module account into the fee
+// collector (where x/distribution pays it out), rather than leaving it stranded
+// in the module account.
+func (suite *MsgServerTestSuite) TestSettlementRoutesPaymentToFeeCollector() {
+	suite.setupValidatorSet()
+
+	suite.T().Run("PayForFibre routes the full payment to the fee collector", func(t *testing.T) {
+		privKey := secp256k1.GenPrivKey()
+		signerPubKey := *privKey.PubKey().(*secp256k1.PubKey)
+		signer := sdk.AccAddress(privKey.PubKey().Address()).String()
+		promise := suite.createPaymentPromise(signerPubKey, privKey)
+
+		gas := keeper.EstimateGasForPayForFibre(promise.BlobSize)
+		payment := sdk.NewInt64Coin(appconsts.BondDenom, int64(gas))
+		balance := sdk.NewInt64Coin(appconsts.BondDenom, int64(gas)+1000)
+		suite.keeper.SetEscrowAccount(suite.ctx, types.EscrowAccount{Signer: signer, Balance: balance, AvailableBalance: balance})
+
+		transfers := suite.recordModuleTransfers()
+		defer func() { suite.bankKeeper.SendCoinsFromModuleToModuleFn = nil }()
+
+		_, err := suite.msgServer.PayForFibre(suite.ctx, &types.MsgPayForFibre{
+			Signer:              signer,
+			PaymentPromise:      promise,
+			ValidatorSignatures: suite.generateValidatorSignatures(&promise),
+		})
+		suite.NoError(err)
+		suite.Require().Len(*transfers, 1)
+		suite.Equal(types.ModuleName, (*transfers)[0].from)
+		suite.Equal(authtypes.FeeCollectorName, (*transfers)[0].to)
+		suite.Equal(sdk.NewCoins(payment), (*transfers)[0].amt)
+	})
+
+	suite.T().Run("PaymentPromiseTimeout routes the full payment to the fee collector", func(t *testing.T) {
+		privKey := secp256k1.GenPrivKey()
+		signerPubKey := *privKey.PubKey().(*secp256k1.PubKey)
+		signer := sdk.AccAddress(privKey.PubKey().Address()).String()
+		params := suite.keeper.GetParams(suite.ctx)
+		oldTime := suite.ctx.BlockTime().Add(-params.PaymentPromiseTimeout).Add(-time.Hour)
+		promise := suite.createPaymentPromiseWithTime(signerPubKey, privKey, oldTime)
+
+		gas := keeper.EstimateGasForPayForFibre(promise.BlobSize)
+		payment := sdk.NewInt64Coin(appconsts.BondDenom, int64(gas))
+		balance := sdk.NewInt64Coin(appconsts.BondDenom, int64(gas)+1000)
+		suite.keeper.SetEscrowAccount(suite.ctx, types.EscrowAccount{Signer: signer, Balance: balance, AvailableBalance: balance})
+
+		transfers := suite.recordModuleTransfers()
+		defer func() { suite.bankKeeper.SendCoinsFromModuleToModuleFn = nil }()
+
+		processor := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address()).String()
+		_, err := suite.msgServer.PaymentPromiseTimeout(suite.ctx, &types.MsgPaymentPromiseTimeout{
+			Signer:         processor,
+			PaymentPromise: promise,
+		})
+		suite.NoError(err)
+		suite.Require().Len(*transfers, 1)
+		suite.Equal(types.ModuleName, (*transfers)[0].from)
+		suite.Equal(authtypes.FeeCollectorName, (*transfers)[0].to)
+		suite.Equal(sdk.NewCoins(payment), (*transfers)[0].amt)
+	})
+
+	suite.T().Run("full payment is routed even when partly covered by pending withdrawals", func(t *testing.T) {
+		privKey := secp256k1.GenPrivKey()
+		signerPubKey := *privKey.PubKey().(*secp256k1.PubKey)
+		signer := sdk.AccAddress(privKey.PubKey().Address()).String()
+		promise := suite.createPaymentPromise(signerPubKey, privKey)
+
+		gas := keeper.EstimateGasForPayForFibre(promise.BlobSize)
+		payment := sdk.NewInt64Coin(appconsts.BondDenom, int64(gas))
+		// AvailableBalance is zero: the whole payment is a shortfall covered by a
+		// pending withdrawal. The full payment must still leave the module account.
+		suite.keeper.SetEscrowAccount(suite.ctx, types.EscrowAccount{
+			Signer:           signer,
+			Balance:          payment,
+			AvailableBalance: sdk.NewInt64Coin(appconsts.BondDenom, 0),
+		})
+		suite.keeper.SetWithdrawal(suite.ctx, types.Withdrawal{
+			Signer:             signer,
+			Amount:             payment,
+			RequestedTimestamp: suite.ctx.BlockTime(),
+			AvailableTimestamp: suite.ctx.BlockTime().Add(time.Hour),
+		})
+
+		transfers := suite.recordModuleTransfers()
+		defer func() { suite.bankKeeper.SendCoinsFromModuleToModuleFn = nil }()
+
+		_, err := suite.msgServer.PayForFibre(suite.ctx, &types.MsgPayForFibre{
+			Signer:              signer,
+			PaymentPromise:      promise,
+			ValidatorSignatures: suite.generateValidatorSignatures(&promise),
+		})
+		suite.NoError(err)
+		suite.Require().Len(*transfers, 1)
+		suite.Equal(sdk.NewCoins(payment), (*transfers)[0].amt)
+	})
+
+	suite.T().Run("a failed fee-collector transfer fails the settlement", func(t *testing.T) {
+		privKey := secp256k1.GenPrivKey()
+		signerPubKey := *privKey.PubKey().(*secp256k1.PubKey)
+		signer := sdk.AccAddress(privKey.PubKey().Address()).String()
+		promise := suite.createPaymentPromise(signerPubKey, privKey)
+
+		gas := keeper.EstimateGasForPayForFibre(promise.BlobSize)
+		balance := sdk.NewInt64Coin(appconsts.BondDenom, int64(gas)+1000)
+		suite.keeper.SetEscrowAccount(suite.ctx, types.EscrowAccount{Signer: signer, Balance: balance, AvailableBalance: balance})
+
+		suite.bankKeeper.SendCoinsFromModuleToModuleFn = func(_ context.Context, _, _ string, _ sdk.Coins) error {
+			return sdkerrors.ErrInsufficientFunds
+		}
+		defer func() { suite.bankKeeper.SendCoinsFromModuleToModuleFn = nil }()
+
+		resp, err := suite.msgServer.PayForFibre(suite.ctx, &types.MsgPayForFibre{
+			Signer:              signer,
+			PaymentPromise:      promise,
+			ValidatorSignatures: suite.generateValidatorSignatures(&promise),
+		})
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "fee collector")
+	})
+}
+
 // TestUpdateFibreParams tests the UpdateFibreParams message handler
 func (suite *MsgServerTestSuite) TestUpdateFibreParams() {
 	suite.T().Run("successful params update", func(t *testing.T) {

--- a/x/fibre/types/expected_keepers.go
+++ b/x/fibre/types/expected_keepers.go
@@ -10,6 +10,7 @@ import (
 type BankKeeper interface {
 	SendCoinsFromAccountToModule(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
 	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToModule(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }
 
 type StakingKeeper interface {


### PR DESCRIPTION
 Settling a Fibre payment (via `MsgPayForFibre` or `MsgPaymentPromiseTimeout`) only shrank the escrow account's `Balance`/`AvailableBalance` but left the actual coins sitting in the fibre module account, where they were paid to no one.
 
This routes the settled payment from the fibre module account to the `fee_collector`, so it's distributed to validators and delegators by `x/distribution` like a regular data-availability fee — keeping the module-account invariant (bank balance == sum of escrow balances) intact.


https://linear.app/celestia/issue/PROTOCO-1972