### PR TITLE
fix!: ignore equivocation evidence for a deleted validator

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -396,9 +396,8 @@ func New(
 		packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
 	)
 
-	// create evidence keeper with router. The staking keeper is wrapped so that
-	// evidence naming a deleted validator is ignored rather than halting the
-	// chain. See evidenceStakingKeeper.
+	// create evidence keeper with router. See evidenceStakingKeeper for why
+	// the staking keeper is wrapped.
 	evidenceKeeper := evidencekeeper.NewKeeper(
 		encodingConfig.Codec, runtime.NewKVStoreService(keys[evidencetypes.StoreKey]), evidenceStakingKeeper{app.StakingKeeper}, app.SlashingKeeper, app.AccountKeeper.AddressCodec(), runtime.ProvideCometInfoService(),
 	)

--- a/app/app.go
+++ b/app/app.go
@@ -396,9 +396,11 @@ func New(
 		packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
 	)
 
-	// create evidence keeper with router
+	// create evidence keeper with router. The staking keeper is wrapped so that
+	// evidence naming a deleted validator is ignored rather than halting the
+	// chain. See evidenceStakingKeeper.
 	evidenceKeeper := evidencekeeper.NewKeeper(
-		encodingConfig.Codec, runtime.NewKVStoreService(keys[evidencetypes.StoreKey]), app.StakingKeeper, app.SlashingKeeper, app.AccountKeeper.AddressCodec(), runtime.ProvideCometInfoService(),
+		encodingConfig.Codec, runtime.NewKVStoreService(keys[evidencetypes.StoreKey]), evidenceStakingKeeper{app.StakingKeeper}, app.SlashingKeeper, app.AccountKeeper.AddressCodec(), runtime.ProvideCometInfoService(),
 	)
 	app.EvidenceKeeper = *evidenceKeeper
 

--- a/app/evidence.go
+++ b/app/evidence.go
@@ -9,16 +9,10 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 )
 
-// evidenceStakingKeeper wraps the staking keeper used by the evidence module so
-// that equivocation evidence naming a validator whose record no longer exists
-// is ignored instead of halting the chain.
-//
-// The evidence handler treats a non-nil error from ValidatorByConsAddr as fatal
-// and returns it, which propagates out of FinalizeBlock with nothing to recover
-// it. ValidatorByConsAddr returns ErrNoValidatorFound once the validator's
-// consensus-address index entry has been deleted, so the handler's own
-// defensive "validator == nil" branch is never reached. Translating that error
-// into (nil, nil) restores the intended defensive behavior.
+// evidenceStakingKeeper wraps the staking keeper so that equivocation evidence
+// naming a deleted validator is ignored instead of halting the chain: it maps
+// ErrNoValidatorFound to (nil, nil), which the evidence handler skips instead
+// of returning an error from FinalizeBlock.
 type evidenceStakingKeeper struct {
 	evidencetypes.StakingKeeper
 }

--- a/app/evidence.go
+++ b/app/evidence.go
@@ -1,0 +1,32 @@
+package app
+
+import (
+	"context"
+	"errors"
+
+	evidencetypes "cosmossdk.io/x/evidence/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+)
+
+// evidenceStakingKeeper wraps the staking keeper used by the evidence module so
+// that equivocation evidence naming a validator whose record no longer exists
+// is ignored instead of halting the chain.
+//
+// The evidence handler treats a non-nil error from ValidatorByConsAddr as fatal
+// and returns it, which propagates out of FinalizeBlock with nothing to recover
+// it. ValidatorByConsAddr returns ErrNoValidatorFound once the validator's
+// consensus-address index entry has been deleted, so the handler's own
+// defensive "validator == nil" branch is never reached. Translating that error
+// into (nil, nil) restores the intended defensive behavior.
+type evidenceStakingKeeper struct {
+	evidencetypes.StakingKeeper
+}
+
+func (k evidenceStakingKeeper) ValidatorByConsAddr(ctx context.Context, consAddr sdk.ConsAddress) (stakingtypes.ValidatorI, error) {
+	validator, err := k.StakingKeeper.ValidatorByConsAddr(ctx, consAddr)
+	if errors.Is(err, stakingtypes.ErrNoValidatorFound) {
+		return nil, nil
+	}
+	return validator, err
+}

--- a/app/test/evidence_test.go
+++ b/app/test/evidence_test.go
@@ -15,31 +15,39 @@ import (
 // CELESTIA-267. Equivocation evidence naming a consensus address that is not in
 // staking state (e.g. a validator that fully unbonded and was removed) must be
 // ignored rather than propagating an error out of FinalizeBlock, which would
-// halt the chain. See evidenceStakingKeeper.
+// halt the chain. See evidenceStakingKeeper. Both misbehavior types route
+// through the same handler, so both are covered.
 func TestFinalizeBlockIgnoresEvidenceForUnknownValidator(t *testing.T) {
-	accounts := testfactory.GenerateAccounts(1)
-	testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
-
 	// A consensus address that was never (or is no longer) a validator.
 	unknownConsAddr := make([]byte, 20)
 	for i := range unknownConsAddr {
 		unknownConsAddr[i] = byte(i + 1)
 	}
 
-	misbehavior := abci.Misbehavior{
-		Type:             abci.MisbehaviorType_DUPLICATE_VOTE,
-		Validator:        abci.Validator{Address: unknownConsAddr, Power: 100},
-		Height:           1,
-		Time:             time.Now(),
-		TotalVotingPower: 100,
-	}
+	for _, misbehaviorType := range []abci.MisbehaviorType{
+		abci.MisbehaviorType_DUPLICATE_VOTE,
+		abci.MisbehaviorType_LIGHT_CLIENT_ATTACK,
+	} {
+		t.Run(misbehaviorType.String(), func(t *testing.T) {
+			accounts := testfactory.GenerateAccounts(1)
+			testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 
-	resp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
-		Time:        time.Now(),
-		Height:      testApp.LastBlockHeight() + 1,
-		Hash:        testApp.LastCommitID().Hash,
-		Misbehavior: []abci.Misbehavior{misbehavior},
-	})
-	require.NoError(t, err, "evidence for an unknown validator must not halt FinalizeBlock")
-	require.NotNil(t, resp)
+			misbehavior := abci.Misbehavior{
+				Type:             misbehaviorType,
+				Validator:        abci.Validator{Address: unknownConsAddr, Power: 100},
+				Height:           1,
+				Time:             time.Now(),
+				TotalVotingPower: 100,
+			}
+
+			resp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+				Time:        time.Now(),
+				Height:      testApp.LastBlockHeight() + 1,
+				Hash:        testApp.LastCommitID().Hash,
+				Misbehavior: []abci.Misbehavior{misbehavior},
+			})
+			require.NoError(t, err, "evidence for an unknown validator must not halt FinalizeBlock")
+			require.NotNil(t, resp)
+		})
+	}
 }

