### PR TITLE
feat(talis): add fibre storage-limiter experiment controls

### DIFF
--- a/test/util/genesis/modifier.go
+++ b/test/util/genesis/modifier.go
@@ -8,6 +8,7 @@ import (
 	"cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v10/app/params"
 	blobtypes "github.com/celestiaorg/celestia-app/v10/x/blob/types"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	minfeetypes "github.com/celestiaorg/celestia-app/v10/x/minfee/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -29,6 +30,16 @@ func SetBlobParams(codec codec.Codec, params blobtypes.Params) Modifier {
 		blobGenState := blobtypes.DefaultGenesis()
 		blobGenState.Params = params
 		state[blobtypes.ModuleName] = codec.MustMarshalJSON(blobGenState)
+		return state
+	}
+}
+
+// SetFibreParams will set the provided fibre params as genesis state.
+func SetFibreParams(codec codec.Codec, params fibretypes.Params) Modifier {
+	return func(state map[string]json.RawMessage) map[string]json.RawMessage {
+		fibreGenState := fibretypes.DefaultGenesis()
+		fibreGenState.Params = params
+		state[fibretypes.ModuleName] = codec.MustMarshalJSON(fibreGenState)
 		return state
 	}
 }

--- a/tools/talis/fibre.md
+++ b/tools/talis/fibre.md
@@ -58,6 +58,9 @@ talis start-fibre
 | `--ssh-key-path`    | *(from env/config)* | Path to SSH private key                                       |
 | `--instances`       | `0` (all)           | Number of validators to start fibre on                        |
 | `--otel-endpoint`   | *(auto)*            | OTLP HTTP endpoint for metrics/traces (auto-enabled with observability) |
+| `--storage-limit`   | `false`             | Enable the Fibre storage limiter (off by default so experiments run at full throughput) |
+
+The storage limiter is disabled by default: `start-fibre` passes `--unlimited-budget` to the fibre server so uploads are never rejected on budget and experiments measure full throughput. Pass `--storage-limit` to run the limiter instead (e.g. to reproduce the ADR-029 storage-budget behaviour), in which case set the budget via the genesis flags in section 0.
 
 The fibre server delegates signing to the colocated validator node's PrivValidatorAPI gRPC endpoint (default `127.0.0.1:26669`). Override with `--signer-grpc-address` if needed. Metrics and traces are auto-enabled via OTLP when observability nodes are configured.
 

--- a/tools/talis/genesis.go
+++ b/tools/talis/genesis.go
@@ -5,6 +5,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v10/test/util/genesis"
@@ -32,6 +35,9 @@ func generateCmd() *cobra.Command {
 		fibreReaderBinaryPath         string
 		observabilityDirPath          string
 		useMainnetStakingDistribution bool
+		stakingWeightsCSV             string
+		fibreBudgetGiB                int
+		fibreShardRetention           time.Duration
 		fibreAccounts                 int
 		encoderFibreAccounts          int
 	)
@@ -61,7 +67,17 @@ func generateCmd() *cobra.Command {
 				return fmt.Errorf("failed to remove old reader-payload directory: %w", err)
 			}
 
-			err = createPayload(cfg.Validators, cfg.Encoders, cfg.ChainID, payloadDir, squareSize, useMainnetStakingDistribution, fibreAccounts, encoderFibreAccounts)
+			stakingWeights, err := parseStakingWeights(stakingWeightsCSV, len(cfg.Validators))
+			if err != nil {
+				return err
+			}
+
+			var fibreMods []genesis.Modifier
+			if fibreBudgetGiB > 0 || fibreShardRetention > 0 {
+				fibreMods = append(fibreMods, fibreParamsModifier(uint64(fibreBudgetGiB)<<30, fibreShardRetention))
+			}
+
+			err = createPayload(cfg.Validators, cfg.Encoders, cfg.ChainID, payloadDir, squareSize, useMainnetStakingDistribution, stakingWeights, fibreAccounts, encoderFibreAccounts, fibreMods...)
 			if err != nil {
 				log.Fatalf("Failed to create payload: %v", err)
 			}
