### PR TITLE
fix!: require canonical encoding for blob txs

### DIFF
--- a/app/blob_tx_canonical.go
+++ b/app/blob_tx_canonical.go
@@ -7,19 +7,10 @@ import (
 )
 
 // blobTxIsCanonical reports whether raw is the canonical protobuf encoding of
-// btx. The canonical encoding of a blob tx is defined as the output of
-// go-square's MarshalBlobTx for its decoded content: every field encoded
-// exactly once, in ascending field number order, with no unknown fields.
-//
-// UnmarshalBlobTx accepts non-canonical encodings (unknown fields, or repeated
-// singular fields where the last value wins) and silently drops the extra
-// bytes, so re-marshaling the decoded blob tx yields the canonical form. Raw
-// bytes that differ carry padding that never reaches the block, yet would
-// inflate the mempool, gossip, and the proposal byte budget without being paid
-// for. Requiring canonical encoding closes that gap.
-//
-// This predicate is consensus critical: it is enforced in CheckTx,
-// PrepareProposal (separateTxs), and ProcessProposal.
+// btx, i.e. re-marshaling the decoded blob tx reproduces raw. UnmarshalBlobTx
+// accepts non-canonical encodings (unknown or repeated fields used as padding)
+// and drops the extra bytes; requiring canonical encoding rejects that padding.
+// Enforced in CheckTx, PrepareProposal, and ProcessProposal.
 func blobTxIsCanonical(raw []byte, btx *blobtx.BlobTx) bool {
 	canonical, err := blobtx.MarshalBlobTx(btx.Tx, btx.Blobs...)
 	if err != nil {

--- a/app/blob_tx_canonical.go
+++ b/app/blob_tx_canonical.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"bytes"
+
+	blobtx "github.com/celestiaorg/go-square/v4/tx"
+)
+
+// blobTxIsCanonical reports whether raw is the canonical protobuf encoding of
+// btx. The canonical encoding of a blob tx is defined as the output of
+// go-square's MarshalBlobTx for its decoded content: every field encoded
+// exactly once, in ascending field number order, with no unknown fields.
+//
+// UnmarshalBlobTx accepts non-canonical encodings (unknown fields, or repeated
+// singular fields where the last value wins) and silently drops the extra
+// bytes, so re-marshaling the decoded blob tx yields the canonical form. Raw
+// bytes that differ carry padding that never reaches the block, yet would
+// inflate the mempool, gossip, and the proposal byte budget without being paid
+// for. Requiring canonical encoding closes that gap.
+//
+// This predicate is consensus critical: it is enforced in CheckTx,
+// PrepareProposal (separateTxs), and ProcessProposal.
+func blobTxIsCanonical(raw []byte, btx *blobtx.BlobTx) bool {
+	canonical, err := blobtx.MarshalBlobTx(btx.Tx, btx.Blobs...)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(raw, canonical)
+}

--- a/app/blob_tx_canonical_test.go
+++ b/app/blob_tx_canonical_test.go
@@ -1,0 +1,60 @@
+package app
+
+import (
+	"testing"
+
+	"cosmossdk.io/log"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	blobtx "github.com/celestiaorg/go-square/v4/tx"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlobTxIsCanonical(t *testing.T) {
+	txConfig := encoding.MakeConfig(ModuleEncodingRegisters...).TxConfig
+	canonical := newBlobTx(t, txConfig)
+
+	bTx, isBlob, err := blobtx.UnmarshalBlobTx(canonical)
+	require.True(t, isBlob)
+	require.NoError(t, err)
+	require.True(t, blobTxIsCanonical(canonical, bTx), "a freshly marshaled blob tx is canonical")
+
+	padded := appendUnknownProtoField(canonical, 4096)
+	paddedTx, isBlob, err := blobtx.UnmarshalBlobTx(padded)
+	require.True(t, isBlob)
+	require.NoError(t, err, "unknown protobuf fields decode without error")
+	require.False(t, blobTxIsCanonical(padded, paddedTx), "a padded blob tx is not canonical")
+}
+
+func TestSeparateTxsDropsNonCanonicalBlobTx(t *testing.T) {
+	txConfig := encoding.MakeConfig(ModuleEncodingRegisters...).TxConfig
+	padded := appendUnknownProtoField(newBlobTx(t, txConfig), 4096)
+
+	normalTxs, blobTxs, pffTxs := separateTxs(log.NewNopLogger(), txConfig, [][]byte{padded})
+	require.Empty(t, normalTxs)
+	require.Empty(t, pffTxs)
+	require.Empty(t, blobTxs, "a non-canonically encoded blob tx must be dropped")
+}
+
+// appendUnknownProtoField appends a length-delimited unknown protobuf field
+// (field number 100, wire type 2) whose value is padLen zero bytes.
+// proto.Unmarshal accepts it, but MarshalBlobTx drops it, so the result decodes
+// to the same blob tx while being a distinct, non-canonical encoding.
+func appendUnknownProtoField(raw []byte, padLen int) []byte {
+	tag := protoVarint(uint64(100)<<3 | 2)
+	length := protoVarint(uint64(padLen))
+	out := make([]byte, 0, len(raw)+len(tag)+len(length)+padLen)
+	out = append(out, raw...)
+	out = append(out, tag...)
+	out = append(out, length...)
+	out = append(out, make([]byte, padLen)...)
+	return out
+}
+
+func protoVarint(v uint64) []byte {
+	var out []byte
+	for v >= 0x80 {
+		out = append(out, byte(v)|0x80)
+		v >>= 7
+	}
+	return append(out, byte(v))
+}

--- a/app/blob_tx_canonical_test.go
+++ b/app/blob_tx_canonical_test.go
@@ -48,11 +48,9 @@ func TestSeparateTxsDropsNonCanonicalBlobTx(t *testing.T) {
 	require.Empty(t, rawBlobTxs, "a non-canonically encoded blob tx must be dropped")
 }
 
-// TestBlobTxCanonicalEncodingGolden pins the canonical encoding of a fixed
-// blob tx to a golden value. The canonical predicate compares raw bytes
-// against MarshalBlobTx output, so any change to the wire format produced by
-// go-square or the protobuf library (e.g. after a dependency bump) is
-// consensus breaking and must fail this test.
+// TestBlobTxCanonicalEncodingGolden pins the canonical encoding of a fixed blob
+// tx so a wire-format change (e.g. a go-square or protobuf bump), which would be
+// consensus breaking, fails this test.
 func TestBlobTxCanonicalEncodingGolden(t *testing.T) {
 	namespace := share.MustNewV0Namespace(bytes.Repeat([]byte{0x01}, share.NamespaceVersionZeroIDSize))
 	blob, err := share.NewBlob(namespace, []byte("data"), share.ShareVersionZero, nil)
@@ -73,10 +71,9 @@ func TestBlobTxCanonicalEncodingGolden(t *testing.T) {
 	require.Equal(t, blob, bTx.Blobs[0])
 }
 
-// appendUnknownProtoField appends a length-delimited unknown protobuf field
-// (field number 100, wire type 2) whose value is padLen zero bytes.
-// proto.Unmarshal accepts it, but MarshalBlobTx drops it, so the result decodes
-// to the same blob tx while being a distinct, non-canonical encoding.
+// appendUnknownProtoField appends an unknown protobuf field (field 100, wire
+// type 2) of padLen zero bytes: proto.Unmarshal accepts it but MarshalBlobTx
+// drops it, yielding a distinct, non-canonical encoding of the same blob tx.
 func appendUnknownProtoField(raw []byte, padLen int) []byte {
 	tag := protoVarint(uint64(100)<<3 | 2)
 	length := protoVarint(uint64(padLen))

--- a/app/blob_tx_canonical_test.go
+++ b/app/blob_tx_canonical_test.go
@@ -1,10 +1,13 @@
 package app
 
 import (
+	"bytes"
+	"encoding/hex"
 	"testing"
 
 	"cosmossdk.io/log"
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/go-square/v4/share"
 	blobtx "github.com/celestiaorg/go-square/v4/tx"
 	"github.com/stretchr/testify/require"
 )
@@ -23,16 +26,51 @@ func TestBlobTxIsCanonical(t *testing.T) {
 	require.True(t, isBlob)
 	require.NoError(t, err, "unknown protobuf fields decode without error")
 	require.False(t, blobTxIsCanonical(padded, paddedTx), "a padded blob tx is not canonical")
+
+	// Repeat the singular type_id field (field 3, wire type 2, value "BLOB").
+	// proto.Unmarshal keeps the last value, so it decodes to the same blob tx,
+	// but the bytes are a distinct, non-canonical encoding.
+	repeated := append(append([]byte{}, canonical...), 0x1a, 0x04, 'B', 'L', 'O', 'B')
+	repeatedTx, isBlob, err := blobtx.UnmarshalBlobTx(repeated)
+	require.True(t, isBlob)
+	require.NoError(t, err, "repeated singular protobuf fields decode without error")
+	require.False(t, blobTxIsCanonical(repeated, repeatedTx), "a blob tx with a repeated singular field is not canonical")
 }
 
 func TestSeparateTxsDropsNonCanonicalBlobTx(t *testing.T) {
 	txConfig := encoding.MakeConfig(ModuleEncodingRegisters...).TxConfig
 	padded := appendUnknownProtoField(newBlobTx(t, txConfig), 4096)
 
-	normalTxs, blobTxs, pffTxs := separateTxs(log.NewNopLogger(), txConfig, [][]byte{padded})
+	normalTxs, blobTxs, rawBlobTxs, pffTxs := separateTxs(log.NewNopLogger(), txConfig, [][]byte{padded})
 	require.Empty(t, normalTxs)
 	require.Empty(t, pffTxs)
 	require.Empty(t, blobTxs, "a non-canonically encoded blob tx must be dropped")
+	require.Empty(t, rawBlobTxs, "a non-canonically encoded blob tx must be dropped")
+}
+
+// TestBlobTxCanonicalEncodingGolden pins the canonical encoding of a fixed
+// blob tx to a golden value. The canonical predicate compares raw bytes
+// against MarshalBlobTx output, so any change to the wire format produced by
+// go-square or the protobuf library (e.g. after a dependency bump) is
+// consensus breaking and must fail this test.
+func TestBlobTxCanonicalEncodingGolden(t *testing.T) {
+	namespace := share.MustNewV0Namespace(bytes.Repeat([]byte{0x01}, share.NamespaceVersionZeroIDSize))
+	blob, err := share.NewBlob(namespace, []byte("data"), share.ShareVersionZero, nil)
+	require.NoError(t, err)
+
+	raw, err := blobtx.MarshalBlobTx([]byte("tx"), blob)
+	require.NoError(t, err)
+
+	const golden = "0a02747812240a1c000000000000000000000000000000000000010101010101010101011204646174611a04424c4f42"
+	require.Equal(t, golden, hex.EncodeToString(raw))
+
+	bTx, isBlob, err := blobtx.UnmarshalBlobTx(raw)
+	require.True(t, isBlob)
+	require.NoError(t, err)
+	require.True(t, blobTxIsCanonical(raw, bTx))
+	require.Equal(t, []byte("tx"), bTx.Tx)
+	require.Len(t, bTx.Blobs, 1)
+	require.Equal(t, blob, bTx.Blobs[0])
 }
 
 // appendUnknownProtoField appends a length-delimited unknown protobuf field

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"bytes"
 	"fmt"
 
 	"cosmossdk.io/errors"
@@ -89,21 +88,6 @@ func (app *App) handleBlobCheckTx(req *abci.RequestCheckTx, btx *blobtx.BlobTx) 
 	}
 
 	return app.forwardCheckTx(baseReq, sdkTx)
-}
-
-// blobTxIsCanonical reports whether raw is the canonical protobuf encoding of
-// btx. UnmarshalBlobTx accepts non-canonical encodings (unknown fields, or
-// repeated singular fields where the last value wins) and silently drops the
-// extra bytes, so re-marshaling the decoded blob tx yields the canonical form.
-// Raw bytes that differ carry padding that never reaches the block, yet would
-// inflate the mempool, gossip, and the proposal byte budget without being paid
-// for. Requiring canonical encoding closes that gap.
-func blobTxIsCanonical(raw []byte, btx *blobtx.BlobTx) bool {
-	canonical, err := blobtx.MarshalBlobTx(btx.Tx, btx.Blobs...)
-	if err != nil {
-		return false
-	}
-	return bytes.Equal(raw, canonical)
 }
 
 func (app *App) forwardCheckTx(req *abci.RequestCheckTx, sdkTx sdk.Tx) (*abci.ResponseCheckTx, error) {

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"fmt"
 
 	"cosmossdk.io/errors"
@@ -35,6 +36,9 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 	}
 
 	if isBlob {
+		if !blobTxIsCanonical(tx, btx) {
+			return responseCheckTxWithEvents(apperr.ErrNonCanonicalBlobTx, 0, 0, []abci.Event{}, false), nil
+		}
 		return app.handleBlobCheckTx(req, btx)
 	}
 
@@ -85,6 +89,21 @@ func (app *App) handleBlobCheckTx(req *abci.RequestCheckTx, btx *blobtx.BlobTx) 
 	}
 
 	return app.forwardCheckTx(baseReq, sdkTx)
+}
+
+// blobTxIsCanonical reports whether raw is the canonical protobuf encoding of
+// btx. UnmarshalBlobTx accepts non-canonical encodings (unknown fields, or
+// repeated singular fields where the last value wins) and silently drops the
+// extra bytes, so re-marshaling the decoded blob tx yields the canonical form.
+// Raw bytes that differ carry padding that never reaches the block, yet would
+// inflate the mempool, gossip, and the proposal byte budget without being paid
+// for. Requiring canonical encoding closes that gap.
+func blobTxIsCanonical(raw []byte, btx *blobtx.BlobTx) bool {
+	canonical, err := blobtx.MarshalBlobTx(btx.Tx, btx.Blobs...)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(raw, canonical)
 }
 
 func (app *App) forwardCheckTx(req *abci.RequestCheckTx, sdkTx sdk.Tx) (*abci.ResponseCheckTx, error) {

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -27,4 +27,9 @@ var (
 	// ErrInvalidPayForFibreTx is returned when MsgPayForFibre is not the only tx
 	// message or its payment promise fails stateless validation.
 	ErrInvalidPayForFibreTx = errors.Register(AppErrorsCodespace, 11146, "invalid MsgPayForFibre transaction")
+
+	// ErrNonCanonicalBlobTx is returned when a blob tx is not canonically
+	// encoded, i.e. re-marshaling the decoded blob tx does not reproduce the
+	// original bytes (e.g. unknown or repeated protobuf fields used as padding).
+	ErrNonCanonicalBlobTx = errors.Register(AppErrorsCodespace, 11147, "blob tx is not canonically encoded")
 )

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -29,7 +29,6 @@ var (
 	ErrInvalidPayForFibreTx = errors.Register(AppErrorsCodespace, 11146, "invalid MsgPayForFibre transaction")
 
 	// ErrNonCanonicalBlobTx is returned when a blob tx is not canonically
-	// encoded, i.e. re-marshaling the decoded blob tx does not reproduce the
-	// original bytes (e.g. unknown or repeated protobuf fields used as padding).
+	// encoded (e.g. unknown or repeated protobuf fields used as padding).
 	ErrNonCanonicalBlobTx = errors.Register(AppErrorsCodespace, 11147, "blob tx is not canonically encoded")
 )

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -81,7 +81,7 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 	}
 
 	// note that there is an additional filter step for tx size of raw txs here
