### PR TITLE
test: cover power-of-two non-square share counts in TestExtendShares

### DIFF
--- a/pkg/da/data_availability_header_test.go
+++ b/pkg/da/data_availability_header_test.go
@@ -159,6 +159,24 @@ func TestExtendShares(t *testing.T) {
 			expectedErr: true,
 			shares:      generateShares(5),
 		},
+		// Share counts that are powers of two but not perfect squares get past
+		// the IsPowerOfTwo check both functions start with, so rejecting them is
+		// left to rsmt2d. Assert both functions still agree.
+		{
+			name:        "two shares is not a perfect square",
+			expectedErr: true,
+			shares:      generateShares(2),
+		},
+		{
+			name:        "eight shares is not a perfect square",
+			expectedErr: true,
+			shares:      generateShares(8),
+		},
+		{
+			name:        "thirty two shares is not a perfect square",
+			expectedErr: true,
+			shares:      generateShares(32),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Test-only. `TestExtendShares` runs `ExtendShares` and `ExtendSharesWithTreePool` over the same cases to assert the two agree. Share counts that are powers of two but not perfect squares get past that check and rely on rsmt2d's `newDataSquare` to reject them, which was untested. Adds 2, 8, and 32.

Closes PROTOCO-2291
