### PR TITLE
test: add benchmark to compare fibre vs core tree implementations

### DIFF
--- a/pkg/rsema1d/merkle/comparison_bench_test.go
+++ b/pkg/rsema1d/merkle/comparison_bench_test.go
@@ -1,0 +1,143 @@
+package merkle_test
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/merkle"
+	cmtmerkle "github.com/cometbft/cometbft/crypto/merkle"
+)
+
+// benchCase is one (leaf count, leaf size) point on the comparison grid.
+type benchCase struct {
+	name      string
+	numLeaves int
+	leafSize  int
+}
+
+// rowTreeCases model the row tree: many large data-row leaves. Counts stop at
+// 16384 because 65536 large leaves would allocate tens of GB across b.N.
+var rowTreeCases = []benchCase{
+	{"rows_256x2KiB", 256, 2 << 10},
+	{"rows_1024x2KiB", 1024, 2 << 10},
+	{"rows_4096x2KiB", 4096, 2 << 10},
+	{"rows_16384x2KiB", 16384, 2 << 10},
+}
+
+// rlcTreeCases model the RLC tree: K tiny 16-byte leaves. Here hashing overhead,
+// not leaf bytes, dominates — the regime core guards with its small-leaf
+// parallelization threshold (minItemsForSmallLeaves).
+var rlcTreeCases = []benchCase{
+	{"rlc_1024x16B", 1024, 16},
+	{"rlc_4096x16B", 4096, 16},
+	{"rlc_16384x16B", 16384, 16},
+	{"rlc_65536x16B", 65536, 16},
+}
+
+// makeLeaves builds n leaves of the given size with deterministic content.
+func makeLeaves(n, size int) [][]byte {
+	leaves := make([][]byte, n)
+	for i := range leaves {
+		leaf := make([]byte, size)
+		for j := range leaf {
+			leaf[j] = byte((i*31 + j) % 251)
+		}
+		leaves[i] = leaf
+	}
+	return leaves
+}
+
+// requireSameRoots fails the benchmark unless fibre, core-sequential and
+// core-parallel agree, so every timed loop below is measuring equivalent work.
+func requireSameRoots(b *testing.B, leaves [][]byte) {
+	b.Helper()
+	fibre := merkle.NewTree(leaves, runtime.NumCPU()).Root()
+	coreSeq := cmtmerkle.HashFromByteSlices(leaves)
+	corePar := cmtmerkle.ParallelHashFromByteSlices(leaves)
+	if !bytes.Equal(fibre[:], coreSeq) || !bytes.Equal(fibre[:], corePar) {
+		b.Fatalf("root mismatch (%d leaves):\n  fibre=%x\n  core/seq=%x\n  core/par=%x",
+			len(leaves), fibre, coreSeq, corePar)
+	}
+}
+
+// BenchmarkCompareRoot times root construction for both implementations across
+// the row-tree and RLC-tree workloads. Sub-benchmark names are
+// <workload>/<impl>, e.g. rows_4096x2KiB/fibre_par, so `benchstat` can line the
+// four implementations up per workload.
+func BenchmarkCompareRoot(b *testing.B) {
+	workers := runtime.NumCPU()
+	for _, tc := range append(append([]benchCase{}, rowTreeCases...), rlcTreeCases...) {
+		leaves := makeLeaves(tc.numLeaves, tc.leafSize)
+		requireSameRoots(b, leaves)
+
+		b.Run(tc.name+"/fibre_seq", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = merkle.NewTree(leaves, 1)
+			}
+		})
+		b.Run(tc.name+"/fibre_par", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = merkle.NewTree(leaves, workers)
+			}
+		})
+		b.Run(tc.name+"/core_seq", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = cmtmerkle.HashFromByteSlices(leaves)
+			}
+		})
+		b.Run(tc.name+"/core_par", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_ = cmtmerkle.ParallelHashFromByteSlices(leaves)
+			}
+		})
+	}
+}
+
+// BenchmarkCompareProofs times generating an inclusion proof for every leaf
+// (the coder/verifier pattern): fibre builds the tree then streams all proofs
+// via Tree.Proofs, core uses ParallelProofsFromByteSlices which returns the
+// root and every proof in one call.
+func BenchmarkCompareProofs(b *testing.B) {
+	workers := runtime.NumCPU()
+	// Proofs materialize len(leaves) aunt paths, so keep large-leaf counts modest.
+	cases := []benchCase{
+		{"rows_1024x2KiB", 1024, 2 << 10},
+		{"rows_4096x2KiB", 4096, 2 << 10},
+		{"rlc_4096x16B", 4096, 16},
+		{"rlc_16384x16B", 16384, 16},
+	}
+	for _, tc := range cases {
+		leaves := makeLeaves(tc.numLeaves, tc.leafSize)
+		requireSameRoots(b, leaves)
+		positions := make([]int, tc.numLeaves)
+		for i := range positions {
+			positions[i] = i
+		}
+
+		b.Run(tc.name+"/fibre_seq", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				tree := merkle.NewTree(leaves, 1)
+				_ = tree.Proofs(positions, func(int, [][]byte) {})
+			}
+		})
+		b.Run(tc.name+"/fibre_par", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				tree := merkle.NewTree(leaves, workers)
+				_ = tree.Proofs(positions, func(int, [][]byte) {})
+			}
+		})
+		b.Run(tc.name+"/core_par", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				_, _ = cmtmerkle.ParallelProofsFromByteSlices(leaves)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Resolves https://linear.app/celestia/issue/PROTOCO-1829/benchmark-which-tree-implementation-is-faster-fibre-or-core-and-have 

This test benchmarks the fibre Merkle tree against celestia-core's tree to answer issue #7318 : "Benchmark which tree implementation is faster: fibre or core and have only one." The core package also ships a parallel builder (ParallelHashFromByteSlices / ParallelProofsFromByteSlices) that we could adopt to consolidate on one implementation, so it is measured alongside the sequential one. 

 Dimensions mirror the two real rsema1d workloads:
  - row tree: K+N leaves over data rows (large leaves) 
  - RLC tree: K leaves over 16-byte GF(2^128) values (tiny leaves)

Notes:
 -  fibre is measured through NewTree, which allocates its node buffer, so it matches core's allocating APIs. Fibre additionally offers zero-alloc buffer-reuse APIs (RootFromFunc, NewTreeFuncInto) with no core equivalent;  those are the real coder/verifier hot path and are benched separately in tree_bench_test.go. This file is the apples-to-apples allocating comparison.
 - core parallelizes off runtime.NumCPU() internally; fibre takes an explicit  worker count, so the parallel fibre case is given runtime.NumCPU() to match.

Results (Apple M3 Max, 14 workers). benchstat means over 6 runs, sec/op -  lower is better:

| workload         | fibre_seq | fibre_par | core_seq | core_par |
|------------------|-----------|-----------|----------|----------|
| rows_256x2KiB    | 198.2µs   | 197.8µs   | 209.9µs  | 188.5µs  |
| rows_1024x2KiB   | 860.3µs   | 308.7µs   | 836.3µs  | 588.5µs  |
| rows_4096x2KiB   | 3.402ms   | 680.0µs   | 3.218ms  | 1.960ms  |
| rows_16384x2KiB  | 12.63ms   | 1.968ms*  | 13.18ms  | 7.410ms  |
| rlc_1024x16B     | 115.6µs   | 102.5µs   | 129.8µs  | 298.7µs  |
| rlc_4096x16B     | 457.6µs   | 261.8µs   | 530.3µs  | 907.7µs  |
| rlc_16384x16B    | 1.825ms   | 623.1µs   | 2.171ms  | 3.140ms  |
| rlc_65536x16B    | 7.320ms   | 1.580ms   | 8.429ms  | 11.84ms  |

Results:
- fibre_par is fastest on every real rsema1d size and scales cleanly with worker count: ~1.9x core_par at 1024 rows, ~3.8x at 16384 rows, ~5.3x core_seq at 65536 RLC leaves. The lone exception is rows_256 (188µs core_par vs 198µs fibre_par, ~5% and within noise), where the tree is too small for fibre's fan-out to pay off.
 - core's parallel builder helps for large leaves but LOSES to its own sequential path for the small-leaf/high-count regime the RLC tree lives in (rlc_65536: core_par 11.84ms > core_seq 8.43ms), because its per-node channel work-stealing and allocations swamp the tiny hash work.
- fibre allocates a constant handful of times (flat node buffer + worker fan-out) vs core's O(numLeaves) allocations — 5 vs 131,072 at 65536 leaves - which matters for the coder/verifier hot path.

So, core's parallel_tree.go does not win any measured rsema1d workload.


Next steps:
* investigate the impact on prepare/process proposal times on validator equivalent servers
* investigate improvements on the propagation reactor creating proofs

Will create a relevant task in celestia-core.