### PR TITLE
chore: pin protobuf plugins via go.mod tool directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,8 +222,6 @@ mod-verify: mod
 .PHONY: mod-verify
 
 BUF_VERSION=v1.50.0
-GOLANG_PROTOBUF_VERSION=1.28.1
-GRPC_GATEWAY_VERSION=1.16.0
 GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION=2.20.0
 
 ## proto-all: Format, lint and generate Protobuf files
@@ -231,16 +229,23 @@ proto-all: proto-deps proto-format proto-lint proto-gen
 .PHONY: proto-all
 
 ## proto-deps: Install Protobuf local dependencies
+#
+# protoc-gen-gocosmos and protoc-gen-grpc-gateway are the two plugins that
+# buf.gen.gogo.yaml invokes, so their versions determine the contents of the
+# generated .pb.go files. They are declared as `tool` directives in go.mod
+# (like golangci-lint), which means `go install` without a version suffix
+# builds the version recorded there. That keeps codegen reproducible and lets
+# dependabot bump the plugins along with the rest of the module graph.
+#
+# buf and protoc-gen-openapiv2 stay pinned here rather than as tool directives:
+# adding them to the module graph would drag in large, unrelated dependency
+# upgrades (buf alone adds ~120 go.sum lines and bumps docker/otel deps).
 proto-deps:
 	@echo "Installing proto deps"
 	@go install github.com/bufbuild/buf/cmd/buf@$(BUF_VERSION)
-	@go install github.com/cosmos/cosmos-proto/cmd/protoc-gen-go-pulsar@latest
-	@go install github.com/cosmos/gogoproto/protoc-gen-gocosmos@latest
-	@go install github.com/cosmos/gogoproto/protoc-gen-gogo@latest
-	@go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway@v$(GRPC_GATEWAY_VERSION)
+	@go install github.com/cosmos/gogoproto/protoc-gen-gocosmos
+	@go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
 	@go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v$(GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION)
-	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-	@go install google.golang.org/protobuf/cmd/protoc-gen-go@v$(GOLANG_PROTOBUF_VERSION)
 .PHONY: proto-deps
 
 ## proto-gen: Generate Protobuf files.

