### PR TITLE
ci: re-add proto-gen check to flag hand-edited generated code

### DIFF
--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -1,10 +1,17 @@
 name: Protobuf
-# Protobuf runs buf (https://buf.build/) lint and check-breakage
-# This workflow is only run when a .proto file has been changed
+# Protobuf runs buf (https://buf.build/) lint and check-breakage, and verifies
+# that the committed generated code matches the output of `make proto-gen`.
+# This workflow is only run when a .proto file, a generated file, or part of the
+# proto toolchain has been changed.
 on:
   pull_request:
     paths:
       - "proto/**"
+      - "**/*.pb.go"
+      - "**/*.pb.gw.go"
+      - "Makefile"
+      - "scripts/protocgen.sh"
+      - ".github/workflows/protobuf.yml"
   merge_group:
 
 permissions:
@@ -12,13 +19,14 @@ permissions:
 
 jobs:
   # GitHub does not support native path filters on merge_group, so use
-  # dorny/paths-filter to detect proto changes and gate the lint/break-check
-  # jobs. On pull_request the native path filter already handles this, but
-  # the changes job is harmless and keeps the logic consistent.
+  # dorny/paths-filter to detect proto changes and gate the downstream jobs. On
+  # pull_request the native path filter already handles this, but the changes
+  # job is harmless and keeps the logic consistent.
   changes:
     runs-on: ubuntu-latest
     outputs:
       proto: ${{ steps.filter.outputs.proto }}
+      protogen: ${{ steps.filter.outputs.protogen }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 #v4.0.2
@@ -27,6 +35,13 @@ jobs:
           filters: |
             proto:
               - 'proto/**'
+            protogen:
+              - 'proto/**'
+              - '**/*.pb.go'
+              - '**/*.pb.gw.go'
+              - 'Makefile'
+              - 'scripts/protocgen.sh'
+              - '.github/workflows/protobuf.yml'
 
   lint:
     needs: changes
@@ -57,3 +72,29 @@ jobs:
           against: >-
             https://github.com/${{ github.repository }}.git#branch=${{
             github.event.pull_request.base.ref || 'main' }},subdir=proto
+
+  # Regenerate the protobuf code and fail if it differs from what is committed.
+  # This catches hand-edits to generated files and .proto changes that were not
+  # accompanied by a `make proto-gen`.
+  gen-check:
+    needs: changes
+    if: needs.changes.outputs.protogen == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7.0.0
+        with:
+          go-version-file: "go.mod"
+      - run: make proto-deps
+      - run: make proto-gen
+      - name: Check that generated code matches committed code
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Generated protobuf code does not match the committed code."
+            echo ">> Run 'make proto-gen' and commit the result."
+            git status --porcelain
+            git --no-pager diff
+            exit 1
+          fi
+          echo "Generated protobuf code is up to date."


### PR DESCRIPTION
Closes #7627

## Motivation

A `proto-gen` diff check ran on every PR from #1950 (June 2023) until #4400 (April 2025), which rewrote `protobuf.yml` around the `buf` GitHub Actions and dropped the job. Since then nothing has verified that the committed `.pb.go` / `.pb.gw.go` files actually match the `.proto` sources.

## Changes

Adds a `gen-check` job to `.github/workflows/protobuf.yml` that runs `make proto-deps && make proto-gen` and fails if the working tree is dirty afterwards.

The workflow's path filter is widened so the job also fires when generated files or the proto toolchain change — not just `proto/**` — since hand-editing a `.pb.go` doesn't touch `proto/`:

- `**/*.pb.go`, `**/*.pb.gw.go`
- `Makefile`, `scripts/protocgen.sh`, `.github/workflows/protobuf.yml`

`lint` and `break-check` keep their existing `proto/**`-only gate.

## Verification

- Green: `gen-check` passes on this PR in 1m50s, confirming generated code on `main` is already in sync.
- Red: pushing a hand-edit to a comment in `x/blob/types/tx.pb.go` made `gen-check` fail with the offending diff printed ([job log](https://github.com/celestiaorg/celestia-app/actions/runs/31037522678/job/92413386583)). That commit was then reverted.
- Gating works: `lint` and `break-check` correctly skipped on this PR since no `proto/**` file changed.
- `yamllint -c .yamllint.yml` and `actionlint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBBKZUrftsN5p4yKCzYMSH