### PR TITLE
fix(deps): bump cosmos-sdk to v0.52.8 on v8.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -447,9 +447,6 @@ replace (
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.30
-	// v0.52.8 includes BaseApp checkStateMu coverage for workingHash (#740) and
-	// CheckTx (#741), closing the remaining inter-block / IAVL races vs Simulate.
-	// See https://github.com/celestiaorg/celestia-app/issues/7469
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.8
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"

--- a/go.mod
+++ b/go.mod
@@ -447,7 +447,10 @@ replace (
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.30
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.6
+	// v0.52.8 includes BaseApp checkStateMu coverage for workingHash (#740) and
+	// CheckTx (#741), closing the remaining inter-block / IAVL races vs Simulate.
+	// See https://github.com/celestiaorg/celestia-app/issues/7469
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.8
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/go.sum
+++ b/go.sum
@@ -860,8 +860,8 @@ github.com/celestiaorg/celestia-core v0.39.30 h1:Hmh97CQIRE7i2ddlbi0i6PAop1vlH0O
 github.com/celestiaorg/celestia-core v0.39.30/go.mod h1:pWRN2gpl+Yb6ioIAwhEx1G8lwROMnUUxJM8Q4YJDjVM=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35 h1:FREwqZwPvYsodr1AqqEIyW+VsBnwTzJNtC6NFdZX8rs=
 github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35/go.mod h1:SI38xqZZ4ccoAxszUJqsJ/a5rOkzQRijzHQQlLKkyUc=
-github.com/celestiaorg/cosmos-sdk v0.52.6 h1:8dNW6ONrOokGh25MMnh4uQhQKTRDYvM5Rv1hf3ApbW4=
-github.com/celestiaorg/cosmos-sdk v0.52.6/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
+github.com/celestiaorg/cosmos-sdk v0.52.8 h1:8L8YG90DjO23T9lsEI2AXJ7kXIJ/SQWGoA4X9Zz9dy0=
+github.com/celestiaorg/cosmos-sdk v0.52.8/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -297,9 +297,6 @@ replace (
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/celestiaorg/celestia-app/v8 => ../..
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.30
-	// v0.52.8 includes BaseApp checkStateMu coverage for workingHash (#740) and
-	// CheckTx (#741), closing the remaining inter-block / IAVL races vs Simulate.
-	// See https://github.com/celestiaorg/celestia-app/issues/7469
 	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.8
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -297,7 +297,10 @@ replace (
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/celestiaorg/celestia-app/v8 => ../..
 	github.com/cometbft/cometbft => github.com/celestiaorg/celestia-core v0.39.30
-	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.6
+	// v0.52.8 includes BaseApp checkStateMu coverage for workingHash (#740) and
+	// CheckTx (#741), closing the remaining inter-block / IAVL races vs Simulate.
+	// See https://github.com/celestiaorg/celestia-app/issues/7469
+	github.com/cosmos/cosmos-sdk => github.com/celestiaorg/cosmos-sdk v0.52.8
 	github.com/cosmos/ibc-go/v8 => github.com/celestiaorg/ibc-go/v8 v8.7.2
 	// Use ledger-cosmos-go v0.16.0 because v0.15.0 causes "hidapi: unknown failure"
 	// See https://github.com/celestiaorg/celestia-app/issues/5453

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -772,8 +772,8 @@ github.com/bufbuild/protocompile v0.14.1/go.mod h1:ppVdAIhbr2H8asPk6k4pY7t9zB1OU
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
 github.com/celestiaorg/celestia-core v0.39.30 h1:Hmh97CQIRE7i2ddlbi0i6PAop1vlH0OYyGNXUM62cjs=
 github.com/celestiaorg/celestia-core v0.39.30/go.mod h1:pWRN2gpl+Yb6ioIAwhEx1G8lwROMnUUxJM8Q4YJDjVM=
-github.com/celestiaorg/cosmos-sdk v0.52.6 h1:8dNW6ONrOokGh25MMnh4uQhQKTRDYvM5Rv1hf3ApbW4=
-github.com/celestiaorg/cosmos-sdk v0.52.6/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
+github.com/celestiaorg/cosmos-sdk v0.52.8 h1:8L8YG90DjO23T9lsEI2AXJ7kXIJ/SQWGoA4X9Zz9dy0=
+github.com/celestiaorg/cosmos-sdk v0.52.8/go.mod h1:2N4NRio08+WQsB7hsKo/ELXCQSWl78GiYdd9M1H6MpQ=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/CmdcQAUhbiUU=
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.1.1-0.20251116153902-f48fea92e627 h1:qYV81fA5E739ZtdMFCjChx0AMY+qBmMVPfRE3ol+VCE=


### PR DESCRIPTION
## Summary
- Bump `celestiaorg/cosmos-sdk` `v0.52.6` → `v0.52.8` (BaseApp race fixes #740, #741)
- Partial fix for #7469 (v8 only)

## Test plan
- [x] `make build-standalone`
- [x] `make test-short`