### PR TITLE
test: skip TestE2EFullStackPFB until celestia-node supports app v10

### DIFF
--- a/test/docker-e2e/e2e_full_stack_pfb_test.go
+++ b/test/docker-e2e/e2e_full_stack_pfb_test.go
@@ -44,6 +44,12 @@ func (s *CelestiaTestSuite) TestE2EFullStackPFB() {
 	if testing.Short() {
 		t.Skip("skipping in short mode")
 	}
+	// TODO: re-enable (and bump celestiaNodeVersion) once a celestia-node
+	// release supports celestia-app/v10. celestia-node cb0ffce (and celestia-node
+	// main) still depend on celestia-app/v9 and reject v10 block headers, so the
+	// bridge node produces no headers and the light node fails to sync its
+	// network head. The app was bumped to v10 in #7492.
+	t.Skip("skipping until celestia-node supports app v10")
 
 	ctx := context.TODO()
 


### PR DESCRIPTION
## Summary

`TestE2EFullStackPFB` has failed on **every** post-merge run on `main` since the app was bumped to v10 in #7492 (runs on `908f74471`, `d93977b27`, `aa6e955cf`, `a593f682f`).

**Root cause:** the test pins `celestiaNodeVersion = "cb0ffce"`, which (like celestia-node `main`) still depends on `celestia-app/v9` and rejects v10 block headers. The bridge node produces no headers, so the light node fails to sync its network head and errors on startup:

```
Error: node: failed to start: error getting latest head during Start:
network head: subjective head: exchange head: header: not found
```

(fails at `e2e_full_stack_pfb_test.go:169`, "failed to start light node")

No released celestia-node version supports app v10 yet, so this can't be fixed with a version bump. This mirrors the earlier v9 workaround in #7079: skip the test so `main` / merge-queue CI goes green.

Re-enable (and bump `celestiaNodeVersion`) once a v10-compatible celestia-node release exists.

## Test plan

- CI: `test / test-docker-e2e (TestE2EFullStackPFB)` reports SKIP instead of FAIL.