### PR TITLE
refactor(fibre): rework HostRegistry

### DIFF
--- a/fibre/client.go
+++ b/fibre/client.go
@@ -85,7 +85,7 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 		tracer:      cfg.Tracer,
 		metrics:     metrics,
 		clock:       cfg.Clock,
-		clientCache: fibregrpc.NewClientCache(cfg.NewClientFn, stateClient, DefaultProtocolParams.MaxValidatorCount, fibregrpc.WithTracer(cfg.Tracer)),
+		clientCache: fibregrpc.NewClientCache(cfg.NewClientFn, DefaultProtocolParams.MaxValidatorCount, fibregrpc.WithTracer(cfg.Tracer)),
 	}, nil
 }
 

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -391,10 +391,6 @@ func (r *testHostRegistry) GetHost(ctx context.Context, val *core.Validator) (va
 	return validator.Host(addr), nil
 }
 
-func (r *testHostRegistry) RefreshHost(context.Context, *core.Validator) (bool, bool, error) {
-	return false, false, nil
-}
-
 // shufflingValidatorSetGetter returns deterministically shuffled validator sets based on height.
 // Each height produces a different but deterministic ordering using height as the random seed.
 type shufflingValidatorSetGetter struct {

--- a/fibre/cmd/start_cmd_test.go
+++ b/fibre/cmd/start_cmd_test.go
@@ -164,10 +164,6 @@ func (s *stubStateClient) GetHost(context.Context, *core.Validator) (validator.H
 	return "", nil
 }
 
-func (s *stubStateClient) RefreshHost(context.Context, *core.Validator) (bool, bool, error) {
-	return false, false, nil
-}
-
 func (s *stubStateClient) VerifyPromise(context.Context, *state.PaymentPromise) (state.VerifiedPromise, error) {
 	return state.VerifiedPromise{}, nil
 }

--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -288,7 +288,3 @@ func (r *fixedHostRegistry) GetHost(_ context.Context, _ *core.Validator) (valid
 	}
 	return validator.Host(r.addr), nil
 }
-
-func (r *fixedHostRegistry) RefreshHost(context.Context, *core.Validator) (bool, bool, error) {
-	return false, false, nil
-}

--- a/fibre/internal/grpc/client_cache.go
+++ b/fibre/internal/grpc/client_cache.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/celestiaorg/celestia-app/v10/fibre/validator"
 	core "github.com/cometbft/cometbft/types"
 	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	grpccodes "google.golang.org/grpc/codes"
