### PR TITLE
chore: pin protobuf plugin versions in proto-deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,9 +222,16 @@ mod-verify: mod
 .PHONY: mod-verify
 
 BUF_VERSION=v1.50.0
+# COSMOS_PROTO_VERSION and GOGOPROTO_VERSION should match the
+# github.com/cosmos/cosmos-proto and github.com/cosmos/gogoproto versions in
+# go.mod. protoc-gen-gocosmos emits the .pb.go files, so an unpinned version
+# here would make `make proto-gen` output depend on when it was run.
+COSMOS_PROTO_VERSION=v1.0.0-beta.5
+GOGOPROTO_VERSION=v1.7.2
 GOLANG_PROTOBUF_VERSION=1.28.1
 GRPC_GATEWAY_VERSION=1.16.0
 GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION=2.20.0
+PROTOC_GEN_GO_GRPC_VERSION=v1.6.2
 
 ## proto-all: Format, lint and generate Protobuf files
 proto-all: proto-deps proto-format proto-lint proto-gen
@@ -234,12 +241,12 @@ proto-all: proto-deps proto-format proto-lint proto-gen
 proto-deps:
 	@echo "Installing proto deps"
 	@go install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
-	@go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest
-	@go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@latest
-	@go install github.com/cosmos/gogoproto/protoc-gen-gogo@latest
+	@go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@$(COSMOS_PROTO_VERSION)
+	@go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@$(GOGOPROTO_VERSION)
+	@go install github.com/cosmos/gogoproto/protoc-gen-gogo@$(GOGOPROTO_VERSION)
 	@go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v$(GRPC_GATEWAY_VERSION)
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v$(GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION)
-	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@$(PROTOC_GEN_GO_GRPC_VERSION)
 	@go install google.golang.org/protobuf/cmd/protoc-gen-go@v$(GOLANG_PROTOBUF_VERSION)
 .PHONY: proto-deps
 


### PR DESCRIPTION
Closes #7637

> [!NOTE]
> Stacked on #7636 so that the `gen-check` job added there runs on this PR and proves the pins don't change generated output. Retarget to `main` once #7636 merges.

## Motivation

Four of the eight plugin installs in `make proto-deps` used `@latest`. `protoc-gen-gocosmos` is what emits the `.pb.go` files, so an upstream release that changed codegen would fail the new `gen-check` job on every proto-touching PR, with a diff nobody authored — and two developers running `make proto-gen` on different days could produce different output from identical `.proto` sources.

## Changes

| plugin | before | after |
|---|---|---|
| `cosmos-proto/cmd/protoc-gen-go-pulsar` | `@latest` | `v1.0.0-beta.5` |
| `gogoproto/protoc-gen-gocosmos` | `@latest` | `v1.7.2` |
| `gogoproto/protoc-gen-gogo` | `@latest` | `v1.7.2` |
| `grpc/cmd/protoc-gen-go-grpc` | `@latest` | `v1.6.2` |

Versions are declared as Makefile variables alongside the existing `BUF_VERSION` / `GRPC_GATEWAY_VERSION` pins. `COSMOS_PROTO_VERSION` and `GOGOPROTO_VERSION` match the corresponding `go.mod` versions; `protoc-gen-go-grpc` is a separate module not in `go.mod`, so it's pinned to the version `@latest` currently resolves to.

## Verification

- Deleted all four plugin binaries, re-ran `make proto-deps` to install the pinned versions from scratch, then `make proto-gen`: only `Makefile` shows as modified, so **generated output is byte-identical**.
- `make -n proto-deps` confirms all eight installs now resolve to explicit versions with no `@latest` remaining.

## Not addressed here

Two pre-existing pins have drifted from `go.mod` (`GOLANG_PROTOBUF_VERSION=1.28.1` vs `google.golang.org/protobuf v1.36.11`; `GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION=2.20.0` vs `grpc-gateway/v2 v2.29.0`). Left alone deliberately — correcting them may legitimately change generated output, which doesn't belong in a no-op pinning PR. Noted in #7637.

Also noted in #7637: Makefile pins go stale silently since dependabot's `gomod` ecosystem doesn't read the Makefile. Migrating these to `tool` directives in `go.mod` (as already done for `golangci-lint`) would fix that, at the cost of go.mod/go.sum surface and the `test/docker-e2e` tidy-parity dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBBKZUrftsN5p4yKCzYMSH