### PR TITLE
feat(fibre)!: use Celestia-owned OID for TLS identity extension

### DIFF
--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -161,9 +161,9 @@ Why the scheme looks the way it does:
   chain-ID-enforcing remote signers and HSM policy remain compatible.
 - **Endorsement carried in a custom DER X.509 extension.** The endorsement
   signature must reach the client at handshake time, so it rides in the cert. DER
-  is canonical (friendly to non-Go verifiers like lumina). The extension OID will
-  live under a Celestia-owned IANA PEN; it is a documented placeholder until the
-  PEN is registered (PROTOCO-1808).
+  is canonical (friendly to non-Go verifiers like lumina). The extension OID is
+  `1.3.6.1.4.1.66463.1.1`, under the Celestia-registered IANA PEN 66463; see the
+  OID allocations table in `specs/src/fibre_server.md`.
 
 ## Observability
 

--- a/fibre/internal/tlsid/tlsid.go
+++ b/fibre/internal/tlsid/tlsid.go
@@ -110,13 +110,12 @@ const MaxCertValidity = CertValidity + 2*clockSkew
 // signedIDExtensionOID identifies the custom certificate extension carrying the
 // fibre identity endorsement.
 //
-// TODO(PROTOCO-1808): this is the placeholder IANA PEN 32473, which RFC 5612
-// reserves for documentation/example use (so it is unassigned to any real
-// organization, unlike the previous 56843 = KASSEX s.r.o.). Replace the
-// enterprise number with the Celestia-allocated PEN once registered
-// (https://linear.app/celestia/issue/PROTOCO-1808). Bumping this OID is a
-// protocol-level break.
-var signedIDExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 32473, 1, 1}
+// 66463 is the Celestia-registered IANA Private Enterprise Number
+// (https://www.iana.org/assignments/enterprise-numbers/?q=66463). Within that
+// arc, .1 is allocated to fibre and .1.1 to this TLS signed-identity
+// extension; see the OID allocations note in specs/src/fibre_server.md.
+// Bumping this OID is a protocol-level break.
+var signedIDExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 66463, 1, 1}
 
 // signedIdentity is the ASN.1 payload of the custom extension.
 type signedIdentity struct {

--- a/fibre/internal/tlsid/tlsid_test.go
+++ b/fibre/internal/tlsid/tlsid_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,12 @@ import (
 )
 
 const testChainID = "test-chain"
+
+// identityExtensionOID is an independent copy of the production extension OID
+// (Celestia IANA PEN 66463). It is deliberately not shared with the tlsid
+// package: the OID is a wire-level protocol constant, and a change to it must
+// fail these tests loudly rather than propagate silently.
+var identityExtensionOID = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 66463, 1, 1}
 
 func TestBuildAndVerify_RoundTrip(t *testing.T) {
 	pv := core.NewMockPV()
@@ -33,6 +40,30 @@ func TestBuildAndVerify_RoundTrip(t *testing.T) {
 
 	verify := tlsid.VerifyPeer(expectedPub, testChainID)
 	require.NoError(t, verify(cert.Certificate, nil))
+}
+
+// TestBuildServerCert_ExtensionOID pins the identity extension to the
+// Celestia-registered OID (IANA PEN 66463) and proves the retired placeholder
+// arc (PEN 32473, RFC 5612 example space) is gone. The OID is a wire-level
+// protocol constant: changing it breaks handshakes against every deployed
+// peer, so a change must be deliberate and fail this test.
+func TestBuildServerCert_ExtensionOID(t *testing.T) {
+	cert, err := tlsid.BuildServerCert(core.NewMockPV(), testChainID)
+	require.NoError(t, err)
+
+	parsed, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+
+	var found bool
+	for _, ext := range parsed.Extensions {
+		if ext.Id.Equal(identityExtensionOID) {
+			found = true
+			continue
+		}
+		require.False(t, strings.HasPrefix(ext.Id.String(), "1.3.6.1.4.1.32473."),
+			"certificate carries extension under placeholder PEN arc: %s", ext.Id)
+	}
+	require.True(t, found, "certificate is missing identity extension %s", identityExtensionOID)
 }
 
 func TestVerify_RejectsWrongValidator(t *testing.T) {
@@ -219,7 +250,7 @@ func tamperIdentityExtension(t *testing.T, src *x509.Certificate) []byte {
 	t.Helper()
 	var ext pkix.Extension
 	for _, e := range src.Extensions {
-		if e.Id.Equal(asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 32473, 1, 1}) {
+		if e.Id.Equal(identityExtensionOID) {
 			ext = e
 			break
 		}

--- a/specs/src/fibre_server.md
+++ b/specs/src/fibre_server.md
@@ -130,6 +130,35 @@ upload_verify_workers = runtime.GOMAXPROCS(0)
 
 The Fibre server-to-client gRPC link is TLS-only. On startup the server generates an ephemeral TLS keypair and uses the validator consensus signer to endorse that TLS public key. Clients verify the presented TLS key against the expected validator consensus public key and chain ID. There is no client certificate requirement and no mTLS. `DownloadShard` is public to any reachable client that can complete the server-authenticated TLS handshake.
 
+The endorsement travels in a custom, non-critical X.509 extension identified by OID `1.3.6.1.4.1.66463.1.1`. The extension value is the DER encoding of:
+
+```text
+SignedIdentity ::= SEQUENCE {
+    payload   OCTET STRING,  -- DER of BindingPayload (the exact signed bytes)
+    signature OCTET STRING   -- consensus-key signature over the payload
+}
+
+BindingPayload ::= SEQUENCE {
+    version    INTEGER,      -- schema version (currently 1)
+    notBefore  INTEGER,      -- unix seconds; equals the cert NotBefore
+    notAfter   INTEGER,      -- unix seconds; equals the cert NotAfter
+    tlsPubKey  OCTET STRING  -- DER SubjectPublicKeyInfo of the TLS key
+}
+```
+
+The signature is a CometBFT `SignRawBytes` signature over `"celestia-fibre-tls:" || BindingPayload-DER`, with unique ID `celestia-fibre-tls-v1` and the runtime chain ID in the signing envelope. The full verifier rules (payload byte-equality, validity-window and extended-key-usage checks, size caps) are documented in the `fibre/internal/tlsid` package.
+
+### OID allocations
+
+`1.3.6.1.4.1.66463` is the [IANA Private Enterprise Number 66463](https://www.iana.org/assignments/enterprise-numbers/?q=66463) arc used for Celestia protocol identifiers. Allocations:
+
+| OID | Meaning |
+|-----|---------|
+| `1.3.6.1.4.1.66463.1` | Fibre |
+| `1.3.6.1.4.1.66463.1.1` | Fibre TLS signed-identity certificate extension |
+
+New allocations under this arc must be recorded in this table. The extension OID is a wire-level protocol constant: changing it breaks TLS handshakes between peers on different versions.
+
 ## State Client
 
 The server depends on `state.Client` for chain ID, validator sets, validator host lookup, and payment-promise state validation. The default implementation is `fibre/internal/grpc.AppClient`, which uses app-node gRPC. Validator sets are fetched through the CometBFT Block API `ValidatorSet` endpoint. Payment promises are checked with the app `x/fibre` `ValidatePaymentPromise` query, which returns the expiration time used for local pruning.


### PR DESCRIPTION
## Overview

Replaces the placeholder IANA PEN 32473 (RFC 5612 example/documentation space) in the fibre TLS signed-identity certificate extension with the registered Celestia PEN [66463](https://www.iana.org/assignments/enterprise-numbers/?q=66463). The extension OID is now `1.3.6.1.4.1.66463.1.1` (`.1` = fibre, `.1.1` = TLS signed-identity extension).

Closes PROTOCO-1910.

## Details

- The OID is only the extension locator — the endorsement signature covers the `BindingPayload` bytes under the `celestia-fibre-tls-v1` privval domain, so `SignUniqueID` and `bindingVersion` are unchanged.
- **No dual-OID migration window**: no tagged release contains the placeholder (`git tag --contains 7f6b0fe5a` is empty; fibre is not deployed on the v9 line), and certs are ephemeral (minted in memory on server start, never persisted). The only exposure is devnets running `main` builds, which must restart fibre servers and clients together — handshakes fail across the cut in both directions.
- Adds `TestBuildServerCert_ExtensionOID`, a golden test that pins the new OID from the external test package and asserts nothing remains under the placeholder arc, so a future change to this wire constant fails loudly.
- Documents the numeric OID, the ASN.1 layout of `SignedIdentity`/`BindingPayload`, and a PEN 66463 arc-allocation table in `specs/src/fibre_server.md`, making the spec the reference for any future non-Go verifier.

Marked `!` because it changes a wire-visible protocol constant: peers on opposite sides of this commit cannot complete a fibre TLS handshake.

## Testing

- `make build`, `make lint` (golangci-lint 0 issues, markdownlint clean)
- `go test ./fibre/...` — all packages pass, including the new golden test and the end-to-end TLS handshake tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)