### PR TITLE
chore(deps): bump github/codeql-action to v4.36.3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
 
@@ -55,6 +55,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Motivation

Dependabot split the `github/codeql-action` v4.36.3 bump into two separate PRs — #7505 (`init`) and #7507 (`analyze`) — each touching only one step. Bumping just one leaves `init` and `analyze` at mismatched versions, so the analyze post-action step fails with:

```
Loaded a configuration file for version '4.36.2', but running version '4.36.3'
```

This PR bumps both steps together in a single commit so the versions stay in sync, which is why the two dependabot PRs can be closed in favor of this one.

Supersedes #7505 and #7507.