### PR TITLE
feat(fibre): add escrow StartupGracePeriod to prevent over-signing after a restart

### DIFF
--- a/fibre/client_config.go
+++ b/fibre/client_config.go
@@ -83,6 +83,10 @@ func defaultEscrowConfig(p ProtocolParams) EscrowConfig {
 		LowWatermark:        maxBlobPayment.MulRaw(2),
 		HighWatermark:       maxBlobPayment.MulRaw(10),
 		RefillCheckInterval: time.Second,
+		// Disabled by default (seed immediately). Set to at least the chain's
+		// `DefaultPaymentPromiseTimeout` to make a restart safe against
+		// over-signing while pre-crash promises are still unsettled.
+		StartupGracePeriod: 0,
 	}
 }
 

--- a/fibre/escrow_ledger.go
+++ b/fibre/escrow_ledger.go
@@ -30,6 +30,16 @@ type EscrowConfig struct {
 	// RefillCheckInterval is how often waitForBudget re-checks the balance while
 	// blocked waiting for a refill to land. Default 1s.
 	RefillCheckInterval time.Duration
+	// StartupGracePeriod delays trusting on-chain escrow state after the ledger
+	// starts. The local balance is in-memory only, so a client that crashed while
+	// promises it signed were still unsettled would, on restart, re-seed from a
+	// chain balance that still counts those committed funds as available and
+	// could over-sign. Within this window the ledger seeds nothing, admits
+	// nothing, and deposits nothing; once it passes, any pre-crash promise has
+	// settled or timed out on chain, so the seed is exact. Set it to at least the
+	// chain's PaymentPromiseTimeout to close that gap. Zero (the default) disables
+	// the grace and seeds immediately, preserving the prior behavior.
+	StartupGracePeriod time.Duration
 }
 
 // EscrowQuerier reads on-chain escrow state for a signer. It wraps the
@@ -68,6 +78,7 @@ type escrowLedger struct {
 	querier   EscrowQuerier
 	depositor Depositor
 	log       *slog.Logger
+	createdAt time.Time // ledger start; gates the StartupGracePeriod window
 
 	mu      sync.Mutex
 	balance math.Int // = on-chain escrow − committed (signed) promises
@@ -87,8 +98,20 @@ func newEscrowLedger(signer string, cfg EscrowConfig, clk clock.Clock, q EscrowQ
 		querier:   q,
 		depositor: d,
 		log:       log,
+		createdAt: clk.Now(),
 		balance:   math.ZeroInt(),
 	}
+}
+
+// inStartupGrace reports whether the ledger is still within its post-start grace
+// window, during which chain escrow state can't be trusted (see ensureSeeded and
+// EscrowConfig.StartupGracePeriod). Always false when StartupGracePeriod is zero,
+// which preserves immediate seeding.
+func (l *escrowLedger) inStartupGrace() bool {
+	if l.cfg.StartupGracePeriod <= 0 {
+		return false
+	}
+	return l.clk.Now().Before(l.createdAt.Add(l.cfg.StartupGracePeriod))
 }
 
 // ensureSeeded initializes balance from the chain exactly once (the first time
