### PR TITLE
docs(fibre): document the validator operator path end to end

### DIFF
--- a/docs/release-notes/release-notes.md
+++ b/docs/release-notes/release-notes.md
@@ -6,6 +6,10 @@ This guide provides notes for major version releases. These notes may be helpful
 
 ### Node Operators (v10.0.0)
 
+#### Fibre
+
+v10 introduces fibre, a data availability protocol served by validator-operated fibre servers. Validators should follow the [fibre server guide](../../fibre/cmd/README.md) — prerequisites, setup, and the on-chain host registration via [`x/valaddr`](../../x/valaddr/README.md) — to start serving fibre traffic once v10 is live.
+
 #### Key Management Systems (KMS)
 
 The horcrux deprecation announced in the v7 release notes is superseded. Any KMS infrastructure may be used, provided it meets both requirements:

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -2,6 +2,17 @@
 
 Standalone binary for the Fibre data availability server.
 
+## Prerequisites
+
+Before starting, make sure:
+
+- [ ] A `celestia-appd` node runs on the same host (or a trusted host-local network). The server's app link (`--app-grpc-address`) and signer link (`--signer-grpc-address`) are **not** TLS-protected — see [Transport security](#transport-security-tls).
+- [ ] The chain is on **app version 10 or later**. The `x/fibre` and `x/valaddr` modules the server depends on do not exist in earlier versions.
+- [ ] The node's application gRPC endpoint is enabled (default `127.0.0.1:9090`).
+- [ ] The node's privval gRPC endpoint is enabled — see [Signing](#signing). If the consensus key lives in an external KMS, the KMS must support the privval `SignRawBytes` message; see the [release notes](../../docs/release-notes/release-notes.md) for the KMS policy.
+- [ ] The fibre listen port (default `7980`) is reachable by clients from outside your network.
+- [ ] Your validator is bonded. The server derives its storage budget from your stake; a validator outside the active set gets no budget and no traffic.
+
 ## Install
 
 ### Prebuilt binary
@@ -100,6 +111,31 @@ To verify or override, check `config.toml`:
 ```toml
 priv_validator_grpc_laddr = "127.0.0.1:26669"
 ```
