### PR TITLE
fix: reject empty JSON paths in map helpers

### DIFF
--- a/internal/utils/maps.go
+++ b/internal/utils/maps.go
@@ -30,9 +30,16 @@ func RemoveField(bz []byte, path string) ([]byte, error) {
 // Returns an error if the path is invalid or intermediate nodes are not maps.
 func setOrDeleteNestedField(doc map[string]any, path string, value any) error {
 	keys := strings.Split(path, ".")
+	if len(keys) == 0 || keys[0] == "" {
+		return fmt.Errorf("invalid path: path must not be empty")
+	}
 
 	current := doc
 	for i, key := range keys {
+		if key == "" {
+			return fmt.Errorf("invalid path: empty key at position %d", i)
+		}
+
 		// if it's the last key, set the value
 		if i == len(keys)-1 {
 			if value == nil {

--- a/internal/utils/maps_test.go
+++ b/internal/utils/maps_test.go
@@ -59,6 +59,27 @@ func TestSetField(t *testing.T) {
 			value:   "fail",
 			wantErr: errors.New("invalid path"),
 		},
+		{
+			name:    "invalid path - empty path",
+			input:   `{"a": 1}`,
+			path:    "",
+			value:   "fail",
+			wantErr: errors.New("invalid path"),
+		},
+		{
+			name:    "invalid path - empty nested key",
+			input:   `{"a": {"b": 1}}`,
+			path:    "a..b",
+			value:   "fail",
+			wantErr: errors.New("invalid path"),
+		},
+		{
+			name:    "invalid path - trailing separator",
+			input:   `{"a": {"b": 1}}`,
+			path:    "a.",
+			value:   "fail",
+			wantErr: errors.New("invalid path"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -110,6 +131,12 @@ func TestDeleteField(t *testing.T) {
 			name:    "delete invalid nested path",
 			input:   `{"x": 5}`,
 			path:    "x.y.z",
+			wantErr: errors.New("invalid path"),
+		},
+		{
+			name:    "delete invalid empty path",
+			input:   `{"x": 5}`,
+			path:    "",
 			wantErr: errors.New("invalid path"),
 		},
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

This updates the internal JSON map helpers to reject empty dot-delimited paths.

Previously, calling `SetField` or `RemoveField` with an empty path, or a path containing an empty segment such as `a..b`, could silently operate on an empty-string key. This behavior is surprising for helpers that are intended to update or remove fields by explicit JSON paths.



## Changes

- Return an error when the path is empty
- Return an error when the path contains an empty segment
- Add unit tests for empty paths, nested empty keys, and trailing separators

## Testing

- `go test ./internal/utils`
- `go test ./test/util/genesis ./internal/utils`