@@ -97,6 +120,14 @@ func newEscrowLedger(signer string, cfg EscrowConfig, clk clock.Clock, q EscrowQ
 // cheap no-op.
 func (l *escrowLedger) ensureSeeded(ctx context.Context) error {
 	if l.seeded.Load() {
+		return nil
+	}
+	// Hold off seeding until the startup grace window passes: a balance queried
+	// before then could still count promises signed just before a crash (not yet
+	// settled on chain) as available and let us over-sign. balance stays zero
+	// meanwhile, so admit refuses and no commitment is made. See
+	// EscrowConfig.StartupGracePeriod.
+	if l.inStartupGrace() {
 		return nil
 	}
 	l.seedMu.Lock()
@@ -161,6 +192,12 @@ func (l *escrowLedger) refill(ctx context.Context) {
 	if !l.cfg.AutoFund {
 		return
 	}
+	// During the startup grace window the balance is deliberately unseeded (zero),
+	// so a deposit here would top up against an untrusted baseline. Hold off; the
+	// first refill after the window works off the freshly seeded balance.
+	if l.inStartupGrace() {
+		return
+	}
 	if !l.refilling.CompareAndSwap(false, true) {
 		return // another refill is already running
 	}
@@ -197,6 +234,13 @@ func (l *escrowLedger) waitForBudget(ctx context.Context, refill func(), amount 
 	// spin until ctx expires. Surface the misconfiguration immediately instead.
 	if l.cfg.AutoFund && l.cfg.HighWatermark.LT(amount) {
 		return fmt.Errorf("escrow payment %s exceeds high_watermark %s: raise HighWatermark to admit blobs this large", amount, l.cfg.HighWatermark)
+	}
+	// Within the startup grace window admit can never succeed (seeding is
+	// deferred and refill is suppressed), so polling would just spin until ctx
+	// expires. Fail fast with an actionable message instead. See
+	// EscrowConfig.StartupGracePeriod.
+	if l.inStartupGrace() {
+		return fmt.Errorf("escrow ledger in startup grace period; admission deferred to avoid over-signing after a restart (see EscrowConfig.StartupGracePeriod)")
 	}
 	for {
 		if ok, _ := l.admit(amount); ok {

--- a/fibre/escrow_lifecycle_test.go
+++ b/fibre/escrow_lifecycle_test.go
@@ -29,6 +29,44 @@ func TestEscrowLedgerEnsureSeededUsesExistingBalance(t *testing.T) {
 	require.Equal(t, 0, count) // existing balance covered it; no deposit
 }
 
+// TestEscrowLedgerStartupGraceDefersSeeding is the crash-restart regression: a
+// ledger that starts within its StartupGracePeriod must not seed from, admit
+// against, or deposit toward chain state — otherwise a client that restarted
+// while promises it signed were still unsettled would re-seed from a balance
+// that omits them and over-sign. After the window (by when any pre-crash promise
+// has settled or timed out) seeding and admission resume normally.
+func TestEscrowLedgerStartupGraceDefersSeeding(t *testing.T) {
+	clk := clock.NewMock()
+	d := newMockDepositor()
+	q := &mockQuerier{bal: math.NewInt(50_000)}
+	cfg := testEscrowConfig()
+	cfg.StartupGracePeriod = time.Hour
+	l := newEscrowLedger("signer1", cfg, clk, q, d, nil)
+
+	// Within the grace window: no query, no admission, no deposit.
+	require.NoError(t, l.ensureSeeded(t.Context()))
+	require.Equal(t, 0, q.queries())
+	require.Equal(t, int64(0), l.balanceOf().Int64())
+	ok, _ := l.admit(math.NewInt(1))
+	require.False(t, ok)
+	l.refill(t.Context())
+	count, _ := d.deposits()
+	require.Equal(t, 0, count)
+
+	// waitForBudget fails fast with an explicit error (not a ctx timeout) while
+	// in the grace window, since admit can never succeed there.
+	err := l.waitForBudget(t.Context(), func() { l.refill(t.Context()) }, math.NewInt(1))
+	require.ErrorContains(t, err, "startup grace period")
+
+	// After the window: seed from chain and admit normally.
+	clk.Add(time.Hour)
+	require.NoError(t, l.ensureSeeded(t.Context()))
+	require.Equal(t, 1, q.queries())
+	require.Equal(t, int64(50_000), l.balanceOf().Int64())
+	ok, _ = l.admit(math.NewInt(1_000))
+	require.True(t, ok)
+}
+
 // TestEscrowLedgerFundedBurstNeverOvercommits is the core property: under a
 // concurrent burst of admissions that together far exceed the starting balance,
 // auto-funding lets every upload through while the local balance never goes

--- a/specs/src/fibre_client.md
+++ b/specs/src/fibre_client.md
@@ -442,6 +442,8 @@ The safety invariant is that `balance` is never *overstated*: it is only ever cr
 
 The trade-off is one-sided and deliberate: a long-running, never-idle client cannot re-anchor `balance` to on-chain ground truth, so it may *understate* over time (from aborted-before-sign uploads and promises that expire without a timeout settlement). Understating only refuses budget or tops up slightly more often than strictly needed — the excess stays in the escrow and is withdrawable — it never overcommits.
 
+Because the ledger is in-memory only, a client that restarts loses `balance` and re-seeds from chain. `Query.EscrowAccount` reports the on-chain `AvailableBalance`, which does not subtract promises the crashed client had signed but that had not yet settled — so a naive re-seed would *overstate* `balance` and could over-sign. `EscrowConfig.StartupGracePeriod` guards against this: within that window after the ledger starts it seeds nothing, admits nothing, and deposits nothing, and `waitForBudget` fails fast with an explicit error. By the time the window passes, any promise signed before the crash has settled or timed out on chain, so the first seed is exact. It is disabled by default (seed immediately, preserving the behavior above); operators who require crash-safety set it to at least the chain's `PaymentPromiseTimeout`. The alternative — durable local persistence of `balance` — would remove the startup window entirely at the cost of a synchronous disk write on the signing hot path, and is intentionally out of scope here.
+
 ## 12) Errors
 
 Important client-side errors include:


### PR DESCRIPTION
The client-side escrow ledger keeps its balance in memory only, so after a crash it re-seeds from the chain's AvailableBalance, which does not subtract signed-but-not-yet-settled promises. That lets a restarted client admit and
sign new promises against already-committed funds (over-sign).

Add an opt-in StartupGracePeriod: within this window after the ledger starts it does not seed, admit, or deposit, so by the time it first seeds any pre-crash promise has settled or timed out on chain and the balance is exact. waitForBudget fails fast with an explicit error in the window instead of spinning to a ctx timeout.

Resolves https://linear.app/celestia/issue/PROTOCO-2105/fibre-in-memory-escrow-ledger-can-over-sign-after-a-client