### PR TITLE
feat(talis): use ssd in GC servers by default

### DIFF
--- a/tools/talis/google_cloud.go
+++ b/tools/talis/google_cloud.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -23,6 +24,16 @@ const (
 	GCDefaultObservabilityMachineType = "e2-highmem-4"
 	GCDefaultImage                    = "projects/ubuntu-os-cloud/global/images/family/ubuntu-2404-lts-amd64"
 	GCDefaultDiskSizeGB               = 400
+	// GCDefaultDiskType hyperdisk-balanced is GCP's gp3 equivalent: IOPS and throughput are
+	// provisioned independently of disk size. Match the AWS provisioning
+	// (16k IOPS / 1000 MB/s) so the disk doesn't bottleneck fibre's shard
+	// store. c3d-highcpu-16 allows up to 75k IOPS / 1200 MiB/s per
+	// instance; c3d-highcpu-8 caps at 50k IOPS / 800 MiB/s, so shapes with
+	// fewer than 16 vCPUs clamp throughput to 800.
+	GCDefaultDiskType                    = "hyperdisk-balanced"
+	GCDefaultProvisionedIops             = int64(16000)
+	GCDefaultProvisionedThroughputMBs    = int64(1000)
+	GCSmallShapeProvisionedThroughputMBs = int64(800)
 )
 
 var (
@@ -461,6 +472,39 @@ func CreateGCInstances(ctx context.Context, project string, insts []Instance, ss
 	return created, nil
 }
 
+// gcDiskInitializeParams returns the boot-disk parameters for an instance.
+// C3D shapes get a hyperdisk-balanced disk provisioned to match the AWS gp3
+// defaults; other machine families (e.g. the e2 observability node) don't
+// support hyperdisk and keep the API's default disk type.
+func gcDiskInitializeParams(inst Instance, zone string) *computepb.AttachedDiskInitializeParams {
+	params := &computepb.AttachedDiskInitializeParams{
+		SourceImage: new(GCDefaultImage),
+		DiskSizeGb:  &diskSizeGB,
+	}
+
+	if !strings.HasPrefix(inst.Slug, "c3d-") {
+		return params
+	}
+
+	params.DiskType = new(fmt.Sprintf("zones/%s/diskTypes/%s", zone, GCDefaultDiskType))
+	params.ProvisionedIops = new(GCDefaultProvisionedIops)
+	params.ProvisionedThroughput = new(gcProvisionedThroughputMBs(inst.Slug))
+	return params
+}
+
+// gcProvisionedThroughputMBs picks the provisioned throughput for a C3D
+// machine type: shapes with 16+ vCPUs allow the full 1000 MiB/s, smaller
+// shapes are capped at 800 MiB/s by GCE. Falls back to the conservative
+// value when the vCPU count can't be parsed from the slug.
+func gcProvisionedThroughputMBs(slug string) int64 {
+	parts := strings.Split(slug, "-")
+	vcpus, err := strconv.Atoi(parts[len(parts)-1])
+	if err != nil || vcpus < 16 {
+		return GCSmallShapeProvisionedThroughputMBs
+	}
+	return GCDefaultProvisionedThroughputMBs
+}
+
 func createGCInstance(ctx context.Context, project string, inst Instance, zone string, sshKey string, opts []option.ClientOption) (string, string, error) {
 	client, err := compute.NewInstancesRESTClient(ctx, opts...)
 	if err != nil {
@@ -477,7 +521,6 @@ func createGCInstance(ctx context.Context, project string, inst Instance, zone s
 	sshKeyMetadata := fmt.Sprintf("%s:%s", username, strings.TrimSpace(sshKey))
 
 	machineType := fmt.Sprintf("zones/%s/machineTypes/%s", zone, inst.Slug)
-	sourceImage := GCDefaultImage
 
 	req := &computepb.InsertInstanceRequest{
 		Project: project,
@@ -491,12 +534,9 @@ func createGCInstance(ctx context.Context, project string, inst Instance, zone s
 			},
 			Disks: []*computepb.AttachedDisk{
 				{
-					Boot:       &boolTrue,
-					AutoDelete: &boolTrue,
-					InitializeParams: &computepb.AttachedDiskInitializeParams{
-						SourceImage: &sourceImage,
-						DiskSizeGb:  &diskSizeGB,
-					},
+					Boot:             &boolTrue,
+					AutoDelete:       &boolTrue,
+					InitializeParams: gcDiskInitializeParams(inst, zone),
 				},
 			},
 			NetworkInterfaces: []*computepb.NetworkInterface{

--- a/tools/talis/google_cloud_test.go
+++ b/tools/talis/google_cloud_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCDiskInitializeParams(t *testing.T) {
+	tests := []struct {
+		name               string
+		slug               string
+		expectHyperdisk    bool
+		expectedThroughput int64
+	}{
+		{"validator gets full provisioning", GCDefaultValidatorMachineType, true, GCDefaultProvisionedThroughputMBs},
+		{"encoder clamps to 8-vCPU throughput cap", GCDefaultEncoderMachineType, true, GCSmallShapeProvisionedThroughputMBs},
+		{"reader clamps to 8-vCPU throughput cap", GCDefaultReaderMachineType, true, GCSmallShapeProvisionedThroughputMBs},
+		{"unparsable vCPU count falls back to conservative cap", "c3d-standard-8-lssd", true, GCSmallShapeProvisionedThroughputMBs},
+		{"observability keeps default disk type", GCDefaultObservabilityMachineType, false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inst := NewBaseInstance(Validator)
+			inst.Slug = tt.slug
+			params := gcDiskInitializeParams(inst, "us-east1-b")
+
+			require.Equal(t, GCDefaultImage, params.GetSourceImage())
+			require.Equal(t, int64(GCDefaultDiskSizeGB), params.GetDiskSizeGb())
+
+			if !tt.expectHyperdisk {
+				require.Nil(t, params.DiskType)
+				require.Nil(t, params.ProvisionedIops)
+				require.Nil(t, params.ProvisionedThroughput)
+				return
+			}
+			require.Equal(t, "zones/us-east1-b/diskTypes/"+GCDefaultDiskType, params.GetDiskType())
+			require.Equal(t, GCDefaultProvisionedIops, params.GetProvisionedIops())
+			require.Equal(t, tt.expectedThroughput, params.GetProvisionedThroughput())
+		})
+	}
+}


### PR DESCRIPTION
## Overview

GCP talis instances were getting the default boot disk (`pd-balanced`, ~2,400 IOPS), much slower than the AWS gp3 volumes provisioned at 16k IOPS / 1,000 MB/s. This switches C3D machines to `hyperdisk-balanced` with matching provisioning.

Validators are required to run SSDs with similar performance. So, this allows to have a more accurate representation of the realistic network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)