### PR TITLE
fix(fibre): execute PFF messages on proposal state

### DIFF
--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -8,6 +8,7 @@ import (
 	"github.com/celestiaorg/go-square/v4/tx"
 	tmbytes "github.com/cometbft/cometbft/libs/bytes"
 	coretypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/telemetry"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -16,13 +17,15 @@ import (
 // FilteredSquareBuilder filters txs and blobs using a copy of the state and tx validity
 // rules before adding it the square.
 type FilteredSquareBuilder struct {
-	handler  sdk.AnteHandler
-	txConfig client.TxConfig
-	builder  *square.Builder
+	handler   sdk.AnteHandler
+	msgRouter baseapp.MessageRouter
+	txConfig  client.TxConfig
+	builder   *square.Builder
 }
 
 func NewFilteredSquareBuilder(
 	handler sdk.AnteHandler,
+	msgRouter baseapp.MessageRouter,
 	txConfig client.TxConfig,
 	maxSquareSize,
 	subtreeRootThreshold int,
@@ -32,9 +35,10 @@ func NewFilteredSquareBuilder(
 		return nil, err
 	}
 	return &FilteredSquareBuilder{
-		handler:  handler,
-		txConfig: txConfig,
-		builder:  builder,
+		handler:   handler,
+		msgRouter: msgRouter,
+		txConfig:  txConfig,
+		builder:   builder,
 	}, nil
 }
 
@@ -306,7 +310,10 @@ func processFibreTxsForSquare(fsb *FilteredSquareBuilder, ctx sdk.Context, payFo
 			continue
 		}
 
-		ctx = ctx.WithTxBytes(rawTx)
+		// Branch the state per tx so a dropped tx leaves no partial writes
+		// behind for the txs that follow it.
+		txCtx, commit := ctx.CacheContext()
+		txCtx = txCtx.WithTxBytes(rawTx)
 
 		ok, err := fsb.builder.AppendFibreTx(fibreTx)
 		if err != nil {
@@ -318,7 +325,7 @@ func processFibreTxsForSquare(fsb *FilteredSquareBuilder, ctx sdk.Context, payFo
 			continue
 		}
 
-		ctx, err = fsb.handler(ctx, sdkTx, false)
+		txCtx, err = fsb.handler(txCtx, sdkTx, false)
 		if err != nil {
 			logger.Error(
 				"filtering already checked pay-for-fibre transaction",
@@ -332,6 +339,25 @@ func processFibreTxsForSquare(fsb *FilteredSquareBuilder, ctx sdk.Context, payFo
 			}
 			continue
 		}
+
+		// Settle the promise on the branch so later fibre txs are validated
+		// against the escrow debit and processed-payment record it leaves
+		// behind. A promise that cannot settle (overdraw, duplicate, out of
+		// gas) would commit its blob to the square without payment in
+		// FinalizeBlock, so drop the tx.
+		if err := executeTxMsgs(txCtx, sdkTx, fsb.msgRouter); err != nil {
+			logger.Error(
+				"dropping pay-for-fibre tx: promise cannot settle on the proposal state (e.g. escrow overdrawn or promise already processed)",
+				"tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()),
+				"error", err,
+			)
+			telemetry.IncrCounter(1, "prepare_proposal", "unsettleable_pay_for_fibre_txs")
+			if revertErr := fsb.builder.RevertLastPayForFibreTx(); revertErr != nil {
+				logger.Error("reverting last pay-for-fibre transaction", "error", revertErr)
+			}
+			continue
+		}
+		commit()
 
 		pffMessageCount += len(sdkTx.GetMsgs())
 		fibreTxs = append(fibreTxs, rawTx)

--- a/app/filtered_square_builder_fibre_test.go
+++ b/app/filtered_square_builder_fibre_test.go
@@ -208,7 +208,7 @@ func TestFilteredSquareBuilderFillWithPayForFibre(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fsb, err := NewFilteredSquareBuilder(tc.anteHandler, txConfig, 64, 64)
+			fsb, err := NewFilteredSquareBuilder(tc.anteHandler, nil, txConfig, 64, 64)
 			require.NoError(t, err)
 
 			db := dbm.NewMemDB()
@@ -259,7 +259,7 @@ func TestFilteredSquareBuilderFillMaxPayForFibreMessages(t *testing.T) {
 		pffTxs[i] = blobfactory.UnsignedPayForFibreTx(t, txConfig)
 	}
 
-	fsb, err := NewFilteredSquareBuilder(alwaysPass, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	require.NoError(t, err)
 
 	db := dbm.NewMemDB()

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -253,7 +253,7 @@ func TestFilteredSquareBuilderFillMaxTxBytes(t *testing.T) {
 	// configured block max bytes.
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fsb, err := NewFilteredSquareBuilder(alwaysPass, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+			fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 			require.NoError(t, err)
 
 			db := dbm.NewMemDB()

--- a/app/pff_execution.go
+++ b/app/pff_execution.go
@@ -1,0 +1,37 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+)
+
+// executeTxMsgs executes a transaction's messages on a cached branch of ctx,
+// committing writes only if every message succeeds.
+// A nil router skips execution for tests.
+func executeTxMsgs(ctx sdk.Context, sdkTx sdk.Tx, router baseapp.MessageRouter) (err error) {
+	if router == nil {
+		return nil
+	}
+	// Message handlers panic on out of gas; fail the tx instead of crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("recovered panic while executing messages: %v", r)
+		}
+	}()
+	// Discard all message writes if any handler fails.
+	cacheCtx, writeCache := ctx.CacheContext()
+	cacheCtx = cacheCtx.WithEventManager(sdk.NewEventManager())
+	for _, msg := range sdkTx.GetMsgs() {
+		handler := router.Handler(msg)
+		if handler == nil {
+			return fmt.Errorf("no message handler found for %s", sdk.MsgTypeURL(msg))
+		}
+		if _, err := handler(cacheCtx, msg); err != nil {
+			return err
+		}
+	}
+	writeCache()
+	return nil
+}

--- a/app/pff_execution_test.go
+++ b/app/pff_execution_test.go
@@ -1,0 +1,111 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	dbm "github.com/cosmos/cosmos-db"
+	"github.com/cosmos/cosmos-sdk/baseapp"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+// stubMsgRouter returns one handler for every message; nil simulates an
+// unregistered message.
+type stubMsgRouter struct {
+	handler baseapp.MsgServiceHandler
+}
+
+func (r stubMsgRouter) Handler(sdk.Msg) baseapp.MsgServiceHandler         { return r.handler }
+func (r stubMsgRouter) HandlerByTypeURL(string) baseapp.MsgServiceHandler { return r.handler }
+
+func TestExecuteTxMsgs(t *testing.T) {
+	storeKey := storetypes.NewKVStoreKey("test")
+	writtenKey := []byte("written")
+
+	newCtx := func(t *testing.T) sdk.Context {
+		db := dbm.NewMemDB()
+		cms := store.NewCommitMultiStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+		cms.MountStoreWithDB(storeKey, storetypes.StoreTypeIAVL, db)
+		require.NoError(t, cms.LoadLatestVersion())
+		return sdk.NewContext(cms, cmtproto.Header{}, false, log.NewNopLogger())
+	}
+
+	// A two-message tx so failures on the second message can prove the first
+	// message's writes are rolled back.
+	txConfig := encoding.MakeConfig(ModuleEncodingRegisters...).TxConfig
+	addr := sdk.AccAddress(secp256k1.GenPrivKey().PubKey().Address())
+	sendMsg := banktypes.NewMsgSend(addr, addr, sdk.NewCoins(sdk.NewInt64Coin("utia", 1)))
+	builder := txConfig.NewTxBuilder()
+	require.NoError(t, builder.SetMsgs(sendMsg, sendMsg))
+	sdkTx := builder.GetTx()
+
+	exec := func(ctx sdk.Context, handler baseapp.MsgServiceHandler) error {
+		return executeTxMsgs(ctx, sdkTx, stubMsgRouter{handler: handler})
+	}
+	write := func(ctx sdk.Context) {
+		ctx.KVStore(storeKey).Set(writtenKey, []byte{1})
+	}
+	// hasWrite reads with a fresh meter so an exhausted tx meter can't panic the assertion.
+	hasWrite := func(ctx sdk.Context) bool {
+		return ctx.WithGasMeter(storetypes.NewInfiniteGasMeter()).KVStore(storeKey).Has(writtenKey)
+	}
+
+	t.Run("nil router skips execution", func(t *testing.T) {
+		require.NoError(t, executeTxMsgs(newCtx(t), sdkTx, nil))
+	})
+
+	t.Run("commits writes when every message succeeds", func(t *testing.T) {
+		calls := 0
+		ctx := newCtx(t)
+		err := exec(ctx, func(ctx sdk.Context, _ sdk.Msg) (*sdk.Result, error) {
+			calls++
+			write(ctx)
+			return &sdk.Result{}, nil
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, calls, "expected both messages to execute")
+		require.True(t, hasWrite(ctx))
+	})
+
+	t.Run("discards writes for tx when a later message fails, all msgs must succeed", func(t *testing.T) {
+		calls := 0
+		ctx := newCtx(t)
+		err := exec(ctx, func(ctx sdk.Context, _ sdk.Msg) (*sdk.Result, error) {
+			if calls++; calls == 2 {
+				return nil, errors.New("boom")
+			}
+			write(ctx)
+			return &sdk.Result{}, nil
+		})
+		require.ErrorContains(t, err, "boom")
+		require.False(t, hasWrite(ctx), "first message's writes must be rolled back")
+	})
+
+	t.Run("recovers out-of-gas panic as an error and discards writes", func(t *testing.T) {
+		// Enough gas to complete the write, not enough for the follow-up charge.
+		ctx := newCtx(t).WithGasMeter(storetypes.NewGasMeter(50_000))
+		err := exec(ctx, func(ctx sdk.Context, _ sdk.Msg) (*sdk.Result, error) {
+			write(ctx)
+			ctx.GasMeter().ConsumeGas(1_000_000, "settlement")
+			return &sdk.Result{}, nil
+		})
+		require.ErrorContains(t, err, "recovered panic")
+		// The out-of-gas panic payload carries the gas descriptor, proving the
+		// recovered panic was the gas meter's and not some other failure.
+		require.ErrorContains(t, err, "settlement")
+		require.False(t, hasWrite(ctx), "write before the panic must be rolled back")
+	})
+
+	t.Run("errors when no handler is registered", func(t *testing.T) {
+		require.ErrorContains(t, exec(newCtx(t), nil), "no message handler found")
+	})
+}

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -37,6 +37,7 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 
 	fsb, err := NewFilteredSquareBuilder(
 		handler,
+		app.MsgServiceRouter(),
 		app.encodingConfig.TxConfig,
 		app.MaxEffectiveSquareSize(ctx),
 		appconsts.SubtreeRootThreshold,

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -112,15 +112,20 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 				return reject(), nil
 			}
 
-			if payForFibre, ok := payForFibreMsg(sdkTx); ok {
+			_, isPFF := payForFibreMsg(sdkTx)
+			if isPFF {
 				pffMessageCount++
 				if maxPFF > 0 && pffMessageCount > maxPFF {
 					logInvalidPropBlock(app.Logger(), blockHeader, fmt.Sprintf("block exceeds max PayForFibre message count of %d", maxPFF))
 					return reject(), nil
 				}
-
-				if _, err := app.FibreKeeper.ValidatePaymentPromiseStateful(ctx, &payForFibre.PaymentPromise); err != nil {
-					logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("fibre validation failed %d", idx), err)
+				// Settle MsgPayForFibre on the proposal state so promises later in
+				// the block are validated against the escrow debit and
+				// processed-payment record this one leaves behind, not the static
+				// pre-block state. A promise that cannot settle would commit its
+				// blob to the square without payment in FinalizeBlock, so reject.
+				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
+					logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("fibre settlement failed %d", idx), execErr)
 					return reject(), nil
 				}
 			} else {

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -119,15 +119,6 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 					logInvalidPropBlock(app.Logger(), blockHeader, fmt.Sprintf("block exceeds max PayForFibre message count of %d", maxPFF))
 					return reject(), nil
 				}
-				// Settle MsgPayForFibre on the proposal state so promises later in
-				// the block are validated against the escrow debit and
-				// processed-payment record this one leaves behind, not the static
-				// pre-block state. A promise that cannot settle would commit its
-				// blob to the square without payment in FinalizeBlock, so reject.
-				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
-					logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("fibre settlement failed %d", idx), execErr)
-					return reject(), nil
-				}
 			} else {
 				sdkMessageCount += len(msgs)
 				if sdkMessageCount > appconsts.MaxSDKMessages {
@@ -143,6 +134,15 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 			if err != nil {
 				logInvalidPropBlockError(app.Logger(), blockHeader, "failure to increment sequence", err)
 				return reject(), nil
+			}
+
+			// Settle after ante so later promises see the updated state and the tx
+			// pays the same gas it would in FinalizeBlock.
+			if isPFF {
+				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
+					logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("fibre settlement failed %d", idx), execErr)
+					return reject(), nil
+				}
 			}
 
 			// The non-blob path is complete; blob-specific checks below do not apply.

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -588,3 +588,70 @@ func TestPrepareProposalFiltersPayForFibre(t *testing.T) {
 	require.Len(t, resp.Txs, 1)
 	require.True(t, bytes.Equal(validTx, resp.Txs[0]))
 }
+
+func TestPrepareProposalPayForFibreDoubleSpend(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(3)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	infos := queryAccountInfo(testApp, accounts, kr)
+	newSigner := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)
+
+	payment := fibretypes.PaymentAmount(100).Amount.Int64()
+
+	// accounts[0] affords one payment, accounts[1] and accounts[2] afford two.
+	// Funding the duplicate pair's account for both payments makes its second
+	// tx fail on the processed-payment record rather than the balance.
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[0]), payment)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[1]), 2*payment)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[2]), 2*payment)
+
+	base := time.Now()
+	tests := []struct {
+		name     string
+		txs      [][]byte
+		wantKept int
+	}{
+		{
+			name:     "drops second promise that would overdraw the escrow",
+			txs:      newPayForFibreTxPair(t, newSigner(0), accounts[0], base.Add(-2*time.Second), base.Add(-time.Second)),
+			wantKept: 1,
+		},
+		{
+			name:     "drops second tx carrying a duplicate promise",
+			txs:      newPayForFibreTxPair(t, newSigner(1), accounts[1], base, base),
+			wantKept: 1,
+		},
+		{
+			name:     "keeps both promises the escrow can cover",
+			txs:      newPayForFibreTxPair(t, newSigner(2), accounts[2], base.Add(-2*time.Second), base.Add(-time.Second)),
+			wantKept: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Prepare and process must see the same block time: promise
+			// freshness and expiry are judged against it.
+			now := time.Now()
+			height := testApp.LastBlockHeight() + 1
+
+			prepareResp, err := testApp.PrepareProposal(&abci.RequestPrepareProposal{
+				Txs:    tc.txs,
+				Height: height,
+				Time:   now,
+			})
+			require.NoError(t, err)
+			require.Equal(t, tc.txs[:tc.wantKept], prepareResp.Txs)
+
+			processResp, err := testApp.ProcessProposal(&abci.RequestProcessProposal{
+				Height:       height,
+				Time:         now,
+				Txs:          prepareResp.Txs,
+				DataRootHash: prepareResp.DataRootHash,
+				SquareSize:   prepareResp.SquareSize,
+			})
+			require.NoError(t, err)
+			require.Equal(t, abci.ResponseProcessProposal_ACCEPT, processResp.Status, "prepared block must pass process")
+		})
+	}
+}

