### PR TITLE
fix(fibre): return context cancellation from Store.Size

### DIFF
--- a/fibre/store.go
+++ b/fibre/store.go
@@ -363,7 +363,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 		case err != nil:
 			return 0, fmt.Errorf("stat shard file %s: %w", name, err)
 		case ctx.Err() != nil:
-			return 0, err
+			return 0, ctx.Err()
 		}
 		totalSize += info.Size()
 	}

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -1,6 +1,7 @@
 package fibre_test
 
 import (
+	"context"
 	"encoding/hex"
 	"log/slog"
 	"os"
@@ -526,6 +527,12 @@ func testStoreSize(t *testing.T, store *fibre.Store, path string) {
 	size, err = store.Size(ctx)
 	require.NoError(t, err)
 	require.Equal(t, want, size)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	size, err = store.Size(canceledCtx)
+	require.Zero(t, size)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 // PruneBefore reports the total on-disk bytes it freed.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

- return `ctx.Err()` when `Store.Size` observes context cancellation
- add a regression test covering a canceled context on a non-empty store

`Store.Size` previously returned the local error from `fs.Stat`. Because the preceding switch case had already established that this error was nil, cancellation was incorrectly reported as `(0, nil)`.


Closes https://github.com/celestiaorg/celestia-app/issues/7683

