### PR TITLE
feat(fibre): release fibre server binaries with goreleaser

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,3 +13,14 @@ jobs:
           go-version-file: "go.mod"
       - name: build
         run: make build
+
+  build-fibre:
+    name: build-fibre
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7.0.0
+        with:
+          go-version-file: "go.mod"
+      - name: build-fibre
+        run: make build-fibre-server

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -249,6 +249,86 @@ builds:
       - -X "{{ .Env.SDKPath }}.AppName=celestia-appd"
       - -X "{{ .Env.SDKPath }}.Version={{ .Version }}"
       - -X "{{ .Env.SDKPath }}.Commit={{ .FullCommit }}"
+  # The fibre server is a separate binary that validators run alongside
+  # celestia-appd. It has no cgo dependencies of its own, but it is built with
+  # CGO_ENABLED=1 to match celestia-appd: the two binaries then have the same
+  # linking profile and the same libc requirements on a given platform.
+  - id: fibre-darwin-amd64
+    main: ./fibre/cmd
+    binary: fibre
+    env:
+      - CGO_ENABLED=1
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goarch:
+      - amd64
+    goos:
+      - darwin
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .FullCommit }}
+      - -X main.buildDate={{ .CommitDate }}
+  - id: fibre-darwin-arm64
+    main: ./fibre/cmd
+    binary: fibre
+    env:
+      - CGO_ENABLED=1
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goarch:
+      - arm64
+    goos:
+      - darwin
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .FullCommit }}
+      - -X main.buildDate={{ .CommitDate }}
+  - id: fibre-linux-amd64
+    main: ./fibre/cmd
+    binary: fibre
+    env:
+      - CGO_ENABLED=1
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    goarch:
+      - amd64
+    goos:
+      - linux
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .FullCommit }}
+      - -X main.buildDate={{ .CommitDate }}
+  - id: fibre-linux-arm64
+    main: ./fibre/cmd
+    binary: fibre
+    env:
+      - CGO_ENABLED=1
+      - CC=aarch64-linux-gnu-gcc
+      - CXX=aarch64-linux-gnu-g++
+    goarch:
+      - arm64
+    goos:
+      - linux
+    flags:
+      - -trimpath
+    ldflags:
+      - -s
+      - -w
+      - -X main.version={{ .Version }}
+      - -X main.commit={{ .FullCommit }}
+      - -X main.buildDate={{ .CommitDate }}
 dist: ./build/goreleaser
 archives:
   - id: multiplexer
@@ -276,6 +356,22 @@ archives:
     # uname.
     name_template: >-
       {{ .ProjectName }}-standalone_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+  - id: fibre
+    ids:
+      - fibre-darwin-amd64
+      - fibre-darwin-arm64
+      - fibre-linux-amd64
+      - fibre-linux-arm64
+    formats: ['tar.gz']
+    # this name template makes the OS and Arch compatible with the results of
+    # uname.
+    name_template: >-
+      fibre_
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -368,8 +368,6 @@ archives:
       - fibre-linux-amd64
       - fibre-linux-arm64
     formats: ['tar.gz']
-    # this name template makes the OS and Arch compatible with the results of
-    # uname.
     name_template: >-
       fibre_
       {{- title .Os }}_

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,17 @@ LDFLAGS_MULTIPLEXER := $(LDFLAGS_COMMON) -X github.com/cosmos/cosmos-sdk/version
 BUILD_FLAGS_STANDALONE := -tags=$(BUILD_TAGS_STANDALONE) -ldflags '$(LDFLAGS_STANDALONE)'
 BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_MULTIPLEXER)'
 
-# The fibre server keeps its version metadata in package main. These are the
-# same values goreleaser injects for release builds, so `fibre version` reports
-# a real version regardless of whether the binary came from a release or from
-# source. The commit date is used instead of the wall clock so builds of the
-# same commit are reproducible.
+# The fibre server keeps its version metadata in package main, so that a binary
+# built from source reports a real version rather than "dev". These mirror the
+# values goreleaser injects for release builds, except that the commit is the
+# short hash here, the same way LDFLAGS_COMMON stamps celestia-appd. The commit
+# date is used instead of the wall clock so builds of the same commit are
+# reproducible. Each value falls back to the default already compiled into the
+# binary when git metadata is unavailable, e.g. building from an exported source
+# tree with no .git: an empty -X value blanks the field out rather than leaving
+# the default in place.
 COMMIT_DATE := $(shell git log -1 --format=%cI)