--- a/app/test/process_proposal_fibre_test.go
+++ b/app/test/process_proposal_fibre_test.go
@@ -286,10 +286,24 @@ func newSignedPayForFibreTxWithOpts(
 	opts ...user.TxOption,
 ) []byte {
 	t.Helper()
+	return newSignedPayForFibreTxAt(t, signer, account, validValidatorSignatures, time.Now(), opts...)
+}
+
+// newSignedPayForFibreTxAt creates a signed PayForFibre tx whose promise uses
+// creationTime. Equal timestamps create duplicate promises.
+func newSignedPayForFibreTxAt(
+	t *testing.T,
+	signer *user.Signer,
+	account string,
+	validValidatorSignatures bool,
+	creationTime time.Time,
+	opts ...user.TxOption,
+) []byte {
+	t.Helper()
 	acc := signer.Account(account)
 	msg := blobfactory.NewMsgPayForFibre(t, acc.PubKey().(*secp256k1.PubKey), testutil.ChainID)
 	// Keep tx size stable for gas parity tests.
-	msg.PaymentPromise.CreationTimestamp = msg.PaymentPromise.CreationTimestamp.Truncate(time.Second)
+	msg.PaymentPromise.CreationTimestamp = creationTime.Truncate(time.Second)
 
 	pp := fibre.PaymentPromise{}
 	require.NoError(t, pp.FromProto(&msg.PaymentPromise))
@@ -366,6 +380,70 @@ func TestProcessProposalPayForFibreStatefulChecks(t *testing.T) {
 	}
 }
 
