### PR TITLE
fix!: validate the PayForFibre promise namespace

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -159,9 +159,7 @@ func validatePayForFibreTxShape(tx sdk.Tx) error {
 }
 
 // validatePayForFibreNamespace rejects a payment promise namespace that a blob
-// may not occupy. It lives here rather than in MsgPayForFibre.ValidateBasic
-// because ProcessProposal invokes the ante handler directly, skipping the
-// message level validation baseapp runs in CheckTx and DeliverTx.
+// may not occupy.
 func validatePayForFibreNamespace(namespace []byte) error {
 	ns, err := share.NewNamespaceFromBytes(namespace)
 	if err != nil {

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -159,15 +159,9 @@ func validatePayForFibreTxShape(tx sdk.Tx) error {
 }
 
 // validatePayForFibreNamespace rejects a payment promise namespace that a blob
-// may not occupy.
-//
-// The square builder synthesizes a system blob in this namespace without
-// validating it, and places it in the blob region, which follows the reserved
-// namespaces. A reserved namespace there leaves the square's namespaces out of
-// order, so the square builds but its data root cannot be computed. This check
-// has to live here rather than rely on MsgPayForFibre.ValidateBasic, because
-// ProcessProposal invokes the ante handler directly and so never runs the
-// message level validation that baseapp performs in CheckTx and DeliverTx.
+// may not occupy. It lives here rather than in MsgPayForFibre.ValidateBasic
+// because ProcessProposal invokes the ante handler directly, skipping the
+// message level validation baseapp runs in CheckTx and DeliverTx.
 func validatePayForFibreNamespace(namespace []byte) error {
 	ns, err := share.NewNamespaceFromBytes(namespace)
 	if err != nil {

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -8,6 +8,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	blobtypes "github.com/celestiaorg/celestia-app/v10/x/blob/types"
 	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/celestiaorg/go-square/v4/share"
 	blobtx "github.com/celestiaorg/go-square/v4/tx"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -137,13 +138,43 @@ func signerDataFromTx(tx sdk.Tx) ([]byte, uint64, error) {
 	return sigs[0].PubKey.Address().Bytes(), sigs[0].Sequence, nil
 }
 
-// validatePayForFibreTxShape rejects txs that mix MsgPayForFibre with other messages.
+// validatePayForFibreTxShape rejects txs that mix MsgPayForFibre with other
+// messages, and txs whose payment promise names a namespace that cannot hold a
+// blob.
 func validatePayForFibreTxShape(tx sdk.Tx) error {
 	msgs := tx.GetMsgs()
 	for _, msg := range msgs {
-		if _, isPFF := msg.(*fibretypes.MsgPayForFibre); isPFF && len(msgs) > 1 {
+		pff, isPFF := msg.(*fibretypes.MsgPayForFibre)
+		if !isPFF {
+			continue
+		}
+		if len(msgs) > 1 {
 			return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "tx contains a MsgPayForFibre and %d total messages", len(msgs))
 		}
+		if err := validatePayForFibreNamespace(pff.PaymentPromise.Namespace); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validatePayForFibreNamespace rejects a payment promise namespace that a blob
+// may not occupy.
+//
+// The square builder synthesizes a system blob in this namespace without
+// validating it, and places it in the blob region, which follows the reserved
+// namespaces. A reserved namespace there leaves the square's namespaces out of
+// order, so the square builds but its data root cannot be computed. This check
+// has to live here rather than rely on MsgPayForFibre.ValidateBasic, because
+// ProcessProposal invokes the ante handler directly and so never runs the
+// message level validation that baseapp performs in CheckTx and DeliverTx.
+func validatePayForFibreNamespace(namespace []byte) error {
+	ns, err := share.NewNamespaceFromBytes(namespace)
+	if err != nil {
+		return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "invalid payment promise namespace: %s", err)
+	}
+	if err := ns.ValidateForBlob(); err != nil {
+		return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "invalid payment promise namespace: %s", err)
 	}
 	return nil
 }

--- a/app/extract_pff_test.go
+++ b/app/extract_pff_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
 	apperr "github.com/celestiaorg/celestia-app/v10/app/errors"
 	"github.com/celestiaorg/celestia-app/v10/test/util/blobfactory"
+	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -46,6 +47,21 @@ func TestValidatePayForFibreTxShape(t *testing.T) {
 		{
 			name:    "two pay-for-fibre messages are invalid",
 			txBytes: newMultiPayForFibreTx(t, txConfig),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name:    "pay-for-fibre promising a reserved namespace is invalid",
+			txBytes: newPayForFibreTxWithNamespace(t, txConfig, share.TxNamespace.Bytes()),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name:    "pay-for-fibre promising the parity namespace is invalid",
+			txBytes: newPayForFibreTxWithNamespace(t, txConfig, share.ParitySharesNamespace.Bytes()),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name:    "pay-for-fibre promising a malformed namespace is invalid",
+			txBytes: newPayForFibreTxWithNamespace(t, txConfig, []byte{0x01, 0x02}),
 			wantErr: apperr.ErrInvalidPayForFibreTx,
 		},
 	}
@@ -109,6 +125,20 @@ func decodeTx(t *testing.T, txConfig client.TxConfig, txBytes []byte) sdk.Tx {
 	tx, err := txConfig.TxDecoder()(txBytes)
 	require.NoError(t, err)
 	return tx
+}
+
+// newPayForFibreTxWithNamespace creates an unsigned pay-for-fibre tx whose
+// payment promise names the provided namespace.
+func newPayForFibreTxWithNamespace(t *testing.T, txConfig client.TxConfig, namespace []byte) []byte {
+	t.Helper()
+	privKey := secp256k1.GenPrivKey()
+	msg := blobfactory.NewMsgPayForFibre(t, privKey.PubKey().(*secp256k1.PubKey), "test")
+	msg.PaymentPromise.Namespace = namespace
+	builder := txConfig.NewTxBuilder()
+	require.NoError(t, builder.SetMsgs(msg))
+	txBytes, err := txConfig.TxEncoder()(builder.GetTx())
+	require.NoError(t, err)
+	return txBytes
 }
 
 // newMultiMsgSendTx creates an unsigned tx with msgCount MsgSend messages.


### PR DESCRIPTION
The PayForFibre promise namespace was only validated via message `ValidateBasic`, which `ProcessProposal` never reaches. An unchecked reserved namespace could reach `squarev4.Construct`, producing a square whose namespaces are out of order and whose data root can't be computed.

Fix: validate the namespace in `validatePayForFibreTxShape`, which both CheckTx and ProcessProposal call.

Note for reviewers: this rejects proposals ProcessProposal previously accepted, so it's consensus-affecting. Fine while v10 is unreleased; after release it would need version-gating.

Closes PROTOCO-2290
