### PR TITLE
chore: group dependabot updates into weekly batches

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,20 +1,49 @@
 version: 2
+
+# Dependabot cannot combine updates across package-ecosystem/directory entries,
+# so the floor is one pull request per entry below. Each entry groups its
+# minor and patch bumps into a single weekly pull request to keep the review
+# queue small; major bumps are deliberately left ungrouped so a breaking change
+# gets its own pull request rather than being buried in a batch.
+#
+# Every entry runs on Monday so the batches land together instead of trickling
+# in across the week.
 updates:
   # Docker
   - package-ecosystem: docker
     directory: "/docker"
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    groups:
+      docker:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
 
   # Github Actions
+  #
+  # Grouping also keeps github/codeql-action/init and github/codeql-action/analyze
+  # in the same pull request. Bumped separately they disagree on version, which
+  # fails the `Analyze (go)` job until both land.
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
 
@@ -23,13 +52,29 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies
   - package-ecosystem: gomod
     directory: "test/docker-e2e"
     schedule:
       interval: weekly
+      day: monday
     open-pull-requests-limit: 10
+    groups:
+      go-deps-docker-e2e:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
     labels:
       - dependencies


### PR DESCRIPTION
## Motivation

Dependabot currently opens one PR per dependency bump — roughly 12 per week, ~50 merged in the last month — which is tedious to review and approve. This groups them into weekly batches.

## Changes

- Group minor and patch bumps into a single PR per ecosystem entry.
- Pin every entry to `day: monday` so the batches land together instead of trickling in.

Major bumps are deliberately left ungrouped so a breaking change still gets its own PR rather than being buried in a batch.

## Notes

- Dependabot cannot combine updates across `package-ecosystem`/`directory` entries, so the floor is 4 PRs/week (docker, github-actions, gomod `/`, gomod `test/docker-e2e`) rather than 1.
- Grouping the GitHub Actions entry also keeps `github/codeql-action/init` and `github/codeql-action/analyze` in the same PR. Bumped separately they disagree on version and fail the `Analyze (go)` job until both land.
- Fewer, larger Go PRs also means fewer `dependabot-auto-tidy` runs for the `test/docker-e2e` tidy parity issue (#7641).

`yamllint --no-warnings . -c .yamllint.yml` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe82HG8v4H92v7kVYDVNnw