+// newPayForFibreTxPair creates two PayForFibre txs with sequential nonces and
+// the supplied promise creation times.
+func newPayForFibreTxPair(t *testing.T, signer *user.Signer, account string, first, second time.Time) [][]byte {
+	t.Helper()
+	firstTx := newSignedPayForFibreTxAt(t, signer, account, true, first,
+		user.SetGasLimit(1_000_000), user.SetFee(4_000))
+	require.NoError(t, signer.IncrementSequence(account))
+	secondTx := newSignedPayForFibreTxAt(t, signer, account, true, second,
+		user.SetGasLimit(1_000_000), user.SetFee(4_000))
+	return [][]byte{firstTx, secondTx}
+}
+
+func TestProcessProposalPayForFibreDoubleSpend(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(3)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	infos := queryAccountInfo(testApp, accounts, kr)
+	newSigner := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)
+
+	// The blobfactory promise uses BlobSize=100, so every settlement costs the
+	// same payment amount.
+	payment := fibretypes.PaymentAmount(100).Amount.Int64()
+
+	// accounts[0] can afford one payment; accounts[1] and accounts[2] can afford two.
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[0]), payment)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[1]), 2*payment)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[2]), 2*payment)
+
+	base := time.Now()
+	overdrawTxs := newPayForFibreTxPair(t, newSigner(0), accounts[0], base.Add(-2*time.Second), base.Add(-time.Second))
+	duplicateTxs := newPayForFibreTxPair(t, newSigner(1), accounts[1], base, base)
+	affordableTxs := newPayForFibreTxPair(t, newSigner(2), accounts[2], base.Add(-2*time.Second), base.Add(-time.Second))
+
+	tests := []struct {
+		name           string
+		txs            [][]byte
+		expectedStatus abci.ResponseProcessProposal_ProposalStatus
+	}{
+		{
+			name:           "reject two promises that collectively overdraw one escrow",
+			txs:            overdrawTxs,
+			expectedStatus: abci.ResponseProcessProposal_REJECT,
+		},
+		{
+			name:           "reject duplicate promise within one block",
+			txs:            duplicateTxs,
+			expectedStatus: abci.ResponseProcessProposal_REJECT,
+		},
+		{
+			name:           "accept two promises the escrow can cover",
+			txs:            affordableTxs,
+			expectedStatus: abci.ResponseProcessProposal_ACCEPT,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, tc.txs))
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedStatus, resp.Status)
+		})
+	}
+}
+
 // TestProcessProposalChargesTxSizeGas checks the ProcessProposal gas boundary.
 func TestProcessProposalChargesTxSizeGas(t *testing.T) {
 	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
@@ -396,12 +474,24 @@ func TestProcessProposalChargesTxSizeGas(t *testing.T) {
 		require.Equal(t, abci.ResponseProcessProposal_REJECT, resp.Status)
 	})
 
