### PR TITLE
fix: validate JSON field paths in internal map utils

### DIFF
--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -14,7 +14,12 @@ func SetField(bz []byte, path string, value any) ([]byte, error) {
 		return nil, fmt.Errorf("failed to unmarshal genesis: %w", err)
 	}
 
-	if err := setOrDeleteNestedField(doc, path, value); err != nil {
+	keys, err := splitPath(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := setOrDeleteNestedField(doc, keys, value); err != nil {
 		return nil, err
 	}
 
@@ -26,11 +31,19 @@ func RemoveField(bz []byte, path string) ([]byte, error) {
 	return SetField(bz, path, nil)
 }
 
-// setOrDeleteNestedField modifies a nested field in a map based on a dot-delimited path or deletes it if value is nil.
-// Returns an error if the path is invalid or intermediate nodes are not maps.
-func setOrDeleteNestedField(doc map[string]any, path string, value any) error {
+func splitPath(path string) ([]string, error) {
 	keys := strings.Split(path, ".")
+	for _, key := range keys {
+		if key == "" {
+			return nil, fmt.Errorf("invalid path: %q contains an empty segment", path)
+		}
+	}
+	return keys, nil
+}
 
+// setOrDeleteNestedField modifies a nested field in a map based on path keys or deletes it if value is nil.
+// Returns an error if the path is invalid or intermediate nodes are not maps.
+func setOrDeleteNestedField(doc map[string]any, keys []string, value any) error {
 	current := doc
 	for i, key := range keys {
 		// if it's the last key, set the value

--- a/internal/utils/maps_test.go
+++ b/internal/utils/maps_test.go
@@ -59,6 +59,20 @@ func TestSetField(t *testing.T) {
 			value:   "fail",
 			wantErr: errors.New("invalid path"),
 		},
+		{
+			name:    "invalid path - empty",
+			input:   `{"a": {"b": 1}}`,
+			path:    "",
+			value:   10,
+			wantErr: errors.New("invalid path"),
+		},
+		{
+			name:    "invalid path - empty segment",
+			input:   `{"a": {"b": 1}}`,
+			path:    "a..b",
+			value:   10,
+			wantErr: errors.New("invalid path"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,6 +124,12 @@ func TestDeleteField(t *testing.T) {
 			name:    "delete invalid nested path",
 			input:   `{"x": 5}`,
 			path:    "x.y.z",
+			wantErr: errors.New("invalid path"),
+		},
+		{
+			name:    "delete invalid path - empty",
+			input:   `{"x": 5}`,
+			path:    "",
 			wantErr: errors.New("invalid path"),
 		},
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Validate dot-delimited JSON field paths before mutating documents in `internal/utils/maps`.


`SetField` and `RemoveField` previously accepted an empty path. Because `strings.Split("", ".")` returns a single empty segment, this could create or delete a JSON field named `""` instead of rejecting the input.

Paths with empty segments, such as `a..b`, are also invalid for this helper and should fail consistently before mutation.



## Changes

- Add path validation that rejects empty paths and empty path segments.
- Pass validated path segments into the nested field mutation helper.
- Add regression coverage for empty paths and empty path segments.