### PR TITLE
fix(fibre): process withdrawals atomically with bank send

### DIFF
--- a/specs/src/fibre_module.md
+++ b/specs/src/fibre_module.md
@@ -75,13 +75,14 @@ sequenceDiagram
 
     B->>M: processAvailableWithdrawals()
     M->>M: Iterate withdrawals available at block time
-    M->>M: Subtract amount from total balance and store escrow
+    M->>M: Check total balance covers withdrawal
     M->>Bank: Send coins from fibre module account to signer
     alt bank send succeeds
+        M->>M: Subtract amount from total balance and store escrow
         M->>M: Delete withdrawal from both indexes
         M-->>C: EventWithdrawFromEscrowExecuted
     else bank send fails
-        M->>M: Log error and leave withdrawal record
+        M->>M: Log error and leave escrow state and withdrawal unchanged
     end
 
     B->>M: pruneProcessedPayments()
@@ -339,7 +340,7 @@ The destination is independent of which validators signed the PaymentPromise. Th
 
 `BeginBlocker` runs `processAvailableWithdrawals` first and `pruneProcessedPayments` second.
 
-`processAvailableWithdrawals` iterates the withdrawals-by-available-time index in time order, stops when it reaches a future `available_timestamp`, parses the signer from the key, loads the withdrawal, loads the escrow account, subtracts the withdrawal amount from total `balance`, stores the escrow account, sends coins from the `fibre` module account to the signer account, deletes the withdrawal from both indexes after a successful send, and emits `EventWithdrawFromEscrowExecuted`. If key parsing, signer parsing, escrow lookup, balance sufficiency, bank send, or event emission fails, the implementation logs the error and continues; the escrow balance is stored before the bank send and the withdrawal is deleted only after a successful send.
+`processAvailableWithdrawals` iterates the withdrawals-by-available-time index in time order, stops when it reaches a future `available_timestamp`, parses the signer from the key, loads the withdrawal, loads the escrow account, checks that total `balance` covers the withdrawal, sends coins from the `fibre` module account to the signer account, and only after a successful send subtracts the withdrawal amount from total `balance`, stores the escrow account, deletes the withdrawal from both indexes, and emits `EventWithdrawFromEscrowExecuted`. If key parsing, signer parsing, escrow lookup, balance sufficiency, bank send, or event emission fails, the implementation logs the error and continues; the bank send runs before escrow state is updated so a failed send leaves the escrow account and the pending withdrawal unchanged for a safe retry.
 
 `pruneProcessedPayments` computes `cutoff_time = block_time - payment_promise_retention_window`, iterates the processed-payments-by-time index in time order, stops when `processed_at` is after the cutoff, deletes each pruned processed payment from both indexes, and emits `EventProcessedPaymentPruned`.
 

--- a/x/fibre/keeper/abci.go
+++ b/x/fibre/keeper/abci.go
@@ -56,7 +56,7 @@ func (k Keeper) processAvailableWithdrawals(ctx sdk.Context) error {
 			continue
 		}
 
