### PR TITLE
fix(ci): ignore hadolint DL3066 false positive

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,9 @@
+ignored:
+  # DL3066 (non-numeric user-id) fires on `USER ${USER_NAME}` in our Dockerfiles
+  # because hadolint cannot resolve a user supplied via ARG. This is an upstream
+  # false positive that was fixed in hadolint v2.15.1:
+  # https://github.com/hadolint/hadolint/pull/1226
+  #
+  # CI lints via hadolint/hadolint-action@v3.4.0, which still ships hadolint
+  # v2.15.0. Remove this entry once the action ships hadolint v2.15.1 or newer.
+  - DL3066


### PR DESCRIPTION
The `lint / hadolint` job fails on any PR that touches `docker/**` with:

```
docker/standalone.Dockerfile:75 DL3066 info: Non-numeric user-id may not be resolvable by host system
```

DL3066 was introduced in hadolint v2.15.0 and reports `USER ${USER_NAME}` as non-numeric because hadolint cannot resolve a user supplied via `ARG`. Upstream fixed this false positive in [hadolint v2.15.1](https://github.com/hadolint/hadolint/pull/1226), but the newest `hadolint/hadolint-action` release (v3.4.0) still bundles v2.15.0, so there is no action version to bump to.

This is pre-existing on main, not caused by any one PR: main moved to `hadolint-action@v3.4.0` in #7617, and the hadolint job only runs when `docker/**` changes, so it stayed latent until the next Dockerfile change (#7670).

Ignore DL3066 via `.hadolint.yaml` until the action ships hadolint v2.15.1 or newer. All three linted Dockerfiles (`standalone`, `multiplexer`, `txsim`) are affected.

Verified against hadolint v2.15.0 (the exact version CI runs): the three Dockerfiles fail before this change and pass after, while other rules still fire.

v9.x is unaffected — it pins `hadolint-action@v3.3.0`, which ships hadolint v2.14.0 (predating DL3066).