### PR TITLE
feat: execute SDK msgs on cached context

### DIFF
--- a/app/benchmarks/benchmark_ibc_update_client_test.go
+++ b/app/benchmarks/benchmark_ibc_update_client_test.go
@@ -162,6 +162,7 @@ func benchmarkIBCPrepareProposalUpdateClient(b *testing.B, numberOfValidators, c
 	prepareProposalReq := types.RequestPrepareProposal{
 		Txs:    rawTxs,
 		Height: testApp.LastBlockHeight() + 1,
+		Time:   time.Now(),
 	}
 
 	b.ResetTimer()
@@ -211,6 +212,7 @@ func benchmarkIBCProcessProposalUpdateClient(b *testing.B, numberOfValidators, c
 	prepareProposalReq := types.RequestPrepareProposal{
 		Txs:    rawTxs,
 		Height: testApp.LastBlockHeight() + 1,
+		Time:   time.Now(),
 	}
 
 	prepareProposalResp, err := testApp.PrepareProposal(&prepareProposalReq)
@@ -220,6 +222,7 @@ func benchmarkIBCProcessProposalUpdateClient(b *testing.B, numberOfValidators, c
 	processProposalReq := types.RequestProcessProposal{
 		Txs:          prepareProposalResp.Txs,
 		Height:       testApp.LastBlockHeight() + 1,
+		Time:         prepareProposalReq.Time,
 		DataRootHash: prepareProposalResp.DataRootHash,
 		SquareSize:   prepareProposalResp.SquareSize,
 	}
@@ -272,7 +275,7 @@ func generateIBCUpdateClientTransaction(b *testing.B, numberOfValidators, number
 		require.NoError(b, err)
 		rawTxs = append(rawTxs, rawTx)
 		accountSequence++
-		err = signer.SetSequence(account, accountSequence)
+		err = signer.SetSequence(account, accountSequence+uint64(offsetAccountSequence))
 		require.NoError(b, err)
 	}
 

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/celestiaorg/go-square/v4/tx"
 	tmbytes "github.com/cometbft/cometbft/libs/bytes"
 	coretypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -17,12 +18,14 @@ import (
 // rules before adding it the square.
 type FilteredSquareBuilder struct {
 	handler  sdk.AnteHandler
+	router   baseapp.MessageRouter
 	txConfig client.TxConfig
 	builder  *square.Builder
 }
 
 func NewFilteredSquareBuilder(
 	handler sdk.AnteHandler,
+	router baseapp.MessageRouter,
 	txConfig client.TxConfig,
 	maxSquareSize,
 	subtreeRootThreshold int,
@@ -33,6 +36,7 @@ func NewFilteredSquareBuilder(
 	}
 	return &FilteredSquareBuilder{
 		handler:  handler,
+		router:   router,
 		txConfig: txConfig,
 		builder:  builder,
 	}, nil
@@ -88,9 +92,6 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 			continue
 		}
 
-		// Set the tx size on the context before calling the AnteHandler
-		ctx = ctx.WithTxBytes(tx)
-
 		msgTypes := msgTypes(sdkTx)
 		if sdkMessageCount+len(sdkTx.GetMsgs()) > appconsts.MaxSDKMessages {
 			logger.Debug("skipping tx because the max SDK message count was reached", "tx", tmbytes.HexBytes(coretypes.Tx(tx).Hash()))
@@ -102,7 +103,13 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 			continue
 		}
 
-		ctx, err = fsb.handler(ctx, sdkTx, false)
+		// Branch the state per tx so that a dropped tx leaves no partial
+		// writes behind for the txs that follow it.
+		txCtx, commit := ctx.CacheContext()
+		// Set the tx size on the context before calling the AnteHandler
+		txCtx = txCtx.WithTxBytes(tx)
+
+		txCtx, err = fsb.handler(txCtx, sdkTx, false)
 		// either the transaction is invalid (ie incorrect nonce) and we
 		// simply want to remove this tx, or we're catching a panic from one
 		// of the anteHandlers which is logged.
@@ -120,6 +127,23 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 			}
 			continue
 		}
+
+		// Drop the tx if its messages fail; its branch is discarded, so no
+		// writes leak to later txs.
+		if err := executeTxMsgs(txCtx, sdkTx, fsb.router); err != nil {
+			logger.Error(
+				"filtering transaction that failed message execution",
+				"tx", tmbytes.HexBytes(coretypes.Tx(tx).Hash()),
+				"error", err,
+				"msgs", msgTypes,
+			)
+			telemetry.IncrCounter(1, "prepare_proposal", "exec_failed_std_txs")
+			if err := fsb.builder.RevertLastTx(); err != nil {
+				logger.Error("reverting last transaction", "error", err)
+			}
+			continue
+		}
+		commit()
 
 		sdkMessageCount += len(sdkTx.GetMsgs())
 		normalTxs[n] = tx

--- a/app/filtered_square_builder_fibre_test.go
+++ b/app/filtered_square_builder_fibre_test.go
@@ -208,7 +208,7 @@ func TestFilteredSquareBuilderFillWithPayForFibre(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fsb, err := NewFilteredSquareBuilder(tc.anteHandler, txConfig, 64, 64)
+			fsb, err := NewFilteredSquareBuilder(tc.anteHandler, nil, txConfig, 64, 64)
 			require.NoError(t, err)
 
 			db := dbm.NewMemDB()
@@ -259,7 +259,7 @@ func TestFilteredSquareBuilderFillMaxPayForFibreMessages(t *testing.T) {
 		pffTxs[i] = blobfactory.UnsignedPayForFibreTx(t, txConfig)
 	}
 
-	fsb, err := NewFilteredSquareBuilder(alwaysPass, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	require.NoError(t, err)
 
 	db := dbm.NewMemDB()

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -246,7 +246,7 @@ func TestFilteredSquareBuilderFillMaxTxBytes(t *testing.T) {
 	// configured block max bytes.
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fsb, err := NewFilteredSquareBuilder(alwaysPass, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+			fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 			require.NoError(t, err)
 
 			db := dbm.NewMemDB()

--- a/app/msg_execution.go
+++ b/app/msg_execution.go
@@ -1,0 +1,42 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// executeTxMsgs runs an ante-validated tx's messages on a branch of ctx,
+// committing the writes only if all succeed. The tx's ante effects (fee,
+// nonce) are untouched either way.
+//
+// Proposal handlers call this so a later blob tx is checked against the balance
+// an earlier MsgSend already spent. Without it the blob tx passes ante-only
+// validation but fails fee deduction in FinalizeBlock, committing blobs unpaid.
+//
+// A nil router skips execution; only tests pass nil.
+func executeTxMsgs(ctx sdk.Context, sdkTx sdk.Tx, router baseapp.MessageRouter) (err error) {
+	if router == nil {
+		return nil
+	}
+	// Message handlers panic on out of gas; fail the tx instead of crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered panic while executing messages: %v", r)
+		}
+	}()
+	cacheCtx, writeCache := ctx.CacheContext()
+	cacheCtx = cacheCtx.WithEventManager(sdk.NewEventManager())
+	for _, msg := range sdkTx.GetMsgs() {
+		handler := router.Handler(msg)
+		if handler == nil {
+			return fmt.Errorf("no message handler found for %s", sdk.MsgTypeURL(msg))
+		}
+		if _, err := handler(cacheCtx, msg); err != nil {
+			return err
+		}
+	}
+	writeCache()
+	return nil
+}

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -35,6 +35,7 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 
 	fsb, err := NewFilteredSquareBuilder(
 		handler,
+		app.MsgServiceRouter(),
 		app.encodingConfig.TxConfig,
 		app.MaxEffectiveSquareSize(ctx),
 		appconsts.SubtreeRootThreshold,

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -134,6 +134,15 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 				return reject(), nil
 			}
 
+			// Unlike prepare, a failing tx isn't dropped: FinalizeBlock commits
+			// it (failed result, fee paid), so keep the ante effects and
+			// continue. MsgPayForFibre txs aren't executed, matching prepare.
+			if pffCount == 0 {
+				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
+					app.Logger().Debug("proposal tx failed message execution", "index", idx, "err", execErr)
+				}
+			}
+
 			// we do not need to perform further checks on this transaction,
 			// since it has no PFB
 			continue

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -6,8 +6,10 @@ import (
 	"testing"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v10/app"
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/app/params"
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v10/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
@@ -235,6 +237,19 @@ func TestPrepareProposalFiltering(t *testing.T) {
 	// 3 transactions over MaxTxSize limit
 	largeTxs := coretypes.Txs(testutil.SendTxsWithAccounts(t, testApp, enc.TxConfig, kr, 1000, accounts[0], accounts[:3], testutil.ChainID, user.SetMemo(largeString))).ToSliceOfBytes()
 
+	// a MsgSend draining accounts[3] followed by a blob tx from the same
+	// account. The blob tx can no longer pay its fee once the send executes,
+	// so it must be pruned (a raw blob tx staying in the square would get DA
+	// for free).
+	drainPayerBalance := testApp.BankKeeper.GetBalance(testApp.NewContext(true), testfactory.GetAddress(kr, accounts[3]), params.BondDenom).Amount.Uint64()
+	drainSendTx, underfundedBlobTx := buildDrainSendAndBlobTx(t, testApp, kr, accounts[3], accounts[0], drainPayerBalance-drainSendFee)
+
+	// two blob txs from accounts[4]: the first spends the whole balance on its
+	// fee, so the second can no longer pay its fee. No normal tx is involved,
+	// so this exercises fee deduction accumulating across blob txs alone.
+	blobPayerBalance := testApp.BankKeeper.GetBalance(testApp.NewContext(true), testfactory.GetAddress(kr, accounts[4]), params.BondDenom).Amount.Uint64()
+	firstBlobTx, underfundedSecondBlobTx := buildTwoBlobTxs(t, testApp, kr, accounts[4], blobPayerBalance)
+
 	type test struct {
 		name      string
 		txs       func() [][]byte
@@ -292,6 +307,20 @@ func TestPrepareProposalFiltering(t *testing.T) {
 				return largeTxs // All txs are over MaxTxSize limit
 			},
 			prunedTxs: largeTxs,
+		},
+		{
+			name: "blob tx underfunded by a preceding send is pruned",
+			txs: func() [][]byte {
+				return [][]byte{drainSendTx, underfundedBlobTx}
+			},
+			prunedTxs: [][]byte{underfundedBlobTx},
+		},
+		{
+			name: "second blob tx from the same payer is pruned when it cannot pay its fee",
+			txs: func() [][]byte {
+				return [][]byte{firstBlobTx, underfundedSecondBlobTx}
+			},
+			prunedTxs: [][]byte{underfundedSecondBlobTx},
 		},
 	}
 
@@ -476,4 +505,65 @@ func repeat[T any](n int, val T) []T {
 		result[i] = val
 	}
 	return result
+}
+
+const (
+	drainSendFee uint64 = 10_000
+	drainBlobFee uint64 = 10_000
+)
+
+// buildDrainSendAndBlobTx returns a MsgSend transferring sendAmount from payer
+// to receiver at the payer's current sequence, followed by a blob tx from the
+// same payer at the next sequence. It is used to reproduce the paid-DA bypass
+// where an earlier send drains the account paying for a later blob tx.
+func buildDrainSendAndBlobTx(t *testing.T, testApp *app.App, kr keyring.Keyring, payer, receiver string, sendAmount uint64) (sendTxBz, blobTxBz []byte) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	payerAddr := testfactory.GetAddress(kr, payer)
+	receiverAddr := testfactory.GetAddress(kr, receiver)
+	payerAcc := testutil.DirectQueryAccount(testApp, payerAddr)
+
+	sendSigner, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID,
+		user.NewAccount(payer, payerAcc.GetAccountNumber(), payerAcc.GetSequence()))
+	require.NoError(t, err)
+	sendMsg := banktypes.NewMsgSend(payerAddr, receiverAddr,
+		sdk.NewCoins(sdk.NewCoin(params.BondDenom, sdkmath.NewIntFromUint64(sendAmount))))
+	sendTxBz, _, err = sendSigner.CreateTx([]sdk.Msg{sendMsg}, user.SetGasLimit(1_000_000), user.SetFee(drainSendFee))
+	require.NoError(t, err)
+
+	blobSigner, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID,
+		user.NewAccount(payer, payerAcc.GetAccountNumber(), payerAcc.GetSequence()+1))
+	require.NoError(t, err)
+	blob, err := share.NewV0Blob(share.RandomBlobNamespace(), []byte("x"))
+	require.NoError(t, err)
+	blobTxBz, _, err = blobSigner.CreatePayForBlobs(payer, []*share.Blob{blob}, user.SetGasLimit(500_000), user.SetFee(drainBlobFee))
+	require.NoError(t, err)
+
+	return sendTxBz, blobTxBz
+}
+
+// buildTwoBlobTxs returns two blob txs from the same payer at consecutive
+// sequences. The first pays firstFee (used to spend the whole balance), the
+// second pays drainBlobFee, so the second cannot pay its fee once the first is
+// deducted.
+func buildTwoBlobTxs(t *testing.T, testApp *app.App, kr keyring.Keyring, payer string, firstFee uint64) (firstTxBz, secondTxBz []byte) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	payerAcc := testutil.DirectQueryAccount(testApp, testfactory.GetAddress(kr, payer))
+
+	firstSigner, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID,
+		user.NewAccount(payer, payerAcc.GetAccountNumber(), payerAcc.GetSequence()))
+	require.NoError(t, err)
+	firstBlob, err := share.NewV0Blob(share.RandomBlobNamespace(), []byte("x"))
+	require.NoError(t, err)
+	firstTxBz, _, err = firstSigner.CreatePayForBlobs(payer, []*share.Blob{firstBlob}, user.SetGasLimit(500_000), user.SetFee(firstFee))
+	require.NoError(t, err)
+
+	secondSigner, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID,
+		user.NewAccount(payer, payerAcc.GetAccountNumber(), payerAcc.GetSequence()+1))
+	require.NoError(t, err)
+	secondBlob, err := share.NewV0Blob(share.RandomBlobNamespace(), []byte("x"))
+	require.NoError(t, err)
+	secondTxBz, _, err = secondSigner.CreatePayForBlobs(payer, []*share.Blob{secondBlob}, user.SetGasLimit(500_000), user.SetFee(drainBlobFee))
+	require.NoError(t, err)
+
+	return firstTxBz, secondTxBz
 }

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v10/app"
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/app/params"
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v10/pkg/da"
 	"github.com/celestiaorg/celestia-app/v10/pkg/user"
