### PR TITLE
chore(deps): bump github/codeql-action to v4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,7 +44,7 @@ jobs:
           go-version-file: "go.mod"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
 
@@ -55,6 +55,6 @@ jobs:
         run: go build ./...
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Motivation

Dependabot split the `github/codeql-action` v4.37.6 bump into two separate PRs — #7647 (`init`) and #7652 (`analyze`) — each touching only one step. Bumping just one leaves `init` and `analyze` at mismatched versions, so the analyze post-action step fails with:

```
Loaded a configuration file for version '4.37.4', but running version '4.37.6'
```

This PR bumps both steps together in a single commit so the versions stay in sync, which is why the two dependabot PRs can be closed in favor of this one.

Supersedes #7647 and #7652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01APgVFYfBKMczBEWBxkVKLj