### PR TITLE
feat(fibre): add timeout for fibre requests

### DIFF
--- a/fibre/client.go
+++ b/fibre/client.go
@@ -10,6 +10,7 @@ import (
 
 	fibregrpc "github.com/celestiaorg/celestia-app/v10/fibre/internal/grpc"
 	"github.com/celestiaorg/celestia-app/v10/fibre/state"
+	"github.com/celestiaorg/celestia-app/v10/fibre/validator"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	clock "github.com/filecoin-project/go-clock"
 	"go.opentelemetry.io/otel/trace"
@@ -92,6 +93,19 @@ func NewClient(kr keyring.Keyring, cfg ClientConfig) (*Client, error) {
 // ChainID returns the chain ID resolved during [Start].
 func (c *Client) ChainID() string {
 	return c.state.ChainID()
+}
+
+// validatorSet fetches the validator set bounded by [ClientConfig.RPCTimeout]
+// so a hung app node cannot stall an Upload/Download before any shard is
+// exchanged. A height of 0 returns the head set; a non-zero height returns the
+// set at that height.
+func (c *Client) validatorSet(ctx context.Context, height uint64) (validator.Set, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.Config.RPCTimeout)
+	defer cancel()
+	if height > 0 {
+		return c.state.GetByHeight(ctx, height)
+	}
+	return c.state.Head(ctx)
 }
 
 // Await waits for all ongoing [Client.Upload]/[Client.Download] operations to complete.

--- a/fibre/client_config.go
+++ b/fibre/client_config.go
@@ -33,8 +33,11 @@ type ClientConfig struct {
 	MaxMessageSize int
 
 	// RPCTimeout bounds a single UploadShard/DownloadShard call to one peer
-	// (dial + RPC). Sheds black-holed peers below the kernel's ~75s TCP SYN
-	// retry window. See [DefaultClientConfig] for the default value.
+	// (dial + RPC), and also the initial validator-set lookup against the
+	// celestia-app node (state.Head / state.GetByHeight), so a hung app node
+	// cannot stall an Upload/Download before any shard is exchanged. Sheds
+	// black-holed peers below the kernel's ~75s TCP SYN retry window. See
+	// [DefaultClientConfig] for the default value.
 	RPCTimeout time.Duration
 
 	// HostRefreshInterval is the minimum time between on-chain host re-queries

--- a/fibre/client_download.go
+++ b/fibre/client_download.go
@@ -85,12 +85,7 @@ func (c *Client) Download(ctx context.Context, id BlobID, opts ...DownloadOption
 	// Prefer the exact validator set at height when provided; otherwise fall
 	// back to the head set — stakes are stable enough that this only affects
 	// the number of validators contacted, not correctness.
-	var valSet validator.Set
-	if opt.height > 0 {
-		valSet, err = c.state.GetByHeight(ctx, opt.height)
-	} else {
-		valSet, err = c.state.Head(ctx)
-	}
+	valSet, err := c.validatorSet(ctx, opt.height)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get validator set")

--- a/fibre/client_timeout_test.go
+++ b/fibre/client_timeout_test.go
@@ -1,0 +1,181 @@
+package fibre_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	fibregrpc "github.com/celestiaorg/celestia-app/v10/fibre/internal/grpc"
+	"github.com/celestiaorg/celestia-app/v10/fibre/state"
+	"github.com/celestiaorg/celestia-app/v10/fibre/validator"
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/stretchr/testify/require"
+	grpclib "google.golang.org/grpc"
+)
+
+// hangingSetGetter blocks Head/GetByHeight until the context is cancelled,
+// simulating a hung app node. It returns the context's error so callers see
+// the reason the query was aborted (deadline vs. cancellation).
+type hangingSetGetter struct{}
+
+func (hangingSetGetter) Head(ctx context.Context) (validator.Set, error) {
+	<-ctx.Done()
+	return validator.Set{}, ctx.Err()
+}
+
+func (hangingSetGetter) GetByHeight(ctx context.Context, _ uint64) (validator.Set, error) {
+	<-ctx.Done()
+	return validator.Set{}, ctx.Err()
+}
+
+// newClientWithStateGetter builds and starts a client whose validator-set
+// lookups are served by getter, letting tests drive the state-query timeout and
+// cancellation paths without any real app node.
+func newClientWithStateGetter(t *testing.T, cfg fibre.ClientConfig, getter validator.SetGetter) *fibre.Client {
+	t.Helper()
+	cfg.StateClientFn = func() (state.Client, error) {
+		return &mockStateClient{SetGetter: getter, chainID: "celestia"}, nil
+	}
+	client, err := fibre.NewClient(makeTestKeyring(t), cfg)
+	require.NoError(t, err)
+	require.NoError(t, client.Start(t.Context()))
+	t.Cleanup(func() { require.NoError(t, client.Stop(context.Background())) })
+	return client
+}
+
+// A hung app node must abort the Upload's initial validator-set lookup at
+// RPCTimeout rather than blocking forever, so a caller with no deadline of its
+// own is still protected.
+func TestClientUploadStateQueryTimeoutAbortsFast(t *testing.T) {
+	cfg := fibre.DefaultClientConfig()
+	cfg.RPCTimeout = 50 * time.Millisecond
+
+	client := newClientWithStateGetter(t, cfg, hangingSetGetter{})
+	blob := makeTestBlobV0(t, 256*1024)
+
+	start := time.Now()
+	_, err := client.Upload(context.Background(), testNamespace, blob)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "getting validator set")
+	require.GreaterOrEqual(t, elapsed, cfg.RPCTimeout)
+	require.Less(t, elapsed, time.Second)
+}
+
+// The same guarantee holds for Download's initial validator-set lookup.
+func TestClientDownloadStateQueryTimeoutAbortsFast(t *testing.T) {
+	cfg := fibre.DefaultClientConfig()
+	cfg.RPCTimeout = 50 * time.Millisecond
+
+	client := newClientWithStateGetter(t, cfg, hangingSetGetter{})
+	blob := makeTestBlobV0(t, 256*1024)
+
+	start := time.Now()
+	_, err := client.Download(context.Background(), blob.ID())
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Contains(t, err.Error(), "getting validator set")
+	require.Less(t, elapsed, time.Second)
+}
+
+// A caller cancellation must unwind the operation promptly and win over the
+// (larger) RPC timeout — WithTimeout only tightens.
+func TestClientUploadCallerCancellationReturnsPromptly(t *testing.T) {
+	cfg := fibre.DefaultClientConfig()
+	cfg.RPCTimeout = 5 * time.Second
+
+	client := newClientWithStateGetter(t, cfg, hangingSetGetter{})
+	blob := makeTestBlobV0(t, 256*1024)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	_, err := client.Upload(ctx, testNamespace, blob)
+	elapsed := time.Since(start)
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Less(t, elapsed, time.Second)
+}
+
+// hangingUploadClient blocks in UploadShard until its RPC context is cancelled,
+// then records that it observed the cancellation. Shared across all validators
+// so the test can assert at least one in-flight peer RPC was cancelled.
+type hangingUploadClient struct {
+	started   chan struct{}
+	startOnce *sync.Once
+	sawCancel *atomic.Bool
+}
+
+func (h *hangingUploadClient) UploadShard(ctx context.Context, _ *types.UploadShardRequest, _ ...grpclib.CallOption) (*types.UploadShardResponse, error) {
+	h.startOnce.Do(func() { close(h.started) })
+	<-ctx.Done()
+	h.sawCancel.Store(true)
+	return nil, ctx.Err()
+}
+
+func (h *hangingUploadClient) DownloadShard(context.Context, *types.DownloadShardRequest, ...grpclib.CallOption) (*types.DownloadShardResponse, error) {
+	return nil, context.Canceled
+}
+
+func (h *hangingUploadClient) Close() error { return nil }
+
+// Cancelling the caller mid-upload must propagate into the in-flight per-peer
+// RPC context. That propagation is the mechanism by which a cancellation
+// reaches the server so it can stop its own commit.
+func TestClientUploadCancellationPropagatesToPeerRPC(t *testing.T) {
+	validators, _ := makeTestValidators(t, 10)
+	valSet := validator.Set{ValidatorSet: core.NewValidatorSet(validators), Height: 100}
+
+	cfg := fibre.DefaultClientConfig()
+	// Large RPC timeout so the caller cancel — not a timeout — is what unblocks
+	// the hung peer RPC.
+	cfg.RPCTimeout = 30 * time.Second
+
+	started := make(chan struct{})
+	var startOnce sync.Once
+	var sawCancel atomic.Bool
+	cfg.NewClientFn = func(context.Context, *core.Validator) (fibregrpc.Client, error) {
+		return &hangingUploadClient{started: started, startOnce: &startOnce, sawCancel: &sawCancel}, nil
+	}
+
+	client := newClientWithStateGetter(t, cfg, &mockValidatorSetGetter{set: valSet})
+	blob := makeTestBlobV0(t, 256*1024)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errc := make(chan error, 1)
+	go func() {
+		_, err := client.Upload(ctx, testNamespace, blob)
+		errc <- err
+	}()
+
+	select {
+	case <-started:
+	case err := <-errc:
+		t.Fatalf("upload returned before reaching the peer: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload RPC never reached the peer")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errc:
+		require.Error(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("upload did not return after cancellation")
+	}
+	require.True(t, sawCancel.Load(), "in-flight peer RPC context was not cancelled")
+}

--- a/fibre/client_upload.go
+++ b/fibre/client_upload.go
@@ -86,7 +86,7 @@ func (c *Client) Upload(ctx context.Context, ns share.Namespace, blob *Blob, opt
 	defer func() { uploadDone(err) }()
 
 	// 1) get validator set
-	valSet, err := c.state.Head(ctx)
+	valSet, err := c.validatorSet(ctx, 0)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to get validator set")

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -81,6 +81,16 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	storePutStart := time.Now()
 	if err := s.store.Put(ctx, promise, req.Shard, pruneAt); err != nil {
 		s.metrics.observeStoreOp(ctx, s.metrics.storePutDuration, storePutStart, false)
+		// A cancelled/expired client context means the store deliberately
+		// skipped the commit; report it as such rather than as an Internal
+		// error so the caller (and metrics) can tell it apart from a real
+		// storage failure.
+		if ctxErr := context.Cause(ctx); ctxErr != nil {
+			log.WarnContext(ctx, "store upload aborted by client cancellation", "error", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "store upload aborted")
+			return nil, status.Error(cancellationCode(ctxErr), fmt.Sprintf("store upload aborted: %v", err))
+		}
 		log.ErrorContext(ctx, "failed to store upload data", "error", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to store upload data")
@@ -114,6 +124,15 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	return &types.UploadShardResponse{
 		ValidatorSignature: signature,
 	}, nil
+}
+
+// cancellationCode maps a context cancellation cause to the matching gRPC
+// status code so a deadline and an explicit cancel are reported distinctly.
+func cancellationCode(cause error) grpccodes.Code {
+	if errors.Is(cause, context.DeadlineExceeded) {
+		return grpccodes.DeadlineExceeded
+	}
+	return grpccodes.Canceled
 }
 
 // verifyPromise verifies given proto of [PaymentPromise] and returns unmarshaled form with its hash.

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -138,7 +138,13 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 // sweeps at pruneAt.
 // Puts for the same commitment but different promises are stored independently
 // without deduplication.
-func (s *Store) Put(_ context.Context, promise *PaymentPromise, shard *types.BlobShard, pruneAt time.Time) error {
+func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.BlobShard, pruneAt time.Time) error {
+	// Respect a client that has already gone away: skip the staging write
+	// entirely rather than doing work whose result nobody is waiting for.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("aborting store put: %w", err)
+	}
+
 	promiseHash, err := promise.Hash()
 	if err != nil {
 		return fmt.Errorf("getting promise hash: %w", err)
@@ -148,7 +154,7 @@ func (s *Store) Put(_ context.Context, promise *PaymentPromise, shard *types.Blo
 	if err != nil {
 		return fmt.Errorf("writing shard tmp: %w", err)
 	}
-	if err := s.commitAndPublish(promise, promiseHash, tmp, pruneAt); err != nil {
+	if err := s.commitAndPublish(ctx, promise, promiseHash, tmp, pruneAt); err != nil {
 		_ = s.fs.Remove(tmp)
 		return err
 	}
@@ -158,7 +164,7 @@ func (s *Store) Put(_ context.Context, promise *PaymentPromise, shard *types.Blo
 // commitAndPublish renames tmp into the canonical shards/ path, then writes
 // pebble metadata for the published shard. On any error tmp is left in
 // place for the caller to remove.
-func (s *Store) commitAndPublish(promise *PaymentPromise, promiseHash []byte, tmp string, pruneAt time.Time) error {
+func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, promiseHash []byte, tmp string, pruneAt time.Time) error {
 	promiseProto, err := promise.ToProto()
 	if err != nil {
 		return fmt.Errorf("converting payment promise to proto: %w", err)
@@ -179,6 +185,14 @@ func (s *Store) commitAndPublish(promise *PaymentPromise, promiseHash []byte, tm
 	}
 	if err := batch.Set(pruneKey(pruneAt, promise.Commitment, promiseHash), nil, pebbledb.NoSync); err != nil {
 		return fmt.Errorf("putting prune index: %w", err)
+	}
+
+	// Last safe point to honor a client cancellation: the batch is still only
+	// staged in memory and the tmp file is still unpublished, so we can drop
+	// both cleanly. Past the Rename+Commit below the write is durable and
+	// cannot be undone.
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("aborting store commit: %w", err)
 	}
 
 	// Publish the file, then commit the marker that makes it discoverable.

--- a/fibre/store_cancel_test.go
+++ b/fibre/store_cancel_test.go
@@ -1,0 +1,54 @@
+package fibre_test
+
+import (
+	"context"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	"github.com/stretchr/testify/require"
+)
+
+// A cancelled request context must abort Put before the pebble commit: nothing
+// is published or committed, and no staged tmp file is left behind. This is the
+// server honoring a client cancellation and stopping the commit while the data
+// is still only staged.
+func TestStorePutHonorsCancellation(t *testing.T) {
+	store, path := makeTestStore(t)
+
+	blob := makeTestBlobV0(t, 256)
+	shard := makeShardFrom(t, blob, 0, 1)
+	promise := makeTestPaymentPromise(100, blob.ID())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := store.Put(ctx, promise, shard, promise.CreationTimestamp)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+
+	// Not committed: the commitment is not discoverable.
+	_, err = store.Get(context.Background(), blob.ID().Commitment())
+	require.ErrorIs(t, err, fibre.ErrStoreNotFound)
+
+	// No shard file was published under shards/.
+	promiseHash, err := promise.Hash()
+	require.NoError(t, err)
+	shardFile := filepath.Join(path, "shards", blob.ID().Commitment().String()+"-"+hex.EncodeToString(promiseHash))
+	_, statErr := os.Stat(shardFile)
+	require.True(t, os.IsNotExist(statErr), "no shard file should be published on cancel")
+
+	// No staged tmp leaked under staging/.
+	entries, err := os.ReadDir(filepath.Join(path, "staging"))
+	require.NoError(t, err)
+	require.Empty(t, entries, "staging must be clean after a cancelled Put")
+
+	// A subsequent, uncancelled Put of the same data still succeeds and is
+	// discoverable — the aborted attempt left no poisoning state behind.
+	require.NoError(t, store.Put(context.Background(), promise, shard, promise.CreationTimestamp))
+	got, err := store.Get(context.Background(), blob.ID().Commitment())
+	require.NoError(t, err)
+	require.Len(t, got.Rows, 2)
+}


### PR DESCRIPTION
## What
- **Client:** bound the initial validator-set lookup (`state.Head`/`GetByHeight`) with the existing `RPCTimeout`. It was the only blocking call left unbounded,  so a hung app node could stall an Upload/Download before any shard moved.
- **Server:** the store now respects the request context. `Store.Put`/`commitAndPublish` check `ctx.Err()` before the pebble `batch.Commit`, so a  cancelled client stops the commit while the data is still staged — the tmp  file is dropped, nothing is published. Past the commit the write is durable. The handler reports this as `Canceled`/`DeadlineExceeded` instead of `Internal`.

Resolves https://linear.app/celestia/issue/PROTOCO-1329/introduce-fibre-client-timeouts