-		// Update escrow account balance (decrease total balance)
+		// Load escrow and verify sufficient balance
 		escrowAccount, found := k.GetEscrowAccount(ctx, signer)
 		if !found {
 			// This shouldn't happen, but log and continue
@@ -68,16 +68,20 @@ func (k Keeper) processAvailableWithdrawals(ctx sdk.Context) error {
 			k.Logger(ctx).Error("escrow account balance is less than withdrawal amount", "signer", signer, "balance", escrowAccount.Balance, "amount", amount)
 			continue
 		}
-		escrowAccount.Balance = escrowAccount.Balance.Sub(amount)
-		k.SetEscrowAccount(ctx, escrowAccount)
 
-		// Process withdrawal: transfer from module to user account
+		// Transfer before updating escrow state: BeginBlocker continues on bank
+		// errors, so persisting Balance first would leave a pending withdrawal
+		// with a reduced balance and corrupt further on retry.
 		err = k.bankKeeper.SendCoinsFromModuleToAccount(ctx, types.ModuleName, signerAddr, sdk.NewCoins(amount))
 		if err != nil {
 			// Log error but continue processing other withdrawals
 			k.Logger(ctx).Error("failed to process withdrawal", "error", err, "signer", signer)
 			continue
 		}
+
+		// Decrease total escrow balance
+		escrowAccount.Balance = escrowAccount.Balance.Sub(amount)
+		k.SetEscrowAccount(ctx, escrowAccount)
 
 		// Remove from both withdrawal indexes
 		k.DeleteWithdrawal(ctx, withdrawal)

--- a/x/fibre/keeper/abci_test.go
+++ b/x/fibre/keeper/abci_test.go
@@ -1,6 +1,8 @@
 package keeper_test
 
 import (
+	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -167,6 +169,65 @@ func (suite *ABCITestSuite) TestBeginBlocker_ProcessAvailableWithdrawals() {
 	// Verify withdrawal was deleted from store
 	withdrawals := suite.keeper.GetWithdrawalsBySigner(suite.ctx, signer)
 	suite.Empty(withdrawals)
+}
+
+func (suite *ABCITestSuite) TestBeginBlocker_BankSendFailureDoesNotMutateEscrow() {
+	// BeginBlocker continues on bank-send errors. Escrow state must not be
+	// persisted before the send, or a failed transfer leaves a pending withdrawal
+	// with a reduced balance and retries corrupt state further.
+
+	privKey := secp256k1.GenPrivKey()
+	signer := sdk.AccAddress(privKey.PubKey().Address()).String()
+
+	depositAmount := sdk.NewCoin("utia", math.NewInt(1000000))
+	_, err := suite.msgServer.DepositToEscrow(suite.ctx, &types.MsgDepositToEscrow{
+		Signer: signer,
+		Amount: depositAmount,
+	})
+	suite.NoError(err)
+
+	withdrawalAmount := sdk.NewCoin("utia", math.NewInt(500000))
+	_, err = suite.msgServer.RequestWithdrawal(suite.ctx, &types.MsgRequestWithdrawal{
+		Signer: signer,
+		Amount: withdrawalAmount,
+	})
+	suite.NoError(err)
+
+	params := suite.keeper.GetParams(suite.ctx)
+	suite.ctx = suite.ctx.WithBlockTime(suite.ctx.BlockTime().Add(params.WithdrawalDelay))
+
+	suite.bankKeeper.SendCoinsFromModuleToAccountFn = func(_ context.Context, _ string, _ sdk.AccAddress, _ sdk.Coins) error {
+		return errors.New("injected bank send failure")
+	}
+
+	err = suite.keeper.BeginBlocker(suite.ctx)
+	suite.NoError(err)
+
+	escrowAccount, found := suite.keeper.GetEscrowAccount(suite.ctx, signer)
+	suite.True(found)
+	suite.Equal(depositAmount, escrowAccount.Balance, "balance must not change when bank send fails")
+	suite.Equal(depositAmount.Sub(withdrawalAmount), escrowAccount.AvailableBalance)
+	withdrawals := suite.keeper.GetWithdrawalsBySigner(suite.ctx, signer)
+	suite.Len(withdrawals, 1, "withdrawal must remain queued for retry")
+	suite.Equal(withdrawalAmount, withdrawals[0].Amount)
+
+	// A second failed BeginBlock must still leave state unchanged (no double-deduct).
+	err = suite.keeper.BeginBlocker(suite.ctx)
+	suite.NoError(err)
+	escrowAccount, found = suite.keeper.GetEscrowAccount(suite.ctx, signer)
+	suite.True(found)
+	suite.Equal(depositAmount, escrowAccount.Balance)
+	suite.Len(suite.keeper.GetWithdrawalsBySigner(suite.ctx, signer), 1)
+
+	suite.bankKeeper.SendCoinsFromModuleToAccountFn = nil
+	err = suite.keeper.BeginBlocker(suite.ctx)
+	suite.NoError(err)
+
+	escrowAccount, found = suite.keeper.GetEscrowAccount(suite.ctx, signer)
+	suite.True(found)
+	suite.Equal(depositAmount.Sub(withdrawalAmount), escrowAccount.Balance)
+	suite.Equal(depositAmount.Sub(withdrawalAmount), escrowAccount.AvailableBalance)
+	suite.Empty(suite.keeper.GetWithdrawalsBySigner(suite.ctx, signer))
 }
 
 func (suite *ABCITestSuite) TestBeginBlocker_ProcessMultipleWithdrawals() {

--- a/x/fibre/keeper/mocks_test.go
+++ b/x/fibre/keeper/mocks_test.go
@@ -11,6 +11,7 @@ import (
 // MockBankKeeper implements the expected BankKeeper interface for testing
 type MockBankKeeper struct {
 	SendCoinsFromAccountToModuleFn func(ctx context.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	SendCoinsFromModuleToAccountFn func(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromModuleToModuleFn  func(ctx context.Context, senderModule, recipientModule string, amt sdk.Coins) error
 }
 
@@ -22,6 +23,9 @@ func (m *MockBankKeeper) SendCoinsFromAccountToModule(ctx context.Context, sende
 }
 
 func (m *MockBankKeeper) SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error {
+	if m.SendCoinsFromModuleToAccountFn != nil {
+		return m.SendCoinsFromModuleToAccountFn(ctx, senderModule, recipientAddr, amt)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Send coins from the fibre module to the user before updating escrow `Balance` / deleting the withdrawal in BeginBlocker.
- Prevents a failed bank send from leaving a pending withdrawal with a reduced balance (and corrupting retries).
- Adds a regression test and updates the fibre spec/diagram to match.

Fixes finding 1 in #7548

## Test plan
- [x] `go test -count=1 -run TestABCITestSuite ./x/fibre/keeper/`