--- a/go.mod
+++ b/go.mod
@@ -225,6 +225,7 @@ require (
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/fzipp/gocyclo v0.6.0 // indirect
 	github.com/getsentry/sentry-go v0.42.0 // indirect
+	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/ghostiam/protogetter v0.3.20 // indirect
 	github.com/go-critic/go-critic v0.14.3 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
@@ -246,6 +247,7 @@ require (
 	github.com/godoc-lint/godoc-lint v0.11.1 // indirect
 	github.com/gogo/googleapis v1.4.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.2.5 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/snappy v1.0.0 // indirect
@@ -473,4 +475,8 @@ replace (
 	github.com/tendermint/tendermint => github.com/celestiaorg/celestia-core v1.55.0-tm-v0.34.35
 )
 
-tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+tool (
+	github.com/cosmos/gogoproto/protoc-gen-gocosmos
+	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
+	github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+)

--- a/go.sum
+++ b/go.sum
@@ -495,6 +495,7 @@ github.com/getsentry/sentry-go v0.42.0 h1:eeFMACuZTbUQf90RE8dE4tXeSe4CZyfvR1MBL7
 github.com/getsentry/sentry-go v0.42.0/go.mod h1:eRXCoh3uvmjQLY6qu63BjUZnaBu5L5WhMV1RwYO8W5s=
 github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9 h1:r5GgOLGbza2wVHRzK7aAj6lWZjfbAwiu/RDCVOKjRyM=
 github.com/ghemawat/stream v0.0.0-20171120220530-696b145b53b9/go.mod h1:106OIgooyS7OzLDOpUGgm9fA3bQENb/cFSyyBmMoJDs=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghostiam/protogetter v0.3.20 h1:oW7OPFit2FxZOpmMRPP9FffU4uUpfeE/rEdE1f+MzD0=
 github.com/ghostiam/protogetter v0.3.20/go.mod h1:FjIu5Yfs6FT391m+Fjp3fbAYJ6rkL/J6ySpZBfnODuI=
@@ -580,6 +581,8 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
+github.com/golang/glog v1.2.5 h1:DrW6hGnjIhtvhOIiAKT6Psh/Kd/ldepEa81DKeiRJ5I=
+github.com/golang/glog v1.2.5/go.mod h1:6AhwSGph0fcJtXVM/PEHPqZlFeoLxhs7/t5UDAwmO+w=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=


### PR DESCRIPTION
Closes #7637

## Motivation

Four of the eight plugin installs in `make proto-deps` used `@latest`. `protoc-gen-gocosmos` emits the `.pb.go` files, so an upstream release changing codegen would fail the `gen-check` job from #7636 on every proto-touching PR with a diff nobody authored.

Rather than hardcode versions in the Makefile — which dependabot's `gomod` ecosystem can't see, so they'd go stale silently — this uses `tool` directives in `go.mod`, matching the existing `tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint`. `go install` without a version suffix then builds the version recorded in the module graph.

## Changes

**`go.mod`** — two tool directives added:

```
tool (
	github.com/cosmos/gogoproto/protoc-gen-gocosmos
	github.com/golangci/golangci-lint/v2/cmd/golangci-lint
	github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
)
```

**`proto-deps`** — 8 installs down to 4:

| plugin | before | after |
|---|---|---|
| `protoc-gen-gocosmos` | `@latest` | tool directive → `v1.7.2` |
| `protoc-gen-grpc-gateway` | `@v1.16.0` (Makefile var) | tool directive → `v1.16.0` |
| `buf` | `@v1.50.0` | unchanged |
| `protoc-gen-openapiv2` | `@v2.20.0` | unchanged |
| `protoc-gen-go-pulsar` | `@latest` | **removed — unused** |
| `protoc-gen-gogo` | `@latest` | **removed — unused** |
| `protoc-gen-go-grpc` | `@latest` | **removed — unused** |
| `protoc-gen-go` | `@v1.28.1` | **removed — unused** |

Only three plugins are referenced by the two generate templates: `buf.gen.gogo.yaml` uses `gocosmos` and `grpc-gateway`; `buf.gen.openapiv2.yaml` uses `openapiv2`. The other four had no reference anywhere in the repo, so removing them eliminates three `@latest` installs outright instead of pinning binaries nobody builds with.

## Why not tool directives for everything

Measured the go.mod/go.sum churn of each candidate:

| tool | go.mod | go.sum | dep upgrades forced |
|---|---|---|---|
| `protoc-gen-gocosmos` | 4+/1- | 0 | **0** |
| `protoc-gen-grpc-gateway` | 6+/1- | 3+ | **0** |
| `protoc-gen-openapiv2` | 18+/15- | 29+ | 14 |
| `buf` | 67+/14- | 118+ | 18 |

The two plugins on the `proto-gen` critical path convert with **zero** dependency upgrades. `openapiv2` and `buf` would drag in unrelated upgrades to runtime dependencies — otel 1.44→1.45, otelgrpc, genproto, docker — which doesn't belong in a codegen-pinning change. Those two stay as Makefile pins, and the rationale is commented in the Makefile.

Net go.mod cost: 2 new `// indirect` entries (`ghodss/yaml`, `golang/glog`) and 3 go.sum hash lines, with no version changes to anything.

## Verification

- Deleted all plugin binaries, ran `make proto-deps` from scratch, then `make proto-gen`: **generated output byte-identical** (only `Makefile`/`go.mod`/`go.sum` modified). Installed versions resolve to `gogoproto v1.7.2` and `grpc-gateway v1.16.0`.
- `go mod tidy -diff` clean for **both** the root module and `test/docker-e2e`, so no tidy-parity commit is needed.
- `make proto-swagger-gen` still generates `docs/swagger/swagger.json` with 124 endpoints, no diff.
- `go build ./...` passes; `go tool golangci-lint` still resolves (v2.9.0).
- Verified with `GOWORK=off` / no `go.work`, matching CI.
- Once #7636 lands, `Makefile` is in that workflow's path filter, so `gen-check` re-verifies this in CI.

## Not addressed here

`GRPC_GATEWAY_PROTOC_GEN_OPENAPIV2_VERSION=2.20.0` still lags `grpc-gateway/v2 v2.29.0` in go.mod. I tested the bump: it changes the generated swagger substantially — 760 diff lines, `definitions` 308 → 255, and every schema key renamed (`blobv1Params` → `blobV1Params`). Endpoint count is unchanged (124) and there are no dangling `$ref`s, so it is not broken, just different. Renaming every schema key in the published API reference deserves its own PR. Details in #7637.

Also worth knowing: `docs/swagger/swagger.json` is gitignored and regenerated at publish time by the github-pages workflow, so `gen-check` does not cover it — only the `.pb.go` files are protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBBKZUrftsN5p4yKCzYMSH

