### PR TITLE
fix(minfee): export params in ExportGenesis

### DIFF
--- a/x/minfee/keeper/genesis.go
+++ b/x/minfee/keeper/genesis.go
@@ -27,7 +27,7 @@ func (k Keeper) ExportGenesis(ctx context.Context) *types.GenesisState {
 	return &types.GenesisState{
 		Params: params,
 		// The deprecated top-level field must stay populated and in sync with
-		// params: ValidateGenesis rejects a zero value.
+		// params because ValidateGenesis rejects a zero value.
 		NetworkMinGasPrice: params.NetworkMinGasPrice,
 	}
 }

--- a/x/minfee/keeper/genesis.go
+++ b/x/minfee/keeper/genesis.go
@@ -23,8 +23,11 @@ func (k Keeper) InitGenesis(ctx context.Context, genState types.GenesisState) er
 // ExportGenesis returns the minfee module's exported genesis.
 func (k Keeper) ExportGenesis(ctx context.Context) *types.GenesisState {
 	sdkCtx := sdk.UnwrapSDKContext(ctx)
-	genesis := types.DefaultGenesis()
-	// TODO: genesis should hold params not this field.
-	genesis.NetworkMinGasPrice = k.GetParams(sdkCtx).NetworkMinGasPrice
-	return genesis
+	params := k.GetParams(sdkCtx)
+	return &types.GenesisState{
+		Params: params,
+		// The deprecated top-level field must stay populated and in sync with
+		// params: ValidateGenesis rejects a zero value.
+		NetworkMinGasPrice: params.NetworkMinGasPrice,
+	}
 }

--- a/x/minfee/keeper/genesis_test.go
+++ b/x/minfee/keeper/genesis_test.go
@@ -1,0 +1,36 @@
+package keeper_test
+
+import (
+	"testing"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v10/app"
+	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
+	"github.com/celestiaorg/celestia-app/v10/x/minfee/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestGenesisRoundTripPreservesParams sets a non-default network min gas price,
+// exports genesis, and imports it into a fresh app. A default-value round-trip
+// would pass even with ExportGenesis dropping Params, so the non-default value
+// is what makes this test meaningful.
+func TestGenesisRoundTripPreservesParams(t *testing.T) {
+	testApp, _, _ := testutil.NewTestAppWithGenesisSet(app.DefaultConsensusParams())
+	sdkCtx := testApp.NewContext(false)
+
+	want := types.NewParams(sdkmath.LegacyNewDecWithPrec(5, 3)) // 0.005utia, non-default
+	require.NotEqual(t, types.DefaultNetworkMinGasPrice, want.NetworkMinGasPrice,
+		"test requires a non-default value")
+	testApp.MinFeeKeeper.SetParams(sdkCtx, want)
+
+	exported := testApp.MinFeeKeeper.ExportGenesis(sdkCtx)
+	require.Equal(t, want.NetworkMinGasPrice, exported.Params.NetworkMinGasPrice)
+	require.Equal(t, want.NetworkMinGasPrice, exported.NetworkMinGasPrice,
+		"deprecated top-level field must stay in sync with params")
+	require.NoError(t, types.ValidateGenesis(exported))
+
+	freshApp, _, _ := testutil.NewTestAppWithGenesisSet(app.DefaultConsensusParams())
+	freshCtx := freshApp.NewContext(false)
+	require.NoError(t, freshApp.MinFeeKeeper.InitGenesis(freshCtx, *exported))
+	require.Equal(t, want, freshApp.MinFeeKeeper.GetParams(freshCtx))
+}


### PR DESCRIPTION
## Summary

`minfee`'s `ExportGenesis` built its return value from `types.DefaultGenesis()` and only copied over the deprecated top-level `NetworkMinGasPrice` field, leaving `Params` at its default. Any chain that had governance-updated the network min gas price would export a genesis file whose `Params` silently reverted to the default.

This exports the actual keeper params instead:

```go
params := k.GetParams(sdkCtx)
return &types.GenesisState{
    Params:             params,
    NetworkMinGasPrice: params.NetworkMinGasPrice,
}
```

The deprecated top-level `NetworkMinGasPrice` field stays populated and in sync with `Params`, since `ValidateGenesis` rejects a zero value there.

## Testing

Adds `TestGenesisRoundTripPreservesParams`, which sets a non-default network min gas price, exports genesis, and re-imports it into a fresh app. The non-default value is what makes the test meaningful — a default-value round-trip would pass even with the old buggy code.
