### PR TITLE
ci: don't fail-fast the docker-e2e matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -127,6 +127,9 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     strategy:
+      # Don't cancel the other e2e tests when one fails; each test is
+      # independent and we want signal from all of them.
+      fail-fast: false
       matrix:
         include:
           - testcase: TestE2ESimple


### PR DESCRIPTION
## Motivation

The `test-docker-e2e` matrix didn't set `fail-fast: false`, so when one case fails GitHub cancels all the others. Right now `TestE2EFullStackPFB` fails on every merge to `main` (the DA light node only supports app v9, blocked on celestia-node v10 support — tracked in #7495), which cancels the 13 other docker-e2e tests (`TestStateSync`, `TestUpgradeLatest`, IBC, Hyperlane, …). We lose their regression signal on `main` until the upstream bump lands.

## Change

Add `fail-fast: false` to the docker-e2e matrix, mirroring the `go-test` matrix in the same workflow, so each e2e test reports independently.

This does not fix `TestE2EFullStackPFB` itself (still blocked on #7495 / celestia-node#5089) — it stops that known failure from masking the rest.

Related to #7495