@@ -19,7 +17,6 @@ import (
 // TODO(@Wondertan): Needs cleanup strategy, e.g. LRU
 type ClientCache struct {
 	newClient NewClientFn
-	hosts     validator.HostRegistry
 	tracer    trace.Tracer
 	mu        sync.Mutex
 	clients   map[string]*clientEntry // keyed by validator address string
@@ -46,13 +43,12 @@ func WithTracer(tracer trace.Tracer) ClientCacheOption {
 	}
 }
 
-// NewClientCache creates a new [ClientCache] with the given [NewClientFn]. The
-// [validator.HostRegistry] is used by [ClientCache.Request] to re-resolve a
-// validator's host when a request fails because the peer is unreachable.
-func NewClientCache(newClient NewClientFn, hosts validator.HostRegistry, expectedSize int, opts ...ClientCacheOption) *ClientCache {
+// NewClientCache creates a new [ClientCache] with the given [NewClientFn].
+// [ClientCache.Request] re-resolves a validator's host through newClient when a
+// request fails because the peer is unreachable.
+func NewClientCache(newClient NewClientFn, expectedSize int, opts ...ClientCacheOption) *ClientCache {
 	cc := &ClientCache{
 		newClient: newClient,
-		hosts:     hosts,
 		tracer:    otel.Tracer("fibre-client"),
 		clients:   make(map[string]*clientEntry, expectedSize),
 	}
@@ -90,10 +86,11 @@ func (cc *ClientCache) GetClient(ctx context.Context, val *core.Validator) (Clie
 
 // Request runs fn against val's cached [Client]. If it fails in a way a changed
 // host could explain — a failed dial (e.g. an invalid host) or a transport-level
-// gRPC error (an unreachable or timed-out peer) — it re-queries state once
-// (rate-limited per validator) for the host. When the host changed to a valid
-// new value it evicts the stale client, re-dials, and retries fn exactly once.
-// Application-level errors from a reachable server are returned as-is.
+// gRPC error (an unreachable or timed-out peer) — it evicts the stale client and
+// re-dials once, retrying fn exactly once. The re-dial resolves the host afresh
+// through the [NewClientFn] (rate-limited in the host registry), so a host that
+// changed on chain is picked up here. Application-level errors from a reachable
+// server are returned as-is.
 func (cc *ClientCache) Request(ctx context.Context, val *core.Validator, fn func(Client) error) error {
 	ctx, span := cc.tracer.Start(ctx, "client_cache.request")
 	defer span.End()
@@ -108,37 +105,24 @@ func (cc *ClientCache) Request(ctx context.Context, val *core.Validator, fn func
 	span.RecordError(err)
 	span.AddEvent("initial attempt failed")
 
-	// Don't refresh on a cancelled context: the failure is the caller leaving,
+	// Don't retry on a cancelled context: the failure is the caller leaving,
 	// not a stale host.
 	if ctx.Err() != nil {
 		return err
 	}
-	// client == nil means the dial itself failed.
+	// client == nil means the dial itself failed. Only a failed dial or an
+	// unreachable/timed-out peer can be explained by a stale host; an application
+	// error from a reachable server is returned as-is.
 	if client != nil && !isUnreachable(err) {
-		span.AddEvent("application error; not refreshing host")
+		span.AddEvent("application error; not retrying")
 		return err
 	}
 
-	span.AddEvent("refreshing host")
-	changed, valid, refreshErr := cc.hosts.RefreshHost(ctx, val)
-	span.SetAttributes(
-		attribute.Bool("host.changed", changed),
-		attribute.Bool("host.valid", valid),
-	)
-	if refreshErr != nil {
-		span.RecordError(refreshErr)
-	}
-	if !changed {
-		span.AddEvent("host unchanged; not retrying")
-		return err
-	}
-	// The host changed on chain, so the cached connection points at a stale
-	// address whether or not the new host is valid; drop it either way.
+	// Drop the stale connection and re-dial once. GetClient re-runs the
+	// [NewClientFn], which re-resolves the host, so a host that changed on chain
+	// is picked up on the retry.
+	span.AddEvent("evicting and re-dialing")
 	cc.evict(val)
-	if !valid {
-		span.AddEvent("host changed but invalid; not retrying")
-		return err
-	}
 
 	client, retryErr := cc.GetClient(ctx, val)
 	if retryErr != nil {
@@ -146,7 +130,7 @@ func (cc *ClientCache) Request(ctx context.Context, val *core.Validator, fn func
 		span.SetStatus(otelcodes.Error, "re-dial failed")
 		return retryErr
 	}
-	span.AddEvent("retrying against refreshed host")
+	span.AddEvent("retrying against re-resolved host")
 	if err = fn(client); err != nil {
 		span.RecordError(err)
 		span.SetStatus(otelcodes.Error, "retry failed")

--- a/fibre/internal/grpc/client_cache_test.go
+++ b/fibre/internal/grpc/client_cache_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/fibre/internal/grpc"
-	"github.com/celestiaorg/celestia-app/v10/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +25,7 @@ func TestClientCache(t *testing.T) {
 			Address: []byte("validator-2"),
 		},
 	}
-	cache := grpc.NewClientCache(mockClientFn(false), stubHostRegistry{}, len(validators))
+	cache := grpc.NewClientCache(mockClientFn(false), len(validators))
 
 	clients := make([]types.FibreClient, numGoroutines)
 	errors := make([]error, numGoroutines)
@@ -80,7 +79,7 @@ func TestClientCache(t *testing.T) {
 // without holding the entry lock, racing with GetClient's write inside Do.
 func TestClientCacheGetCloseConcurrentRace(t *testing.T) {
 	const numGoroutines = 50
-	cache := grpc.NewClientCache(mockClientFn(false), stubHostRegistry{}, 1)
+	cache := grpc.NewClientCache(mockClientFn(false), 1)
 	val := &core.Validator{Address: []byte("validator-1")}
 
 	var wg sync.WaitGroup
@@ -101,29 +100,29 @@ func TestClientCacheGetCloseConcurrentRace(t *testing.T) {
 	wg.Wait()
 }
 
-// TestClientCacheRequest_EvictsStaleClient verifies that when a host change
-// forces eviction, the stale client is closed and a fresh one is dialed.
+// TestClientCacheRequest_EvictsStaleClient verifies that an unreachable peer
+// forces eviction: the stale client is closed and a fresh one is dialed.
 func TestClientCacheRequest_EvictsStaleClient(t *testing.T) {
-	cache := grpc.NewClientCache(mockClientFn(false), refreshes(true, true, nil), 1)
+	cache := grpc.NewClientCache(mockClientFn(false), 1)
 	val := &core.Validator{Address: []byte("validator-1")}
 
 	var stale, fresh grpc.Client
 	err := cache.Request(t.Context(), val, func(c grpc.Client) error {
 		if stale == nil {
 			stale = c
-			return errUnreachable // stale host triggers refresh + eviction
+			return errUnreachable // unreachable peer triggers eviction + re-dial
 		}
 		fresh = c
-		return nil // corrected host
+		return nil // re-resolved host
 	})
 	require.NoError(t, err)
 	assert.True(t, stale.(*mockFibreClientCloser).closed, "evicted client should be closed")
 	assert.NotSame(t, stale, fresh, "a fresh client should be dialed after eviction")
 }
 
-// TestClientCacheRequest_ClearsCachedDialError verifies that eviction (here
-// driven by a host change) clears a cached dial error so the next call
-// re-dials — the recovery path for a corrected host.
+// TestClientCacheRequest_ClearsCachedDialError verifies that eviction clears a
+// cached dial error so the next call re-dials — the recovery path for a
+// corrected host.
 func TestClientCacheRequest_ClearsCachedDialError(t *testing.T) {
 	var calls int
 	fn := func(_ context.Context, val *core.Validator) (grpc.Client, error) {
@@ -133,7 +132,7 @@ func TestClientCacheRequest_ClearsCachedDialError(t *testing.T) {
 		}
 		return &mockFibreClientCloser{id: val.Address.String()}, nil
 	}
-	cache := grpc.NewClientCache(fn, refreshes(true, true, nil), 1)
+	cache := grpc.NewClientCache(fn, 1)
 	val := &core.Validator{Address: []byte("validator-1")}
 
 	// The first two GetClient calls cache and reuse the dial error.
@@ -143,10 +142,10 @@ func TestClientCacheRequest_ClearsCachedDialError(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, 1, calls, "error should be cached, not re-dialed")
 
-	// A request whose host changed evicts the entry, clearing the cached error
+	// A request whose dial failed evicts the entry, clearing the cached error
 	// and allowing a re-dial.
 	require.NoError(t, cache.Request(t.Context(), val, func(grpc.Client) error { return nil }))
-	require.Equal(t, 2, calls, "host change should clear the cached error and allow a re-dial")
+	require.Equal(t, 2, calls, "dial failure should clear the cached error and allow a re-dial")
 }
 
 // mockFibreClientCloser is a mock implementation for testing
@@ -173,34 +172,6 @@ func mockClientFn(shouldErr bool) grpc.NewClientFn {
 	}
 }
 
-// stubHostRegistry is a configurable validator.HostRegistry for cache tests.
-// refresh, when set, backs RefreshHost; otherwise RefreshHost reports no change.
-type stubHostRegistry struct {
-	refresh func() (changed, valid bool, err error)
-}
-
-func (stubHostRegistry) GetHost(context.Context, *core.Validator) (validator.Host, error) {
-	return "", nil
-}
-
-func (s stubHostRegistry) RefreshHost(context.Context, *core.Validator) (bool, bool, error) {
-	if s.refresh != nil {
-		return s.refresh()
-	}
-	return false, false, nil
-}
-
-// refreshes returns a stubHostRegistry whose RefreshHost reports (changed,
-// valid) and records into called whether it ran.
-func refreshes(changed, valid bool, called *bool) stubHostRegistry {
-	return stubHostRegistry{refresh: func() (bool, bool, error) {
-		if called != nil {
-			*called = true
-		}
-		return changed, valid, nil
-	}}
-}
-
 // errUnreachable is a transport-level error, as a request fn would see from an
 // unreachable peer.
 var errUnreachable = status.Error(grpccodes.Unavailable, "rpc failed")
@@ -208,8 +179,10 @@ var errUnreachable = status.Error(grpccodes.Unavailable, "rpc failed")
 // requestVal is an arbitrary validator; Request tests don't depend on its identity.
 var requestVal = &core.Validator{Address: []byte("v1")}
 
-func TestClientCacheRequest_RetriesAfterHostChange(t *testing.T) {
-	cache := grpc.NewClientCache(mockClientFn(false), refreshes(true, true, nil), 1)
+// TestClientCacheRequest_RetriesAfterUnreachable verifies an unreachable peer
+// triggers exactly one re-dial and retry of fn.
+func TestClientCacheRequest_RetriesAfterUnreachable(t *testing.T) {
+	cache := grpc.NewClientCache(mockClientFn(false), 1)
 
 	calls := 0
 	err := cache.Request(t.Context(), requestVal, func(grpc.Client) error {
@@ -217,41 +190,39 @@ func TestClientCacheRequest_RetriesAfterHostChange(t *testing.T) {
 		if calls == 1 {
 			return errUnreachable // stale host
 		}
-		return nil // corrected host
+		return nil // re-resolved host
 	})
 	require.NoError(t, err)
 	assert.Equal(t, 2, calls, "fn should be retried once against the re-dialed client")
 }
 
-func TestClientCacheRequest_UnchangedReturnsOriginalError(t *testing.T) {
-	cache := grpc.NewClientCache(mockClientFn(false), refreshes(false, false, nil), 1)
-
-	err := cache.Request(t.Context(), requestVal, func(grpc.Client) error { return errUnreachable })
-	assert.Equal(t, grpccodes.Unavailable, status.Code(err))
-}
-
-func TestClientCacheRequest_ChangedButInvalidReturnsOriginalError(t *testing.T) {
-	refreshed := false
-	cache := grpc.NewClientCache(mockClientFn(false), refreshes(true, false, &refreshed), 1)
+// TestClientCacheRequest_RetryFailureReturnsError verifies that when the retry
+// still fails, the retry's error is returned and fn is not attempted a third
+// time.
+func TestClientCacheRequest_RetryFailureReturnsError(t *testing.T) {
+	cache := grpc.NewClientCache(mockClientFn(false), 1)
 
 	calls := 0
 	err := cache.Request(t.Context(), requestVal, func(grpc.Client) error { calls++; return errUnreachable })
-	assert.Equal(t, grpccodes.Unavailable, status.Code(err), "should not retry into a known-invalid host")
-	assert.True(t, refreshed)
-	assert.Equal(t, 1, calls, "fn must not be retried into an invalid host")
+	assert.Equal(t, grpccodes.Unavailable, status.Code(err))
+	assert.Equal(t, 2, calls, "fn is attempted once, then retried once")
 }
 
-func TestClientCacheRequest_AppErrorSkipsRefresh(t *testing.T) {
-	refreshed := false
-	cache := grpc.NewClientCache(mockClientFn(false), refreshes(true, true, &refreshed), 1)
+// TestClientCacheRequest_AppErrorSkipsRetry verifies that an application-level
+// error from a reachable server is returned as-is without a re-dial.
+func TestClientCacheRequest_AppErrorSkipsRetry(t *testing.T) {
+	cache := grpc.NewClientCache(mockClientFn(false), 1)
 
 	appErr := status.Error(grpccodes.NotFound, "blob not found")
-	err := cache.Request(t.Context(), requestVal, func(grpc.Client) error { return appErr })
+	calls := 0
+	err := cache.Request(t.Context(), requestVal, func(grpc.Client) error { calls++; return appErr })
 	assert.Equal(t, grpccodes.NotFound, status.Code(err))
-	assert.False(t, refreshed, "application errors must not trigger a host refresh")
+	assert.Equal(t, 1, calls, "application errors must not trigger a re-dial")
 }
 
-func TestClientCacheRequest_DialFailureTriggersRefresh(t *testing.T) {
+// TestClientCacheRequest_DialFailureTriggersRedial verifies a failed dial (before
+// any RPC) triggers a re-dial.
+func TestClientCacheRequest_DialFailureTriggersRedial(t *testing.T) {
 	dials := 0
 	dial := func(context.Context, *core.Validator) (grpc.Client, error) {
 		dials++
@@ -260,22 +231,25 @@ func TestClientCacheRequest_DialFailureTriggersRefresh(t *testing.T) {
 		}
 		return &mockFibreClientCloser{}, nil
 	}
-	cache := grpc.NewClientCache(dial, refreshes(true, true, nil), 1)
+	cache := grpc.NewClientCache(dial, 1)
 
 	calls := 0
 	err := cache.Request(t.Context(), requestVal, func(grpc.Client) error { calls++; return nil })
 	require.NoError(t, err)
 	assert.Equal(t, 1, calls, "fn runs once, against the re-dialed client")
+	assert.Equal(t, 2, dials, "the failed dial should be retried once")
 }
 
-func TestClientCacheRequest_SkipsRefreshOnCancelledContext(t *testing.T) {
-	refreshed := false
-	cache := grpc.NewClientCache(mockClientFn(false), refreshes(true, true, &refreshed), 1)
+// TestClientCacheRequest_SkipsRetryOnCancelledContext verifies a cancelled
+// context short-circuits the retry path.
+func TestClientCacheRequest_SkipsRetryOnCancelledContext(t *testing.T) {
+	cache := grpc.NewClientCache(mockClientFn(false), 1)
 
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	err := cache.Request(ctx, requestVal, func(grpc.Client) error { return errUnreachable })
+	calls := 0
+	err := cache.Request(ctx, requestVal, func(grpc.Client) error { calls++; return errUnreachable })
 	require.Error(t, err)
-	assert.False(t, refreshed, "a cancelled context must not trigger a refresh")
+	assert.Equal(t, 1, calls, "a cancelled context must not trigger a re-dial")
 }

--- a/fibre/internal/grpc/host_registry.go
+++ b/fibre/internal/grpc/host_registry.go
@@ -23,37 +23,47 @@ var _ validator.HostRegistry = &HostRegistry{}
 var DefaultRefreshInterval = appconsts.DelayedPrecommitTimeout + appconsts.TimeoutCommit
 
 // DefaultQueryTimeout bounds a single on-chain host query in
-// [HostRegistry.RefreshHost]. It matches the client's default RPCTimeout so a
-// slow or black-holed state node can't add unbounded latency to the request
-// that triggered the refresh.
+// [HostRegistry.GetHost]. It matches the client's default RPCTimeout so a slow
+// or black-holed state node can't add unbounded latency to the request that
+// triggered the resolution.
 const DefaultQueryTimeout = 15 * time.Second
 
-// HostRegistry is a registry of validator hosts. It caches the hosts for validators in the active set.
-// It uses the [types.QueryClient] to query the fibre provider information for validators in the active set.
+// HostRegistry resolves validator hosts from on-chain fibre provider state.
+//
+// GetHost always resolves the freshest address, but re-queries state at most
+// once per validator per refreshInterval; within that window it serves the last
+// known host. The rate limit — not a real cache — is what bounds query load,
+// since provider state cannot change faster than one block. Start warms the last
+// known hosts in a single bulk query so the first block of traffic is served
+// without a per-validator query storm.
 type HostRegistry struct {
 	queryClient types.QueryClient
 	log         *slog.Logger
 	mu          sync.RWMutex
-	cachedHosts map[string]validator.Host
+	// lastHosts is the last host resolved per validator consensus address. It is
+	// the rate-limiter's fallback within a window and the warm-up target, not a
+	// standalone cache.
+	lastHosts map[string]validator.Host
 
-	// Refresh timing state used to rate-limit on-chain host re-queries per validator.
+	// Rate-limit state for on-chain host re-queries per validator.
 	clock           clock.Clock
 	refreshInterval time.Duration
 	lastRefresh     map[string]time.Time
-	// queryTimeout bounds a single on-chain host query in RefreshHost.
+	// queryTimeout bounds a single on-chain host query in GetHost.
 	queryTimeout time.Duration
 }
 
 // HostRegistryOption configures a [HostRegistry].
 type HostRegistryOption func(*HostRegistry)
 
-// WithClock sets the clock used to rate-limit [HostRegistry.RefreshHost].
+// WithClock sets the clock used to rate-limit host re-queries in
+// [HostRegistry.GetHost].
 func WithClock(c clock.Clock) HostRegistryOption {
 	return func(g *HostRegistry) { g.clock = c }
 }
 
 // WithRefreshInterval sets the minimum time between on-chain host re-queries
-// for a single validator in [HostRegistry.RefreshHost]. A non-positive value
+// for a single validator in [HostRegistry.GetHost]. A non-positive value
 // leaves the default in place.
 func WithRefreshInterval(d time.Duration) HostRegistryOption {
 	return func(g *HostRegistry) {
@@ -64,7 +74,7 @@ func WithRefreshInterval(d time.Duration) HostRegistryOption {
 }
 
 // WithQueryTimeout sets the timeout bounding a single on-chain host query in
-// [HostRegistry.RefreshHost]. A non-positive value leaves the default in place.
+// [HostRegistry.GetHost]. A non-positive value leaves the default in place.
 func WithQueryTimeout(d time.Duration) HostRegistryOption {
 	return func(g *HostRegistry) {
 		if d > 0 {
@@ -79,7 +89,7 @@ func NewHostRegistry(queryClient types.QueryClient, log *slog.Logger, opts ...Ho
 		log:             log,
 		clock:           clock.New(),
 		refreshInterval: DefaultRefreshInterval,
-		cachedHosts:     make(map[string]validator.Host),
+		lastHosts:       make(map[string]validator.Host),
 		lastRefresh:     make(map[string]time.Time),
 		queryTimeout:    DefaultQueryTimeout,
 	}
@@ -89,12 +99,16 @@ func NewHostRegistry(queryClient types.QueryClient, log *slog.Logger, opts ...Ho
 	return g
 }
 
-// Start the host registry by pulling all active fibre providers.
+// Start warms the registry by pulling all active fibre providers in a single
+// bulk query, so the first block of traffic is served without a per-validator
+// query storm.
 func (g *HostRegistry) Start(ctx context.Context) error {
 	return g.PullAll(ctx)
 }
 
-// GetHost implements the HostRegistry interface.
+// GetHost implements the [validator.HostRegistry] interface. It resolves the
+// freshest on-chain host for val, re-querying state at most once per validator
+// per refresh interval and serving the last known host within that window.
 //
 // The same `host:port` validation that x/valaddr's MsgSetFibreProviderInfo
 // applies on registration is re-applied here so that legacy registrations
@@ -103,7 +117,7 @@ func (g *HostRegistry) Start(ctx context.Context) error {
 // instead of failing later inside grpc.NewClient with a confusing
 // "too many colons in address".
 func (g *HostRegistry) GetHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
-	host, err := g.getHost(ctx, val)
+	host, err := g.resolveHost(ctx, val)
 	if err != nil {
 		return "", err
 	}
@@ -114,20 +128,53 @@ func (g *HostRegistry) GetHost(ctx context.Context, val *core.Validator) (valida
 	return host, nil
 }
 
-func (g *HostRegistry) getHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
-	valConAddr := sdk.ConsAddress(val.Address.Bytes()).String()
+// resolveHost returns the freshest host for val, respecting the per-validator
+// rate limit. Within the refresh window it returns the last known host without
+// querying; otherwise it re-queries state, updating the last known host on
+// success and falling back to it on a transient query failure.
+func (g *HostRegistry) resolveHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
+	consAddr := sdk.ConsAddress(val.Address.Bytes()).String()
 
-	// check the cache first
-	if host, ok := g.readHost(valConAddr); ok {
-		return host, nil
+	// Within the rate-limit window, serve the last known host without querying:
+	// provider state can't change faster than one block, so the window bounds
+	// query load while still returning a usable address.
+	g.mu.Lock()
+	last, resolved := g.lastRefresh[consAddr]
+	fallback, hasFallback := g.lastHosts[consAddr]
+	if hasFallback && resolved && g.clock.Since(last) < g.refreshInterval {
+		g.mu.Unlock()
+		return fallback, nil
+	}
+	// Open (or renew) the window now, so that once this query succeeds the
+	// subsequent dials for the same validator are served from the last known host
+	// instead of re-querying every time.
+	g.lastRefresh[consAddr] = g.clock.Now()
+	g.mu.Unlock()
+
+	// Bound the query so a slow or black-holed state node can't add unbounded
+	// latency to the caller.
+	ctx, cancel := context.WithTimeout(ctx, g.queryTimeout)
+	defer cancel()
+	host, err := g.queryHost(ctx, consAddr)
+	if err != nil {
+		// Fall back to the last known host on a transient query failure rather
+		// than failing the caller; the window will trigger another attempt.
+		if hasFallback {
+			g.log.Debug("host query failed; serving last known host", "validator", consAddr, "err", err)
+			return fallback, nil
+		}
+		return "", err
 	}
 
-	// look up the specific validator's host if it's missing from the cache. It might have
-	// been added to the active set since the last refresh.
-	return g.PullHost(ctx, val)
+	g.writeHost(consAddr, host)
+	g.log.Debug("resolved fibre provider host", "validator", consAddr, "host", host)
+	return host, nil
 }
 
-// PullAll pulls all active fibre providers from the query client and caches them, overwriting any existing cached hosts.
+// PullAll pulls all active fibre providers from the query client and records
+// them as the last known hosts, overwriting any existing entries. It stamps the
+// refresh timestamp for each so the warmed hosts are served for one refresh
+// window before the first per-validator re-query.
 func (g *HostRegistry) PullAll(ctx context.Context) error {
 	resp, err := g.queryClient.AllBondedFibreProviders(ctx, &types.QueryAllBondedFibreProvidersRequest{})
 	if err != nil {
@@ -136,68 +183,13 @@ func (g *HostRegistry) PullAll(ctx context.Context) error {
 
 	g.mu.Lock()
 	defer g.mu.Unlock()
+	now := g.clock.Now()
 	for _, provider := range resp.Providers {
-		g.cachedHosts[provider.ValidatorConsensusAddress] = validator.Host(provider.Info.Host)
+		g.lastHosts[provider.ValidatorConsensusAddress] = validator.Host(provider.Info.Host)
+		g.lastRefresh[provider.ValidatorConsensusAddress] = now
 	}
 	g.log.Info("loaded fibre providers", "count", len(resp.Providers))
 	return nil
-}
-
-// PullHost pulls the host for a specific validator from the query client and caches it, overwriting any existing cached host.
-func (g *HostRegistry) PullHost(ctx context.Context, val *core.Validator) (validator.Host, error) {
-	consAddr := sdk.ConsAddress(val.Address.Bytes())
-	host, err := g.queryHost(ctx, consAddr.String())
-	if err != nil {
-		return "", err
-	}
-
-	g.writeHost(consAddr.String(), host)
-	g.log.Debug("pulled fibre provider host", "validator", consAddr.String(), "host", host)
-
-	return host, nil
-}
-
-// RefreshHost implements the [validator.HostRegistry] interface. See the
-// interface for the returned semantics.
-func (g *HostRegistry) RefreshHost(ctx context.Context, val *core.Validator) (changed bool, isValid bool, err error) {
-	consAddr := sdk.ConsAddress(val.Address.Bytes()).String()
-
-	// rate-limit per validator: state cannot change faster than one block, so
-	// re-querying more often is pointless. The timestamp is stamped upfront,
-	// regardless of the query outcome, to bound query load unconditionally.
-	g.mu.Lock()
-	if last, ok := g.lastRefresh[consAddr]; ok && g.clock.Since(last) < g.refreshInterval {
-		g.mu.Unlock()
-		// Rate-limited: skip the query and report no change. changed=false makes
-		// the caller fall back to the original error, isValid is meaningless
-		// without a fresh query, and err=nil because being rate-limited is not a
-		// failure — the host simply hasn't been re-checked this block.
-		return false, false, nil
-	}
-	old := g.cachedHosts[consAddr]
-	g.lastRefresh[consAddr] = g.clock.Now()
-	g.mu.Unlock()
-
-	// Bound the query so a slow or black-holed state node can't add unbounded
-	// latency to the request that triggered the refresh.
-	qctx, cancel := context.WithTimeout(ctx, g.queryTimeout)
-	defer cancel()
-	host, err := g.queryHost(qctx, consAddr)
-	if err != nil {
-		return false, false, err
-	}
-
-	changed = host != old
-	isValid = types.ValidateHost(host.String()) == nil
-	// Cache the true on-chain host even when invalid, so the next refresh sees
-	// new == old and the "changed" signal goes quiet instead of re-firing every
-	// block.
-	if changed {
-		g.writeHost(consAddr, host)
-		g.log.Debug("refreshed fibre provider host", "validator", consAddr, "host", host, "valid", isValid)
-	}
-
-	return changed, isValid, nil
 }
 
 // queryHost queries the fibre provider host for a validator consensus address.
@@ -214,17 +206,9 @@ func (g *HostRegistry) queryHost(ctx context.Context, consAddr string) (validato
 	return validator.Host(resp.Info.Host), nil
 }
 
-// readHost reads a host from the cache with a read lock.
-func (g *HostRegistry) readHost(key string) (validator.Host, bool) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	host, ok := g.cachedHosts[key]
-	return host, ok
-}
-
-// writeHost writes a single host to the cache with a write lock.
+// writeHost records a single last known host under a write lock.
 func (g *HostRegistry) writeHost(key string, host validator.Host) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.cachedHosts[key] = host
+	g.lastHosts[key] = host
 }

--- a/fibre/internal/grpc/host_registry.go
+++ b/fibre/internal/grpc/host_registry.go
@@ -141,9 +141,12 @@ func (g *HostRegistry) resolveHost(ctx context.Context, val *core.Validator) (va
 	g.mu.Lock()
 	last, resolved := g.lastRefresh[consAddr]
 	fallback, hasFallback := g.lastHosts[consAddr]
-	if hasFallback && resolved && g.clock.Since(last) < g.refreshInterval {
+	if resolved && g.clock.Since(last) < g.refreshInterval {
 		g.mu.Unlock()
-		return fallback, nil
+		if hasFallback {
+			return fallback, nil
+		}
+		return "", fmt.Errorf("no host known for validator %s within refresh window", consAddr)
 	}
 	// Open (or renew) the window now, so that once this query succeeds the
 	// subsequent dials for the same validator are served from the last known host

--- a/fibre/internal/grpc/host_registry_e2e_test.go
+++ b/fibre/internal/grpc/host_registry_e2e_test.go
@@ -136,6 +136,12 @@ func (s *IntegrationTestSuite) TestGetHostWithRegistration() {
 
 	require.NoError(t, s.cctx.WaitForNextBlock())
 
+	// TestGetHostEmpty already opened the rate-limit window for this validator
+	// with a "not found" result. Advance past the window so GetHost re-queries
+	// and picks up the registration just submitted, instead of serving the
+	// cached miss.
+	s.clk.Add(2 * time.Minute)
+
 	host, err := s.hostRegistry.GetHost(s.cctx.GoContext(), s.validator)
 	require.NoError(t, err, "GetHost should now succeed")
 	require.NotEmpty(t, host.String())

--- a/fibre/internal/grpc/host_registry_e2e_test.go
+++ b/fibre/internal/grpc/host_registry_e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/grpc/cmtservice"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+	clock "github.com/filecoin-project/go-clock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -32,6 +33,7 @@ type IntegrationTestSuite struct {
 	ecfg         encoding.Config
 	cctx         testnode.Context
 	hostRegistry *grpc.HostRegistry
+	clk          *clock.Mock
 	validator    *core.Validator
 }
 
@@ -44,7 +46,11 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	s.cctx = cctx
 	s.ecfg = encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
-	s.hostRegistry = grpc.NewHostRegistry(types.NewQueryClient(s.cctx.GRPCClient), slog.Default())
+	// Use a mock clock so the rate-limit window can be advanced deterministically
+	// below to force GetHost to re-query.
+	s.clk = clock.NewMock()
+	s.hostRegistry = grpc.NewHostRegistry(types.NewQueryClient(s.cctx.GRPCClient), slog.Default(),
+		grpc.WithClock(s.clk), grpc.WithRefreshInterval(time.Minute))
 	err := s.hostRegistry.Start(t.Context())
 	require.NoError(t, err)
 
@@ -149,13 +155,17 @@ func (s *IntegrationTestSuite) TestGetHostWithRegistration() {
 
 	require.NoError(t, s.cctx.WaitForNextBlock())
 
+	// Within the rate-limit window the previously resolved host is still served,
+	// even though the on-chain host has already changed.
 	host, err = s.hostRegistry.GetHost(s.cctx.GoContext(), s.validator)
 	require.NoError(t, err)
 	require.NotEmpty(t, host.String())
-	require.Equal(t, testHost, host.String(), "host should match what we registered")
+	require.Equal(t, testHost, host.String(), "within the window the cached host should be served")
 
-	host, err = s.hostRegistry.PullHost(s.cctx.GoContext(), s.validator)
+	// Past the window GetHost re-queries and returns the updated host.
+	s.clk.Add(2 * time.Minute)
+	host, err = s.hostRegistry.GetHost(s.cctx.GoContext(), s.validator)
 	require.NoError(t, err)
 	require.NotEmpty(t, host.String())
-	require.Equal(t, testHost2, host.String(), "host should match what we registered")
+	require.Equal(t, testHost2, host.String(), "past the window the freshest host should be resolved")
 }

--- a/fibre/internal/grpc/host_registry_test.go
+++ b/fibre/internal/grpc/host_registry_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -245,86 +244,60 @@ func TestPullAll(t *testing.T) {
 	}
 }
 
-func TestPullHost(t *testing.T) {
-	val := createTestValidator(nil)
-	expectedHost := "validator1.example.com:9090"
-
-	tests := []struct {
-		name    string
-		mock    *mockQueryClient
-		want    string
-		wantErr string
-	}{
-		{
-			name: "success",
-			mock: &mockQueryClient{
-				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
-					return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: expectedHost}, Found: true}, nil
-				},
-			},
-			want: expectedHost,
-		},
-		{
-			name: "not found",
-			mock: &mockQueryClient{
-				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
-					return &types.QueryFibreProviderInfoResponse{Found: false}, nil
-				},
-			},
-			wantErr: "host not found",
-		},
-		{
-			name: "error",
-			mock: &mockQueryClient{
-				fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
-					return nil, errors.New("grpc error")
-				},
-			},
-			wantErr: "grpc error",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			host, err := grpc.NewHostRegistry(tt.mock, slog.Default()).PullHost(context.Background(), val)
-			if tt.wantErr != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.wantErr)
-			} else {
-				require.NoError(t, err)
-				assert.Equal(t, tt.want, host.String())
-			}
-		})
-	}
-}
-
-func TestPullHost_OverwritesCache(t *testing.T) {
+// TestGetHost_RequeriesAfterInterval verifies GetHost serves the warmed host
+// within the rate-limit window and re-queries for the freshest host once the
+// window elapses.
+func TestGetHost_RequeriesAfterInterval(t *testing.T) {
 	val := createTestValidator(nil)
 	consAddr := getConsAddrString(val)
-	firstHost := "validator1.example.com:9090"
-	secondHost := "validator1.example.com:9091"
+	const (
+		firstHost  = "validator1.example.com:9090"
+		secondHost = "validator1.example.com:9091"
+	)
 
-	registry := grpc.NewHostRegistry(&mockQueryClient{
+	infoCalls := 0
+	mock := &mockQueryClient{
 		allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
 			return &types.QueryAllBondedFibreProvidersResponse{
 				Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: firstHost}}},
 			}, nil
 		},
 		fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
+			infoCalls++
 			return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: secondHost}, Found: true}, nil
 		},
-	}, slog.Default())
-	err := registry.Start(t.Context())
+	}
+
+	mockClock := clock.NewMock()
+	const interval = time.Minute
+	registry := grpc.NewHostRegistry(mock, slog.Default(), grpc.WithClock(mockClock), grpc.WithRefreshInterval(interval))
+	require.NoError(t, registry.Start(t.Context())) // warms firstHost via PullAll
+
+	// Within the window: served from the warmed host, no per-validator query.
+	host, err := registry.GetHost(t.Context(), val)
 	require.NoError(t, err)
-
-	host, _ := registry.GetHost(context.Background(), val)
 	assert.Equal(t, firstHost, host.String())
+	assert.Equal(t, 0, infoCalls, "a warm host must be served without a query")
 
-	host, _ = registry.PullHost(context.Background(), val)
-	assert.Equal(t, secondHost, host.String())
+	// Still within the window after a small advance: still served warm.
+	mockClock.Add(interval / 2)
+	host, err = registry.GetHost(t.Context(), val)
+	require.NoError(t, err)
+	assert.Equal(t, firstHost, host.String())
+	assert.Equal(t, 0, infoCalls)
 
-	host, _ = registry.GetHost(context.Background(), val)
+	// Past the window: re-queries and returns the freshest host.
+	mockClock.Add(interval)
+	host, err = registry.GetHost(t.Context(), val)
+	require.NoError(t, err)
 	assert.Equal(t, secondHost, host.String())
+	assert.Equal(t, 1, infoCalls, "an elapsed window must trigger exactly one re-query")
+
+	// The re-queried host is now cached and served within the new window.
+	host, err = registry.GetHost(t.Context(), val)
+	require.NoError(t, err)
+	assert.Equal(t, secondHost, host.String())
+	assert.Equal(t, 1, infoCalls)
 }
 
 func TestHostRegistry_ConcurrentAccess(t *testing.T) {
@@ -362,75 +335,45 @@ func TestHostRegistry_ConcurrentAccess(t *testing.T) {
 	assert.LessOrEqual(t, callCount, 5)
 }
 
-func TestRefreshHost(t *testing.T) {
+// TestGetHost_ServesLastKnownOnQueryError verifies that once the window elapses,
+// a transient query failure falls back to the last known host rather than
+// failing the caller.
+func TestGetHost_ServesLastKnownOnQueryError(t *testing.T) {
 	val := createTestValidator(nil)
 	consAddr := getConsAddrString(val)
-	const (
-		initialHost = "validator1.example.com:9090"
-		changedHost = "validator1.example.com:9091"
-		invalidHost = "invalid-host-without-port"
-	)
+	const warmHost = "validator1.example.com:9090"
 
-	// All RefreshHost calls below are sequential, so plain variables suffice.
-	curHost := initialHost
-	infoCalls := 0
+	fail := false
 	mock := &mockQueryClient{
 		allFibreProvidersFn: func(context.Context, *types.QueryAllBondedFibreProvidersRequest, ...grpc2.CallOption) (*types.QueryAllBondedFibreProvidersResponse, error) {
 			return &types.QueryAllBondedFibreProvidersResponse{
-				Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: initialHost}}},
+				Providers: []types.FibreProvider{{ValidatorConsensusAddress: consAddr, Info: types.FibreProviderInfo{Host: warmHost}}},
 			}, nil
 		},
 		fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
-			infoCalls++
-			return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: curHost}, Found: true}, nil
+			if fail {
+				return nil, errors.New("boom")
+			}
+			return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: warmHost}, Found: true}, nil
 		},
 	}
 
 	mockClock := clock.NewMock()
 	const interval = time.Minute
 	registry := grpc.NewHostRegistry(mock, slog.Default(), grpc.WithClock(mockClock), grpc.WithRefreshInterval(interval))
-	require.NoError(t, registry.Start(t.Context())) // seeds initialHost via PullAll
+	require.NoError(t, registry.Start(t.Context())) // warms warmHost via PullAll
 
-	// 1) host unchanged -> (false, valid).
-	changed, valid, err := registry.RefreshHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.False(t, changed)
-	assert.True(t, valid)
-
-	// 2) host changed on chain, but within the interval -> rate-limited, no query.
-	curHost = changedHost
-	before := infoCalls
-	changed, _, err = registry.RefreshHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.False(t, changed)
-	assert.Equal(t, before, infoCalls, "rate-limited refresh must not query")
-
-	// 3) advance past the interval -> detects the valid change and updates cache.
-	mockClock.Add(interval)
-	changed, valid, err = registry.RefreshHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.True(t, changed)
-	assert.True(t, valid)
+	// Force a re-query past the window, but make the query fail.
+	mockClock.Add(interval * 2)
+	fail = true
 	host, err := registry.GetHost(t.Context(), val)
 	require.NoError(t, err)
-	assert.Equal(t, changedHost, host.String())
-
-	// 4) host changed to an invalid value -> (changed, !valid); cache still updated.
-	mockClock.Add(interval)
-	curHost = invalidHost
-	changed, valid, err = registry.RefreshHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.True(t, changed)
-	assert.False(t, valid)
-
-	// 5) same invalid host on a later block -> signal goes quiet (no re-fire).
-	mockClock.Add(interval)
-	changed, _, err = registry.RefreshHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.False(t, changed, "an unchanged (still invalid) host must not re-fire changed")
+	assert.Equal(t, warmHost, host.String(), "a transient query failure should serve the last known host")
 }
 
-func TestRefreshHost_QueryError(t *testing.T) {
+// TestGetHost_QueryError verifies that a query failure with no previously known
+// host surfaces the error.
+func TestGetHost_QueryError(t *testing.T) {
 	val := createTestValidator(nil)
 
 	var infoCall int
@@ -440,28 +383,17 @@ func TestRefreshHost_QueryError(t *testing.T) {
 			return nil, errors.New("boom")
 		},
 	}
+	registry := grpc.NewHostRegistry(mock, slog.Default())
 
-	mockClock := clock.NewMock()
-	const interval = time.Minute
-	registry := grpc.NewHostRegistry(mock, slog.Default(), grpc.WithClock(mockClock), grpc.WithRefreshInterval(interval))
-
-	changed, valid, err := registry.RefreshHost(t.Context(), val)
+	_, err := registry.GetHost(t.Context(), val)
 	require.Error(t, err)
-	assert.False(t, changed)
-	assert.False(t, valid)
+	assert.Contains(t, err.Error(), "boom")
 	assert.Equal(t, 1, infoCall)
-
-	// The rate-limit timestamp is stamped even on a failed query: a second call
-	// within the interval is suppressed.
-	_, _, err = registry.RefreshHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.Equal(t, 1, infoCall, "failed query must still count against the per-block budget")
 }
 
-// TestRefreshHost_QueryTimeout verifies the on-chain query is bounded by the
-// configured timeout, so a hanging state node can't stall the request that
-// triggered the refresh.
-func TestRefreshHost_QueryTimeout(t *testing.T) {
+// TestGetHost_QueryTimeout verifies the on-chain query is bounded by the
+// configured timeout, so a hanging state node can't stall the caller.
+func TestGetHost_QueryTimeout(t *testing.T) {
 	val := createTestValidator(nil)
 
 	mock := &mockQueryClient{
@@ -474,57 +406,20 @@ func TestRefreshHost_QueryTimeout(t *testing.T) {
 	registry := grpc.NewHostRegistry(mock, slog.Default(), grpc.WithQueryTimeout(50*time.Millisecond))
 
 	done := make(chan struct{})
-	var (
-		changed, valid bool
-		err            error
-	)
+	var err error
 	go func() {
-		changed, valid, err = registry.RefreshHost(context.Background(), val)
+		_, err = registry.GetHost(context.Background(), val)
 		close(done)
 	}()
 
 	select {
 	case <-done:
 	case <-time.After(5 * time.Second):
-		t.Fatal("RefreshHost did not return; query timeout was not enforced")
+		t.Fatal("GetHost did not return; query timeout was not enforced")
 	}
 
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
-	assert.False(t, changed)
-	assert.False(t, valid)
-}
-
-// TestRefreshHost_BoundsConcurrentQueries verifies that under heavy concurrency
-// a validator's host is queried at most once: the rate-limit timestamp is
-// stamped under the lock before the query runs, so only the first caller to win
-// the lock queries and the rest are suppressed.
-func TestRefreshHost_BoundsConcurrentQueries(t *testing.T) {
-	val := createTestValidator(nil)
-	const newHost = "validator1.example.com:9091"
-
-	var infoCalls atomic.Int32
-	mock := &mockQueryClient{
-		fibreProviderInfoFn: func(context.Context, *types.QueryFibreProviderInfoRequest, ...grpc2.CallOption) (*types.QueryFibreProviderInfoResponse, error) {
-			infoCalls.Add(1)
-			return &types.QueryFibreProviderInfoResponse{Info: &types.FibreProviderInfo{Host: newHost}, Found: true}, nil
-		},
-	}
-	registry := grpc.NewHostRegistry(mock, slog.Default(), grpc.WithClock(clock.NewMock()), grpc.WithRefreshInterval(time.Minute))
-
-	var wg sync.WaitGroup
-	for range 50 {
-		wg.Go(func() {
-			_, _, err := registry.RefreshHost(t.Context(), val)
-			assert.NoError(t, err)
-		})
-	}
-	wg.Wait()
-
-	assert.Equal(t, int32(1), infoCalls.Load(), "concurrent refreshes must issue at most one query")
-	host, err := registry.GetHost(t.Context(), val)
-	require.NoError(t, err)
-	assert.Equal(t, newHost, host.String(), "the refreshed host should be applied to the cache")
 }
 
 func TestGetHost_MultipleValidators(t *testing.T) {

--- a/fibre/server_test.go
+++ b/fibre/server_test.go
@@ -78,12 +78,6 @@ func (m *mockStateClient) Start(context.Context) error { return nil }
 func (m *mockStateClient) Stop(context.Context) error  { return nil }
 func (m *mockStateClient) ChainID() string             { return m.chainID }
 
-// RefreshHost reports no change so failed RPCs in tests surface their original
-// error instead of dereferencing the (often nil) embedded HostRegistry.
-func (m *mockStateClient) RefreshHost(context.Context, *core.Validator) (bool, bool, error) {
-	return false, false, nil
-}
-
 func (m *mockStateClient) VerifyPromise(_ context.Context, promise *state.PaymentPromise) (state.VerifiedPromise, error) {
 	expirationTime := promise.CreationTimestamp.Add(1 * time.Hour)
 	if time.Now().After(expirationTime) || time.Now().Equal(expirationTime) {

--- a/fibre/state/caching_client_test.go
+++ b/fibre/state/caching_client_test.go
@@ -38,10 +38,6 @@ func (m *mockClient) GetHost(_ context.Context, _ *core.Validator) (validator.Ho
 	return "", nil
 }
 
-func (m *mockClient) RefreshHost(_ context.Context, _ *core.Validator) (bool, bool, error) {
-	return false, false, nil
-}
-
 func (m *mockClient) ChainID() string { return "test" }
 
 func (m *mockClient) VerifyPromise(context.Context, *state.PaymentPromise) (state.VerifiedPromise, error) {

--- a/fibre/validator/host.go
+++ b/fibre/validator/host.go
@@ -17,17 +17,9 @@ func (h Host) String() string {
 
 // HostRegistry provides a mapping from validators to their network hosts.
 type HostRegistry interface {
-	// GetHost returns the network host for a given validator.
-	// Returns an error if the validator's host cannot be determined.
+	// GetHost returns the network host for a given validator, resolving the
+	// freshest on-chain address. Implementations may rate-limit the underlying
+	// state query per validator and serve the last known host within that
+	// window. Returns an error if the validator's host cannot be determined.
 	GetHost(context.Context, *core.Validator) (Host, error)
-
-	// RefreshHost re-queries state for the validator's host, rate-limited to
-	// once per block time per validator. It returns:
-	//   - changed: the on-chain host differs from the cached one (the cache is
-	//     updated to the new value, valid or not);
-	//   - isValid: the new host passes host validation;
-	//   - err: the query failed (changed and isValid are false).
-	// When rate-limited, it returns (false, false, nil) without querying.
-	// Callers should retry against the validator only when changed && isValid.
-	RefreshHost(context.Context, *core.Validator) (changed bool, isValid bool, err error)
 }


### PR DESCRIPTION
# What was done:

Collapsed two stacked caches into one.

- ClientCache is now the only real cache (dialed clients). It no longer depends on HostRegistry.
- HostRegistry became a rate-limited resolver: GetHost returns the freshest host, re-querying state at most once per validator per window and serving the last-known host within that window. Start warms hosts via PullAll. Removed RefreshHost and PullHost.
- validator.HostRegistry interface simplified to a single method (GetHost).
- ClientCache.Request simplified: on an unreachable peer it just evicts + re-dials once (the host is re-resolved through NewClientFn), dropping the changed/valid signaling.

Resolves #7410 