### PR TITLE
ci: harden nightly workflow against tag input injection

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -30,16 +30,23 @@ jobs:
           INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ -n "$INPUT_TAG" ]; then
-            # Restrict the tag to the Docker tag charset. Without this a value
-            # containing a newline could smuggle extra lines into
-            # $GITHUB_OUTPUT, and shell metacharacters could reach the steps
-            # that consume the tag. No legitimate image tag is rejected.
+            # Validate against Docker's tag grammar,
+            # [A-Za-z0-9_][A-Za-z0-9._-]{0,127}. This keeps shell
+            # metacharacters out of the steps that consume the tag and stops a
+            # newline from smuggling extra lines into $GITHUB_OUTPUT. Checking
+            # the full grammar (not just the charset) also fails here with a
+            # clear message, rather than later on an opaque "invalid reference
+            # format" from docker build.
             case "$INPUT_TAG" in
-              *[!A-Za-z0-9._-]*)
-                echo "::error::Invalid tag '$INPUT_TAG': expected only A-Za-z0-9 . _ -"
+              [!A-Za-z0-9_]* | *[!A-Za-z0-9._-]*)
+                echo "::error::Invalid tag '$INPUT_TAG': must match [A-Za-z0-9_][A-Za-z0-9._-]{0,127}"
                 exit 1
                 ;;
             esac
+            if [ "${#INPUT_TAG}" -gt 128 ]; then
+              echo "::error::Invalid tag '$INPUT_TAG': ${#INPUT_TAG} characters, max 128"
+              exit 1
+            fi
             echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
             echo "value=$(echo "$GITHUB_SHA" | cut -c1-8)" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -26,20 +26,36 @@ jobs:
 
       - name: Generate image tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
-          if [ -n "${{ inputs.tag }}" ]; then
-            echo "value=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_TAG" ]; then
+            # Restrict the tag to the Docker tag charset. Without this a value
+            # containing a newline could smuggle extra lines into
+            # $GITHUB_OUTPUT, and shell metacharacters could reach the steps
+            # that consume the tag. No legitimate image tag is rejected.
+            case "$INPUT_TAG" in
+              *[!A-Za-z0-9._-]*)
+                echo "::error::Invalid tag '$INPUT_TAG': expected only A-Za-z0-9 . _ -"
+                exit 1
+                ;;
+            esac
+            echo "value=${INPUT_TAG}" >> "$GITHUB_OUTPUT"
           else
-            echo "value=$(echo $GITHUB_SHA | cut -c1-8)" >> $GITHUB_OUTPUT
+            echo "value=$(echo "$GITHUB_SHA" | cut -c1-8)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build Docker image
         if: ${{ inputs.tag == '' }}
-        run: docker build -t "ghcr.io/celestiaorg/celestia-app:${{ steps.tag.outputs.value }}" . -f docker/multiplexer.Dockerfile
+        env:
+          TAG: ${{ steps.tag.outputs.value }}
+        run: docker build -t "ghcr.io/celestiaorg/celestia-app:${TAG}" . -f docker/multiplexer.Dockerfile
 
       - name: Save Docker image as artifact
         if: ${{ inputs.tag == '' }}
-        run: docker save "ghcr.io/celestiaorg/celestia-app:${{ steps.tag.outputs.value }}" | gzip > /tmp/e2e-image.tar.gz
+        env:
+          TAG: ${{ steps.tag.outputs.value }}
+        run: docker save "ghcr.io/celestiaorg/celestia-app:${TAG}" | gzip > /tmp/e2e-image.tar.gz
 
       - name: Upload Docker image artifact
         if: ${{ inputs.tag == '' }}
@@ -62,13 +78,17 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       - name: Build latency-monitor Docker image
+        env:
+          TAG: ${{ needs.build-e2e-image.outputs.tag }}
         run: >-
           docker build
-          -t "ghcr.io/celestiaorg/latency-monitor:${{ needs.build-e2e-image.outputs.tag }}"
+          -t "ghcr.io/celestiaorg/latency-monitor:${TAG}"
           -f docker/latency-monitor/Dockerfile .
 
       - name: Save Docker image as artifact
-        run: docker save "ghcr.io/celestiaorg/latency-monitor:${{ needs.build-e2e-image.outputs.tag }}" | gzip > /tmp/latency-monitor-image.tar.gz
+        env:
+          TAG: ${{ needs.build-e2e-image.outputs.tag }}
+        run: docker save "ghcr.io/celestiaorg/latency-monitor:${TAG}" | gzip > /tmp/latency-monitor-image.tar.gz
 
       - name: Upload Docker image artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #v7.0.1


### PR DESCRIPTION
## Summary

Harden `test-nightly.yml` against script injection through the `workflow_dispatch` tag input. GitHub expands `${{ ... }}` textually before bash sees it, so a tag value interpolated into a `run:` block becomes executable shell.

- Bind `inputs.tag` through `env: INPUT_TAG` in the `Generate image tag` step.
- Do the same at the remaining sinks, where the tag reached `run:` via `${{ steps.tag.outputs.value }}` / `${{ needs.build-e2e-image.outputs.tag }}`. The latency-monitor build/save steps aren't gated on `inputs.tag == ''`, so they saw the untrusted value too.
- Validate the tag against Docker's tag grammar, `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`. This stops a newline from smuggling an extra `value=` line into `$GITHUB_OUTPUT`, and rejects Docker-invalid tags in the tag step with a clear message instead of later on an opaque `invalid reference format`.
- Quote `$GITHUB_OUTPUT` / `$GITHUB_SHA` (shellcheck SC2086, reported by actionlint).

Practical severity is low: `workflow_dispatch` requires write access, so anyone who can supply the input can already modify workflows. This is defense in depth, matching [GitHub's script-injection guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).

Supersedes #7632, which hardened only the first of the three sinks. Thanks @SashaMIT for spotting the issue.

## Testing

Extracted the `Generate image tag` script from the workflow file and ran it against each input:

| input | result | value written |
|---|---|---|
| empty (scheduled run) | accept | `value=abcdef12` (short SHA) |
| `v10.0.0` | accept | `value=v10.0.0` |
| `_build` | accept | `value=_build` |
| `v1.2.3-rc.1` | accept | `value=v1.2.3-rc.1` |
| 128 chars | accept | full tag |
| 129 chars | reject | — |
| `-foo` / `.foo` | reject | — |
| `x"; touch /tmp/PWNED; echo "` | reject | — |
| `x$(touch /tmp/PWNED)` | reject | — |
| `v1\nvalue=evil` | reject | — |

Both real cases behave exactly as before this PR. Against the pre-PR script the two injection inputs **executed** the injected command and the newline input wrote a second `value=evil` line; both now fail closed.

The accept/reject boundary was checked against `docker build` on docker 29.6.2 — 128 chars and `_build` are accepted by Docker, while 129 chars, `-foo`, and `.foo` are rejected as `invalid reference format` — so the validation admits exactly what Docker admits.

`actionlint` and `yamllint --no-warnings . -c .yamllint.yml` pass.
