### PR TITLE
feat(talis): use goleveldb as default db backend

### DIFF
--- a/tools/talis/init.go
+++ b/tools/talis/init.go
@@ -198,6 +198,9 @@ func initCmd() *cobra.Command {
 }
 
 func DefaultConfigProfile(cfg *cmtconfig.Config, tables []string, enablePrometheus bool) *cmtconfig.Config {
+	// Most mainnet nodes run goleveldb (the historical default), so talis
+	// experiments use it too instead of celestia-core's pebbledb default.
+	cfg.DBBackend = "goleveldb"
 	cfg.Instrumentation.TracingTables = strings.Join(tables, ",")
 	cfg.Instrumentation.TraceType = "local"
 	cfg.Instrumentation.Prometheus = enablePrometheus

--- a/tools/talis/init.go
+++ b/tools/talis/init.go
@@ -36,7 +36,6 @@ const (
 	EnvVarDOSpacesBucket          = "DO_SPACES_BUCKET"
 	EnvVarDOSpacesEndpoint        = "DO_SPACES_ENDPOINT"
 	EnvVarChainID                 = "CHAIN_ID"
-	mebibyte                      = 1_048_576
 )
 
 func initCmd() *cobra.Command {
@@ -205,8 +204,6 @@ func DefaultConfigProfile(cfg *cmtconfig.Config, tables []string, enablePromethe
 	cfg.Instrumentation.TraceType = "local"
 	cfg.Instrumentation.Prometheus = enablePrometheus
 	cfg.Instrumentation.PrometheusListenAddr = ":26660"
-	cfg.P2P.SendRate = 100 * mebibyte
-	cfg.P2P.RecvRate = 110 * mebibyte
 	cfg.RPC.ListenAddress = "tcp://0.0.0.0:26657"
 	cfg.RPC.GRPCListenAddress = "tcp://0.0.0.0:9090"
 	return cfg

--- a/tools/talis/sync_node_cmd.go
+++ b/tools/talis/sync_node_cmd.go
@@ -538,6 +538,9 @@ echo "Found $(echo "$PERSISTENT_PEERS" | tr ',' '\n' | wc -l | tr -d ' ') peers"
 # Configure persistent peers
 sed -i "s|^persistent_peers *=.*|persistent_peers = \"$PERSISTENT_PEERS\"|" "$HOME_DIR/config/config.toml"
 
+# Use goleveldb to match the mainnet default
+sed -i "s|^db_backend *=.*|db_backend = \"goleveldb\"|" "$HOME_DIR/config/config.toml"
+
 # Disable block sync verification for faster sync
 sed -i -E "s|^verify_data *=.*|verify_data = false|" "$HOME_DIR/config/config.toml"
 


### PR DESCRIPTION
Closes PROTOCO-2124

## Overview

Talis experiments now default to goleveldb — the db backend most mainnet nodes run — instead of celestia-core's pebbledb default, for both validators and sync nodes. Also removes talis' P2P send/recv rate overrides, which were dead config: the binary already raises them to the mainnet default (200 MiB) at startup. Other configs (peer counts, mempool, timeouts) already match mainnet defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)