-	normalTxs, blobTxs, payForFibreTxs := separateTxs(logger, fsb.txConfig, filteredByMaxBytes)
+	normalTxs, blobTxs, rawBlobTxs, payForFibreTxs := separateTxs(logger, fsb.txConfig, filteredByMaxBytes)
 
 	var (
 		sdkMessageCount = 0
@@ -136,7 +136,7 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 		n++
 	}
 
-	for _, tx := range blobTxs {
+	for i, tx := range blobTxs {
 		sdkTx, err := dec(tx.Tx)
 		if err != nil {
 			logger.Error("decoding already checked blob transaction", "tx", tmbytes.HexBytes(coretypes.Tx(tx.Tx).Hash()), "error", err)
@@ -178,7 +178,7 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 		}
 
 		pfbMessageCount += len(sdkTx.GetMsgs())
-		blobTxs[m] = tx
+		rawBlobTxs[m] = rawBlobTxs[i]
 		m++
 	}
 
@@ -186,7 +186,9 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 
 	kept := make([][]byte, 0, n+m+len(fibreTxs))
 	kept = append(kept, normalTxs[:n]...)
-	kept = append(kept, encodeBlobTxs(blobTxs[:m])...)
+	// separateTxs only keeps canonically encoded blob txs, so the raw bytes
+	// are identical to re-marshaling the decoded blob txs and can be reused.
+	kept = append(kept, rawBlobTxs[:m]...)
 	kept = append(kept, fibreTxs...)
 	return kept
 }
