### PR TITLE
fix(chainbuilder): close leaked CometBFT DBs on TestRun retry

### DIFF
--- a/tools/chainbuilder/integration_test.go
+++ b/tools/chainbuilder/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/test/util"
 	"github.com/celestiaorg/celestia-app/v9/test/util/random"
 	"github.com/celestiaorg/celestia-app/v9/test/util/testnode"
+	dbm "github.com/cometbft/cometbft-db"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	tmlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/node"
@@ -78,6 +79,19 @@ func TestRun(t *testing.T) {
 		nodeKey, err := p2p.LoadNodeKey(tmCfg.NodeKeyFile())
 		require.NoError(t, err)
 
+		// Track the databases CometBFT opens (blockstore, state, etc.) so they
+		// can be closed if this attempt fails. Otherwise their file locks leak
+		// and the retry fails with "lock held by current process".
+		var nodeDBs []dbm.DB
+		dbProvider := func(ctx *cmtcfg.DBContext) (dbm.DB, error) {
+			db, err := cmtcfg.DefaultDBProvider(ctx)
+			if err != nil {
+				return nil, err
+			}
+			nodeDBs = append(nodeDBs, db)
+			return db, nil
+		}
+
 		cmtApp := server.NewCometABCIWrapper(celestiaApp)
 		cometNode, err = node.NewNode(
 			tmCfg,
@@ -85,7 +99,7 @@ func TestRun(t *testing.T) {
 			nodeKey,
 			proxy.NewLocalClientCreator(cmtApp),
 			getGenDocProvider(tmCfg),
-			cmtcfg.DefaultDBProvider,
+			dbProvider,
 			node.DefaultMetricsProvider(tmCfg.Instrumentation),
 			tmlog.NewNopLogger(),
 		)
@@ -94,6 +108,9 @@ func TestRun(t *testing.T) {
 		}
 		if err != nil {
 			_ = appDB.Close()
+			for _, db := range nodeDBs {
+				_ = db.Close()
+			}
 			if testnode.IsPortBindingError(err) && attempt < maxRetries-1 {
 				t.Logf("port binding error on attempt %d/%d, retrying: %v", attempt+1, maxRetries, err)
 				time.Sleep(time.Duration(attempt+1) * time.Second)


### PR DESCRIPTION
## Motivation

The nightly `test-race` job fails in `tools/chainbuilder` `TestRun` ([run 28214610872](https://github.com/celestiaorg/celestia-app/actions/runs/28214610872/job/83582897939)):

```
integration_test.go:98: port binding error on attempt 1/3, retrying: failed to listen on 127.0.0.1:20011: bind: address already in use
Error: failed to initialize database: lock held by current process
--- FAIL: TestRun (411.09s)
```

The retry loop (added in #7388) reopens the node on a port-binding collision but only closed `appDB` between attempts. The blockstore/state/etc. databases opened by `node.NewNode` via `DefaultDBProvider` leaked their file locks, so **every retry was guaranteed to fail** with `lock held by current process` — the retry could never succeed.

## Fix

Wrap `DefaultDBProvider` to track the databases CometBFT opens and close them (alongside `appDB`) before retrying.

## Testing

- `go test -run TestRun ./tools/chainbuilder/` passes
- `go tool golangci-lint run ./tools/chainbuilder/...` clean