--- a/app/test/evidence_test.go
+++ b/app/test/evidence_test.go
@@ -12,11 +12,8 @@ import (
 )
 
 // TestFinalizeBlockIgnoresEvidenceForUnknownValidator is a regression test for
-// CELESTIA-267. Equivocation evidence naming a consensus address that is not in
-// staking state (e.g. a validator that fully unbonded and was removed) must be
-// ignored rather than propagating an error out of FinalizeBlock, which would
-// halt the chain. See evidenceStakingKeeper. Both misbehavior types route
-// through the same handler, so both are covered.
+// CELESTIA-267: evidence naming a validator that is not in staking state must
+// be ignored rather than halting FinalizeBlock. See evidenceStakingKeeper.
 func TestFinalizeBlockIgnoresEvidenceForUnknownValidator(t *testing.T) {
 	// A consensus address that was never (or is no longer) a validator.
 	unknownConsAddr := make([]byte, 20)

--- a/app/test/evidence_test.go
+++ b/app/test/evidence_test.go
@@ -1,0 +1,45 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/app"
+	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testfactory"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFinalizeBlockIgnoresEvidenceForUnknownValidator is a regression test for
+// CELESTIA-267. Equivocation evidence naming a consensus address that is not in
+// staking state (e.g. a validator that fully unbonded and was removed) must be
+// ignored rather than propagating an error out of FinalizeBlock, which would
+// halt the chain. See evidenceStakingKeeper.
+func TestFinalizeBlockIgnoresEvidenceForUnknownValidator(t *testing.T) {
+	accounts := testfactory.GenerateAccounts(1)
+	testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	// A consensus address that was never (or is no longer) a validator.
+	unknownConsAddr := make([]byte, 20)
+	for i := range unknownConsAddr {
+		unknownConsAddr[i] = byte(i + 1)
+	}
+
+	misbehavior := abci.Misbehavior{
+		Type:             abci.MisbehaviorType_DUPLICATE_VOTE,
+		Validator:        abci.Validator{Address: unknownConsAddr, Power: 100},
+		Height:           1,
+		Time:             time.Now(),
+		TotalVotingPower: 100,
+	}
+
+	resp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Time:        time.Now(),
+		Height:      testApp.LastBlockHeight() + 1,
+		Hash:        testApp.LastCommitID().Hash,
+		Misbehavior: []abci.Misbehavior{misbehavior},
+	})
+	require.NoError(t, err, "evidence for an unknown validator must not halt FinalizeBlock")
+	require.NotNil(t, resp)
+}


### PR DESCRIPTION
Closes [PROTOCO-2361](https://linear.app/celestia/issue/PROTOCO-2361/handle-celestia-267-equivocation-evidence-for-a-deleted-validator)

Wraps the staking keeper passed to the evidence module so that `ValidatorByConsAddr` returning `ErrNoValidatorFound` is treated as a nil validator, making the evidence handler's existing defensive branch reachable rather than propagating the error out of `FinalizeBlock`.

Note for reviewers: consensus-affecting — changes evidence BeginBlocker behavior for a consensus address that is not in staking state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)