-	t.Run("accept gas limit at exactly the ante cost", func(t *testing.T) {
-		exactTx := newSignedPayForFibreTxWithOpts(t, newSigner(2), accounts[2], true,
+	t.Run("reject gas limit at exactly the ante cost", func(t *testing.T) {
+		// Settlement executes during proposal validation, so a limit that only
+		// covers ante gas runs out while the promise settles — the same tx
+		// would fail in FinalizeBlock with its blob already in the square.
+		exactTx := newSignedPayForFibreTxWithOpts(t, newSigner(1), accounts[1], true,
 			user.SetGasLimit(anteGas), user.SetFee(4_000))
 		require.Len(t, exactTx, len(referenceTx), "boundary tx must match the reference tx size")
 
 		resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, [][]byte{exactTx}))
+		require.NoError(t, err)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, resp.Status)
+	})
+
+	t.Run("accept gas limit covering ante and settlement", func(t *testing.T) {
+		coveredTx := newSignedPayForFibreTxWithOpts(t, newSigner(2), accounts[2], true,
+			user.SetGasLimit(anteGas+100_000), user.SetFee(4_000))
+
+		resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, [][]byte{coveredTx}))
 		require.NoError(t, err)
 		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, resp.Status)
 	})

--- a/app/test/process_proposal_fibre_test.go
+++ b/app/test/process_proposal_fibre_test.go
@@ -289,8 +289,8 @@ func newSignedPayForFibreTxWithOpts(
 	return newSignedPayForFibreTxAt(t, signer, account, validValidatorSignatures, time.Now(), opts...)
 }
 
