### PR TITLE
fix: reject transactions with duplicate TxRaw fields

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -33,6 +33,17 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 	}
 
+	// Reject transactions that duplicate a top-level TxRaw field. The SDK
+	// decoder and go-square parse these bytes with schemas that disagree about
+	// duplicated fields, so keep the ambiguous encoding out of the mempool.
+	sdkTxBytes := tx
+	if isBlob {
+		sdkTxBytes = btx.Tx
+	}
+	if hasDuplicateTxRawField(sdkTxBytes) {
+		return responseCheckTxWithEvents(apperr.ErrDuplicateTxRawField, 0, 0, []abci.Event{}, false), apperr.ErrDuplicateTxRawField
+	}
+
 	if isBlob {
 		return app.handleBlobCheckTx(req, btx)
 	}

--- a/app/duplicate_field.go
+++ b/app/duplicate_field.go
@@ -1,0 +1,37 @@
+package app
+
+import "google.golang.org/protobuf/encoding/protowire"
+
+// txRawSignaturesField is the TxRaw field number for signatures. It is the only
+// field ADR-027 permits to appear more than once.
+const txRawSignaturesField = 3
+
+// hasDuplicateTxRawField reports whether the raw transaction bytes contain a
+// top-level protobuf field (other than signatures) that appears more than once.
+//
+// The SDK decoder reads a TxRaw as body_bytes(1), auth_info_bytes(2), and
+// repeated signatures(3), resolving a duplicated scalar field to its last
+// occurrence. go-square re-parses the same bytes with a schema that merges
+// duplicated fields instead. A transaction that duplicates body_bytes or
+// auth_info_bytes therefore classifies differently in the two components. This
+// function detects such ambiguous encodings so they can be rejected before they
+// are admitted to the mempool or included in a proposal.
+//
+// Undecodable bytes return false: the SDK decoder rejects those on its own.
+func hasDuplicateTxRawField(txBytes []byte) bool {
+	seen := make(map[protowire.Number]bool)
+	for len(txBytes) > 0 {
+		num, _, n := protowire.ConsumeField(txBytes)
+		if n < 0 {
+			return false
+		}
+		if num != txRawSignaturesField {
+			if seen[num] {
+				return true
+			}
+			seen[num] = true
+		}
+		txBytes = txBytes[n:]
+	}
+	return false
+}

--- a/app/duplicate_field_test.go
+++ b/app/duplicate_field_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// appendBytesField appends a length-delimited field with the given number.
+func appendBytesField(dst []byte, num protowire.Number, value []byte) []byte {
+	dst = protowire.AppendTag(dst, num, protowire.BytesType)
+	return protowire.AppendBytes(dst, value)
+}
+
+func TestHasDuplicateTxRawField(t *testing.T) {
+	body := []byte("body")
+	authInfo := []byte("authInfo")
+	sig := []byte("sig")
+
+	// A well-formed TxRaw: body_bytes(1), auth_info_bytes(2), signatures(3).
+	honest := appendBytesField(nil, 1, body)
+	honest = appendBytesField(honest, 2, authInfo)
+	honest = appendBytesField(honest, 3, sig)
+
+	// Same as honest but with a second signature (field 3). ADR-027 permits
+	// multiple signatures.
+	multiSig := appendBytesField(honest, 3, []byte("sig2"))
+
+	// A duplicated body_bytes (field 1) is the ambiguous encoding.
+	dupBody := appendBytesField(nil, 1, []byte("other"))
+	dupBody = appendBytesField(dupBody, 1, body)
+	dupBody = appendBytesField(dupBody, 2, authInfo)
+	dupBody = appendBytesField(dupBody, 3, sig)
+
+	// A duplicated auth_info_bytes (field 2).
+	dupAuthInfo := appendBytesField(nil, 1, body)
+	dupAuthInfo = appendBytesField(dupAuthInfo, 2, authInfo)
+	dupAuthInfo = appendBytesField(dupAuthInfo, 2, []byte("other"))
+	dupAuthInfo = appendBytesField(dupAuthInfo, 3, sig)
+
+	testCases := []struct {
+		name string
+		tx   []byte
+		want bool
+	}{
+		{"honest tx", honest, false},
+		{"multiple signatures", multiSig, false},
+		{"empty", []byte{}, false},
+		{"garbage", []byte{0xff, 0xff, 0xff}, false},
+		{"duplicate body_bytes", dupBody, true},
+		{"duplicate auth_info_bytes", dupAuthInfo, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasDuplicateTxRawField(tc.tx))
+		})
+	}
+}

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -15,4 +15,7 @@ var (
 
 	// ErrTxExceedsMaxSDKMessages is returned when an SDK tx contains more messages than a single block may ever include.
 	ErrTxExceedsMaxSDKMessages = errors.Register(AppErrorsCodespace, 11143, "transaction exceeds maximum allowed SDK message count")
+
+	// ErrDuplicateTxRawField is returned when a transaction duplicates a top-level TxRaw field that ADR-027 requires to be unique.
+	ErrDuplicateTxRawField = errors.Register(AppErrorsCodespace, 11144, "transaction contains a duplicate TxRaw field")
 )

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -226,6 +226,18 @@ func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (
 		}
 
 		bTx, isBlob, err := tx.UnmarshalBlobTx(rawTx)
