### PR TITLE
fix(fibre): reject oversized RLC field before decoding

### DIFF
--- a/fibre/client_download.go
+++ b/fibre/client_download.go
@@ -9,6 +9,7 @@ import (
 	fibregrpc "github.com/celestiaorg/celestia-app/v10/fibre/internal/grpc"
 	"github.com/celestiaorg/celestia-app/v10/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d"
+	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/field"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/rlc"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"go.opentelemetry.io/otel/attribute"
@@ -173,7 +174,7 @@ func (c *Client) downloadFrom(
 		return err
 	}
 
-	proofs, rlc, err := parseShard(resp.GetShard())
+	proofs, rlc, err := parseShard(resp.GetShard(), state.cfg.OriginalRows)
 	if err != nil {
 		log.WarnContext(ctx, "failed to parse shard", "error", err)
 		span.RecordError(err)
@@ -243,7 +244,7 @@ var errDownloaded = errors.New("downloaded")
 
 // parseShard extracts row proofs and the parsed RLC vector from a BlobShard
 // response.
-func parseShard(shard *types.BlobShard) ([]*rsema1d.RowProof, rlc.Vector, error) {
+func parseShard(shard *types.BlobShard, originalRows int) ([]*rsema1d.RowProof, rlc.Vector, error) {
 	if shard == nil {
 		return nil, nil, fmt.Errorf("shard response is nil")
 	}
@@ -265,12 +266,16 @@ func parseShard(shard *types.BlobShard) ([]*rsema1d.RowProof, rlc.Vector, error)
 		}
 	}
 
+	// reject an RLC field of the wrong size before decoding, mirroring the
+	// server upload check: v0 has exactly one GF128 value per original row.
+	expectedRLCBytes := originalRows * field.GF128Size
+	if len(shard.GetRlcs()) != expectedRLCBytes {
+		return nil, nil, fmt.Errorf("expected %d RLC bytes, got %d", expectedRLCBytes, len(shard.GetRlcs()))
+	}
+
 	rlcs, err := rlc.Unmarshal(shard.GetRlcs())
 	if err != nil {
 		return nil, nil, err
-	}
-	if len(rlcs) == 0 {
-		return nil, nil, errors.New("validator returned no RLCs")
 	}
 
 	return proofs, rlcs, nil

--- a/fibre/download_test.go
+++ b/fibre/download_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/fibre/internal/row"
 	"github.com/celestiaorg/celestia-app/v10/fibre/validator"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d"
+	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/field"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/rlc"
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	cmted25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	core "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/require"
@@ -77,6 +79,20 @@ func newTestDownload(t *testing.T, expected ...int) (*download, []*rsema1d.RowPr
 	require.NoError(t, err)
 	t.Cleanup(d.freeSlab)
 	return d, proofs, rlc
+}
+
+// TestParseShardRejectsOversizedRLCs checks that parseShard rejects a
+// wrong-sized RLC field on byte length before decoding it, mirroring the
+// server upload check. v0 requires exactly one GF128 value per original row.
+func TestParseShardRejectsOversizedRLCs(t *testing.T) {
+	shard := &types.BlobShard{
+		Rows: []*types.BlobRow{{}},                  // one row so the earlier row checks pass
+		Rlcs: make([]byte, 2*testK*field.GF128Size), // twice the expected size, still 16-byte aligned
+	}
+
+	_, _, err := parseShard(shard, testK)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "RLC bytes, got")
 }
 
 // A malicious/custom uploader can serve a shard whose row size exceeds the

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d"
+	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/field"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/rlc"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"go.opentelemetry.io/otel/attribute"
@@ -238,6 +239,13 @@ func (s *Server) verifyShard(ctx context.Context, blobCfg BlobConfig, promise *P
 	if int(promise.UploadSize) != expectedUploadSize {
 		return fmt.Errorf("upload size mismatch: promise has %d, but row size %d * %d original rows = %d",
 			promise.UploadSize, rowSize, blobCfg.OriginalRows, expectedUploadSize)
+	}
+
+	// v0 requires exactly one GF128 value per original row. byte length is fixed and
+	// known up front. 
+	expectedRLCBytes := blobCfg.OriginalRows * field.GF128Size
+	if len(shard.GetRlcs()) != expectedRLCBytes {
+		return fmt.Errorf("expected %d RLC bytes, got %d", expectedRLCBytes, len(shard.GetRlcs()))
 	}
 
 	rlcs, err := rlc.Unmarshal(shard.GetRlcs())

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -242,7 +242,7 @@ func (s *Server) verifyShard(ctx context.Context, blobCfg BlobConfig, promise *P
 	}
 
 	// v0 requires exactly one GF128 value per original row. byte length is fixed and
-	// known up front. 
+	// known up front.
 	expectedRLCBytes := blobCfg.OriginalRows * field.GF128Size
 	if len(shard.GetRlcs()) != expectedRLCBytes {
 		return fmt.Errorf("expected %d RLC bytes, got %d", expectedRLCBytes, len(shard.GetRlcs()))

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -2,6 +2,7 @@ package fibre_test
 
 import (
 	"crypto/ed25519"
+	"fmt"
 	"testing"
 	"time"
 
@@ -170,6 +171,20 @@ func TestServerUploadShard(t *testing.T) {
 			check: func(t *testing.T, resp *types.UploadShardResponse, err error) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), "exceeds maximum")
+				require.Nil(t, resp)
+			},
+		},
+		{
+			name: "OversizedRLCs",
+			requestModifier: func(req *types.UploadShardRequest) {
+				// increase the RLC field to a larger 16-byte-aligned size. The
+				// handler must reject it on length before decoding it into a
+				// vector, since v0 requires exactly one GF128 value per row.
+				req.Shard.Rlcs = make([]byte, len(req.Shard.Rlcs)*2)
+			},
+			check: func(t *testing.T, resp *types.UploadShardResponse, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "RLC bytes, got")
 				require.Nil(t, resp)
 			},
 		},

--- a/fibre/server_upload_test.go
+++ b/fibre/server_upload_test.go
@@ -2,7 +2,6 @@ package fibre_test
 
 import (
 	"crypto/ed25519"
-	"fmt"
 	"testing"
 	"time"
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-2078/oversized-rlc-field-decoded-before-the-size-check-low