-// newSignedPayForFibreTxAt creates a signed PayForFibre tx whose promise uses
-// creationTime. Equal timestamps create duplicate promises.
+// newSignedPayForFibreTxAt creates a signed PayForFibre tx with the given
+// promise creation time. Equal times produce duplicate promises.
 func newSignedPayForFibreTxAt(
 	t *testing.T,
 	signer *user.Signer,
@@ -381,7 +381,7 @@ func TestProcessProposalPayForFibreStatefulChecks(t *testing.T) {
 }
 
 // newPayForFibreTxPair creates two PayForFibre txs with sequential nonces and
-// the supplied promise creation times.
+// the given promise creation times.
 func newPayForFibreTxPair(t *testing.T, signer *user.Signer, account string, first, second time.Time) [][]byte {
 	t.Helper()
 	firstTx := newSignedPayForFibreTxAt(t, signer, account, true, first,
@@ -399,11 +399,10 @@ func TestProcessProposalPayForFibreDoubleSpend(t *testing.T) {
 	infos := queryAccountInfo(testApp, accounts, kr)
 	newSigner := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)
 
-	// The blobfactory promise uses BlobSize=100, so every settlement costs the
-	// same payment amount.
+	// Every factory promise has BlobSize=100 and costs the same amount.
 	payment := fibretypes.PaymentAmount(100).Amount.Int64()
 
-	// accounts[0] can afford one payment; accounts[1] and accounts[2] can afford two.
+	// The first account can afford one payment; the others can afford two.
 	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[0]), payment)
 	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[1]), 2*payment)
 	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[2]), 2*payment)
