### PR TITLE
ci: verify goreleaser-cross image exists before merge

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -23,6 +23,9 @@ jobs:
   markdown-linter:
     uses: ./.github/workflows/markdown-linter.yml
 
+  goreleaser-image-check:
+    uses: ./.github/workflows/goreleaser-image-check.yml
+
   build:
     uses: ./.github/workflows/build.yml
 

--- a/.github/workflows/goreleaser-image-check.yml
+++ b/.github/workflows/goreleaser-image-check.yml
@@ -1,0 +1,16 @@
+name: goreleaser-image-check
+
+# Verifies that the goreleaser-cross Docker image pinned via GOLANG_CROSS_VERSION
+# in the Makefile actually exists. goreleaser-cross does not publish an image for
+# every Go patch version, so a bad bump would otherwise only surface at release
+# time as a silent failure that ships no binaries (see #7356).
+on:
+  workflow_call:
+
+jobs:
+  goreleaser-image-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+      - name: Verify the goreleaser-cross image exists
+        run: make check-goreleaser-image

--- a/Makefile
+++ b/Makefile
@@ -509,6 +509,11 @@ adr-gen:
 	@curl -sSL https://raw.githubusercontent.com/celestiaorg/.github/main/adr-template.md > docs/architecture/adr-template.md
 .PHONY: adr-gen
 
+## check-goreleaser-image: Verify the pinned goreleaser-cross Docker image exists so releases don't silently ship without binaries.
+check-goreleaser-image:
+	@./scripts/check-goreleaser-image.sh ${GOLANG_CROSS_VERSION}
+.PHONY: check-goreleaser-image
+
 ## goreleaser-check: Check the .goreleaser.yaml config file.
 goreleaser-check:
 	@if [ ! -f ".release-env" ]; then \

--- a/scripts/check-goreleaser-image.sh
+++ b/scripts/check-goreleaser-image.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Usage: ./scripts/check-goreleaser-image.sh <version>
+#
+# Verifies that the goreleaser-cross Docker image exists for the given tag.
+# goreleaser-cross does not publish an image for every Go patch version (e.g. it
+# skipped v1.26.1), so bumping GOLANG_CROSS_VERSION to a non-existent tag makes
+# the release job fail silently and ship no binaries. This check fails loudly at
+# PR time instead.
+
+set -euo pipefail
+
+version=${1:?"usage: $0 <version>"}
+repository="goreleaser/goreleaser-cross"
+image="ghcr.io/${repository}:${version}"
+
+echo "Checking that ${image} exists..."
+
+# Retry on transient network failures so a blip doesn't fail the check.
+curl_opts=(--retry 5 --retry-connrefused --retry-delay 5)
+
+# GHCR requires a bearer token even for anonymous pulls of public images.
+token=$(curl -fsSL "${curl_opts[@]}" "https://ghcr.io/token?scope=repository:${repository}:pull" |
+    sed -E 's/.*"token":"([^"]+)".*/\1/')
+
+code=$(curl -sSL "${curl_opts[@]}" -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${token}" \
+    -H "Accept: application/vnd.oci.image.index.v1+json" \
+    -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+    "https://ghcr.io/v2/${repository}/manifests/${version}")
+
+if [ "${code}" = "200" ]; then
+    echo "OK: ${image} exists."
+    exit 0
+fi
+
+if [ "${code}" = "404" ]; then
+    echo "ERROR: ${image} does not exist."
+    echo "goreleaser-cross does not publish an image for every Go patch version."
+    echo "Pick a published tag from https://github.com/goreleaser/goreleaser-cross/pkgs/container/goreleaser-cross"
+    echo "and update GOLANG_CROSS_VERSION in the Makefile."
+    exit 1
+fi
+
+echo "ERROR: unexpected HTTP status ${code} while checking ${image}."
+echo "Could not determine whether the image exists; failing to be safe."
+exit 1


### PR DESCRIPTION
## Problem

`goreleaser-cross` does not publish an image for every Go patch version (it skipped `v1.26.1`). Bumping `GOLANG_CROSS_VERSION` to a non-existent tag makes the release job fail silently with `manifest unknown` and ship no binaries — the exact failure mode behind #7353.

## Fix

- `scripts/check-goreleaser-image.sh` verifies `ghcr.io/goreleaser/goreleaser-cross:<tag>` exists via the GHCR registry API (anonymous token + `HEAD`-style manifest check, with curl retries).
- `make check-goreleaser-image` runs it against the same `GOLANG_CROSS_VERSION` the release job uses, so the check can't drift from the pin.
- A reusable `goreleaser-image-check` workflow runs `make check-goreleaser-image` on every PR (wired into `ci-release`), so a bad bump fails CI loudly before merge instead of only surfacing at release time.

Verified locally: passes for the current pin `v1.26.2` and fails for the offending `v1.26.1`.

Closes #7356