@@ -200,18 +202,6 @@ func msgTypes(sdkTx sdk.Tx) []string {
 	return msgNames
 }
 
-func encodeBlobTxs(blobTxs []*tx.BlobTx) [][]byte {
-	txs := make([][]byte, len(blobTxs))
-	var err error
-	for i, blobTx := range blobTxs {
-		txs[i], err = tx.MarshalBlobTx(blobTx.Tx, blobTx.Blobs...)
-		if err != nil {
-			panic(err)
-		}
-	}
-	return txs
-}
-
 // separateTxs decodes raw tendermint txs into normal, blob, and pay-for-fibre txs.
 // This function filters out:
 //   - transactions that exceed MaxTxSize
@@ -219,9 +209,10 @@ func encodeBlobTxs(blobTxs []*tx.BlobTx) [][]byte {
 //   - transactions containing MsgPayForFibre mixed with other messages
 //   - transactions containing more than one MsgPayForFibre
 //   - transactions whose payment promise fails stateless validation
-func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (normalTxs [][]byte, blobTxs []*tx.BlobTx, payForFibreTxs [][]byte) {
+func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (normalTxs [][]byte, blobTxs []*tx.BlobTx, rawBlobTxs [][]byte, payForFibreTxs [][]byte) {
 	normalTxs = make([][]byte, 0, len(rawTxs))
 	blobTxs = make([]*tx.BlobTx, 0, len(rawTxs))
+	rawBlobTxs = make([][]byte, 0, len(rawTxs))
 	payForFibreTxs = make([][]byte, 0, len(rawTxs))
 	dec := txConfig.TxDecoder()
 
@@ -252,6 +243,7 @@ func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (
 				continue
 			}
 			blobTxs = append(blobTxs, bTx)
+			rawBlobTxs = append(rawBlobTxs, rawTx)
 			continue
 		}
 
@@ -275,7 +267,7 @@ func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (
 
 		normalTxs = append(normalTxs, rawTx)
 	}
-	return normalTxs, blobTxs, payForFibreTxs
+	return normalTxs, blobTxs, rawBlobTxs, payForFibreTxs
 }
 
 // countMsgPayForFibre returns the number of MsgPayForFibre messages in a transaction.

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -244,9 +244,9 @@ func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (
 				continue
 			}
 			if !blobTxIsCanonical(rawTx, bTx) {
-				// Drop non-canonically encoded blob txs. Matches ProcessProposalHandler
-				// and CheckTx. Padding is stripped on re-marshal, so counting it
-				// against the byte budget here would starve honest txs.
+				// Drop non-canonically encoded blob txs, matching CheckTx and
+				// ProcessProposalHandler. CheckTx already rejects these before
+				// they enter the mempool, so this is a defense-in-depth backstop.
 				logger.Error("dropping non-canonically encoded blob tx", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()))
 				telemetry.IncrCounter(1, "prepare_proposal", "non_canonical_blob_txs")
 				continue

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -243,6 +243,14 @@ func separateTxs(logger log.Logger, txConfig client.TxConfig, rawTxs [][]byte) (
 				telemetry.IncrCounter(1, "prepare_proposal", "malformed_blob_txs")
 				continue
 			}
+			if !blobTxIsCanonical(rawTx, bTx) {
+				// Drop non-canonically encoded blob txs. Matches ProcessProposalHandler
+				// and CheckTx. Padding is stripped on re-marshal, so counting it
+				// against the byte budget here would starve honest txs.
+				logger.Error("dropping non-canonically encoded blob tx", "tx", tmbytes.HexBytes(coretypes.Tx(rawTx).Hash()))
+				telemetry.IncrCounter(1, "prepare_proposal", "non_canonical_blob_txs")
+				continue
+			}
 			blobTxs = append(blobTxs, bTx)
 			continue
 		}

