### PR TITLE
fix: compare unscaled square size in ProcessProposal (backport #7661)

### DIFF
--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -179,8 +179,11 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 		return reject(), nil
 	}
 
-	// Assert that the square size stated by the proposer is correct
-	if uint64(eds.Width()) != req.SquareSize*2 {
+	// Assert that the square size stated by the proposer is correct. Compare
+	// the halved EDS width rather than the doubled proposer value: doubling an
+	// attacker controlled uint64 wraps, so SquareSize and SquareSize+2^63 would
+	// otherwise be indistinguishable.
+	if uint64(eds.Width())/2 != req.SquareSize {
 		logInvalidPropBlock(app.Logger(), blockHeader, "proposed square size differs from calculated square size")
 		return reject(), nil
 	}

--- a/app/test/square_size_overflow_test.go
+++ b/app/test/square_size_overflow_test.go
@@ -1,0 +1,61 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v9/app"
+	testutil "github.com/celestiaorg/celestia-app/v9/test/util"
+	"github.com/celestiaorg/celestia-app/v9/test/util/testfactory"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessProposalSquareSizeOverflow verifies that ProcessProposal rejects a
+// proposal whose declared SquareSize is congruent to the correct value modulo
+// 2^63. The check in app/process_proposal.go compares
+// `uint64(eds.Width()) != req.SquareSize*2`, and the multiplication wraps, so
+// `S` and `S + 2^63` are indistinguishable to that comparison.
+func TestProcessProposalSquareSizeOverflow(t *testing.T) {
+	accounts := testfactory.GenerateAccounts(1)
+	testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	blockTime := time.Now()
+	height := testApp.LastBlockHeight() + 1
+
+	prepared, err := testApp.PrepareProposal(&abci.RequestPrepareProposal{
+		Height: height,
+		Time:   blockTime,
+	})
+	require.NoError(t, err)
+
+	honest := prepared.SquareSize
+	aliased := honest + (uint64(1) << 63)
+	// Sanity check: the two values are indistinguishable after doubling.
+	require.Equal(t, honest*2, aliased*2)
+
+	t.Run("honest square size is accepted", func(t *testing.T) {
+		resp, err := testApp.ProcessProposal(&abci.RequestProcessProposal{
+			Time:         blockTime,
+			Height:       height,
+			Txs:          prepared.Txs,
+			DataRootHash: prepared.DataRootHash,
+			SquareSize:   honest,
+		})
+		require.NoError(t, err)
+		require.Equal(t, abci.ResponseProcessProposal_ACCEPT, resp.Status)
+	})
+
+	t.Run("aliased square size is rejected", func(t *testing.T) {
+		resp, err := testApp.ProcessProposal(&abci.RequestProcessProposal{
+			Time:         blockTime,
+			Height:       height,
+			Txs:          prepared.Txs,
+			DataRootHash: prepared.DataRootHash,
+			SquareSize:   aliased,
+		})
+		require.NoError(t, err)
+		require.Equal(t, abci.ResponseProcessProposal_REJECT, resp.Status,
+			"ProcessProposal accepted SquareSize=%d when the real square size is %d", aliased, honest)
+	})
+}


### PR DESCRIPTION
Backport of #7661 to `v9.x`. The fix landed on `main` (v10, unreleased), so every shipping release line still carries the original comparison.

Closes [PROTOCO-2276](https://linear.app/celestia/issue/PROTOCO-2276/processproposal-squaresize-check-overflows-allowing-a-malformed-square). See the Linear issue for details.

## Test plan

- [x] `app/test/square_size_overflow_test.go` fails on `v9.x` before the change, passes after
- [x] `make build`, `go tool golangci-lint run ./app/...` pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NkQD9uxoDRG5KQwANkxktu
