### PR TITLE
test(fibre): add missing e2e tests

### DIFF
--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -284,7 +284,6 @@ func (s *FibreE2ETestSuite) Test03Put() {
 }
 
 func (s *FibreE2ETestSuite) Test04Download() {
-	t := s.T()
 	ctx := s.cctx.GoContext()
 
 	cases := []struct {
@@ -298,6 +297,7 @@ func (s *FibreE2ETestSuite) Test04Download() {
 
 	for _, tc := range cases {
 		s.Run(tc.name, func() {
+			t := s.T()
 			// wait for a fresh block to avoid clock skew with the payment promise.
 			require.NoError(t, s.cctx.WaitForNextBlock())
 
@@ -313,6 +313,7 @@ func (s *FibreE2ETestSuite) Test04Download() {
 			downloaded, err := s.fibreClient.Download(ctx, result.BlobID, fibre.WithHeight(result.Height))
 			require.NoError(t, err)
 			require.NotNil(t, downloaded)
+			defer downloaded.Free()
 			require.Equal(t, data, downloaded.Data(), "downloaded blob must byte-match the submitted data")
 
 			// Charged on the padded upload size the promise commits to, not len(data).
@@ -361,10 +362,10 @@ func (s *FibreE2ETestSuite) Test05InsufficientEscrow() {
 }
 
 func (s *FibreE2ETestSuite) Test06DownloadFailures() {
-	t := s.T()
 	ctx := s.cctx.GoContext()
 
 	s.Run("NotFound", func() {
+		t := s.T()
 		var c fibre.Commitment
 		_, err := rand.Read(c[:])
 		require.NoError(t, err)
@@ -375,6 +376,7 @@ func (s *FibreE2ETestSuite) Test06DownloadFailures() {
 	})
 
 	s.Run("MalformedID", func() {
+		t := s.T()
 		_, err := s.fibreClient.Download(ctx, fibre.BlobID{0x00})
 		require.Error(t, err, "download of a malformed blob ID must fail")
 		require.ErrorContains(t, err, "blob ID")

--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -30,6 +30,10 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+// noEscrowKeyName is a genesis-funded account that never deposits
+// into escrow
+const noEscrowKeyName = "no-escrow-account"
+
 func TestFibreE2ETestSuite(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping fibre e2e test in short mode")
@@ -52,7 +56,7 @@ func (s *FibreE2ETestSuite) SetupSuite() {
 	t := s.T()
 
 	cfg := testnode.DefaultConfig().
-		WithFundedAccounts(fibre.DefaultKeyName).
+		WithFundedAccounts(fibre.DefaultKeyName, noEscrowKeyName).
 		WithDelayedPrecommitTimeout(500 * time.Millisecond)
 
 	cctx, _, grpcAddr := testnode.NewNetwork(t, cfg)
@@ -277,6 +281,160 @@ func (s *FibreE2ETestSuite) Test03Put() {
 	// verify the PayForFibre tx was included on chain by waiting for the block.
 	_, err = s.cctx.WaitForTx(result.TxHash, 5)
 	require.NoError(t, err)
+}
+
+func (s *FibreE2ETestSuite) Test04Download() {
+	t := s.T()
+	ctx := s.cctx.GoContext()
+
+	cases := []struct {
+		name string
+		ns   share.Namespace
+		size int
+	}{
+		{"SmallBlob", share.MustNewV0Namespace([]byte{0xBE, 0xEF}), 4 * 1024},
+		{"LargeBlob", share.MustNewV0Namespace([]byte{0xCA, 0xFE}), 256 * 1024},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			// wait for a fresh block to avoid clock skew with the payment promise.
+			require.NoError(t, s.cctx.WaitForNextBlock())
+
+			data := make([]byte, tc.size)
+			_, err := rand.Read(data)
+			require.NoError(t, err)
+
+			before := s.escrowAccount(ctx)
+
+			result, err := fibre.Put(ctx, s.fibreClient, s.txClient, tc.ns, data)
+			require.NoError(t, err)
+
+			downloaded, err := s.fibreClient.Download(ctx, result.BlobID, fibre.WithHeight(result.Height))
+			require.NoError(t, err)
+			require.NotNil(t, downloaded)
+			require.Equal(t, data, downloaded.Data(), "downloaded blob must byte-match the submitted data")
+
+			// Charged on the padded upload size the promise commits to, not len(data).
+			uploadSize := uint32(fibre.DefaultBlobConfigV0().UploadSize(len(data)))
+			wantDebit := fibretypes.PaymentAmount(uploadSize)
+			after := s.escrowAccount(ctx)
+			require.Equal(t, wantDebit, before.Balance.Sub(after.Balance),
+				"escrow Balance should drop by the payment amount")
+			require.Equal(t, wantDebit, before.AvailableBalance.Sub(after.AvailableBalance),
+				"escrow AvailableBalance should drop by the payment amount")
+		})
+	}
+}
+
+func (s *FibreE2ETestSuite) Test05InsufficientEscrow() {
+	t := s.T()
+	ctx := s.cctx.GoContext()
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
+	ecfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	poorClient, err := user.SetupTxClient(
+		ctx, s.cctx.Keyring, s.cctx.GRPCClient, ecfg,
+		user.WithDefaultAccount(noEscrowKeyName),
+	)
+	require.NoError(t, err)
+
+	fibreQueryClient := fibretypes.NewQueryClient(s.cctx.GRPCClient)
+	signer := poorClient.DefaultAddress().String()
+
+	escrowResp, err := fibreQueryClient.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{Signer: signer})
+	require.NoError(t, err)
+	require.False(t, escrowResp.Found, "signer must start without an escrow account")
+
+	data := make([]byte, 4*1024)
+	_, err = rand.Read(data)
+	require.NoError(t, err)
+	ns := share.MustNewV0Namespace([]byte{0x1D, 0x1E})
+
+	_, err = fibre.Put(ctx, s.fibreClient, poorClient, ns, data)
+	require.Error(t, err, "Put must fail when the signer has no escrow to cover the payment")
+	t.Logf("insufficient-escrow Put rejected as expected: %v", err)
+
+	escrowResp, err = fibreQueryClient.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{Signer: signer})
+	require.NoError(t, err)
+	require.False(t, escrowResp.Found, "no escrow account should exist after a rejected Put")
+}
+
+func (s *FibreE2ETestSuite) Test06DownloadFailures() {
+	t := s.T()
+	ctx := s.cctx.GoContext()
+
+	s.Run("NotFound", func() {
+		var c fibre.Commitment
+		_, err := rand.Read(c[:])
+		require.NoError(t, err)
+
+		_, err = s.fibreClient.Download(ctx, fibre.NewBlobID(0, c))
+		require.Error(t, err, "download of a never-uploaded commitment must fail")
+		require.ErrorIs(t, err, fibre.ErrNotFound)
+	})
+
+	s.Run("MalformedID", func() {
+		_, err := s.fibreClient.Download(ctx, fibre.BlobID{0x00})
+		require.Error(t, err, "download of a malformed blob ID must fail")
+		require.ErrorContains(t, err, "blob ID")
+	})
+}
+
+func (s *FibreE2ETestSuite) Test07DuplicatePayment() {
+	t := s.T()
+	ctx := s.cctx.GoContext()
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
+	data := make([]byte, 4*1024)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+
+	blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+	require.NoError(t, err)
+	defer blob.Free()
+
+	// Upload once, then drive settlement manually
+	ns := share.MustNewV0Namespace([]byte{0xAB, 0xCD})
+	signed, err := s.fibreClient.Upload(ctx, ns, blob, fibre.WithKeyName(s.txClient.DefaultAccountName()))
+	require.NoError(t, err)
+
+	promiseProto, err := signed.ToProto()
+	require.NoError(t, err)
+	msg := &fibretypes.MsgPayForFibre{
+		Signer:              s.txClient.DefaultAddress().String(),
+		PaymentPromise:      *promiseProto,
+		ValidatorSignatures: signed.ValidatorSignatures,
+	}
+
+	resp, err := s.txClient.BroadcastTx(ctx, []sdk.Msg{msg})
+	require.NoError(t, err)
+	_, err = s.txClient.ConfirmTx(ctx, resp.TxHash)
+	require.NoError(t, err)
+
+	hash, err := signed.Hash()
+	require.NoError(t, err)
+	q := fibretypes.NewQueryClient(s.cctx.GRPCClient)
+	processed, err := q.IsPaymentProcessed(ctx, &fibretypes.QueryIsPaymentProcessedRequest{PromiseHash: hash})
+	require.NoError(t, err)
+	require.True(t, processed.Found, "payment promise should be recorded as processed after settlement")
+
+	resp, err = s.txClient.BroadcastTx(ctx, []sdk.Msg{msg})
+	if err == nil {
+		_, err = s.txClient.ConfirmTx(ctx, resp.TxHash)
+	}
+	require.Error(t, err, "replayed PayForFibre must be rejected by the dedup guard")
+	t.Logf("duplicate PayForFibre rejected as expected: %v", err)
+}
+
+func (s *FibreE2ETestSuite) escrowAccount(ctx context.Context) *fibretypes.EscrowAccount {
+	q := fibretypes.NewQueryClient(s.cctx.GRPCClient)
+	resp, err := q.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{
+		Signer: s.txClient.DefaultAddress().String(),
+	})
+	s.Require().NoError(err)
+	s.Require().True(resp.Found, "escrow account should exist")
+	return resp.EscrowAccount
 }
 
 // fixedHostRegistry returns the same address for every validator.

--- a/fibre/internal/e2e/fibre_pruning_e2e_test.go
+++ b/fibre/internal/e2e/fibre_pruning_e2e_test.go
@@ -1,0 +1,96 @@
+package e2e_test
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v10/app"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v10/pkg/user"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testnode"
+	"github.com/celestiaorg/go-square/v4/share"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// FibrePruningTestSuite covers shard pruning.
+type FibrePruningTestSuite struct {
+	suite.Suite
+
+	cctx        testnode.Context
+	fibreServer *fibre.Server
+	fibreClient *fibre.Client
+	txClient    *user.TxClient
+}
+
+func TestFibrePruningTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fibre pruning e2e test in short mode")
+	}
+	suite.Run(t, new(FibrePruningTestSuite))
+}
+
+func (s *FibrePruningTestSuite) SetupSuite() {
+	t := s.T()
+
+	ecfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	cfg := testnode.DefaultConfig().
+		WithFundedAccounts(fibre.DefaultKeyName).
+		WithDelayedPrecommitTimeout(500 * time.Millisecond).
+		WithModifiers(setFibreShortLifetimes(ecfg.Codec, 5*time.Second, 5*time.Second))
+
+	cctx, _, grpcAddr := testnode.NewNetwork(t, cfg)
+	s.cctx = cctx
+	_, err := s.cctx.WaitForHeight(1)
+	require.NoError(t, err)
+
+	stack := startFibreStack(t, cctx, ecfg, grpcAddr)
+	s.fibreServer, s.fibreClient, s.txClient = stack.server, stack.client, stack.tx
+
+	fundEscrow(t, cctx, s.txClient, sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(50_000_000)))
+}
+
+func (s *FibrePruningTestSuite) TearDownSuite() {
+	if s.fibreServer != nil {
+		_ = s.fibreServer.Stop(context.Background())
+	}
+	if s.fibreClient != nil {
+		_ = s.fibreClient.Stop(context.Background())
+	}
+}
+
+func (s *FibrePruningTestSuite) TestPruneExpiredShard() {
+	t := s.T()
+	ctx := s.cctx.GoContext()
+
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
+	data := make([]byte, 4*1024)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+
+	blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+	require.NoError(t, err)
+	defer blob.Free()
+
+	ns := share.MustNewV0Namespace([]byte{0x9A, 0x9B})
+	_, err = s.fibreClient.Upload(ctx, ns, blob, fibre.WithKeyName(s.txClient.DefaultAccountName()))
+	require.NoError(t, err)
+
+	downloaded, err := s.fibreClient.Download(ctx, blob.ID())
+	require.NoError(t, err)
+	require.Equal(t, data, downloaded.Data())
+
+	pruned, err := s.fibreServer.Store().PruneBefore(ctx, time.Now().Add(2*time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned, "the expired shard should be pruned")
+
+	_, err = s.fibreClient.Download(ctx, blob.ID())
+	require.ErrorIs(t, err, fibre.ErrNotFound)
+}

--- a/fibre/internal/e2e/fibre_pruning_e2e_test.go
+++ b/fibre/internal/e2e/fibre_pruning_e2e_test.go
@@ -85,9 +85,14 @@ func (s *FibrePruningTestSuite) TestPruneExpiredShard() {
 
 	downloaded, err := s.fibreClient.Download(ctx, blob.ID())
 	require.NoError(t, err)
+	defer downloaded.Free()
 	require.Equal(t, data, downloaded.Data())
 
-	pruned, err := s.fibreServer.Store().PruneBefore(ctx, time.Now().Add(2*time.Minute))
+	pruned, err := s.fibreServer.Store().PruneBefore(ctx, time.Now())
+	require.NoError(t, err)
+	require.Zero(t, pruned, "shard must not be pruned before its retention deadline")
+
+	pruned, err = s.fibreServer.Store().PruneBefore(ctx, time.Now().Add(2*time.Minute))
 	require.NoError(t, err)
 	require.Equal(t, 1, pruned, "the expired shard should be pruned")
 

--- a/fibre/internal/e2e/fibre_stack_test.go
+++ b/fibre/internal/e2e/fibre_stack_test.go
@@ -1,0 +1,86 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	grpcfibre "github.com/celestiaorg/celestia-app/v10/fibre/internal/grpc"
+	"github.com/celestiaorg/celestia-app/v10/pkg/user"
+	"github.com/celestiaorg/celestia-app/v10/test/util/genesis"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testnode"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/cometbft/cometbft/privval"
+	core "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+)
+
+// fibreStack is a running FSP server plus a fibre client wired to it and a
+// TxClient for the funded default account.
+type fibreStack struct {
+	server *fibre.Server
+	client *fibre.Client
+	tx     *user.TxClient
+}
+
+func startFibreStack(t *testing.T, cctx testnode.Context, ecfg encoding.Config, grpcAddr string) fibreStack {
+	t.Helper()
+	ctx := cctx.GoContext()
+
+	pvKeyFile := filepath.Join(cctx.HomeDir, "config", "priv_validator_key.json")
+	pvStateFile := filepath.Join(cctx.HomeDir, "data", "priv_validator_state.json")
+	filePV := privval.LoadFilePV(pvKeyFile, pvStateFile)
+
+	serverCfg := fibre.DefaultServerConfig()
+	serverCfg.AppGRPCAddress = grpcAddr
+	serverCfg.ServerListenAddress = "127.0.0.1:0"
+	serverCfg.SignerFn = func(_ string) (core.PrivValidator, error) { return filePV, nil }
+	serverCfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+		return fibre.NewMemoryStore(scfg), nil
+	}
+	server, err := fibre.NewServer(serverCfg)
+	require.NoError(t, err)
+	require.NoError(t, server.Start(ctx))
+
+	txClient, err := user.SetupTxClient(ctx, cctx.Keyring, cctx.GRPCClient, ecfg, user.WithDefaultAccount(fibre.DefaultKeyName))
+	require.NoError(t, err)
+
+	var client *fibre.Client
+	clientCfg := fibre.DefaultClientConfig()
+	clientCfg.StateAddress = grpcAddr
+	clientCfg.NewClientFn = grpcfibre.DefaultNewClientFn(
+		&fixedHostRegistry{addr: server.ListenAddress()},
+		func() string { return client.ChainID() },
+		clientCfg.MaxMessageSize,
+		nil,
+	)
+	client, err = fibre.NewClient(cctx.Keyring, clientCfg)
+	require.NoError(t, err)
+	require.NoError(t, client.Start(ctx))
+
+	return fibreStack{server: server, client: client, tx: txClient}
+}
+
+func fundEscrow(t *testing.T, cctx testnode.Context, tx *user.TxClient, amount sdk.Coin) {
+	t.Helper()
+	resp, err := tx.SubmitTx(cctx.GoContext(),
+		[]sdk.Msg{&fibretypes.MsgDepositToEscrow{Signer: tx.DefaultAddress().String(), Amount: amount}},
+		user.SetGasLimit(200_000), user.SetFee(5_000))
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), resp.Code)
+}
+
+func setFibreShortLifetimes(cdc codec.Codec, shardRetention, promiseTimeout time.Duration) genesis.Modifier {
+	return func(state map[string]json.RawMessage) map[string]json.RawMessage {
+		gs := fibretypes.DefaultGenesis()
+		gs.Params.ShardRetention = shardRetention
+		gs.Params.PaymentPromiseTimeout = promiseTimeout
+		state[fibretypes.ModuleName] = cdc.MustMarshalJSON(gs)
+		return state
+	}
+}

--- a/fibre/internal/e2e/fibre_timeout_e2e_test.go
+++ b/fibre/internal/e2e/fibre_timeout_e2e_test.go
@@ -1,0 +1,133 @@
+package e2e_test
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v10/app"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v10/pkg/user"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testnode"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/celestiaorg/go-square/v4/share"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+// promiseTimeout is shortened so an unsettled promise expires within the test.
+const promiseTimeout = 5 * time.Second
+
+// FibreTimeoutTestSuite covers the timeout settlement path
+type FibreTimeoutTestSuite struct {
+	suite.Suite
+
+	cctx        testnode.Context
+	fibreServer *fibre.Server
+	fibreClient *fibre.Client
+	txClient    *user.TxClient
+}
+
+func TestFibreTimeoutTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fibre timeout e2e test in short mode")
+	}
+	suite.Run(t, new(FibreTimeoutTestSuite))
+}
+
+func (s *FibreTimeoutTestSuite) SetupSuite() {
+	t := s.T()
+
+	ecfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	cfg := testnode.DefaultConfig().
+		WithFundedAccounts(fibre.DefaultKeyName).
+		WithDelayedPrecommitTimeout(500 * time.Millisecond).
+		WithModifiers(setFibreShortLifetimes(ecfg.Codec, promiseTimeout, promiseTimeout))
+
+	cctx, _, grpcAddr := testnode.NewNetwork(t, cfg)
+	s.cctx = cctx
+	_, err := s.cctx.WaitForHeight(1)
+	require.NoError(t, err)
+
+	stack := startFibreStack(t, cctx, ecfg, grpcAddr)
+	s.fibreServer, s.fibreClient, s.txClient = stack.server, stack.client, stack.tx
+
+	fundEscrow(t, cctx, s.txClient, sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(50_000_000)))
+}
+
+func (s *FibreTimeoutTestSuite) TearDownSuite() {
+	if s.fibreServer != nil {
+		_ = s.fibreServer.Stop(context.Background())
+	}
+	if s.fibreClient != nil {
+		_ = s.fibreClient.Stop(context.Background())
+	}
+}
+
+// TestTimeoutSettlement uploads a blob but never submits its PayForFibre
+func (s *FibreTimeoutTestSuite) TestTimeoutSettlement() {
+	t := s.T()
+	ctx := s.cctx.GoContext()
+
+	require.NoError(t, s.cctx.WaitForNextBlock())
+
+	data := make([]byte, 4*1024)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+
+	blob, err := fibre.NewBlob(data, fibre.DefaultBlobConfigV0())
+	require.NoError(t, err)
+	defer blob.Free()
+
+	ns := share.MustNewV0Namespace([]byte{0x7A, 0x7B})
+	signed, err := s.fibreClient.Upload(ctx, ns, blob, fibre.WithKeyName(s.txClient.DefaultAccountName()))
+	require.NoError(t, err)
+
+	promiseProto, err := signed.ToProto()
+	require.NoError(t, err)
+
+	timeoutMsg := &fibretypes.MsgPaymentPromiseTimeout{
+		Signer:         s.txClient.DefaultAddress().String(),
+		PaymentPromise: *promiseProto,
+	}
+	submit := func() error {
+		_, err := s.txClient.SubmitTx(ctx, []sdk.Msg{timeoutMsg},
+			user.SetGasLimit(300_000), user.SetFee(5_000))
+		return err
+	}
+
+	fibreQ := fibretypes.NewQueryClient(s.cctx.GRPCClient)
+	signer := s.txClient.DefaultAddress().String()
+	escrowBalance := func() sdk.Coin {
+		resp, err := fibreQ.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{Signer: signer})
+		require.NoError(t, err)
+		require.True(t, resp.Found)
+		return resp.EscrowAccount.Balance
+	}
+
+	before := escrowBalance()
+
+	err = submit()
+	require.Error(t, err, "timeout settlement must be refused before the promise expires")
+	require.ErrorContains(t, err, "timed out")
+
+	time.Sleep(promiseTimeout + 2*time.Second)
+	require.NoError(t, s.cctx.WaitForNextBlock())
+	require.NoError(t, submit(), "timeout settlement should succeed once the promise has expired")
+
+	uploadSize := uint32(fibre.DefaultBlobConfigV0().UploadSize(len(data)))
+	wantDebit := fibretypes.PaymentAmount(uploadSize)
+	require.Equal(t, wantDebit, before.Sub(escrowBalance()),
+		"escrow should be debited by the payment amount on timeout settlement")
+
+	hash, err := signed.Hash()
+	require.NoError(t, err)
+	processed, err := fibreQ.IsPaymentProcessed(ctx, &fibretypes.QueryIsPaymentProcessedRequest{PromiseHash: hash})
+	require.NoError(t, err)
+	require.True(t, processed.Found, "timed-out promise should be recorded as processed")
+}

