### PR TITLE
feat(fibre)!: set the default FullStakeStorageBudget to 2 TiB

### DIFF
--- a/x/fibre/types/params.go
+++ b/x/fibre/types/params.go
@@ -26,10 +26,9 @@ var (
 	// DefaultShardRetention is the initial value of the shard retention parameter. It is the
 	// minimum local duration validators keep uploaded shards, decoupled from PaymentPromiseTimeout.
 	DefaultShardRetention = 4 * time.Hour
-	// DefaultFullStakeStorageBudget is a conservative placeholder for the ramp-up.
-	// The real value is a governance decision (see PROTOCO tracking issue); it caps
-	// the Fibre disk of a 100%-stake validator over one ShardRetention window.
-	DefaultFullStakeStorageBudget uint64 = 256 << 30 // 256 GiB (~18 MiB/s full-stake)
+	// DefaultFullStakeStorageBudget caps the Fibre disk of a 100%-stake validator
+	// over one ShardRetention window.
+	DefaultFullStakeStorageBudget uint64 = 2 << 40 // 2 TiB (~146 MiB/s full-stake)
 )
 
 const (


### PR DESCRIPTION
## Overview

The 256 GiB default for `fibre.FullStakeStorageBudget` was a conservative ramp-up placeholder pending a decision on the real value. That decision is **2 TiB** (`2 << 40` = 2,199,023,255,552 bytes): over the default 4h `shard_retention` window this corresponds to ~146 MiB/s of sustained full-stake upload throughput, with each fibre server deriving its own stake-proportional share of the budget.

One-line change to `DefaultFullStakeStorageBudget` in `x/fibre/types/params.go` (plus dropping the now-obsolete placeholder wording from its comment). The parameter remains governance-changeable with the same `> 0` validation.

The documentation PRs already state the new value (#7688: `x/fibre/README.md`, `parameters_v10.md`, `fibre_module.md`), so merging both keeps code and docs in sync.

## Verification

`make build` passes; `go test ./x/fibre/... ./fibre/ -short` passes unchanged — no test asserts the numeric default (they reference the constant symbolically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)