-LDFLAGS_FIBRE := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildDate=$(COMMIT_DATE)
+LDFLAGS_FIBRE := -X main.version=$(or $(VERSION),dev) -X main.commit=$(or $(COMMIT),unknown) -X main.buildDate=$(or $(COMMIT_DATE),unknown)
 BUILD_FLAGS_FIBRE := -ldflags '$(LDFLAGS_FIBRE)'
 
 # NOTE: This version must be updated at the same time as the version in:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,15 @@ LDFLAGS_MULTIPLEXER := $(LDFLAGS_COMMON) -X github.com/cosmos/cosmos-sdk/version
 BUILD_FLAGS_STANDALONE := -tags=$(BUILD_TAGS_STANDALONE) -ldflags '$(LDFLAGS_STANDALONE)'
 BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_MULTIPLEXER)'
 
+# The fibre server keeps its version metadata in package main. These are the
+# same values goreleaser injects for release builds, so `fibre version` reports
+# a real version regardless of whether the binary came from a release or from
+# source. The commit date is used instead of the wall clock so builds of the
+# same commit are reproducible.
+COMMIT_DATE := $(shell git log -1 --format=%cI)
+LDFLAGS_FIBRE := -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.buildDate=$(COMMIT_DATE)
+BUILD_FLAGS_FIBRE := -ldflags '$(LDFLAGS_FIBRE)'
+
 # NOTE: This version must be updated at the same time as the version in:
 # internal/embedding/data.go
 # .goreleaser.yaml
@@ -411,13 +420,13 @@ test-fuzz:
 build-fibre-server:
 	@mkdir -p build/
 	@echo "--> Building build/fibre"
-	@go build -o build/fibre ./fibre/cmd
+	@go build $(BUILD_FLAGS_FIBRE) -o build/fibre ./fibre/cmd
 .PHONY: build-fibre-server
 
 ## install-fibre-server: Build and install the fibre server binary into the $GOPATH/bin directory.
 install-fibre-server:
 	@echo "--> Installing fibre server"
-	@go build -o $(shell go env GOPATH)/bin/fibre ./fibre/cmd
+	@go build $(BUILD_FLAGS_FIBRE) -o $(shell go env GOPATH)/bin/fibre ./fibre/cmd
 .PHONY: install-fibre-server
 
 ## txsim-install: Install the tx simulator.

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_M
 # binary when git metadata is unavailable, e.g. building from an exported source
 # tree with no .git: an empty -X value blanks the field out rather than leaving
 # the default in place.
-COMMIT_DATE := $(shell git log -1 --format=%cI)
+COMMIT_DATE := $(shell git log -1 --format=%cI 2>/dev/null)
 LDFLAGS_FIBRE := -X main.version=$(or $(VERSION),dev) -X main.commit=$(or $(COMMIT),unknown) -X main.buildDate=$(or $(COMMIT_DATE),unknown)
 BUILD_FLAGS_FIBRE := -ldflags '$(LDFLAGS_FIBRE)'
 

--- a/Makefile
+++ b/Makefile
@@ -34,13 +34,14 @@ BUILD_FLAGS_MULTIPLEXER := -tags=$(BUILD_TAGS_MULTIPLEXER) -ldflags '$(LDFLAGS_M
 # The fibre server keeps its version metadata in package main, so that a binary
 # built from source reports a real version rather than "dev". These mirror the
 # values goreleaser injects for release builds, except that the commit is the
