### PR TITLE
fix(app): PrepareProposal must match Core's protobuf byte accounting

### DIFF
--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -53,6 +53,11 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 	// Required because the data square can be configured larger than
 	// block.MaxBytes.
 	//
+	// Size each tx by its protobuf-framed length (tag + length prefix + bytes),
+	// matching how CometBFT validates the returned list. Raw len(tx) under-counts
+	// the framing, so a list that fits here could still be rejected by Core. The
+	// kept list is a subset of what's admitted here, so the bound carries over.
+	//
 	// A non-positive maxTxBytes means "no limit" — CometBFT always sets a
 	// positive value in production, but some tests construct requests
 	// directly and leave it at zero.
@@ -61,11 +66,12 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 		var currentTxBytes int64
 		filteredByMaxBytes = make([][]byte, 0, len(txs))
 		for _, tx := range txs {
-			if currentTxBytes+int64(len(tx)) > maxTxBytes {
+			txProtoSize := coretypes.ComputeProtoSizeForTxs([]coretypes.Tx{tx})
+			if currentTxBytes+txProtoSize > maxTxBytes {
 				logger.Debug("skipping tx because it was too large to fit in the block", "tx", tmbytes.HexBytes(coretypes.Tx(tx).Hash()))
 				continue
 			}
-			currentTxBytes += int64(len(tx))
+			currentTxBytes += txProtoSize
 			filteredByMaxBytes = append(filteredByMaxBytes, tx)
 		}
 	}

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/celestiaorg/go-square/v4/tx"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	coretypes "github.com/cometbft/cometbft/types"
 	dbm "github.com/cosmos/cosmos-db"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -154,13 +155,19 @@ func TestFilteredSquareBuilderFillMaxTxBytes(t *testing.T) {
 		return ctx, nil
 	}
 
+	// Fill budgets each tx by its protobuf-encoded size (the same figure Core
+	// validates against), not raw len(tx), so the boundaries below use that.
+	framedSize := func(tx []byte) int64 {
+		return coretypes.ComputeProtoSizeForTxs([]coretypes.Tx{tx})
+	}
+
 	// Three txs of identical size for cumulative max tx bytes tests.
 	tx1 := newNormalTx(t, txConfig)
 	tx2 := newNormalTx(t, txConfig)
 	tx3 := newNormalTx(t, txConfig)
 	require.Equal(t, len(tx1), len(tx2))
 	require.Equal(t, len(tx1), len(tx3))
-	normalTxSize := int64(len(tx1))
+	normalTxSize := framedSize(tx1)
 
 	// A small and a larger tx for the "continue, not break" test: a high-priority
 	// tx that exceeds max tx bytes should be skipped, but a smaller subsequent
@@ -169,14 +176,14 @@ func TestFilteredSquareBuilderFillMaxTxBytes(t *testing.T) {
 	largeTx := newNormalTxWithMemo(t, txConfig, strings.Repeat("a", 1024))
 	require.Less(t, len(smallTx), len(largeTx))
 
-	// A blob tx — the full marshaled size (inner tx + blob data) must be the
+	// A blob tx — the full encoded size (inner tx + blob data) must be the
 	// number used for the byte budget, not just the inner tx size.
 	blobTx := blobfactory.UnsignedBlobTx(t)
-	blobTxSize := int64(len(blobTx))
+	blobTxSize := framedSize(blobTx)
 
 	// A blob tx with a real MsgPayForBlobs inside (non-nil inner SDK tx).
 	signedBlobTx := newBlobTx(t, txConfig)
-	signedBlobTxSize := int64(len(signedBlobTx))
+	signedBlobTxSize := framedSize(signedBlobTx)
 
 	tests := []struct {
 		name       string
@@ -211,7 +218,7 @@ func TestFilteredSquareBuilderFillMaxTxBytes(t *testing.T) {
 		{
 			name:       "smaller later tx fits after larger one is skipped",
 			txs:        [][]byte{largeTx, smallTx},
-			maxTxBytes: int64(len(smallTx)),
+			maxTxBytes: framedSize(smallTx),
 			wantKept:   1,
 		},
 		{

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -316,6 +316,48 @@ func TestPrepareProposalFiltering(t *testing.T) {
 	}
 }
 
+func TestPrepareProposalRespectsCoreProtoByteBudget(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(6)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	// several valid MsgSend txs, each from a distinct account.
+	sendTxs := coretypes.Txs(testutil.SendTxsWithAccounts(
+		t, testApp, enc.TxConfig, kr, 1000, accounts[0], accounts[1:], testutil.ChainID,
+	)).ToSliceOfBytes()
+
+	framedSize := func(txs [][]byte) int64 {
+		return coretypes.ComputeProtoSizeForTxs(coretypes.ToTxs(txs))
+	}
+
+	// Give the proposer a budget equal to the raw byte total of all candidates.
+	// This is the trap: raw len(tx) accounting sees the whole list fitting
+	// exactly, but the framed size is larger, so the full list does NOT fit and
+	// the proposer must drop at least one tx.
+	budget := int64(0)
+	for _, tx := range sendTxs {
+		budget += int64(len(tx))
+	}
+	require.Greater(t, framedSize(sendTxs), budget, "framed size of all txs should exceed the raw budget")
+
+	resp, err := testApp.PrepareProposal(&abci.RequestPrepareProposal{
+		Txs:        sendTxs,
+		Height:     testApp.LastBlockHeight() + 1,
+		Time:       time.Now(),
+		MaxTxBytes: budget,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, resp.Txs)
+
+	// The observable effect of the fix: the proposer dropped at least one tx to
+	// stay within the framed budget. Raw-byte accounting kept the whole list.
+	require.Less(t, len(resp.Txs), len(sendTxs), "proposer should drop a tx to fit the framed budget")
+
+	// And what it did return fits the framed budget, so Core accepts it instead
+	// of rejecting with "transaction data size exceeds maximum".
+	require.LessOrEqual(t, framedSize(resp.Txs), budget)
+}
+
 func TestPrepareProposalCappingNumberOfMessages(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping prepare proposal capping number of transactions test in short mode.")


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-2077/prepareproposal-byte-accounting-can-exceed-cores-budget-medium
