### PR TITLE
fix!: validate the whole PayForFibre promise in the shape check

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -8,7 +8,6 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	blobtypes "github.com/celestiaorg/celestia-app/v10/x/blob/types"
 	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
-	"github.com/celestiaorg/go-square/v4/share"
 	blobtx "github.com/celestiaorg/go-square/v4/tx"
 	abci "github.com/cometbft/cometbft/abci/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -139,8 +138,9 @@ func signerDataFromTx(tx sdk.Tx) ([]byte, uint64, error) {
 }
 
 // validatePayForFibreTxShape rejects txs that mix MsgPayForFibre with other
-// messages, and txs whose payment promise names a namespace that cannot hold a
-// blob.
+// messages, and txs whose payment promise fails stateless validation. Both
+// CheckTx and ProcessProposal call this, so a promise that would fail
+// ValidateBasic in FinalizeBlock never reaches the square.
 func validatePayForFibreTxShape(tx sdk.Tx) error {
 	msgs := tx.GetMsgs()
 	for _, msg := range msgs {
@@ -151,22 +151,9 @@ func validatePayForFibreTxShape(tx sdk.Tx) error {
 		if len(msgs) > 1 {
 			return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "tx contains a MsgPayForFibre and %d total messages", len(msgs))
 		}
-		if err := validatePayForFibreNamespace(pff.PaymentPromise.Namespace); err != nil {
-			return err
+		if err := pff.PaymentPromise.ValidateBasic(); err != nil {
+			return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "invalid payment promise: %s", err)
 		}
-	}
-	return nil
-}
-
-// validatePayForFibreNamespace rejects a payment promise namespace that a blob
-// may not occupy.
-func validatePayForFibreNamespace(namespace []byte) error {
-	ns, err := share.NewNamespaceFromBytes(namespace)
-	if err != nil {
-		return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "invalid payment promise namespace: %s", err)
-	}
-	if err := ns.ValidateForBlob(); err != nil {
-		return errors.Wrapf(apperr.ErrInvalidPayForFibreTx, "invalid payment promise namespace: %s", err)
 	}
 	return nil
 }

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -24,6 +24,7 @@ var (
 	// a tx containing more or fewer than one message.
 	ErrMultiMsgIndexWrapper = errors.Register(AppErrorsCodespace, 11145, "index wrapper txs must contain exactly one message")
 
-	// ErrInvalidPayForFibreTx is returned when MsgPayForFibre is not the only tx message.
-	ErrInvalidPayForFibreTx = errors.Register(AppErrorsCodespace, 11146, "MsgPayForFibre must be the only message in a transaction")
+	// ErrInvalidPayForFibreTx is returned when MsgPayForFibre is not the only tx
+	// message or its payment promise fails stateless validation.
+	ErrInvalidPayForFibreTx = errors.Register(AppErrorsCodespace, 11146, "invalid MsgPayForFibre transaction")
 )

--- a/app/extract_pff_test.go
+++ b/app/extract_pff_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
 	apperr "github.com/celestiaorg/celestia-app/v10/app/errors"
 	"github.com/celestiaorg/celestia-app/v10/test/util/blobfactory"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
@@ -62,6 +63,34 @@ func TestValidatePayForFibreTxShape(t *testing.T) {
 		{
 			name:    "pay-for-fibre promising a malformed namespace is invalid",
 			txBytes: newPayForFibreTxWithNamespace(t, txConfig, []byte{0x01, 0x02}),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name: "pay-for-fibre promising an unsupported blob version is invalid",
+			txBytes: newPayForFibreTx(t, txConfig, func(msg *fibretypes.MsgPayForFibre) {
+				msg.PaymentPromise.BlobVersion = 999
+			}),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name: "pay-for-fibre promising a zero blob size is invalid",
+			txBytes: newPayForFibreTx(t, txConfig, func(msg *fibretypes.MsgPayForFibre) {
+				msg.PaymentPromise.BlobSize = 0
+			}),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name: "pay-for-fibre promising a malformed commitment is invalid",
+			txBytes: newPayForFibreTx(t, txConfig, func(msg *fibretypes.MsgPayForFibre) {
+				msg.PaymentPromise.Commitment = []byte{0x01}
+			}),
+			wantErr: apperr.ErrInvalidPayForFibreTx,
+		},
+		{
+			name: "pay-for-fibre promising an empty chain ID is invalid",
+			txBytes: newPayForFibreTx(t, txConfig, func(msg *fibretypes.MsgPayForFibre) {
+				msg.PaymentPromise.ChainId = ""
+			}),
 			wantErr: apperr.ErrInvalidPayForFibreTx,
 		},
 	}
@@ -127,18 +156,27 @@ func decodeTx(t *testing.T, txConfig client.TxConfig, txBytes []byte) sdk.Tx {
 	return tx
 }
 