@@ -177,6 +193,9 @@ func generateCmd() *cobra.Command {
 	cmd.Flags().StringVar(&fibreReaderBinaryPath, "fibre-reader-binary", filepath.Join(gopath, "fibre-reader"), "fibre-reader binary to include in the reader payload")
 	cmd.Flags().StringVar(&observabilityDirPath, "observability-dir", "", "path to observability directory containing docker-compose, Prometheus config, and scripts (required if observability nodes are configured)")
 	cmd.Flags().BoolVarP(&useMainnetStakingDistribution, "mainnet-staking-distribution", "m", false, "replace the default uniform staking distribution with the actual mainnet distribution")
+	cmd.Flags().StringVar(&stakingWeightsCSV, "staking-weights", "", "comma-separated per-validator staking weights, e.g. 50,25,13,12; overrides the uniform/mainnet distribution (count must match the number of validators)")
+	cmd.Flags().IntVar(&fibreBudgetGiB, "fibre-full-stake-budget-gib", 0, "override the fibre FullStakeStorageBudget genesis param, in GiB (0 = module default)")
+	cmd.Flags().DurationVar(&fibreShardRetention, "fibre-shard-retention", 0, "override the fibre ShardRetention genesis param, e.g. 10m (0 = module default)")
 	cmd.Flags().IntVar(&fibreAccounts, "fibre-accounts", 1, "number of pre-funded fibre accounts to create per validator")
 	cmd.Flags().IntVar(&encoderFibreAccounts, "encoder-fibre-accounts", 1, "number of pre-funded fibre accounts to create per encoder instance")
 
@@ -185,7 +204,7 @@ func generateCmd() *cobra.Command {
 
 // createPayload takes ips created by pulumi and the path to the payload directory
 // to create the payload required for the experiment.
-func createPayload(ips, encoders []Instance, chainID, ppath string, squareSize int, useMainnetDistribution bool, fibreAccounts, encoderFibreAccounts int, mods ...genesis.Modifier) error {
+func createPayload(ips, encoders []Instance, chainID, ppath string, squareSize int, useMainnetDistribution bool, stakingWeights []int64, fibreAccounts, encoderFibreAccounts int, mods ...genesis.Modifier) error {
 	n, err := NewNetwork(chainID, squareSize, mods...)
 	if err != nil {
 		return err
@@ -193,7 +212,12 @@ func createPayload(ips, encoders []Instance, chainID, ppath string, squareSize i
 
 	stake := int64(genesis.DefaultInitialBalance) / 2
 	for index, info := range ips {
-		if useMainnetDistribution {
+		switch {
+		case len(stakingWeights) > 0:
+			// Scale so weight 100 equals the uniform default stake; the ratios
+			// between validators are exactly the given weights.
+			stake = int64(genesis.DefaultInitialBalance) / 200 * stakingWeights[index]
+		case useMainnetDistribution:
 			stake = getMainnetStake(index)
 		}
 		err = n.AddValidator(
@@ -239,6 +263,28 @@ func createPayload(ips, encoders []Instance, chainID, ppath string, squareSize i
 	}
 
 	return nil
+}
+
+// parseStakingWeights parses a comma-separated list of positive per-validator
+// staking weights (e.g. "50,25,13,12"). An empty string returns nil, leaving the
+// uniform or mainnet distribution in effect. The count must match numValidators.
+func parseStakingWeights(csv string, numValidators int) ([]int64, error) {
+	if csv == "" {
+		return nil, nil
+	}
+	parts := strings.Split(csv, ",")
+	weights := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		w, err := strconv.ParseInt(strings.TrimSpace(p), 10, 64)
+		if err != nil || w <= 0 {
+			return nil, fmt.Errorf("invalid staking weight %q: must be a positive integer", p)
+		}
+		weights = append(weights, w)
+	}
+	if len(weights) != numValidators {
+		return nil, fmt.Errorf("staking-weights has %d entries but there are %d validators", len(weights), numValidators)
+	}
+	return weights, nil
 }
 
 // mainnetVotingPowers contains the current Celestia mainnet staking distribution for more realistic tests.

--- a/tools/talis/network.go
+++ b/tools/talis/network.go
@@ -5,12 +5,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	sdkmath "cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v10/app"
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
 	"github.com/celestiaorg/celestia-app/v10/test/util/genesis"
 	blobtypes "github.com/celestiaorg/celestia-app/v10/x/blob/types"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	minfeetypes "github.com/celestiaorg/celestia-app/v10/x/minfee/types"
 	"github.com/celestiaorg/go-square/v4/share"
 	cmtconfig "github.com/cometbft/cometbft/config"
@@ -69,6 +71,20 @@ func NewNetwork(chainID string, squareSize int, mods ...genesis.Modifier) (*Netw
 		validators: make(map[string]NodeInfo),
 		ecfg:       codec,
 	}, nil
+}
+
+// fibreParamsModifier returns a genesis modifier that overrides fibre params.
+// A zero value for either field leaves that param at its module default.
+func fibreParamsModifier(fullStakeStorageBudget uint64, shardRetention time.Duration) genesis.Modifier {
+	c := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	params := fibretypes.DefaultParams()
+	if fullStakeStorageBudget > 0 {
+		params.FullStakeStorageBudget = fullStakeStorageBudget
+	}
+	if shardRetention > 0 {
+		params.ShardRetention = shardRetention
+	}
+	return genesis.SetFibreParams(c.Codec, params)
 }
 
 func SetMinFee(codec codec.Codec, minFee float64) genesis.Modifier {

--- a/tools/talis/start_fibre.go
+++ b/tools/talis/start_fibre.go
@@ -17,6 +17,7 @@ func startFibreCmd() *cobra.Command {
 		instances         int
 		metricsAddress    string
 		pyroscopeEndpoint string
+		storageLimit      bool
 	)
 
 	cmd := &cobra.Command{
@@ -43,6 +44,11 @@ func startFibreCmd() *cobra.Command {
 			// Build the remote command
 			// OTEL_METRICS_EXEMPLAR_FILTER=always_on attaches trace exemplars to all metric observations
 			remoteCmd := "OTEL_METRICS_EXEMPLAR_FILTER=always_on fibre start --home .celestia-fibre --app-grpc-address localhost:9091"
+			// Disable the storage limiter by default so experiments run at full
+			// throughput; pass --storage-limit to exercise the limiter instead.
+			if !storageLimit {
+				remoteCmd += " --unlimited-budget"
+			}
 			// Auto-enable metrics when observability nodes are configured
 			if metricsAddress == "" && len(cfg.Observability) > 0 {
 				metricsAddress = fmt.Sprintf("http://%s:4318", cfg.Observability[0].PublicIP)
@@ -86,6 +92,7 @@ func startFibreCmd() *cobra.Command {
 	cmd.Flags().IntVar(&instances, "instances", 0, "number of validators to start fibre on (default all)")
 	cmd.Flags().StringVar(&metricsAddress, "otel-endpoint", "", "OTLP HTTP endpoint for metrics/traces (e.g. http://host:4318; empty = disabled)")
 	cmd.Flags().StringVar(&pyroscopeEndpoint, "pyroscope-endpoint", "", "Pyroscope endpoint for continuous profiling (default: auto-detected from observability config, e.g. http://host:4040)")
+	cmd.Flags().BoolVar(&storageLimit, "storage-limit", false, "enable the Fibre storage limiter (default: disabled so experiments run at full throughput)")
 
 	return cmd
 }


### PR DESCRIPTION
Disable the Fibre storage limiter by default so experiments run at full throughput: start-fibre now passes --unlimited-budget unless --storage-limit is set. Add genesis flags to configure limiter experiments when it is enabled via a new fibreParamsModifier and a SetFibreParams genesis modifier