@@ -456,12 +455,24 @@ func TestProcessProposalChargesTxSizeGas(t *testing.T) {
 		seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, account), 1_000_000)
 	}
 
-	// Measure the full ante gas for a same-sized reference tx.
+	// Measure ante-only and full execution gas. Neither call commits state.
 	referenceTx := newSignedPayForFibreTx(t, newSigner(0), accounts[0], true)
 	checkResp, err := testApp.CheckTx(&abci.RequestCheckTx{Tx: referenceTx, Type: abci.CheckTxType_New})
 	require.NoError(t, err)
 	require.Equal(t, abci.CodeTypeOK, checkResp.Code, checkResp.Log)
 	anteGas := uint64(checkResp.GasUsed)
+
+	finalizeResp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Time:   time.Now(),
+		Height: testApp.LastBlockHeight() + 1,
+		Hash:   testApp.LastCommitID().Hash,
+		Txs:    [][]byte{referenceTx},
+	})
+	require.NoError(t, err)
+	require.Len(t, finalizeResp.TxResults, 1)
+	require.Equal(t, abci.CodeTypeOK, finalizeResp.TxResults[0].Code, finalizeResp.TxResults[0].Log)
+	finalizeGas := uint64(finalizeResp.TxResults[0].GasUsed)
+	require.Greater(t, finalizeGas, anteGas, "executing the payment must consume gas beyond ante")
 
 	// The proposal is otherwise valid, so only the gas limit decides the result.
 	t.Run("reject gas limit one below the ante cost", func(t *testing.T) {
@@ -474,22 +485,23 @@ func TestProcessProposalChargesTxSizeGas(t *testing.T) {
 		require.Equal(t, abci.ResponseProcessProposal_REJECT, resp.Status)
 	})
 
-	t.Run("reject gas limit at exactly the ante cost", func(t *testing.T) {
-		// Settlement executes during proposal validation, so a limit that only
-		// covers ante gas runs out while the promise settles — the same tx
-		// would fail in FinalizeBlock with its blob already in the square.
-		exactTx := newSignedPayForFibreTxWithOpts(t, newSigner(1), accounts[1], true,
-			user.SetGasLimit(anteGas), user.SetFee(4_000))
-		require.Len(t, exactTx, len(referenceTx), "boundary tx must match the reference tx size")
+	t.Run("reject gas limit one below the FinalizeBlock cost", func(t *testing.T) {
+		// Reject a tx without enough gas to execute its payment.
+		underTx := newSignedPayForFibreTxWithOpts(t, newSigner(1), accounts[1], true,
+			user.SetGasLimit(finalizeGas-1), user.SetFee(4_000))
+		require.Len(t, underTx, len(referenceTx), "boundary tx must match the reference tx size")
 
-		resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, [][]byte{exactTx}))
+		resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, [][]byte{underTx}))
 		require.NoError(t, err)
 		require.Equal(t, abci.ResponseProcessProposal_REJECT, resp.Status)
 	})
 