--- a/app/filtered_square_builder_fibre_test.go
+++ b/app/filtered_square_builder_fibre_test.go
@@ -96,9 +96,10 @@ func TestSeparateTxsFibre(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			normalTxs, blobTxs, payForFibreTxs := separateTxs(log.NewNopLogger(), txConfig, tc.rawTxs)
+			normalTxs, blobTxs, rawBlobTxs, payForFibreTxs := separateTxs(log.NewNopLogger(), txConfig, tc.rawTxs)
 			require.Len(t, normalTxs, tc.wantNorm)
 			require.Len(t, blobTxs, tc.wantBlob)
+			require.Len(t, rawBlobTxs, tc.wantBlob)
 			require.Len(t, payForFibreTxs, tc.wantPFF)
 		})
 	}

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -82,9 +82,10 @@ func TestSeparateTxs(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			normalTxs, blobTxs, payForFibreTxs := separateTxs(log.NewNopLogger(), txConfig, tc.rawTxs)
+			normalTxs, blobTxs, rawBlobTxs, payForFibreTxs := separateTxs(log.NewNopLogger(), txConfig, tc.rawTxs)
 			require.Len(t, normalTxs, tc.wantNorm)
 			require.Len(t, blobTxs, tc.wantBlob)
+			require.Len(t, rawBlobTxs, tc.wantBlob)
 			require.Len(t, payForFibreTxs, tc.wantPFF)
 		})
 	}

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -82,6 +82,10 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 				logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("err with blob tx %d", idx), err)
 				return reject(), nil
 			}
