### PR TITLE
fix(chainbuilder): release node DB locks before retrying TestRun

### DIFF
--- a/tools/chainbuilder/integration_test.go
+++ b/tools/chainbuilder/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v9/test/util"
 	"github.com/celestiaorg/celestia-app/v9/test/util/random"
 	"github.com/celestiaorg/celestia-app/v9/test/util/testnode"
+	cometdbm "github.com/cometbft/cometbft-db"
 	cmtcfg "github.com/cometbft/cometbft/config"
 	tmlog "github.com/cometbft/cometbft/libs/log"
 	"github.com/cometbft/cometbft/node"
@@ -78,6 +79,19 @@ func TestRun(t *testing.T) {
 		nodeKey, err := p2p.LoadNodeKey(tmCfg.NodeKeyFile())
 		require.NoError(t, err)
 
+		// Track the databases the node opens (blockstore, state, etc.) so they
+		// can be closed if the node fails to start. Otherwise their locks leak
+		// and the next retry attempt fails with "lock held by current process".
+		var nodeDBs []cometdbm.DB
+		dbProvider := func(ctx *cmtcfg.DBContext) (cometdbm.DB, error) {
+			db, err := cmtcfg.DefaultDBProvider(ctx)
+			if err != nil {
+				return nil, err
+			}
+			nodeDBs = append(nodeDBs, db)
+			return db, nil
+		}
+
 		cmtApp := server.NewCometABCIWrapper(celestiaApp)
 		cometNode, err = node.NewNode(
 			tmCfg,
@@ -85,7 +99,7 @@ func TestRun(t *testing.T) {
 			nodeKey,
 			proxy.NewLocalClientCreator(cmtApp),
 			getGenDocProvider(tmCfg),
-			cmtcfg.DefaultDBProvider,
+			dbProvider,
 			node.DefaultMetricsProvider(tmCfg.Instrumentation),
 			tmlog.NewNopLogger(),
 		)
@@ -94,6 +108,9 @@ func TestRun(t *testing.T) {
 		}
 		if err != nil {
 			_ = appDB.Close()
+			for _, db := range nodeDBs {
+				_ = db.Close()
+			}
 			if testnode.IsPortBindingError(err) && attempt < maxRetries-1 {
 				t.Logf("port binding error on attempt %d/%d, retrying: %v", attempt+1, maxRetries, err)
 				time.Sleep(time.Duration(attempt+1) * time.Second)


### PR DESCRIPTION
## Problem

The Nightly `test-race` job failed on `tools/chainbuilder` `TestRun` with:

```
integration_test.go:98: port binding error on attempt 1/3, retrying: ... bind: address already in use
integration_test.go:102: Received unexpected error:
    failed to initialize database: lock held by current process
--- FAIL: TestRun (411.09s)
```

The port-binding retry loop added in #7388 only closed `appDB` on a failed attempt. The CometBFT node's internal databases (blockstore, state, evidence, tx_index) — opened by `cmtcfg.DefaultDBProvider` inside `node.NewNode` — were leaked. The next retry attempt then failed with `lock held by current process`, defeating the retry that was meant to absorb port collisions under `-race`.

## Fix

Wrap the DB provider so the databases the node opens are tracked, and close them alongside `appDB` before retrying.

Verified with `go test -run TestRun -race ./tools/chainbuilder/` (passes) and `golangci-lint` (0 issues). The underlying port collision is a non-deterministic TOCTOU race, so the broken retry path isn't reproducible on demand; the fix follows directly from the failure log.