### PR TITLE
test(docker-e2e): skip TestArabicaLoad when Arabica is unreachable

### DIFF
--- a/test/docker-e2e/e2e_arabica_load_test.go
+++ b/test/docker-e2e/e2e_arabica_load_test.go
@@ -84,7 +84,15 @@ func (s *CelestiaTestSuite) TestArabicaLoad() {
 	require.NoError(t, err, "failed to create RPC client")
 
 	status, err := rpcClient.Status(ctx)
-	require.NoError(t, err, "failed to query Arabica status")
+	if err != nil {
+		// Arabica is an external, best-effort public devnet. When its RPC
+		// endpoint is transiently unavailable (e.g. HTTP 503) this initial
+		// status query fails before any celestia-app behavior is exercised, so
+		// treat it as an infrastructure skip rather than a test failure. Real
+		// regressions still surface in the block-time assertions below, which
+		// only run once the network is reachable.
+		t.Skipf("skipping Arabica load test: Arabica endpoint %s unavailable: %v", arabicaCfg.RPCs[0], err)
+	}
 	startHeight := status.SyncInfo.LatestBlockHeight
 	t.Logf("Connected to Arabica at height %d", startHeight)
 


### PR DESCRIPTION
## Motivation

`TestArabicaLoad` runs against the external, best-effort public Arabica devnet. The last four consecutive Nightly Tests runs hard-failed on the **initial** status query with `503 Service Unavailable` from `rpc.celestia-arabica-11.com` — before any celestia-app behavior is exercised. The endpoint is only intermittently unavailable (it responds `200` right now), so these are pure infrastructure flakes, not regressions.

No tracking issue exists; this addresses recurring Nightly Tests noise.

## Change

Treat an unreachable Arabica endpoint on the initial status query as a `t.Skip` rather than a failure. The block-time assertions that actually catch regressions still run whenever the network is reachable, so real signal is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)