+
+		// Drop txs that duplicate a top-level TxRaw field. CheckTx should have
+		// rejected these, but filter here too so a proposal never includes an
+		// encoding that the SDK decoder and go-square classify differently.
+		sdkTxBytes := rawTx
+		if isBlob && err == nil {
+			sdkTxBytes = bTx.Tx
+		}
+		if hasDuplicateTxRawField(sdkTxBytes) {
+			continue
+		}
+
 		if isBlob {
 			if err != nil {
 				// Drop malformed blob txs. Matches ProcessProposalHandler.

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -32,6 +32,11 @@ func TestSeparateTxs(t *testing.T) {
 	normalTx := newNormalTx(t, txConfig)
 	blobTx := blobfactory.UnsignedBlobTx(t)
 
+	// dupFieldTx duplicates the top-level body_bytes (field 1) field by
+	// prepending a second occurrence to an otherwise honest tx.
+	dupFieldTx := appendBytesField(nil, 1, []byte("extra"))
+	dupFieldTx = append(dupFieldTx, normalTx...)
+
 	tests := []struct {
 		name     string
 		rawTxs   [][]byte
@@ -63,6 +68,13 @@ func TestSeparateTxs(t *testing.T) {
 		{
 			name:     "undecodable tx is dropped",
 			rawTxs:   [][]byte{[]byte("garbage")},
+			wantNorm: 0,
+			wantBlob: 0,
+			wantPFF:  0,
+		},
+		{
+			name:     "duplicate TxRaw field tx is dropped",
+			rawTxs:   [][]byte{dupFieldTx},
 			wantNorm: 0,
 			wantBlob: 0,
 			wantPFF:  0,

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -30,6 +30,7 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
 // Here we only need to check the functionality that is added to CheckTx. We
@@ -281,6 +282,23 @@ func TestCheckTx(t *testing.T) {
 				return tx
 			},
 			expectedABCICode: apperr.ErrTxExceedsMaxSDKMessages.ABCICode(),
+		},
+		{
+			name:      "transaction with duplicate TxRaw field, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				signer := signers[10]
+				addr := signer.Account(accounts[10]).Address()
+				msg := banktypes.NewMsgSend(addr, addr, sdk.NewCoins(sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(1))))
+				txBz, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimitAndGasPrice(1e6, appconsts.DefaultMinGasPrice))
+				require.NoError(t, err)
+				// Prepend a second body_bytes (field 1) to make the encoding
+				// ambiguous between the SDK decoder and go-square.
+				dup := protowire.AppendTag(nil, 1, protowire.BytesType)
+				dup = protowire.AppendBytes(dup, []byte("extra"))
+				return append(dup, txBz...)
+			},
+			expectedABCICode: apperr.ErrDuplicateTxRawField.ABCICode(),
 		},
 	}
 


### PR DESCRIPTION
Part of [PROTOCO-2288](https://linear.app/celestia/issue/PROTOCO-2288/duplicate-txrawbody-bytes-splits-fibre-tx-classification-between).

Reject transactions that duplicate a top-level `TxRaw` field (other than signatures, which ADR-027 permits to repeat) at CheckTx and while building a proposal. Such encodings are ambiguous — the SDK decoder resolves a duplicated scalar field to its last occurrence while go-square merges duplicates — so the two components can classify the same bytes differently. This node-local guard does not change ProcessProposal's verdict on any bytes, so it is safe to roll out one validator at a time.

Note for reviewers: `main` will get the more comprehensive go-square fix instead, so this guard targets `v9.x` only.