@@ -370,6 +372,118 @@ func TestProcessProposal_ProposalWithInconsistentBlobTxFails(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, res.Status, "ProcessProposal should accept original blob")
 	})
+}
+
+// TestProcessProposalRejectsUnderfundedBlobTx is a regression test for the
+// paid-DA bypass: a proposal where an earlier MsgSend drains the account
+// paying for a later blob tx must be rejected, since the blob tx's fee
+// deduction fails once the send is executed against the same intra-block state
+// FinalizeBlock uses. Prepare proposal filters this block; this test asserts
+// that validators reject it even if a malicious proposer builds it anyway.
+func TestProcessProposalRejectsUnderfundedBlobTx(t *testing.T) {
+	accounts := testfactory.GenerateAccounts(2)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	balance := testApp.BankKeeper.GetBalance(testApp.NewContext(true), testfactory.GetAddress(kr, accounts[0]), params.BondDenom).Amount.Uint64()
+	sendTx, blobTx := buildDrainSendAndBlobTx(t, testApp, kr, accounts[0], accounts[1], balance-drainSendFee)
+
+	txs := [][]byte{sendTx, blobTx}
+	res, err := testApp.ProcessProposal(&abci.RequestProcessProposal{
+		Height:       testApp.LastBlockHeight() + 1,
+		Time:         time.Now(),
+		Txs:          txs,
+		DataRootHash: calculateNewDataHash(t, txs),
+		SquareSize:   2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_REJECT, res.Status)
+}
+
+// TestProcessProposalRejectsUnderfundedSecondBlobTx asserts the PFB-only case:
+// two blob txs from the same payer where the first spends the whole balance on
+// its fee. Fee deduction accumulates across blob txs (ante runs on shared
+// state), so the second can no longer pay and the block is rejected — no
+// normal tx is required to trigger this.
+func TestProcessProposalRejectsUnderfundedSecondBlobTx(t *testing.T) {
+	accounts := testfactory.GenerateAccounts(1)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	balance := testApp.BankKeeper.GetBalance(testApp.NewContext(true), testfactory.GetAddress(kr, accounts[0]), params.BondDenom).Amount.Uint64()
+	firstBlobTx, secondBlobTx := buildTwoBlobTxs(t, testApp, kr, accounts[0], balance)
+
+	txs := [][]byte{firstBlobTx, secondBlobTx}
+	res, err := testApp.ProcessProposal(&abci.RequestProcessProposal{
+		Height:       testApp.LastBlockHeight() + 1,
+		Time:         time.Now(),
+		Txs:          txs,
+		DataRootHash: calculateNewDataHash(t, txs),
+		SquareSize:   2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_REJECT, res.Status)
+}
+
+// TestProcessProposalToleratesFailingNormalTx asserts that a normal tx which
+// pays its fee but fails message execution is not grounds for rejecting the
+// block. FinalizeBlock commits such a tx with a failed result and its fee
+// deducted, so process proposal must accept it to stay consistent.
+func TestProcessProposalToleratesFailingNormalTx(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(3)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	// A MsgSend of the full balance: the ante handler still deducts the fee,
+	// but message execution then fails with insufficient funds.
+	payerAddr := testfactory.GetAddress(kr, accounts[0])
+	payerAcc := testutil.DirectQueryAccount(testApp, payerAddr)
+	balance := testApp.BankKeeper.GetBalance(testApp.NewContext(true), payerAddr, params.BondDenom).Amount.Uint64()
+	sendSigner, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID,
+		user.NewAccount(accounts[0], payerAcc.GetAccountNumber(), payerAcc.GetSequence()))
+	require.NoError(t, err)
+	sendMsg := banktypes.NewMsgSend(payerAddr, testfactory.GetAddress(kr, accounts[1]),
+		sdk.NewCoins(sdk.NewCoin(params.BondDenom, sdkmath.NewIntFromUint64(balance))))
+	sendTx, _, err := sendSigner.CreateTx([]sdk.Msg{sendMsg}, user.SetGasLimit(1_000_000), user.SetFee(drainSendFee))
+	require.NoError(t, err)
+
+	// An unrelated, well-funded blob tx follows it in the block.
+	blobberAddr := testfactory.GetAddress(kr, accounts[2])
+	blobberAcc := testutil.DirectQueryAccount(testApp, blobberAddr)
+	blobSigner, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID,
+		user.NewAccount(accounts[2], blobberAcc.GetAccountNumber(), blobberAcc.GetSequence()))
+	require.NoError(t, err)
+	blob, err := share.NewV0Blob(share.RandomBlobNamespace(), []byte("x"))
+	require.NoError(t, err)
+	blobTx, _, err := blobSigner.CreatePayForBlobs(accounts[2], []*share.Blob{blob}, user.SetGasLimit(500_000), user.SetFee(drainBlobFee))
+	require.NoError(t, err)
+
+	txs := [][]byte{sendTx, blobTx}
+	dataSquare, err := square.Construct(txs, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	require.NoError(t, err)
+	squareSize, err := dataSquare.Size()
+	require.NoError(t, err)
+
+	height := testApp.LastBlockHeight() + 1
+	blockTime := time.Now()
+	res, err := testApp.ProcessProposal(&abci.RequestProcessProposal{
+		Height:       height,
+		Time:         blockTime,
+		Txs:          txs,
+		DataRootHash: calculateNewDataHash(t, txs),
+		SquareSize:   uint64(squareSize),
+	})
+	require.NoError(t, err)
+	require.Equal(t, abci.ResponseProcessProposal_ACCEPT, res.Status)
+
+	// FinalizeBlock parity: the send fails, the blob tx succeeds.
+	finalizeResp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Height: height,
+		Time:   blockTime,
+		Txs:    txs,
+	})
+	require.NoError(t, err)
+	require.Len(t, finalizeResp.TxResults, 2)
+	require.NotEqualValues(t, abci.CodeTypeOK, finalizeResp.TxResults[0].Code)
+	require.EqualValues(t, abci.CodeTypeOK, finalizeResp.TxResults[1].Code)
 }
 
 func TestProcessProposalCappingNumberOfMessages(t *testing.T) {

--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -46,6 +46,7 @@ func (a *App) OutOfOrderPrepareProposal(req *abci.RequestPrepareProposal) (*abci
 
 	fsb, err := app.NewFilteredSquareBuilder(
 		handler,
+		a.MsgServiceRouter(),
 		a.GetEncodingConfig().TxConfig,
 		a.MaxEffectiveSquareSize(sdkCtx),
 		appconsts.SubtreeRootThreshold,


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-1947/medium-state-changing-predecessor-transactions-let-later-blobtxs-pass
