### PR TITLE
fix: retry chain start on host-port collision in IBC e2e suite

### DIFF
--- a/test/docker-e2e/e2e_ibc_test.go
+++ b/test/docker-e2e/e2e_ibc_test.go
@@ -67,23 +67,46 @@ func (s *IBCTestSuite) setupIBCInfrastructure(appVersion uint64) {
 
 	g, gCtx := errgroup.WithContext(ctx)
 
+	// Build and start each chain, retrying on Docker host-port collisions
+	// ("address already in use"). The two chains start concurrently and may
+	// race each other (or a prior test's not-yet-released ports) for the same
+	// published host port; rebuilding the chain allocates fresh ports. See
+	// isPortBindingError for details.
 	g.Go(func() error {
-		var err error
-		s.chainA, err = dockerchain.NewCelestiaChainBuilder(t, s.celestiaCfg).Build(gCtx)
-		if err != nil {
-			return fmt.Errorf("failed to build chain A: %w", err)
-		}
-		return s.chainA.Start(gCtx)
+		return retryOnPortCollision(gCtx, 3, 2*time.Second, func() error {
+			built, err := dockerchain.NewCelestiaChainBuilder(t, s.celestiaCfg).Build(gCtx)
+			if err != nil {
+				return fmt.Errorf("failed to build chain A: %w", err)
+			}
+			if err := built.Start(gCtx); err != nil {
+				// Release the partially-started chain's containers and host
+				// ports before retrying so the next attempt can rebind cleanly.
+				if removeErr := built.Remove(gCtx); removeErr != nil {
+					t.Logf("Error removing chain A after failed start: %v", removeErr)
+				}
+				return err
+			}
+			s.chainA = built
+			return nil
+		})
 	})
 
 	g.Go(func() error {
-		var err error
-		builder := s.newSimappChainBuilder(t, s.celestiaCfg)
-		s.chainB, err = builder.Build(gCtx)
-		if err != nil {
-			return fmt.Errorf("failed to build chain B: %w", err)
-		}
-		return s.chainB.Start(gCtx)
+		return retryOnPortCollision(gCtx, 3, 2*time.Second, func() error {
+			builder := s.newSimappChainBuilder(t, s.celestiaCfg)
+			built, err := builder.Build(gCtx)
+			if err != nil {
+				return fmt.Errorf("failed to build chain B: %w", err)
+			}
+			if err := built.Start(gCtx); err != nil {
+				if removeErr := built.Remove(gCtx); removeErr != nil {
+					t.Logf("Error removing chain B after failed start: %v", removeErr)
+				}
+				return err
+			}
+			s.chainB = built
+			return nil
+		})
 	})
 
 	s.Require().NoError(g.Wait(), "failed to setup chains")


### PR DESCRIPTION
## Overview

The `ci-release` run on the `v9.0.5-arabica` tag ([28177358229](https://github.com/celestiaorg/celestia-app/actions/runs/28177358229)) failed in `TestIBCTestSuite/TestICA` with:

> failed to set up container networking: ... failed to listen on TCP socket: address already in use

The IBC suite builds and starts two chains **concurrently** in `setupIBCInfrastructure`. Each chain publishes ephemeral host ports; when the two starts race each other (or a prior test's not-yet-released ports), Docker fails with `address already in use` — the same flake fixed for `TestAllUpgrades` in #7437.

## Fix

Wrap both chain build+start sequences in `retryOnPortCollision` (added in #7437), which rebuilds the chain to allocate fresh ports and retries **only** on port-binding collisions; any other error fails immediately. On a failed start the partially-started chain is `Remove`d so the retry can rebind cleanly. Mirrors the existing `e2e_upgrade_test.go` usage.

No linked issue — this resolves an observed CI flake.