### PR TITLE
fix(fibre): verify PP ChainID matches executing chain

### DIFF
--- a/app/test/fibre_settlement_test.go
+++ b/app/test/fibre_settlement_test.go
@@ -28,7 +28,9 @@ func TestFibreSettlementRoutesToFeeCollector(t *testing.T) {
 	funder := testfactory.GenerateAccounts(1)[0]
 	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), funder)
 
-	ctx := testApp.NewContext(true).WithBlockTime(time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC))
+	ctx := testApp.NewContext(true).
+		WithBlockTime(time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)).
+		WithChainID("test-chain")
 
 	moduleAddr := testApp.AccountKeeper.GetModuleAddress(fibretypes.ModuleName)
 	feeCollectorAddr := testApp.AccountKeeper.GetModuleAddress(authtypes.FeeCollectorName)

--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -312,6 +312,10 @@ func (k Keeper) ParseProcessedPaymentsByTimeKey(key []byte) (processedAt time.Ti
 // The isTimeout parameter indicates whether this is being called for timeout processing,
 // which skips expiration and height validation to allow processing older promises.
 func (k Keeper) validatePaymentPromiseStatefulInternal(ctx sdk.Context, promise *types.PaymentPromise, isTimeout bool) (time.Time, error) {
+	if promise.ChainId != ctx.ChainID() {
+		return time.Time{}, fmt.Errorf("payment promise chain_id %q does not match executing chain %q", promise.ChainId, ctx.ChainID())
+	}
+
 	params := k.GetParams(ctx)
 	currentTime := ctx.BlockTime()
 	creationTime := promise.CreationTimestamp

--- a/x/fibre/keeper/keeper_test.go
+++ b/x/fibre/keeper/keeper_test.go
@@ -52,7 +52,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 
 	mockBankKeeper := &MockBankKeeper{}
 	authority := authtypes.NewModuleAddress("gov").String()
-	suite.ctx = sdk.NewContext(stateStore, cmtproto.Header{Time: time.Now().UTC(), Height: 100}, false, nil)
+	suite.ctx = sdk.NewContext(stateStore, cmtproto.Header{ChainID: "test-chain", Time: time.Now().UTC(), Height: 100}, false, nil)
 	mockStakingKeeper := &MockStakingKeeper{}
 	suite.keeper = keeper.NewKeeper(suite.cdc, storeKey, mockBankKeeper, mockStakingKeeper, authority)
 	suite.keeper.SetParams(suite.ctx, types.DefaultParams())

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -63,7 +63,7 @@ func (suite *MsgServerTestSuite) SetupTest() {
 	suite.bankKeeper = &MockBankKeeper{}
 	suite.stakingKeeper = &MockStakingKeeper{}
 	suite.authority = authtypes.NewModuleAddress("gov").String()
-	suite.ctx = sdk.NewContext(stateStore, cmtproto.Header{Time: time.Now().UTC(), Height: 100}, false, nil)
+	suite.ctx = sdk.NewContext(stateStore, cmtproto.Header{ChainID: "test-chain", Time: time.Now().UTC(), Height: 100}, false, nil)
 	suite.keeper = keeper.NewKeeper(suite.cdc, storeKey, suite.bankKeeper, suite.stakingKeeper, suite.authority)
 	suite.keeper.SetParams(suite.ctx, types.DefaultParams())
 	suite.msgServer = keeper.NewMsgServerImpl(*suite.keeper)
@@ -554,6 +554,38 @@ func (suite *MsgServerTestSuite) TestPaymentPromiseTimeout() {
 		suite.Nil(resp)
 		suite.Contains(err.Error(), "insufficient balance")
 	})
+
+	suite.T().Run("rejects payment promise signed for a different chain", func(t *testing.T) {
+		foreignPrivKey := secp256k1.GenPrivKey()
+		foreignPubKey := *foreignPrivKey.PubKey().(*secp256k1.PubKey)
+		foreignSigner := sdk.AccAddress(foreignPrivKey.PubKey().Address()).String()
+
+		// A promise validly signed for another chain, timed out, with funded
+		// escrow on the executing chain. Every other check passes, so only the
+		// chain-binding check can reject it.
+		foreignPromise := suite.createPaymentPromiseWithChainID(foreignPubKey, foreignPrivKey, oldTime, "other-chain")
+
+		suite.keeper.SetEscrowAccount(suite.ctx, types.EscrowAccount{
+			Signer:           foreignSigner,
+			Balance:          requiredAmount,
+			AvailableBalance: requiredAmount,
+		})
+
+		msg := &types.MsgPaymentPromiseTimeout{
+			Signer:         processor,
+			PaymentPromise: foreignPromise,
+		}
+
+		resp, err := suite.msgServer.PaymentPromiseTimeout(suite.ctx, msg)
+		suite.Error(err)
+		suite.Nil(resp)
+		suite.Contains(err.Error(), "does not match executing chain")
+
+		// Escrow must be untouched.
+		escrow, found := suite.keeper.GetEscrowAccount(suite.ctx, foreignSigner)
+		suite.True(found)
+		suite.Equal(requiredAmount, escrow.Balance)
+	})
 }
 
 // moduleTransfer records a SendCoinsFromModuleToModule call.
@@ -895,6 +927,24 @@ func (suite *MsgServerTestSuite) createPaymentPromiseWithTime(signerPubKey secp2
 	signBytes, err := pp.SignBytes()
 	suite.NoError(err)
 
+	signature, err := privKey.Sign(signBytes)
+	suite.NoError(err)
+	paymentPromise.Signature = signature
+
+	return paymentPromise
+}
+
+// createPaymentPromiseWithChainID builds a validly signed promise stamped with
+// an arbitrary chain_id. The signature covers chain_id, so the promise is
+// re-signed after the field is overridden.
+func (suite *MsgServerTestSuite) createPaymentPromiseWithChainID(signerPubKey secp256k1.PubKey, privKey *secp256k1.PrivKey, creationTime time.Time, chainID string) types.PaymentPromise {
+	paymentPromise := suite.createPaymentPromiseWithTime(signerPubKey, privKey, creationTime)
+	paymentPromise.ChainId = chainID
+
+	pp := fibre.PaymentPromise{}
+	suite.NoError(pp.FromProto(&paymentPromise))
+	signBytes, err := pp.SignBytes()
+	suite.NoError(err)
 	signature, err := privKey.Sign(signBytes)
 	suite.NoError(err)
 	paymentPromise.Signature = signature


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-2075/paymentpromisetimeout-accepts-foreign-chain-promises-medium
