### PR TITLE
fix(fibre)!: unique available withdrawal index

### DIFF
--- a/specs/src/fibre_module.md
+++ b/specs/src/fibre_module.md
@@ -109,7 +109,7 @@ Payments are validated against and deducted from total `balance`, not only `avai
 
 ### Withdrawal
 
-Withdrawal requests are stored in two indexes. The signer index key is `0x03 || signer || "/" || sdk.FormatTimeBytes(requested_timestamp)` and the availability index key is `0x04 || sdk.FormatTimeBytes(available_timestamp) || "/" || signer`.
+Withdrawal requests are stored in two indexes. The signer index key is `0x03 || signer || "/" || sdk.FormatTimeBytes(requested_timestamp)` and the availability index key is `0x04 || sdk.FormatTimeBytes(available_timestamp) || "/" || sdk.FormatTimeBytes(requested_timestamp) || "/" || signer`. The requested timestamp is included in the availability key so two requests from the same signer that share an `available_timestamp` after a `withdrawal_delay` parameter change do not overwrite each other.
 
 ```proto
 message Withdrawal {

--- a/x/fibre/keeper/abci.go
+++ b/x/fibre/keeper/abci.go
@@ -31,7 +31,7 @@ func (k Keeper) processAvailableWithdrawals(ctx sdk.Context) error {
 
 	for ; iterator.Valid(); iterator.Next() {
 		// Parse key to extract available_at timestamp and signer address
-		availableTime, signer, err := k.ParseWithdrawalsByAvailableKey(iterator.Key())
+		availableTime, _, signer, err := k.ParseWithdrawalsByAvailableKey(iterator.Key())
 		if err != nil {
 			// Log error but continue processing other withdrawals
 			k.Logger(ctx).Error("failed to parse withdrawals-by-available key", "error", err)

--- a/x/fibre/keeper/abci_test.go
+++ b/x/fibre/keeper/abci_test.go
@@ -449,6 +449,84 @@ func (suite *ABCITestSuite) TestBeginBlocker_WithdrawalDelayParamChange() {
 	suite.Empty(withdrawals, "all withdrawals should be processed")
 }
 
+func (suite *ABCITestSuite) TestBeginBlocker_ShortenedDelayKeepsDistinctAvailableIndexEntries() {
+	// Shortening WithdrawalDelay can make two requests from the same signer share
+	// the same available_timestamp. The available-index key must include
+	// requested_timestamp so the later request does not overwrite the earlier
+	// secondary-index entry and leave it unprocessable by BeginBlocker.
+
+	privKey := secp256k1.GenPrivKey()
+	signer := sdk.AccAddress(privKey.PubKey().Address()).String()
+
+	depositAmount := sdk.NewCoin("utia", math.NewInt(2000000))
+	_, err := suite.msgServer.DepositToEscrow(suite.ctx, &types.MsgDepositToEscrow{
+		Signer: signer,
+		Amount: depositAmount,
+	})
+	suite.NoError(err)
+
+	params := suite.keeper.GetParams(suite.ctx)
+	suite.Equal(24*time.Hour, params.WithdrawalDelay)
+
+	withdrawal1Amount := sdk.NewCoin("utia", math.NewInt(500000))
+	time1 := suite.ctx.BlockTime()
+	_, err = suite.msgServer.RequestWithdrawal(suite.ctx, &types.MsgRequestWithdrawal{
+		Signer: signer,
+		Amount: withdrawal1Amount,
+	})
+	suite.NoError(err)
+
+	// Shorten delay by 1h so a request made 1h later shares the same available time.
+	params.WithdrawalDelay = 23 * time.Hour
+	suite.keeper.SetParams(suite.ctx, params)
+
+	suite.ctx = suite.ctx.WithBlockTime(time1.Add(1 * time.Hour))
+	withdrawal2Amount := sdk.NewCoin("utia", math.NewInt(700000))
+	time2 := suite.ctx.BlockTime()
+	_, err = suite.msgServer.RequestWithdrawal(suite.ctx, &types.MsgRequestWithdrawal{
+		Signer: signer,
+		Amount: withdrawal2Amount,
+	})
+	suite.NoError(err)
+
+	withdrawals := suite.keeper.GetWithdrawalsBySigner(suite.ctx, signer)
+	suite.Len(withdrawals, 2)
+	suite.Equal(time1.Add(24*time.Hour), withdrawals[0].AvailableTimestamp)
+	suite.Equal(time2.Add(23*time.Hour), withdrawals[1].AvailableTimestamp)
+	suite.Equal(withdrawals[0].AvailableTimestamp, withdrawals[1].AvailableTimestamp,
+		"both withdrawals must share the same available timestamp for this collision case")
+
+	// Both secondary-index entries must exist (distinct keys despite same available time).
+	availableAt := withdrawals[0].AvailableTimestamp
+	iterator := suite.keeper.GetWithdrawalsByAvailableIterator(suite.ctx, availableAt)
+	defer iterator.Close()
+
+	var indexed []types.Withdrawal
+	for ; iterator.Valid(); iterator.Next() {
+		availableFromKey, requestedFromKey, signerFromKey, parseErr := suite.keeper.ParseWithdrawalsByAvailableKey(iterator.Key())
+		suite.NoError(parseErr)
+		if signerFromKey != signer || !availableFromKey.Equal(availableAt) {
+			continue
+		}
+		var w types.Withdrawal
+		suite.cdc.MustUnmarshal(iterator.Value(), &w)
+		suite.Equal(requestedFromKey, w.RequestedTimestamp)
+		indexed = append(indexed, w)
+	}
+	suite.Len(indexed, 2, "available index must retain both withdrawals when available times collide")
+
+	// Advance to the shared available time and process both.
+	suite.ctx = suite.ctx.WithBlockTime(availableAt)
+	err = suite.keeper.BeginBlocker(suite.ctx)
+	suite.NoError(err)
+
+	escrowAccount, found := suite.keeper.GetEscrowAccount(suite.ctx, signer)
+	suite.True(found)
+	suite.Equal(depositAmount.Sub(withdrawal1Amount).Sub(withdrawal2Amount), escrowAccount.Balance)
+	suite.Equal(depositAmount.Sub(withdrawal1Amount).Sub(withdrawal2Amount), escrowAccount.AvailableBalance)
+	suite.Empty(suite.keeper.GetWithdrawalsBySigner(suite.ctx, signer), "both withdrawals must be processed")
+}
+
 func (suite *ABCITestSuite) TestBeginBlocker_InsufficientEscrowBalanceForSecondWithdrawal() {
 	// This test verifies that if the escrow account's balance is insufficient
 	// for a withdrawal during processing, the withdrawal is skipped but other

--- a/x/fibre/keeper/keeper.go
+++ b/x/fibre/keeper/keeper.go
@@ -114,7 +114,7 @@ func (k Keeper) GetWithdrawal(ctx sdk.Context, signer string, requestedTimestamp
 
 // SetWithdrawal saves a withdrawal to both indexes:
 // 1. Primary index: withdrawals_by_signer/{signer}/{requested_timestamp}
-// 2. Secondary index: withdrawals_by_available/{available_timestamp}/{signer}
+// 2. Secondary index: withdrawals_by_available/{available_timestamp}/{requested_timestamp}/{signer}
 func (k Keeper) SetWithdrawal(ctx sdk.Context, withdrawal types.Withdrawal) {
 	store := ctx.KVStore(k.storeKey)
 	bz := k.cdc.MustMarshal(&withdrawal)
@@ -124,7 +124,7 @@ func (k Keeper) SetWithdrawal(ctx sdk.Context, withdrawal types.Withdrawal) {
 	store.Set(primaryKey, bz)
 
 	// Store in secondary index
-	secondaryKey := types.WithdrawalsByAvailableKey(withdrawal.AvailableTimestamp, withdrawal.Signer)
+	secondaryKey := types.WithdrawalsByAvailableKey(withdrawal.AvailableTimestamp, withdrawal.RequestedTimestamp, withdrawal.Signer)
 	store.Set(secondaryKey, bz)
 }
 
@@ -138,7 +138,7 @@ func (k Keeper) DeleteWithdrawal(ctx sdk.Context, withdrawal types.Withdrawal) {
 	store.Delete(primaryKey)
 
 	// Delete from secondary index
-	secondaryKey := types.WithdrawalsByAvailableKey(withdrawal.AvailableTimestamp, withdrawal.Signer)
+	secondaryKey := types.WithdrawalsByAvailableKey(withdrawal.AvailableTimestamp, withdrawal.RequestedTimestamp, withdrawal.Signer)
 	store.Delete(secondaryKey)
 }
 
@@ -169,17 +169,19 @@ func (k Keeper) GetWithdrawalsByAvailableIterator(ctx sdk.Context, upToTime time
 	return store.Iterator(start, end)
 }
 
-// ParseWithdrawalsByAvailableKey parses the available_at timestamp and signer from the key
-func (k Keeper) ParseWithdrawalsByAvailableKey(key []byte) (available time.Time, signer string, err error) {
+// ParseWithdrawalsByAvailableKey parses available_at, requested_at, and signer from the key.
+// Key layout: 0x04 || available || "/" || requested || "/" || signer
+func (k Keeper) ParseWithdrawalsByAvailableKey(key []byte) (available, requested time.Time, signer string, err error) {
 	// Remove the prefix
 	key = key[len(types.WithdrawalsByAvailableKeyPrefix):]
 
-	// Parse the timestamp (first 29 bytes as per SDK's FormatTimeBytes)
-	timestampBytes := key[:29]
-
-	available, err = sdk.ParseTimeBytes(timestampBytes)
+	// Parse available timestamp (first 29 bytes as per SDK's FormatTimeBytes)
+	if len(key) < 29 {
+		return time.Time{}, time.Time{}, "", fmt.Errorf("key too short for available timestamp")
+	}
+	available, err = sdk.ParseTimeBytes(key[:29])
 	if err != nil {
-		return time.Time{}, "", fmt.Errorf("failed to parse timestamp: %w", err)
+		return time.Time{}, time.Time{}, "", fmt.Errorf("failed to parse available timestamp: %w", err)
 	}
 
 	// Skip the separator "/"
@@ -188,9 +190,23 @@ func (k Keeper) ParseWithdrawalsByAvailableKey(key []byte) (available time.Time,
 		key = key[1:]
 	}
 
-	// The rest is the signer address
+	// Parse requested timestamp (next 29 bytes)
+	if len(key) < 29 {
+		return time.Time{}, time.Time{}, "", fmt.Errorf("key too short for requested timestamp")
+	}
+	requested, err = sdk.ParseTimeBytes(key[:29])
+	if err != nil {
+		return time.Time{}, time.Time{}, "", fmt.Errorf("failed to parse requested timestamp: %w", err)
+	}
+
+	// Skip the separator "/"
+	key = key[29:]
+	if len(key) > 0 && key[0] == '/' {
+		key = key[1:]
+	}
+
 	signer = string(key)
-	return available, signer, nil
+	return available, requested, signer, nil
 }
 
 // GetProcessedPayment retrieves a processed payment by promiseHash

--- a/x/fibre/keeper/keeper_test.go
+++ b/x/fibre/keeper/keeper_test.go
@@ -165,32 +165,41 @@ func (suite *KeeperTestSuite) TestWithdrawal() {
 
 	suite.T().Run("keeper should parse withdrawals by available key", func(t *testing.T) {
 		testSigner := "celestia15drmhzw5kwgenvemy30rqqqgq52axf5wwrruf7"
+		testRequestedAt := testTime.Add(1 * time.Hour)
 		testAvailableAt := testTime.Add(10 * time.Hour)
 
 		// Create a key using the types function
-		key := types.WithdrawalsByAvailableKey(testAvailableAt, testSigner)
+		key := types.WithdrawalsByAvailableKey(testAvailableAt, testRequestedAt, testSigner)
 
 		// Parse it back
-		parsedTime, parsedSigner, err := suite.keeper.ParseWithdrawalsByAvailableKey(key)
+		parsedAvailable, parsedRequested, parsedSigner, err := suite.keeper.ParseWithdrawalsByAvailableKey(key)
 		suite.NoError(err)
 
 		// Verify parsed values match original
-		suite.Equal(testAvailableAt, parsedTime, "parsed time should match original")
+		suite.Equal(testAvailableAt, parsedAvailable, "parsed available time should match original")
+		suite.Equal(testRequestedAt, parsedRequested, "parsed requested time should match original")
 		suite.Equal(testSigner, parsedSigner, "parsed signer should match original")
 
 		// Test with different signer (different length)
 		testSigner2 := "celestia1abcdefghijklmnopqrstuvwxyz12345678901234"
+		testRequestedAt2 := testTime.Add(2 * time.Hour)
 		testAvailableAt2 := testTime.Add(20 * time.Hour)
 
-		key2 := types.WithdrawalsByAvailableKey(testAvailableAt2, testSigner2)
-		parsedTime2, parsedSigner2, err2 := suite.keeper.ParseWithdrawalsByAvailableKey(key2)
+		key2 := types.WithdrawalsByAvailableKey(testAvailableAt2, testRequestedAt2, testSigner2)
+		parsedAvailable2, parsedRequested2, parsedSigner2, err2 := suite.keeper.ParseWithdrawalsByAvailableKey(key2)
 		suite.NoError(err2)
-		suite.Equal(testAvailableAt2, parsedTime2, "parsed time should match original")
+		suite.Equal(testAvailableAt2, parsedAvailable2, "parsed available time should match original")
+		suite.Equal(testRequestedAt2, parsedRequested2, "parsed requested time should match original")
 		suite.Equal(testSigner2, parsedSigner2, "parsed signer should match original")
 
-		// Test that we can distinguish between different times
-		suite.NotEqual(parsedTime, parsedTime2, "different times should parse differently")
+		// Test that we can distinguish between different times and signers
+		suite.NotEqual(parsedAvailable, parsedAvailable2, "different available times should parse differently")
+		suite.NotEqual(parsedRequested, parsedRequested2, "different requested times should parse differently")
 		suite.NotEqual(parsedSigner, parsedSigner2, "different signers should parse differently")
+
+		// Same available+signer but different requested must produce distinct keys
+		keySameAvailable := types.WithdrawalsByAvailableKey(testAvailableAt, testRequestedAt2, testSigner)
+		suite.NotEqual(key, keySameAvailable, "requested timestamp must uniquify the available-index key")
 	})
 
 	suite.T().Run("keeper should get withdrawals by available timestamp", func(t *testing.T) {
@@ -235,7 +244,7 @@ func (suite *KeeperTestSuite) TestWithdrawal() {
 		// Should find withdrawal1 and withdrawal2, but not withdrawal3
 		var foundWithdrawals []types.Withdrawal
 		for ; iterator.Valid(); iterator.Next() {
-			availableAt, signerFromKey, err := suite.keeper.ParseWithdrawalsByAvailableKey(iterator.Key())
+			availableAt, requestedAt, signerFromKey, err := suite.keeper.ParseWithdrawalsByAvailableKey(iterator.Key())
 			suite.NoError(err)
 
 			// Skip if not one of our test withdrawals (from previous tests)
@@ -248,6 +257,7 @@ func (suite *KeeperTestSuite) TestWithdrawal() {
 			var withdrawal types.Withdrawal
 			suite.cdc.MustUnmarshal(iterator.Value(), &withdrawal)
 			suite.Equal(signerFromKey, withdrawal.Signer, "signer from key should match withdrawal signer")
+			suite.Equal(requestedAt, withdrawal.RequestedTimestamp, "requested time from key should match withdrawal")
 			foundWithdrawals = append(foundWithdrawals, withdrawal)
 		}
 

--- a/x/fibre/types/keys.go
+++ b/x/fibre/types/keys.go
@@ -51,12 +51,14 @@ func WithdrawalsBySignerPrefix(signer string) []byte {
 	return append(WithdrawalsBySignerKeyPrefix, []byte(signer)...)
 }
 
-// WithdrawalsByAvailableKey returns the store key for a withdrawal indexed by available time
-// This index is used for efficient time-ordered iteration in BeginBlocker
-func WithdrawalsByAvailableKey(availableAt time.Time, signer string) []byte {
+// WithdrawalsByAvailableKey returns the store key for a withdrawal indexed by available time.
+// Layout: 0x04 || available || "/" || requested || "/" || signer.
+// The requested timestamp keeps the key unique per request after a WithdrawalDelay change.
+func WithdrawalsByAvailableKey(availableAt, requestedAt time.Time, signer string) []byte {
 	key := WithdrawalsByAvailableKeyPrefix
-	timestampBytes := sdk.FormatTimeBytes(availableAt)
-	key = append(key, timestampBytes...)
+	key = append(key, sdk.FormatTimeBytes(availableAt)...)
+	key = append(key, []byte("/")...)
+	key = append(key, sdk.FormatTimeBytes(requestedAt)...)
 	key = append(key, []byte("/")...)
 	return append(key, []byte(signer)...)
 }


### PR DESCRIPTION
## Summary
- Include `requested_timestamp` in the withdrawals-by-available key so two requests from the same signer cannot overwrite each other when `WithdrawalDelay` is shortened.
- Add a regression test for the shared-`available_timestamp` case and update the fibre spec.

Fixes finding 2 in #7548 


## Test plan
- [x] `go test -count=1 -run 'TestKeeperTestSuite|TestABCITestSuite' ./x/fibre/keeper/`
- [x] `TestBeginBlocker_ShortenedDelayKeepsDistinctAvailableIndexEntries` passes