### PR TITLE
fix(fibre): reject future dated PP creation timestamp

### DIFF
--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -14,6 +14,11 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
+// maxPromiseClockSkew is how far a promise's creation_timestamp may lead block
+// time. Absorbs clock drift only, so it must stay well under
+// WithdrawalDelay - PaymentPromiseTimeout.
+const maxPromiseClockSkew = 10 * time.Minute
+
 // Keeper handles all the state changes for the fibre module.
 type Keeper struct {
 	cdc           codec.Codec
@@ -324,6 +329,13 @@ func (k Keeper) validatePaymentPromiseStatefulInternal(ctx sdk.Context, promise 
 	minAllowedTime := currentTime.Add(-params.WithdrawalDelay)
 	if !creationTime.After(minAllowedTime) {
 		return time.Time{}, fmt.Errorf("creation_timestamp %v must be greater than %v (current_time - withdrawal_delay)", creationTime, minAllowedTime)
+	}
+
+	// Reject a future-dated creation_timestamp (beyond clock skew) on both paths;
+	// see maxPromiseClockSkew for why.
+	maxAllowedTime := currentTime.Add(maxPromiseClockSkew)
+	if creationTime.After(maxAllowedTime) {
+		return time.Time{}, fmt.Errorf("creation_timestamp %v must not be after %v (current_time + max_clock_skew)", creationTime, maxAllowedTime)
 	}
 
 	expirationTime := creationTime.Add(params.PaymentPromiseTimeout)

--- a/x/fibre/keeper/keeper_test.go
+++ b/x/fibre/keeper/keeper_test.go
@@ -584,18 +584,31 @@ func (suite *KeeperTestSuite) TestValidatePaymentPromiseInternal() {
 }
 
 func (suite *KeeperTestSuite) TestValidatePaymentPromiseStateful() {
-	suite.T().Run("payment promise with future creation timestamp should be accepted", func(t *testing.T) {
+	suite.T().Run("payment promise within clock-skew tolerance should be accepted", func(t *testing.T) {
 		paymentPromise := suite.createPaymentPromise()
 		suite.createEscrowAccount(paymentPromise)
 
-		// Set creation timestamp to the future
-		paymentPromise.CreationTimestamp = suite.ctx.BlockTime().Add(1 * time.Hour)
+		// A timestamp slightly in the future (within skew) is accepted to absorb clock drift.
+		paymentPromise.CreationTimestamp = suite.ctx.BlockTime().Add(1 * time.Minute)
 
-		// Validate should fail because creation timestamp is in the future
 		expirationTime, err := suite.keeper.ValidatePaymentPromiseStateful(suite.ctx, &paymentPromise)
 		suite.NoError(err)
 		wantTime := paymentPromise.CreationTimestamp.Add(suite.keeper.GetParams(suite.ctx).PaymentPromiseTimeout)
 		suite.Equal(wantTime, expirationTime)
+	})
+
+	suite.T().Run("payment promise dated beyond clock-skew tolerance should be rejected", func(t *testing.T) {
+		paymentPromise := suite.createPaymentPromise()
+		suite.createEscrowAccount(paymentPromise)
+
+		// A far-future timestamp would slide the timeout window past the
+		// withdrawal-execution point, so it must be rejected.
+		paymentPromise.CreationTimestamp = suite.ctx.BlockTime().Add(1 * time.Hour)
+
+		_, err := suite.keeper.ValidatePaymentPromiseStateful(suite.ctx, &paymentPromise)
+		suite.Error(err)
+		suite.Contains(err.Error(), "creation_timestamp")
+		suite.Contains(err.Error(), "must not be after")
 	})
 
 	suite.T().Run("payment promise with timestamp before withdrawal delay should be rejected", func(t *testing.T) {
@@ -709,6 +722,19 @@ func (suite *KeeperTestSuite) TestValidatePaymentPromiseStatefulForTimeout() {
 		// ValidatePaymentPromiseStatefulForTimeout should accept it (height validation is skipped)
 		_, err := suite.keeper.ValidatePaymentPromiseStatefulForTimeout(suite.ctx, &paymentPromise)
 		suite.NoError(err)
+	})
+
+	suite.T().Run("timeout mechanism should reject a future-dated promise", func(t *testing.T) {
+		paymentPromise := suite.createPaymentPromise()
+		suite.createEscrowAccount(paymentPromise)
+
+		// The future-timestamp upper bound applies on the timeout path too, so a
+		// future-dated promise cannot be settled via timeout either.
+		paymentPromise.CreationTimestamp = suite.ctx.BlockTime().Add(1 * time.Hour)
+
+		_, err := suite.keeper.ValidatePaymentPromiseStatefulForTimeout(suite.ctx, &paymentPromise)
+		suite.Error(err)
+		suite.Contains(err.Error(), "must not be after")
 	})
 }
 


### PR DESCRIPTION
## Overview


Fixes https://linear.app/celestia/issue/PROTOCO-2115/future-dated-payment-promises-let-a-payer-drain-the-escrow-before-the