+
+## Registration
+
+A running server alone receives no traffic: fibre clients discover servers through the on-chain [`x/valaddr`](../../x/valaddr/README.md) registry and only dial hosts registered there. Once the server is up, register its publicly reachable address, signing with your validator's account key:
+
+```sh
+celestia-appd tx valaddr set-host 203.0.113.7:7980 --from <validator-account-key>
+```
+
+The host must be in `host:port` form — an IP literal or a DNS name both work (TLS identity is bound to your consensus key, not the network address; see [Transport security](#transport-security-tls)). Port range is [1, 65535], the whole string is capped at 100 characters, and schemes (`http://`, `dns:///`) or URL paths are rejected.
+
+Verify the registration (your consensus address is printed by `celestia-appd comet show-address`):
+
+```sh
+celestia-appd query valaddr provider <celestiavalcons-address>
+```
+
+`celestia-appd query valaddr providers` lists the registered hosts of all currently bonded validators — yours should appear there once you are bonded.
+
+### When to register
+
+- `set-host` is only accepted once the chain runs app version 10; before the v10 upgrade activates, the `x/valaddr` module does not exist and the transaction is rejected.
+- Prepare everything else — install the binary, configure the signer links, verify the KMS supports `SignRawBytes` — before the upgrade, then start the server and register once v10 is live.
+- Start the server **before** registering: a registered-but-unreachable host makes clients dial and time out against you.
+- Registration is persistent. Re-run `set-host` only when the address changes. The entry is garbage-collected automatically if your validator permanently leaves the set (removed from staking, or jailed and unbonded for over 7 days) — after coming back, register again.
 
 ## Transport security (TLS)
 
@@ -285,6 +321,32 @@ fibre start \
 ```
 
 Profiles are tagged with `version` and `hostname` for filtering in the Grafana UI.
+
+## Troubleshooting
+
+### `starting server: creating signer: ...`
+
+The server could not reach the node's privval gRPC endpoint at startup and exits. Check that the node is running, that `priv_validator_grpc_laddr` is set in the node's `config.toml`, and that `--signer-grpc-address` (or `signer_grpc_address` in `server_config.toml`) points at it.
+
+### Warning: `derived storage budget is 0 (validator not in the active set?)`
+
+The server started, but the app node reports no stake for your validator. Either the validator is not bonded, or `--app-grpc-address` points at a node that is still syncing (or at the wrong network). The server keeps running without a storage limit and re-derives the budget periodically.
+
+### Server runs but no uploads arrive
+
+Clients only dial registered, bonded validators. In order:
+
+1. `celestia-appd query valaddr provider <celestiavalcons-address>` — if `found: false`, [register](#registration).
+2. Check the registered `host:port` actually routes to this server's `server_listen_address` port through your firewall — from an outside machine, a TCP connect to it must succeed.
+3. Confirm the validator is bonded: unbonded validators are omitted from `query valaddr providers`, so clients never see them.
+
+### Clients report TLS identity verification failures
+
+Clients verify that the server's certificate is endorsed by the consensus key of the validator they picked from the registry. A mismatch means the privval endpoint the server signs through does not hold the consensus key the chain knows for your validator — typical after pointing `--signer-grpc-address` at the wrong node (e.g. a sentry with its own key). The certificate is minted once at startup, so restart the server after any signer change.
+
+### Uploads rejected with `payment promise verification failed`
+
+The server validates every upload's payment promise against the app node. A chain-ID mismatch means `--app-grpc-address` points at a different network than the client used. Other causes sit on the submitter's side — an underfunded escrow account or a stale promise height — and resolve there, not on the server.
 
 ## Signals
 

--- a/x/valaddr/README.md
+++ b/x/valaddr/README.md
@@ -1,0 +1,81 @@
+# `x/valaddr`
+
+## Abstract
+
+The `x/valaddr` module is an on-chain registry that maps a validator's consensus address to the network host of the [fibre](../../specs/src/fibre.md) data availability server that validator operates. Fibre clients read this registry to discover which host to dial for each validator in the active set; a validator whose fibre server is not registered here receives no fibre traffic, because clients have no way to find it.
+
+The module is available starting from app version 10.
+
+## State
+
+The module stores one record per validator, keyed by the validator's consensus address:
+
+```proto
+// FibreProviderInfo contains the service details for a fibre provider.
+message FibreProviderInfo {
+  // host is the network address for the fibre service provider
+  string host = 1;
+}
+```
+
+Entries are garbage-collected in `EndBlock`: a record is deleted once its validator has either been removed from staking state entirely, or has been jailed and unbonded for longer than a 7-day grace period (`JailedGracePeriod`). A re-registered validator simply submits a new `MsgSetFibreProviderInfo`.
+
+The module has no parameters and an empty genesis state — the registry is populated exclusively through transactions.
+
+## Messages
+
+### `MsgSetFibreProviderInfo`
+
+Sets or updates the fibre host for a validator.
+
+```proto
+// MsgSetFibreProviderInfo allows a validator to set or update their fibre provider information.
+message MsgSetFibreProviderInfo {
+  option (cosmos.msg.v1.signer) = "signer";
+  // signer is the validator's operator address (celestiavaloper...)
+  string signer = 1 [(cosmos_proto.scalar) = "cosmos.ValidatorAddressString"];
+  // host is the network address for the fibre service provider
+  string host = 2;
+}
+```
+
+Validation rules:
+
+1. `signer` must be a valid `celestiavaloper` address, and a validator with that operator address must exist in staking state. The transaction is signed by the validator's account key (the account address underlying the operator address).
+1. `host` must be in `host:port` form: a non-empty host part (IP literal or DNS name — both work, see the [transport security notes](../../fibre/cmd/README.md#transport-security-tls)) followed by a numeric port in the range [1, 65535]. Schemes (`http://`, `dns:///`, …) and URL paths are rejected.
+1. `host` must be at most 100 characters.
+
+The record is stored under the validator's **consensus** address, derived on-chain from the validator's consensus public key — the submitting operator never provides it directly.
+
+## Events
+
+### `EventSetFibreProviderInfo`
+
+| Attribute Key               | Attribute Value                                 |
+|-----------------------------|-------------------------------------------------|
+| validator_consensus_address | {bech32 `celestiavalcons` address}              |
+| host                        | {registered host in `host:port` form}           |
+
+## Usage
+
+Register (or update) your fibre host, signing with the validator's account key:
+
+```shell
+celestia-appd tx valaddr set-host 203.0.113.7:7980 --from <validator-account-key>
+```
+
+Verify the registration:
+
+```shell
+celestia-appd query valaddr provider <celestiavalcons-address>
+```
+
+List the registered providers of all currently bonded validators (entries whose validator has left the active set are omitted):
+
+```shell
+celestia-appd query valaddr providers
+```
+
+The same queries are available over gRPC (`celestia.valaddr.v1.Query`) and REST (`/valaddr/v1/fibre-provider-info/{validator_consensus_address}`, `/valaddr/v1/all-bonded-fibre-providers`).
+
+For the end-to-end operator path — running the fibre server itself and then registering it here — see [fibre/cmd/README.md](../../fibre/cmd/README.md). For the protocol-level specification of the registry, see [specs/src/fibre_registry_module.md](../../specs/src/fibre_registry_module.md).


### PR DESCRIPTION
Closes [PROTOCO-1101](https://linear.app/celestia/issue/PROTOCO-1101)
Part of [PROTOCO-1085](https://linear.app/celestia/issue/PROTOCO-1085) (closed by the companion PR #7688)

## Overview

The fibre server README covered install, config, signing, TLS, and observability — but never mentioned the on-chain `valaddr` registration step, so an operator following only that page would run a server no client can discover.

This PR completes the operator path:

- **Prerequisites checklist** in `fibre/cmd/README.md`: privval gRPC, `SignRawBytes` KMS support, app v10+, port exposure, bonded validator.
- **Registration section**: `celestia-appd tx valaddr set-host`, host format rules, verification via `query valaddr provider`/`providers`, and when to register relative to the v10 upgrade (the `x/valaddr` store is added at the v10 upgrade, so `set-host` is only accepted once v10 is live).
- **Troubleshooting section**: signer unreachable at startup, zero storage budget, no uploads arriving, TLS identity verification failures, payment promise rejections.
- **`x/valaddr/README.md`**: new module README following the `x/blob` structure (state, message validation rules, events, usage), also fixing the dangling valaddr README link expected by the v10 module list in the specs.
- **Release notes**: a pointer in the v10 section so validators find the setup docs (PROTOCO-1101).

## Verification

Dogfooded against a local single-node testnet (per #7463) using only the documented commands: `fibre start` with the documented flags (signer ready, serving gRPC), `comet show-address`, `tx valaddr set-host`, and both provider queries returning the registered host. `priv_validator_grpc_laddr` being enabled by default on `celestia-appd init` was confirmed against the generated config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)