### PR TITLE
fix(fibre): reject non canonical proof segment lengths

### DIFF
--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/field"
+	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/merkle"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/rlc"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"go.opentelemetry.io/otel/attribute"
@@ -344,6 +345,13 @@ func parseRow(row *types.BlobRow) (*rsema1d.RowProof, error) {
 	}
 	if len(row.Data) == 0 {
 		return nil, fmt.Errorf("row %d missing data", row.Index)
+	}
+	// Reject non canonical segment lengths so padding past the required
+	// NodeSize prefix can't be persisted and served.
+	for i, seg := range row.Proof {
+		if len(seg) != merkle.NodeSize {
+			return nil, fmt.Errorf("row %d proof segment %d must be %d bytes, got %d", row.Index, i, merkle.NodeSize, len(seg))
+		}
 	}
 
 	return &rsema1d.RowProof{

--- a/fibre/server_upload_parse_test.go
+++ b/fibre/server_upload_parse_test.go
@@ -1,0 +1,46 @@
+package fibre
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/merkle"
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRowRejectsNonCanonicalProofSegments(t *testing.T) {
+	canonicalSeg := make([]byte, merkle.NodeSize)
+
+	t.Run("canonical proof accepted", func(t *testing.T) {
+		row := &types.BlobRow{
+			Index: 0,
+			Data:  []byte("row-data"),
+			Proof: [][]byte{canonicalSeg},
+		}
+		_, err := parseRow(row)
+		require.NoError(t, err)
+	})
+
+	t.Run("oversized segment rejected", func(t *testing.T) {
+		// A correct 32-byte prefix plus attacker padding: verification would
+		// truncate it back to a valid node, but it must never be stored.
+		padded := append(append([]byte(nil), canonicalSeg...), 0xAA, 0xBB)
+		row := &types.BlobRow{
+			Index: 3,
+			Data:  []byte("row-data"),
+			Proof: [][]byte{padded},
+		}
+		_, err := parseRow(row)
+		require.Error(t, err)
+	})
+
+	t.Run("undersized segment rejected", func(t *testing.T) {
+		row := &types.BlobRow{
+			Index: 3,
+			Data:  []byte("row-data"),
+			Proof: [][]byte{canonicalSeg[:merkle.NodeSize-1]},
+		}
+		_, err := parseRow(row)
+		require.Error(t, err)
+	})
+}

--- a/pkg/rsema1d/merkle/proof.go
+++ b/pkg/rsema1d/merkle/proof.go
@@ -59,6 +59,9 @@ func RootFromProof(leaf []byte, index int, proof [][]byte) (Root, error) {
 
 	pos := index
 	for _, siblingBytes := range proof {
+		if len(siblingBytes) != NodeSize {
+			return Root{}, fmt.Errorf("proof sibling must be %d bytes, got %d", NodeSize, len(siblingBytes))
+		}
 		var sibling Root
 		copy(sibling[:], siblingBytes)
 

--- a/pkg/rsema1d/merkle/tree_test.go
+++ b/pkg/rsema1d/merkle/tree_test.go
@@ -3,6 +3,7 @@ package merkle_test
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/merkle"
@@ -274,6 +275,16 @@ func TestRootFromProof(t *testing.T) {
 		wrongRoot, _ = merkle.RootFromProof(wrongLeaf, i, proof)
 		if bytes.Equal(expectedRoot[:], wrongRoot[:]) {
 			t.Errorf("Index %d: proof should fail with wrong leaf", i)
+		}
+
+		// A sibling padded past NodeSize must be rejected, not silently
+		// truncated back to a valid 32-byte prefix.
+		padded := make([][]byte, len(proof))
+		copy(padded, proof)
+		padded[0] = append(append([]byte(nil), proof[0]...), 0xAA, 0xBB)
+		_, err = merkle.RootFromProof(leaves[i], i, padded)
+		if err == nil || !strings.Contains(err.Error(), "proof sibling must be 32 bytes, got 34") {
+			t.Errorf("Index %d: expected oversized-sibling error, got %v", i, err)
 		}
 	}
 }

--- a/pkg/rsema1d/merkle/tree_test.go
+++ b/pkg/rsema1d/merkle/tree_test.go
@@ -283,7 +283,7 @@ func TestRootFromProof(t *testing.T) {
 		copy(padded, proof)
 		padded[0] = append(append([]byte(nil), proof[0]...), 0xAA, 0xBB)
 		_, err = merkle.RootFromProof(leaves[i], i, padded)
-		if err == nil || !strings.Contains(err.Error(), "proof sibling must be 32 bytes, got 34") {
+		if err == nil || !strings.Contains(err.Error(), fmt.Sprintf("proof sibling must be %d bytes, got %d", merkle.NodeSize, merkle.NodeSize+2)) {
 			t.Errorf("Index %d: expected oversized-sibling error, got %v", i, err)
 		}
 	}


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-2114/oversized-merkle-proof-segments-are-silently-truncated-by-verification