-	t.Run("accept gas limit covering ante and settlement", func(t *testing.T) {
+	t.Run("accept gas limit just above the FinalizeBlock cost", func(t *testing.T) {
+		// Store value sizes make gas vary slightly by account. This small margin
+		// allows that variation while keeping the boundary tight.
 		coveredTx := newSignedPayForFibreTxWithOpts(t, newSigner(2), accounts[2], true,
-			user.SetGasLimit(anteGas+100_000), user.SetFee(4_000))
+			user.SetGasLimit(finalizeGas+2_000), user.SetFee(4_000))
+		require.Len(t, coveredTx, len(referenceTx), "boundary tx must match the reference tx size")
 
 		resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, [][]byte{coveredTx}))
 		require.NoError(t, err)

--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -48,6 +48,7 @@ func (a *App) OutOfOrderPrepareProposal(req *abci.RequestPrepareProposal) (*abci
 
 	fsb, err := app.NewFilteredSquareBuilder(
 		handler,
+		a.MsgServiceRouter(),
 		a.GetEncodingConfig().TxConfig,
 		a.MaxEffectiveSquareSize(sdkCtx),
 		appconsts.SubtreeRootThreshold,


### PR DESCRIPTION
## Overview

Fixes https://linear.app/celestia/issue/PROTOCO-2233/escrow-overdraw-duplicate-promises-still-commit-blobs
