### PR TITLE
chore: instruct dependabot to ignore cosmos-sdk dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -61,6 +61,12 @@ updates:
         update-types:
           - minor
           - patch
+    # cosmos-sdk is replaced by the celestiaorg/cosmos-sdk fork, and the
+    # cosmossdk.io/* modules must stay at versions compatible with that fork.
+    # Newer upstream versions fail to compile against it.
+    ignore:
+      - dependency-name: "github.com/cosmos/cosmos-sdk"
+      - dependency-name: "cosmossdk.io/*"
     labels:
       - dependencies
   - package-ecosystem: gomod
@@ -76,5 +82,8 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      - dependency-name: "github.com/cosmos/cosmos-sdk"
+      - dependency-name: "cosmossdk.io/*"
     labels:
       - dependencies


### PR DESCRIPTION
Dependabot's weekly go-deps group bumped `cosmossdk.io/x/evidence`, `cosmossdk.io/x/circuit`, `cosmossdk.io/errors`, and the `github.com/cosmos/cosmos-sdk` require line (#7698), which broke the build: `cosmos-sdk` is replaced by the `celestiaorg/cosmos-sdk` fork, and the unreplaced `cosmossdk.io/*` modules must stay at versions compatible with it (`x/evidence` v0.2.0 targets upstream cosmos-sdk >= v0.53 and fails to compile against the fork). Add ignore rules so dependabot leaves these pinned; they'll be bumped manually alongside fork upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155ZnB8EV7XWRXtUhWdZjxC