-# short hash here, the same way LDFLAGS_COMMON stamps celestia-appd. The commit
-# date is used instead of the wall clock so builds of the same commit are
-# reproducible. Each value falls back to the default already compiled into the
-# binary when git metadata is unavailable, e.g. building from an exported source
-# tree with no .git: an empty -X value blanks the field out rather than leaving
-# the default in place.
-COMMIT_DATE := $(shell git log -1 --format=%cI 2>/dev/null)
+# short hash here, the same way LDFLAGS_COMMON stamps celestia-appd. The date is
+# the commit date rather than the wall clock, so builds of the same commit are
+# reproducible, formatted in UTC to match goreleaser's .CommitDate exactly. Each
+# value falls back to the default already compiled into the binary when git
+# metadata is unavailable, e.g. building from an exported source tree with no
+# .git: an empty -X value blanks the field out rather than leaving the default in
+# place.
+COMMIT_DATE := $(shell TZ=UTC git log -1 --date=format-local:%Y-%m-%dT%H:%M:%SZ --format=%cd 2>/dev/null)
 LDFLAGS_FIBRE := -X main.version=$(or $(VERSION),dev) -X main.commit=$(or $(COMMIT),unknown) -X main.buildDate=$(or $(COMMIT_DATE),unknown)
 BUILD_FLAGS_FIBRE := -ldflags '$(LDFLAGS_FIBRE)'
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The [GitHub Releases](https://github.com/celestiaorg/celestia-app/releases) page
 
 Linux binaries built with the multiplexer require **glibc >= 2.38** (Ubuntu 24.04 or equivalent). See [Prerequisites](#prerequisites) for details.
 
+Each release also ships the Fibre server as its own archive (`fibre_Linux_x86_64.tar.gz`, `fibre_Darwin_arm64.tar.gz`, etc.) for the same four platforms, built the same way and versioned in lockstep with `celestia-appd`. See [fibre/cmd/README.md](fibre/cmd/README.md) for usage.
+
 ### Known incompatibilities
 
 - **Windows**: the `celestia-appd` binary does not support signing with Ledger hardware wallets.

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -2,13 +2,32 @@
 
 Standalone binary for the Fibre data availability server.
 
-## Build
+## Install
+
+### Prebuilt binary
+
+Every celestia-app release attaches a `fibre` archive for Linux and macOS on both
+`amd64` and `arm64`. The version matches the celestia-app release it ships with.
+
+```sh
+# pick the archive matching `uname -s` and `uname -m`
+curl -LO https://github.com/celestiaorg/celestia-app/releases/latest/download/fibre_Linux_x86_64.tar.gz
+curl -LO https://github.com/celestiaorg/celestia-app/releases/latest/download/checksums.txt
+sha256sum --ignore-missing --check checksums.txt
+tar -xvf fibre_Linux_x86_64.tar.gz
+./fibre version
+```
+
+Like `celestia-appd`, the Linux archives are dynamically linked against glibc.
+
+### Build from source
 
 ```sh
 make build-fibre-server
 ```
 
-The binary is output to `build/fibre`.
+The binary is output to `build/fibre`, stamped with the same version and commit
+that a release build reports.
 
 ## Usage
 

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -29,8 +29,10 @@ Like `celestia-appd`, the Linux archives are dynamically linked against glibc.
 make build-fibre-server
 ```
 
-The binary is output to `build/fibre`, stamped with the same version and commit
-that a release build reports.
+The binary is output to `build/fibre`, stamped with the version from
+`git describe` and the short commit hash, so `fibre version` reports something
+real rather than `dev`. A release build stamps the release tag and the full
+commit hash instead.
 
 ## Usage
 

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -9,10 +9,13 @@ Standalone binary for the Fibre data availability server.
 Every celestia-app release attaches a `fibre` archive for Linux and macOS on both
 `amd64` and `arm64`. The version matches the celestia-app release it ships with.
 
+The archives are named `fibre_{Linux,Darwin}_{x86_64,arm64}.tar.gz`. Note that a
+Linux arm64 host reports `aarch64` from `uname -m`, but the archive is `arm64`.
+
 ```sh
-# pick the archive matching `uname -s` and `uname -m`
 curl -LO https://github.com/celestiaorg/celestia-app/releases/latest/download/fibre_Linux_x86_64.tar.gz
 curl -LO https://github.com/celestiaorg/celestia-app/releases/latest/download/checksums.txt
+# on macOS: shasum -a 256 --ignore-missing --check checksums.txt
 sha256sum --ignore-missing --check checksums.txt
 tar -xvf fibre_Linux_x86_64.tar.gz
 ./fibre version

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -21,7 +21,10 @@ tar -xvf fibre_Linux_x86_64.tar.gz
 ./fibre version
 ```
 
-Like `celestia-appd`, the Linux archives are dynamically linked against glibc.
+The Linux archives are dynamically linked and require **glibc >= 2.34**, so
+Ubuntu 22.04 and Debian 12 work. This is lower than the **glibc >= 2.38** floor
+of the multiplexer `celestia-appd` build, which comes from its embedded binaries;
+fibre embeds none.
 
 ### Build from source
 


### PR DESCRIPTION
## Overview

Releases the fibre server binaries along with the celestia-appd when releasing.

Closes https://github.com/celestiaorg/celestia-app/issues/7476 and PROTOCO-2025