--- a/fibre/internal/e2e/fibre_timeout_e2e_test.go
+++ b/fibre/internal/e2e/fibre_timeout_e2e_test.go
@@ -116,7 +116,10 @@ func (s *FibreTimeoutTestSuite) TestTimeoutSettlement() {
 	require.Error(t, err, "timeout settlement must be refused before the promise expires")
 	require.ErrorContains(t, err, "timed out")
 
-	time.Sleep(promiseTimeout + 2*time.Second)
+	expiration := promiseProto.CreationTimestamp.Add(promiseTimeout)
+	for time.Now().Before(expiration) {
+		require.NoError(t, s.cctx.WaitForNextBlock())
+	}
 	require.NoError(t, s.cctx.WaitForNextBlock())
 	require.NoError(t, submit(), "timeout settlement should succeed once the promise has expired")
 

--- a/fibre/internal/e2e/fibre_withdrawal_e2e_test.go
+++ b/fibre/internal/e2e/fibre_withdrawal_e2e_test.go
@@ -1,0 +1,115 @@
+package e2e_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	sdkmath "cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v10/app"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v10/pkg/user"
+	"github.com/celestiaorg/celestia-app/v10/test/util/genesis"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testnode"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/cosmos/cosmos-sdk/codec"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFibreWithdrawalLifecycle covers the escrow-exit path
+func TestFibreWithdrawalLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping fibre withdrawal e2e test in short mode")
+	}
+
+	const withdrawalDelay = 5 * time.Second
+	ecfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+
+	cfg := testnode.DefaultConfig().
+		WithFundedAccounts(fibre.DefaultKeyName).
+		WithDelayedPrecommitTimeout(500 * time.Millisecond).
+		WithModifiers(setFibreWithdrawalDelay(ecfg.Codec, withdrawalDelay))
+
+	cctx, _, _ := testnode.NewNetwork(t, cfg)
+	ctx := cctx.GoContext()
+	_, err := cctx.WaitForHeight(1)
+	require.NoError(t, err)
+
+	txClient, err := user.SetupTxClient(ctx, cctx.Keyring, cctx.GRPCClient, ecfg, user.WithDefaultAccount(fibre.DefaultKeyName))
+	require.NoError(t, err)
+	signer := txClient.DefaultAddress().String()
+
+	fibreQ := fibretypes.NewQueryClient(cctx.GRPCClient)
+	bankQ := banktypes.NewQueryClient(cctx.GRPCClient)
+
+	bankBalance := func() sdk.Coin {
+		resp, err := bankQ.Balance(ctx, &banktypes.QueryBalanceRequest{Address: signer, Denom: appconsts.BondDenom})
+		require.NoError(t, err)
+		return *resp.Balance
+	}
+	escrow := func() *fibretypes.EscrowAccount {
+		resp, err := fibreQ.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{Signer: signer})
+		require.NoError(t, err)
+		require.True(t, resp.Found)
+		return resp.EscrowAccount
+	}
+	pendingWithdrawals := func() []fibretypes.Withdrawal {
+		resp, err := fibreQ.Withdrawals(ctx, &fibretypes.QueryWithdrawalsRequest{Signer: signer})
+		require.NoError(t, err)
+		return resp.Withdrawals
+	}
+
+	deposit := sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(50_000_000))
+	withdraw := sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(20_000_000))
+
+	depositResp, err := txClient.SubmitTx(ctx,
+		[]sdk.Msg{&fibretypes.MsgDepositToEscrow{Signer: signer, Amount: deposit}},
+		user.SetGasLimit(200_000), user.SetFee(5_000))
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), depositResp.Code)
+
+	acc := escrow()
+	require.Equal(t, deposit, acc.Balance)
+	require.Equal(t, deposit, acc.AvailableBalance)
+
+	reqResp, err := txClient.SubmitTx(ctx,
+		[]sdk.Msg{&fibretypes.MsgRequestWithdrawal{Signer: signer, Amount: withdraw}},
+		user.SetGasLimit(200_000), user.SetFee(5_000))
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), reqResp.Code)
+
+	acc = escrow()
+	require.Equal(t, deposit, acc.Balance, "total balance stays locked until the withdrawal executes")
+	require.Equal(t, deposit.Sub(withdraw), acc.AvailableBalance, "available balance drops by the requested amount")
+
+	pending := pendingWithdrawals()
+	require.Len(t, pending, 1, "one pending withdrawal should be recorded")
+	require.Equal(t, withdraw, pending[0].Amount)
+
+	balanceBeforeExec := bankBalance()
+
+	require.Eventually(t, func() bool {
+		return len(pendingWithdrawals()) == 0
+	}, 60*time.Second, 500*time.Millisecond, "withdrawal should be auto-executed after the delay")
+
+	acc = escrow()
+	require.Equal(t, deposit.Sub(withdraw), acc.Balance, "total balance should drop by the withdrawn amount after execution")
+	require.Equal(t, deposit.Sub(withdraw), acc.AvailableBalance)
+
+	require.Equal(t, balanceBeforeExec.Add(withdraw), bankBalance(),
+		"withdrawn funds should return to the signer's bank account")
+}
+
+// setFibreWithdrawalDelay overrides the fibre module's withdrawal delay in genesis
+func setFibreWithdrawalDelay(cdc codec.Codec, delay time.Duration) genesis.Modifier {
+	return func(state map[string]json.RawMessage) map[string]json.RawMessage {
+		gs := fibretypes.DefaultGenesis()
+		gs.Params.WithdrawalDelay = delay
+		state[fibretypes.ModuleName] = cdc.MustMarshalJSON(gs)
+		return state
+	}
+}


### PR DESCRIPTION
Add missing e2e tests for fibre

Resolves https://linear.app/celestia/issue/PROTOCO-2170/fibre-add-missing-e2e-tests