+			if !blobTxIsCanonical(rawTx, blobTx) {
+				logInvalidPropBlock(app.Logger(), blockHeader, fmt.Sprintf("blob tx %d is not canonically encoded", idx))
+				return reject(), nil
+			}
 			sdkTxBytes = blobTx.Tx
 		}
 

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -337,6 +337,21 @@ func TestCheckTx(t *testing.T) {
 			},
 			expectedABCICode: apperr.ErrTxExceedsMaxSDKMessages.ABCICode(),
 		},
+		{
+			name:      "non-canonically encoded blob tx, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(
+					signers[10],
+					[]share.Namespace{namespace1},
+					[]int{100},
+				)[0]
+				// Append an unknown protobuf field. UnmarshalBlobTx accepts it
+				// but it is not the canonical encoding, so CheckTx must reject it.
+				return appendUnknownProtoField(btx, 4096)
+			},
+			expectedABCICode: apperr.ErrNonCanonicalBlobTx.ABCICode(),
+		},
 	}
 
 	for _, tt := range tests {
@@ -484,4 +499,24 @@ func TestCheckTxPayForFibre(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, apperr.ErrInvalidPayForFibreTx.ABCICode(), resp.Code)
 	})
+}
+
+// appendUnknownProtoField appends a length-delimited unknown protobuf field
+// (field 100, wire type 2) of padLen zero bytes. proto.Unmarshal accepts it but
+// MarshalBlobTx drops it, yielding a valid-but-non-canonical blob tx encoding.
+func appendUnknownProtoField(raw []byte, padLen int) []byte {
+	varint := func(v uint64) []byte {
+		var out []byte
+		for v >= 0x80 {
+			out = append(out, byte(v)|0x80)
+			v >>= 7
+		}
+		return append(out, byte(v))
+	}
+	out := make([]byte, 0, len(raw)+padLen+8)
+	out = append(out, raw...)
+	out = append(out, varint(uint64(100)<<3|2)...)
+	out = append(out, varint(uint64(padLen))...)
+	out = append(out, make([]byte, padLen)...)
+	return out
 }

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -518,9 +518,9 @@ func TestCheckTxPayForFibre(t *testing.T) {
 	})
 }
 
