### PR TITLE
fix(ci): retry TestTxSubmission to de-flake nightly latency assertion

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -94,7 +94,14 @@ jobs:
           - test: TestSyncToTipMocha
             max-attempts: 3
           - test: TestAllUpgrades
+          # TestTxSubmission asserts a wall-clock average tx-inclusion latency
+          # bound. On shared GitHub-hosted runners a single run can occasionally
+          # see sustained CPU contention that inflates latency well above the
+          # threshold (e.g. 17s avg vs the usual ~4.6s). A genuine latency
+          # regression shifts the whole distribution and fails every attempt,
+          # so a retry de-flakes transient runner noise without masking it.
           - test: TestTxSubmission
+            max-attempts: 2
             extra-image: true
           - test: TestArabicaLoad
             extra-image: true


### PR DESCRIPTION
## Motivation

The [2026-06-28 nightly](https://github.com/celestiaorg/celestia-app/actions/runs/28309676219) failed on `TestTxSubmission`. It asserts an average tx-inclusion latency `<= 8s`, but recorded **16.97s avg (53s max)** versus the usual **~4.6s avg / ~6.3s max** — with a **100% tx success rate** and no plausible code change in the image (only the gasestimation query fix #7477, which doesn't touch block production). This is transient CPU contention on the shared GitHub-hosted runner.

The test runs single-attempt, so one noisy run fails the whole nightly.

## Change

Give `TestTxSubmission` `max-attempts: 2`, mirroring `TestSyncToTipMocha`. A genuine latency regression shifts the whole distribution and fails every attempt, so the retry de-flakes transient runner noise without masking real regressions. Two attempts (~16m each) fit within the 90m job budget.

No tracking issue exists; this de-flakes a flaky nightly job.