-// newPayForFibreTxWithNamespace creates an unsigned pay-for-fibre tx whose
-// payment promise names the provided namespace.
-func newPayForFibreTxWithNamespace(t *testing.T, txConfig client.TxConfig, namespace []byte) []byte {
+// newPayForFibreTx creates an unsigned pay-for-fibre tx, applying mutate to the
+// message before encoding it.
+func newPayForFibreTx(t *testing.T, txConfig client.TxConfig, mutate func(*fibretypes.MsgPayForFibre)) []byte {
 	t.Helper()
 	privKey := secp256k1.GenPrivKey()
 	msg := blobfactory.NewMsgPayForFibre(t, privKey.PubKey().(*secp256k1.PubKey), "test")
-	msg.PaymentPromise.Namespace = namespace
+	mutate(msg)
 	builder := txConfig.NewTxBuilder()
 	require.NoError(t, builder.SetMsgs(msg))
 	txBytes, err := txConfig.TxEncoder()(builder.GetTx())
 	require.NoError(t, err)
 	return txBytes
+}
+
+// newPayForFibreTxWithNamespace creates an unsigned pay-for-fibre tx whose
+// payment promise names the provided namespace.
+func newPayForFibreTxWithNamespace(t *testing.T, txConfig client.TxConfig, namespace []byte) []byte {
+	t.Helper()
+	return newPayForFibreTx(t, txConfig, func(msg *fibretypes.MsgPayForFibre) {
+		msg.PaymentPromise.Namespace = namespace
+	})
 }
 
 // newMultiMsgSendTx creates an unsigned tx with msgCount MsgSend messages.

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -218,6 +218,7 @@ func encodeBlobTxs(blobTxs []*tx.BlobTx) [][]byte {
 //   - transactions that fail SDK decoding
 //   - transactions containing MsgPayForFibre mixed with other messages
 //   - transactions containing more than one MsgPayForFibre
+//   - transactions whose payment promise fails stateless validation
 func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (normalTxs [][]byte, blobTxs []*tx.BlobTx, payForFibreTxs [][]byte) {
 	normalTxs = make([][]byte, 0, len(rawTxs))
 	blobTxs = make([]*tx.BlobTx, 0, len(rawTxs))
@@ -253,15 +254,14 @@ func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (
 			continue
 		}
 
-		// A valid PayForFibre tx must contain exactly one message: the MsgPayForFibre.
-		// This is consistent with BlobTx which also requires exactly one MsgPayForBlobs.
-		pffCount := countMsgPayForFibre(sdkTx)
-		if pffCount == 1 && len(sdkTx.GetMsgs()) == 1 {
+		if countMsgPayForFibre(sdkTx) > 0 {
+			// Reuse the predicate ProcessProposal enforces so a proposer never
+			// builds a block its own ProcessProposal would reject.
+			if err := validatePayForFibreTxShape(sdkTx); err != nil {
+				logger.Debug("dropping invalid pay-for-fibre tx", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()), "err", err)
+				continue
+			}
 			payForFibreTxs = append(payForFibreTxs, rawTx)
-			continue
-		}
-		if pffCount > 0 {
-			// Drop invalid txs: multiple MsgPayForFibre or mixed with other messages.
 			continue
 		}
 

--- a/app/filtered_square_builder_fibre_test.go
+++ b/app/filtered_square_builder_fibre_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v10/test/util/blobfactory"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"github.com/celestiaorg/go-square/v4/share"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	dbm "github.com/cosmos/cosmos-db"
@@ -30,6 +31,10 @@ func TestSeparateTxsFibre(t *testing.T) {
 	payForFibreTx := blobfactory.UnsignedPayForFibreTx(t, txConfig)
 	multiPayForFibreTx := newMultiPayForFibreTx(t, txConfig)
 	mixedPayForFibreTx := newMixedPayForFibreTx(t, txConfig)
+	reservedNamespacePayForFibreTx := newPayForFibreTxWithNamespace(t, txConfig, share.TxNamespace.Bytes())
+	unsupportedBlobVersionPayForFibreTx := newPayForFibreTx(t, txConfig, func(msg *fibretypes.MsgPayForFibre) {
+		msg.PaymentPromise.BlobVersion = 999
+	})
 
 	tests := []struct {
 		name     string
@@ -69,6 +74,20 @@ func TestSeparateTxsFibre(t *testing.T) {
 		{
 			name:     "tx with MsgPayForFibre mixed with MsgSend is dropped",
 			rawTxs:   [][]byte{mixedPayForFibreTx},
+			wantNorm: 0,
+			wantBlob: 0,
+			wantPFF:  0,
+		},
+		{
+			name:     "tx promising a reserved namespace is dropped",
+			rawTxs:   [][]byte{reservedNamespacePayForFibreTx},
+			wantNorm: 0,
+			wantBlob: 0,
+			wantPFF:  0,
+		},
+		{
+			name:     "tx promising an unsupported blob version is dropped",
+			rawTxs:   [][]byte{unsupportedBlobVersionPayForFibreTx},
 			wantNorm: 0,
 			wantBlob: 0,
 			wantPFF:  0,


### PR DESCRIPTION
Follow-up to the [FLUPs on #7677](https://github.com/celestiaorg/celestia-app/pull/7677#pullrequestreview-4933818574).

`validatePayForFibreTxShape` now calls `PaymentPromise.ValidateBasic()` (wrapped in `ErrInvalidPayForFibreTx`) instead of duplicating the namespace check, so CheckTx and ProcessProposal reject any promise that would fail `ValidateBasic` in FinalizeBlock. That closes the residual `blob_version` gap Rachid pointed out: a promise with `blob_version=999` and a valid namespace used to construct a square fine and get committed, then fail in FinalizeBlock, leaving an orphaned system blob with an unsupported fibre blob version in a committed square. `separateTxs` now reuses the same predicate so a proposer never builds a block its own ProcessProposal would reject.

FLUP 2 (a shared `ValidatePromiseNamespace` helper) is moot: the app-side copy of the namespace check is deleted here, so `fibretypes` is the only place it lives and there is nothing left to drift.

Note for reviewers: consensus-affecting, same as #7677 — this rejects proposals ProcessProposal previously accepted. Fine while v10 is unreleased.