### PR TITLE
docs: require clickable issue links in PR descriptions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,4 +81,5 @@ All branches use forked cosmos-sdk and celestia-core:
 1. **Multi-module repo**: Copy `go.work.example` to `go.work` and run `go work sync`
 2. **Conventional commits**: PR titles must follow [conventionalcommits.org](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `chore:`, `feat!:` for breaking changes)
 3. **Validate inputs** in message handlers; be cautious with arithmetic overflow and gas consumption
-4. **Hacken bug bounty PRs**: When creating a PR that resolves a Hacken bug bounty report, do NOT include details about the bug in the PR description. Instead, link to a Linear issue that contains more details on the bug and the link to the Hacken bug bounty report.
+4. **Linking issues**: PR descriptions must start with a `Closes <link>` line when an issue exists, and the link must be clickable. Linear issues use `Closes [PROTOCO-1234](https://linear.app/celestia/issue/PROTOCO-1234)` — a bare `Closes PROTOCO-1234` is not acceptable because GitHub does not linkify it.
+5. **Hacken bug bounty PRs**: When creating a PR that resolves a Hacken bug bounty report, do NOT include details about the bug in the PR description. Instead, link to a Linear issue (as a clickable link, per the previous item) that contains more details on the bug and the link to the Hacken bug bounty report.


### PR DESCRIPTION
Agents keep writing bare identifiers like `Closes PROTOCO-2289`, which GitHub doesn't linkify, so reviewers can't click through to the Linear issue. This adds a workflow item requiring the description to start with a `Closes <link>` line using the full Linear URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCU9Qd5vTnohRrLVKnN2Dn