### PR TITLE
test: run fibre codec fuzzers in nightly CI

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -165,6 +165,10 @@ jobs:
       - name: Run tests in race mode
         run: make test-race
 
+  # WARNING: Required job — a defense line against codec / wire-format bugs,
+  # including the fibre scatter codec. The fuzz targets live in
+  # scripts/test_fuzz.sh. Do NOT remove or disable this job; doing so re-opens
+  # https://github.com/celestiaorg/celestia-app/issues/7392.
   test-fuzz:
     runs-on: ubuntu-latest
     steps:

--- a/fibre/internal/grpc/codec_scatter_test.go
+++ b/fibre/internal/grpc/codec_scatter_test.go
@@ -148,6 +148,11 @@ func TestScatterMarshalWireParity(t *testing.T) {
 // shapes and asserts byte equality against gogoproto's canonical marshal.
 // Catches drift if new fields are added to UploadShardRequest / BlobShard /
 // BlobRow without updating codec_scatter.go.
+//
+// WARNING: This fuzzer is a defense line against fibre scatter-codec wire-format
+// drift and runs nightly in CI via scripts/test_fuzz.sh. Do NOT delete it, and
+// if you rename it update the matching -fuzz line in scripts/test_fuzz.sh in
+// lockstep. See https://github.com/celestiaorg/celestia-app/issues/7392.
 func FuzzScatterMarshalParity(f *testing.F) {
 	f.Add(int64(1), uint32(4), uint32(3), uint32(2))
 	f.Add(int64(42), uint32(0), uint32(0), uint32(0))

--- a/fibre/store_codec_test.go
+++ b/fibre/store_codec_test.go
@@ -105,6 +105,11 @@ func TestShardCodecRejectsBomb(t *testing.T) {
 
 // FuzzShardCodecRoundTrip builds a structurally valid BlobShard from each
 // fuzz seed, round-trips it through write/read, and asserts equality.
+//
+// WARNING: This fuzzer is a defense line against fibre shard-codec bugs and runs
+// nightly in CI via scripts/test_fuzz.sh. Do NOT delete it, and if you rename it
+// update the matching -fuzz line in scripts/test_fuzz.sh in lockstep. See
+// https://github.com/celestiaorg/celestia-app/issues/7392.
 func FuzzShardCodecRoundTrip(f *testing.F) {
 	f.Add([]byte{0x01, 0x02, 0x03, 0x04})
 	f.Add(bytes.Repeat([]byte{0xff}, 128))
@@ -134,6 +139,11 @@ func FuzzShardCodecRoundTrip(f *testing.F) {
 // FuzzShardCodecReadNoPanic feeds arbitrary bytes to the reader. Length caps
 // keep allocations bounded, so the only outcomes are a parse (rare) or an
 // error — never a panic.
+//
+// WARNING: This fuzzer is a defense line against fibre shard-codec bugs and runs
+// nightly in CI via scripts/test_fuzz.sh. Do NOT delete it, and if you rename it
+// update the matching -fuzz line in scripts/test_fuzz.sh in lockstep. See
+// https://github.com/celestiaorg/celestia-app/issues/7392.
 func FuzzShardCodecReadNoPanic(f *testing.F) {
 	f.Add([]byte{})
 	f.Add([]byte{0x00, 0x00, 0x00, 0x01})

--- a/scripts/test_fuzz.sh
+++ b/scripts/test_fuzz.sh
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
 set -e
 
+# =============================================================================
+# WARNING: These fuzzers are a defense line against wire-format / codec bugs.
+# The fibre scatter codec (fibre/internal/grpc/codec_scatter.go) is a hand-rolled
+# marshaler that MUST stay byte-for-byte identical to gogoproto's canonical
+# output, and the fibre shard codec is the on-the-wire shard encoding. DO NOT
+# remove or disable any target below without an equivalent replacement; silently
+# dropping one re-opens https://github.com/celestiaorg/celestia-app/issues/7392.
+#
+# The Go toolchain only fuzzes one target in one package per invocation, so each
+# target is listed explicitly. When you add codec/encoding logic, add its fuzz
+# target here too. If you rename a fuzz function, update the matching line below.
+# =============================================================================
+
 echo "Running fuzz tests..."
-# manually specify the tests to fuzz since go toolchain doesn't support
-# fuzzing multiple packages with multiple fuzz tests
-go test -fuzz=FuzzPFBGasEstimation -fuzztime 3m ./x/blob/types
+go test -fuzz=FuzzPFBGasEstimation -fuzztime 5m ./x/blob/types
+go test -fuzz=FuzzScatterMarshalParity -fuzztime 5m ./fibre/internal/grpc
+go test -fuzz=FuzzShardCodecRoundTrip -fuzztime 5m ./fibre
+go test -fuzz=FuzzShardCodecReadNoPanic -fuzztime 5m ./fibre


### PR DESCRIPTION
## Overview

Runs the fibre codec fuzzers in CI's nightly fuzz job. Previously only `FuzzPFBGasEstimation` was fuzzed; the fibre scatter codec and shard codec fuzzers existed but never executed in CI.

Added to `scripts/test_fuzz.sh` (which the nightly `test-fuzz` job already runs via `make test-fuzz`):

- **`FuzzScatterMarshalParity`** (`fibre/internal/grpc`) — the fibre scatter codec; asserts byte-for-byte parity with gogoproto's canonical marshal so a new field can't silently break the hand-rolled marshaler.
- **`FuzzShardCodecRoundTrip`** and **`FuzzShardCodecReadNoPanic`** (`fibre`) — the on-the-wire shard codec.

Each target fuzzes for `5m`. The existing PFB fuzzer was bumped from `3m` to `5m` for a uniform budget (~20m total nightly).

### Why nightly, not per-PR

`go test -fuzz` burns a fixed wall-clock budget per target regardless of outcome, so running all four per PR would add ~20m to every PR. The fuzz **seed corpus** (`f.Add(...)` cases) already runs on every PR for free, since Go executes seeds as normal subtests when `-fuzz` is unset and `fibre/...` is in the PR test matrix. Nightly performs the actual randomized fuzzing.

### Warnings

Per the issue, added prominent "do not disable" warnings in three places: the fuzz script header, above the nightly `test-fuzz` job, and above each fibre fuzz function (each notes the matching `-fuzz` line in `scripts/test_fuzz.sh` must be updated in lockstep on rename).

### Verification

All three fibre targets run green locally; no failing corpus entries written. `gofmt` and `yamllint` clean.

Closes PROTOCO-1924
Closes #7392

🤖 Generated with [Claude Code](https://claude.com/claude-code)