-// appendUnknownProtoField appends a length-delimited unknown protobuf field
-// (field 100, wire type 2) of padLen zero bytes. proto.Unmarshal accepts it but
-// MarshalBlobTx drops it, yielding a valid-but-non-canonical blob tx encoding.
+// appendUnknownProtoField appends an unknown protobuf field (field 100, wire
+// type 2) of padLen zero bytes: proto.Unmarshal accepts it but MarshalBlobTx
+// drops it, yielding a valid-but-non-canonical blob tx encoding.
 func appendUnknownProtoField(raw []byte, padLen int) []byte {
 	varint := func(v uint64) []byte {
 		var out []byte

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -352,6 +352,23 @@ func TestCheckTx(t *testing.T) {
 			},
 			expectedABCICode: apperr.ErrNonCanonicalBlobTx.ABCICode(),
 		},
+		{
+			name:      "blob tx with repeated singular protobuf field, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				btx := blobfactory.RandBlobTxsWithNamespacesAndSigner(
+					signers[10],
+					[]share.Namespace{namespace1},
+					[]int{100},
+				)[0]
+				// Repeat the singular type_id field (field 3, wire type 2,
+				// value "BLOB"). proto.Unmarshal keeps the last value so it
+				// decodes to the same blob tx, but the encoding is not
+				// canonical, so CheckTx must reject it.
+				return append(btx, 0x1a, 0x04, 'B', 'L', 'O', 'B')
+			},
+			expectedABCICode: apperr.ErrNonCanonicalBlobTx.ABCICode(),
+		},
 	}
 
 	for _, tt := range tests {

--- a/app/test/prepare_proposal_test.go
+++ b/app/test/prepare_proposal_test.go
@@ -238,6 +238,10 @@ func TestPrepareProposalFiltering(t *testing.T) {
 	// 3 transactions over MaxTxSize limit
 	largeTxs := coretypes.Txs(testutil.SendTxsWithAccounts(t, testApp, enc.TxConfig, kr, 1000, accounts[0], accounts[:3], testutil.ChainID, user.SetMemo(largeString))).ToSliceOfBytes()
 
+	// a valid blob tx padded with an unknown protobuf field, making its
+	// encoding non-canonical
+	nonCanonicalBlobTx := appendUnknownProtoField(blobTxs[0], 4096)
+
 	type test struct {
 		name      string
 		txs       func() [][]byte
@@ -295,6 +299,13 @@ func TestPrepareProposalFiltering(t *testing.T) {
 				return largeTxs // All txs are over MaxTxSize limit
 			},
 			prunedTxs: largeTxs,
+		},
+		{
+			name: "non-canonically encoded blob tx",
+			txs: func() [][]byte {
+				return [][]byte{nonCanonicalBlobTx}
+			},
+			prunedTxs: [][]byte{nonCanonicalBlobTx},
 		},
 	}
 

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -261,6 +261,17 @@ func TestProcessProposal(t *testing.T) {
 			expectedResult: abci.ResponseProcessProposal_REJECT,
 		},
 		{
+			name:  "non-canonically encoded blob tx",
+			input: validData(),
+			mutator: func(d *tmproto.Data) {
+				// Append an unknown protobuf field to an otherwise valid blob
+				// tx. It decodes to the same tx but is a distinct, larger
+				// encoding whose padding never reaches the block.
+				d.Txs[0] = appendUnknownProtoField(d.Txs[0], 4096)
+			},
+			expectedResult: abci.ResponseProcessProposal_REJECT,
+		},
+		{
 			name:  "tx size exceeds max tx size limit",
 			input: validData(),
 			mutator: func(d *tmproto.Data) {


### PR DESCRIPTION
Closes [PROTOCO-2367](https://linear.app/celestia/issue/PROTOCO-2367)

Require that a blob tx's raw bytes are the canonical protobuf encoding (the output of go-square's `MarshalBlobTx`) of the decoded blob tx, and reject it otherwise. Enforced at `CheckTx`, in `separateTxs` (PrepareProposal), and in `ProcessProposal`, mirroring the existing `MaxTxSize` checks. `CheckTx` is the primary gate; the other two are backstops so a proposer never builds or accepts a non-canonical blob tx. Since kept blob txs are now guaranteed canonical, PrepareProposal reuses their raw bytes instead of re-marshaling them. A golden test pins the canonical encoding so a protobuf or go-square bump that changes the wire format fails CI.

Note for reviewers: consensus-affecting. `ProcessProposal` now rejects a block containing a non-canonically encoded blob tx. Honest proposers only include canonically encoded blob txs, so honest blocks are unaffected.