### PR TITLE
feat(fibre)!: add min/max bounds for payment promise timeout and shard retention

### DIFF
--- a/specs/src/fibre_module.md
+++ b/specs/src/fibre_module.md
@@ -435,6 +435,7 @@ message Params {
   google.protobuf.Duration payment_promise_timeout = 3 [(gogoproto.moretags) = "yaml:\"payment_promise_timeout\"", (gogoproto.stdduration) = true, (gogoproto.nullable) = false];
   google.protobuf.Duration payment_promise_retention_window = 4 [(gogoproto.moretags) = "yaml:\"payment_promise_retention_window\"", (gogoproto.stdduration) = true, (gogoproto.nullable) = false];
   uint64 payment_promise_height_window = 5 [(gogoproto.moretags) = "yaml:\"payment_promise_height_window\""];
+  google.protobuf.Duration shard_retention = 6 [(gogoproto.moretags) = "yaml:\"shard_retention\"", (gogoproto.stdduration) = true, (gogoproto.nullable) = false];
 }
 ```
 
@@ -442,9 +443,12 @@ message Params {
 | --- | --- | --- | --- |
 | `gas_per_blob_byte` | `1` | Must be nonzero | Stored and exposed as a parameter, but not used by the current PayForFibre payment formula |
 | `withdrawal_delay` | `24h` | Must be positive | Sets withdrawal availability and the oldest accepted payment-promise creation time |
-| `payment_promise_timeout` | `1h` | Must be positive | Defines normal promise expiration and when timeout processing becomes valid |
+| `payment_promise_timeout` | `1h` | Must be between `10m` and `12h` | Defines normal promise expiration and when timeout processing becomes valid |
 | `payment_promise_retention_window` | `24h` | Must be positive | Defines when processed-payment replay records are pruned |
 | `payment_promise_height_window` | `1000` | Must be nonzero | Limits how far behind the current height a normal payment promise can be |
+| `shard_retention` | `4h` | Must be between `10m` and `168h` | Sets the local retention floor validators apply to uploaded shards |
+
+`payment_promise_timeout` is bounded below so a promise stays valid long enough to be uploaded, signed, and settled in a block, and bounded above so it stays well inside both the `withdrawal_delay` window gating its `creation_timestamp` and the `payment_promise_retention_window` record that prevents double settlement. `shard_retention` is bounded below so shards outlive the window in which a client fetches them back, and above to cap the local storage obligation it places on assigned validators.
 
 ## CLI
 

--- a/x/fibre/types/params.go
+++ b/x/fibre/types/params.go
@@ -35,6 +35,22 @@ var (
 	DefaultShardRetention = 4 * time.Hour
 )
 
+const (
+	// MinPaymentPromiseTimeout is the lower bound of the payment promise timeout
+	// parameter. A promise has to stay valid long enough for the client to upload
+	// its shards to the assigned validators, collect their signatures, and get
+	// MsgPayForFibre included in a block.
+	MinPaymentPromiseTimeout = 10 * time.Minute
+	// MaxPaymentPromiseTimeout is the upper bound of the payment promise timeout
+	// parameter.
+	MaxPaymentPromiseTimeout = 12 * time.Hour
+
+	// MinShardRetention is the lower bound of the shard retention parameter.
+	MinShardRetention = 10 * time.Minute
+	// MaxShardRetention is the upper bound of the shard retention parameter.
+	MaxShardRetention = 7 * 24 * time.Hour
+)
+
 // ParamKeyTable returns the param key table for the fibre module
 func ParamKeyTable() paramtypes.KeyTable {
 	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
@@ -141,8 +157,12 @@ func validatePaymentPromiseTimeout(v any) error {
 		return fmt.Errorf("payment promise timeout cannot be nil")
 	}
 
-	if *duration <= 0 {
-		return fmt.Errorf("payment promise timeout must be positive: %s", *duration)
+	if *duration < MinPaymentPromiseTimeout {
+		return fmt.Errorf("payment promise timeout must be at least %s: %s", MinPaymentPromiseTimeout, *duration)
+	}
+
+	if *duration > MaxPaymentPromiseTimeout {
+		return fmt.Errorf("payment promise timeout must be at most %s: %s", MaxPaymentPromiseTimeout, *duration)
 	}
 
 	return nil
@@ -191,8 +211,12 @@ func validateShardRetention(v any) error {
 		return fmt.Errorf("shard retention cannot be nil")
 	}
 
-	if *duration <= 0 {
-		return fmt.Errorf("shard retention must be positive: %s", *duration)
+	if *duration < MinShardRetention {
+		return fmt.Errorf("shard retention must be at least %s: %s", MinShardRetention, *duration)
+	}
+
+	if *duration > MaxShardRetention {
+		return fmt.Errorf("shard retention must be at most %s: %s", MaxShardRetention, *duration)
 	}
 
 	return nil

--- a/x/fibre/types/params_test.go
+++ b/x/fibre/types/params_test.go
@@ -1,0 +1,144 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validatePaymentPromiseTimeout(t *testing.T) {
+	type test struct {
+		name      string
+		input     any
+		expectErr bool
+	}
+	tests := []test{
+		{
+			name:      "default",
+			input:     &DefaultPaymentPromiseTimeout,
+			expectErr: false,
+		},
+		{
+			name:      "wrong type",
+			input:     DefaultPaymentPromiseTimeout,
+			expectErr: true,
+		},
+		{
+			name:      "nil",
+			input:     (*time.Duration)(nil),
+			expectErr: true,
+		},
+		{
+			name:      "zero",
+			input:     new(time.Duration(0)),
+			expectErr: true,
+		},
+		{
+			name:      "negative",
+			input:     new(-time.Hour),
+			expectErr: true,
+		},
+		{
+			name:      "below the lower bound",
+			input:     new(MinPaymentPromiseTimeout - time.Nanosecond),
+			expectErr: true,
+		},
+		{
+			name:      "exactly at the lower bound",
+			input:     new(MinPaymentPromiseTimeout),
+			expectErr: false,
+		},
+		{
+			// Beyond this a promise outlives the withdrawal delay window and the
+			// processed payment retention window that prevents double settlement.
+			name:      "above the upper bound",
+			input:     new(MaxPaymentPromiseTimeout + time.Nanosecond),
+			expectErr: true,
+		},
+		{
+			name:      "exactly at the upper bound",
+			input:     new(MaxPaymentPromiseTimeout),
+			expectErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validatePaymentPromiseTimeout(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func Test_validateShardRetention(t *testing.T) {
+	type test struct {
+		name      string
+		input     any
+		expectErr bool
+	}
+	tests := []test{
+		{
+			name:      "default",
+			input:     &DefaultShardRetention,
+			expectErr: false,
+		},
+		{
+			name:      "wrong type",
+			input:     DefaultShardRetention,
+			expectErr: true,
+		},
+		{
+			name:      "nil",
+			input:     (*time.Duration)(nil),
+			expectErr: true,
+		},
+		{
+			name:      "zero",
+			input:     new(time.Duration(0)),
+			expectErr: true,
+		},
+		{
+			name:      "negative",
+			input:     new(-time.Hour),
+			expectErr: true,
+		},
+		{
+			name:      "below the lower bound",
+			input:     new(MinShardRetention - time.Nanosecond),
+			expectErr: true,
+		},
+		{
+			name:      "exactly at the lower bound",
+			input:     new(MinShardRetention),
+			expectErr: false,
+		},
+		{
+			name:      "above the upper bound",
+			input:     new(MaxShardRetention + time.Nanosecond),
+			expectErr: true,
+		},
+		{
+			name:      "exactly at the upper bound",
+			input:     new(MaxShardRetention),
+			expectErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateShardRetention(tt.input)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestDefaultParamsAreValid(t *testing.T) {
+	assert.NoError(t, DefaultParams().Validate())
+}


### PR DESCRIPTION
Closes #7504
PROTOCO-2060

## Problem

`payment_promise_timeout` and `shard_retention` validated only that they were positive. As raised in [this review comment](https://github.com/celestiaorg/celestia-app/pull/7489#discussion_r3518266325), governance could set them to values like `1ms`, at which point the protocol would not work at all.

## Change

Both params are now range-checked:

| Param | Min | Max | Default |
|---|---|---|---|
| `payment_promise_timeout` | `10m` | `12h` | `1h` (unchanged) |
| `shard_retention` | `10m` | `168h` (7d) | `4h` (unchanged) |

`payment_promise_timeout` is bounded below so a promise stays valid long enough for the client to upload its shards, collect validator signatures, and get `MsgPayForFibre` into a block. It is bounded above so it stays well inside both the `withdrawal_delay` window gating how old its `creation_timestamp` may be and the `payment_promise_retention_window` record that prevents double settlement.

`shard_retention` is bounded below so shards outlive the window in which a client fetches them back, and above because retention is a local storage obligation on every assigned validator.

Both defaults fall inside the new ranges, so no migration is needed.

## Testing

Added `x/fibre/types/params_test.go` covering wrong type, nil, zero, negative, and each bound at ±1ns and exactly on it, plus a check that `DefaultParams()` validates. The boundary cases are meaningful guards: `10m-1ns` and `168h+1ns` are both strictly positive, so the previous `<= 0` check accepted them.

`make build`, `make test-short` (69/69 packages), and `golangci-lint run ./x/fibre/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)