### PR TITLE
fix(gasestimation): use gov max bytes when extracting mempool gas prices

### DIFF
--- a/app/grpc/gasestimation/gas_estimator.go
+++ b/app/grpc/gasestimation/gas_estimator.go
@@ -139,7 +139,7 @@ func (s *gasEstimatorServer) estimateGasPrice(ctx context.Context, priority TxPr
 		// Return the maximum of the default min gas price and network min gas price
 		return math.Max(appconsts.DefaultMinGasPrice, minGasPrice), nil
 	}
-	gasPrices, err := SortAndExtractGasPrices(s.txDecoder, txsResp.Txs, int64(appconsts.DefaultUpperBoundMaxBytes))
+	gasPrices, err := SortAndExtractGasPrices(s.txDecoder, txsResp.Txs, int64(govMaxSquareBytes))
 	if err != nil {
 		return 0, err
 	}

--- a/app/grpc/gasestimation/gas_estimator_test.go
+++ b/app/grpc/gasestimation/gas_estimator_test.go
@@ -2,6 +2,7 @@ package gasestimation
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"math"
 	"testing"
@@ -10,8 +11,10 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/test/util/random"
 	rpctypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/cometbft/cometbft/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	protov2 "google.golang.org/protobuf/proto"
 )
 
 func TestMedian(t *testing.T) {
@@ -294,6 +297,95 @@ func TestGasEstimatorWithNetworkMinGasPrice(t *testing.T) {
 	_, err = serverWithError.estimateGasPrice(context.Background(), TxPriority_TX_PRIORITY_MEDIUM)
 	require.Error(t, err)
 }
+
+// TestEstimateGasPriceLimitsToGovMaxBytes verifies that estimateGasPrice only
+// considers the transactions that would actually fit within the governance max
+// block size (gov max square bytes) rather than the larger upper bound on max
+// bytes. When the mempool contains a small set of high gas price transactions
+// that fill a gov-sized block plus many cheaper transactions that would only
+// fit in a larger block, the estimate must reflect the high gas price
+// transactions that would actually be included.
+func TestEstimateGasPriceLimitsToGovMaxBytes(t *testing.T) {
+	const txSize = 100
+	// govMaxSquareBytes only has room for the high gas price transactions.
+	const govMaxSquareBytes = 10 * txSize
+
+	decoder := newMockTxDecoder()
+	txs := make([]types.Tx, 0, 110)
+	// 10 high gas price transactions with prices spread across 100..109 so the
+	// values aren't tightly clustered (which would trigger a priority
+	// adjustment). The median of these prices is 104.5.
+	for i := range 10 {
+		txs = append(txs, decoder.add(txSize, int64(100+i), 1))
+	}
+	// 100 low gas price transactions: gas price = 1. These only fit when the
+	// larger upper bound on max bytes is (incorrectly) used.
+	for range 100 {
+		txs = append(txs, decoder.add(txSize, 1, 1))
+	}
+
+	server := &gasEstimatorServer{
+		mempoolClient: newMockMempoolClient(txs),
+		txDecoder:     decoder.decode,
+		minGasPriceFn: func() (float64, error) { return 0, nil },
+		govMaxSquareBytesFn: func() (uint64, error) {
+			return govMaxSquareBytes, nil
+		},
+	}
+
+	gasPrice, err := server.estimateGasPrice(context.Background(), TxPriority_TX_PRIORITY_MEDIUM)
+	require.NoError(t, err)
+	// Only the high gas price transactions fit in a gov-sized block, so the
+	// estimate should be their median (104.5), not the cheaper transactions'
+	// price of 1.
+	require.Equal(t, 104.5, gasPrice)
+}
+
+// mockTxDecoder builds mock transactions of a chosen size and decodes them back
+// into mockFeeTx values carrying a fee and gas.
+type mockTxDecoder struct {
+	feeTxs map[string]mockFeeTx
+	next   uint32
+}
+
+func newMockTxDecoder() *mockTxDecoder {
+	return &mockTxDecoder{feeTxs: make(map[string]mockFeeTx)}
+}
+
+// add returns a transaction of the requested size whose decoded form reports
+// the provided fee and gas.
+func (d *mockTxDecoder) add(size int, fee, gas int64) types.Tx {
+	raw := make([]byte, size)
+	// Make each transaction unique so the decoder map keys don't collide.
+	binary.BigEndian.PutUint32(raw, d.next)
+	d.next++
+	d.feeTxs[string(raw)] = mockFeeTx{
+		fee: sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, fee)),
+		gas: uint64(gas),
+	}
+	return raw
+}
+
+func (d *mockTxDecoder) decode(txBytes []byte) (sdk.Tx, error) {
+	feeTx, ok := d.feeTxs[string(txBytes)]
+	if !ok {
+		return nil, errors.New("unknown transaction")
+	}
+	return feeTx, nil
+}
+
+// mockFeeTx is a minimal sdk.FeeTx used to exercise gas price extraction.
+type mockFeeTx struct {
+	fee sdk.Coins
+	gas uint64
+}
+
+func (m mockFeeTx) GetGas() uint64                        { return m.gas }
+func (m mockFeeTx) GetFee() sdk.Coins                     { return m.fee }
+func (m mockFeeTx) FeePayer() []byte                      { return nil }
+func (m mockFeeTx) FeeGranter() []byte                    { return nil }
+func (m mockFeeTx) GetMsgs() []sdk.Msg                    { return nil }
+func (m mockFeeTx) GetMsgsV2() ([]protov2.Message, error) { return nil, nil }
 
 type mockMempoolClient struct {
 	txs        []types.Tx


### PR DESCRIPTION
## Overview

The gas price estimator extracted candidate gas prices from the mempool up to `appconsts.DefaultUpperBoundMaxBytes` (32 MiB) instead of the governance max square size (`govMaxSquareBytes`) that it already computes for the block-fullness threshold.

When the gov max block size is smaller than the upper bound, this pulls in cheaper transactions that would not actually fit in a block, dragging the estimate down toward the network minimum even when a gov-sized block would be congested. As the issue notes, this gets worse as the upper bound grows (e.g. 128 MiB).

## Fix

Pass `govMaxSquareBytes` to `SortAndExtractGasPrices` so the extraction is consistent with the fullness check and reflects only the transactions that would really be included in a block.

## Test

Added `TestEstimateGasPriceLimitsToGovMaxBytes`: a mempool of 10 high-price txs (that fill a gov-sized block) plus 100 cheap txs. The estimate now reflects the high-price txs' median; before the fix it returned the cheap price.

Closes #5256