### PR TITLE
feat: support TLS and auth token for corto gRPC in nightly

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -172,11 +172,13 @@ jobs:
           CORTO_PRIV_KEY: ${{ secrets.CORTO_PRIV_KEY }}
           CORTO_RPC: ${{ secrets.CORTO_RPC }}
           CORTO_GRPC: ${{ secrets.CORTO_GRPC }}
+          CORTO_GRPC_TOKEN: ${{ secrets.CORTO_GRPC_TOKEN }}
         run: |
           missing=""
           [ -z "$CORTO_PRIV_KEY" ] && missing="$missing CORTO_PRIV_KEY"
           [ -z "$CORTO_RPC" ] && missing="$missing CORTO_RPC"
           [ -z "$CORTO_GRPC" ] && missing="$missing CORTO_GRPC"
+          [ -z "$CORTO_GRPC_TOKEN" ] && missing="$missing CORTO_GRPC_TOKEN"
           if [ -n "$missing" ]; then
             echo "::error::Missing required secrets for TestCortoLoad:$missing"
             exit 1
@@ -196,6 +198,7 @@ jobs:
           CORTO_PRIV_KEY: ${{ secrets.CORTO_PRIV_KEY }}
           CORTO_RPC: ${{ secrets.CORTO_RPC }}
           CORTO_GRPC: ${{ secrets.CORTO_GRPC }}
+          CORTO_GRPC_TOKEN: ${{ secrets.CORTO_GRPC_TOKEN }}
           CELESTIA_APP_VERSION: ${{ needs.build-e2e-image.outputs.tag }}
           PUSHGATEWAY_URL: ${{ secrets.PUSHGATEWAY_URL }}
           PUSHGATEWAY_USERNAME: ${{ secrets.PUSHGATEWAY_USERNAME }}

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -172,13 +172,13 @@ jobs:
           CORTO_PRIV_KEY: ${{ secrets.CORTO_PRIV_KEY }}
           CORTO_RPC: ${{ secrets.CORTO_RPC }}
           CORTO_GRPC: ${{ secrets.CORTO_GRPC }}
-          CORTO_GRPC_TOKEN: ${{ secrets.CORTO_GRPC_TOKEN }}
+          CORTO_AUTH_TOKEN: ${{ secrets.CORTO_AUTH_TOKEN }}
         run: |
           missing=""
           [ -z "$CORTO_PRIV_KEY" ] && missing="$missing CORTO_PRIV_KEY"
           [ -z "$CORTO_RPC" ] && missing="$missing CORTO_RPC"
           [ -z "$CORTO_GRPC" ] && missing="$missing CORTO_GRPC"
-          [ -z "$CORTO_GRPC_TOKEN" ] && missing="$missing CORTO_GRPC_TOKEN"
+          [ -z "$CORTO_AUTH_TOKEN" ] && missing="$missing CORTO_AUTH_TOKEN"
           if [ -n "$missing" ]; then
             echo "::error::Missing required secrets for TestCortoLoad:$missing"
             exit 1
@@ -198,7 +198,7 @@ jobs:
           CORTO_PRIV_KEY: ${{ secrets.CORTO_PRIV_KEY }}
           CORTO_RPC: ${{ secrets.CORTO_RPC }}
           CORTO_GRPC: ${{ secrets.CORTO_GRPC }}
-          CORTO_GRPC_TOKEN: ${{ secrets.CORTO_GRPC_TOKEN }}
+          CORTO_AUTH_TOKEN: ${{ secrets.CORTO_AUTH_TOKEN }}
           CELESTIA_APP_VERSION: ${{ needs.build-e2e-image.outputs.tag }}
           PUSHGATEWAY_URL: ${{ secrets.PUSHGATEWAY_URL }}
           PUSHGATEWAY_USERNAME: ${{ secrets.PUSHGATEWAY_USERNAME }}

--- a/test/docker-e2e/e2e_corto_load_test.go
+++ b/test/docker-e2e/e2e_corto_load_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ const (
 //
 // Optional env vars (with defaults):
 //
+//	CORTO_GRPC_TOKEN       – auth token sent as an x-token header on gRPC calls
 //	CORTO_KEYRING_DIR      – keyring directory (alternative to CORTO_PRIV_KEY)
 //	CORTO_BLOB_SIZE        – blob size in bytes (default: 5 MiB)
 //	CORTO_SUBMISSION_DELAY – delay between blobs (default: 250ms)
@@ -74,9 +76,13 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 	cortoCfg, err := networks.NewCortoConfig()
 	require.NoError(t, err, "failed to build Corto config")
 
+	// Endpoints on port 443 sit behind a TLS-terminating proxy (e.g.
+	// grpc.celestia-corto.com:443), so dial them with TLS.
+	useTLS := strings.HasSuffix(cortoCfg.GRPCs[0], ":443")
+
 	t.Logf("Corto Load Test Configuration:")
 	t.Logf("  RPC:              %s", cortoCfg.RPCs[0])
-	t.Logf("  gRPC:             %s", cortoCfg.GRPCs[0])
+	t.Logf("  gRPC:             %s (tls=%v, auth=%v)", cortoCfg.GRPCs[0], useTLS, cortoCfg.GRPCToken != "")
 	t.Logf("  Blob size:        %d bytes", blobSize)
 	t.Logf("  Submission delay: %v", submissionDelay)
 	t.Logf("  Workers:          %d", workers)
@@ -105,6 +111,8 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 		Workers:         workers,
 		PrivKeyHex:      privKeyHex,
 		KeyringDir:      keyringDir,
+		TLS:             useTLS,
+		AuthToken:       cortoCfg.GRPCToken,
 	})
 	require.NoError(t, err, "failed to deploy latency-monitor")
 

--- a/test/docker-e2e/e2e_corto_load_test.go
+++ b/test/docker-e2e/e2e_corto_load_test.go
@@ -3,6 +3,7 @@ package docker_e2e
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"strconv"
 	"strings"
@@ -10,8 +11,8 @@ import (
 	"time"
 
 	"celestiaorg/celestia-app/test/docker-e2e/networks"
-
 	rpchttp "github.com/cometbft/cometbft/rpc/client/http"
+	jsonrpcclient "github.com/cometbft/cometbft/rpc/jsonrpc/client"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +47,8 @@ const (
 //
 // Optional env vars (with defaults):
 //
-//	CORTO_GRPC_TOKEN       – auth token sent as an x-token header on gRPC calls
+//	CORTO_AUTH_TOKEN       – auth token sent as an x-token header on gRPC calls
+//	                         and as an Authorization Bearer header on RPC requests
 //	CORTO_KEYRING_DIR      – keyring directory (alternative to CORTO_PRIV_KEY)
 //	CORTO_BLOB_SIZE        – blob size in bytes (default: 5 MiB)
 //	CORTO_SUBMISSION_DELAY – delay between blobs (default: 250ms)
@@ -79,11 +81,11 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 	// A configured token implies a TLS-terminating auth proxy, whatever the
 	// port. Unauthenticated endpoints on port 443 (e.g.
 	// grpc.celestia-corto.com:443) are also dialed with TLS.
-	useTLS := cortoCfg.GRPCToken != "" || strings.HasSuffix(cortoCfg.GRPCs[0], ":443")
+	useTLS := cortoCfg.AuthToken != "" || strings.HasSuffix(cortoCfg.GRPCs[0], ":443")
 
 	t.Logf("Corto Load Test Configuration:")
-	t.Logf("  RPC:              %s", cortoCfg.RPCs[0])
-	t.Logf("  gRPC:             %s (tls=%v, auth=%v)", cortoCfg.GRPCs[0], useTLS, cortoCfg.GRPCToken != "")
+	t.Logf("  RPC:              %s (auth=%v)", cortoCfg.RPCs[0], cortoCfg.AuthToken != "")
+	t.Logf("  gRPC:             %s (tls=%v, auth=%v)", cortoCfg.GRPCs[0], useTLS, cortoCfg.AuthToken != "")
 	t.Logf("  Blob size:        %d bytes", blobSize)
 	t.Logf("  Submission delay: %v", submissionDelay)
 	t.Logf("  Workers:          %d", workers)
@@ -94,7 +96,7 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 	ctx := context.Background()
 
 	// --- 1. Connect to Corto RPC for block time monitoring ---
-	rpcClient, err := rpchttp.New(cortoCfg.RPCs[0], "/websocket")
+	rpcClient, err := newAuthedRPCClient(cortoCfg.RPCs[0], cortoCfg.AuthToken)
 	require.NoError(t, err, "failed to create RPC client")
 
 	// Corto is an internal testnet: when the test is configured to run against
@@ -113,7 +115,7 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 		PrivKeyHex:      privKeyHex,
 		KeyringDir:      keyringDir,
 		TLS:             useTLS,
-		AuthToken:       cortoCfg.GRPCToken,
+		AuthToken:       cortoCfg.AuthToken,
 	})
 	require.NoError(t, err, "failed to deploy latency-monitor")
 
@@ -163,6 +165,31 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 		"max block time %v exceeds %v under 20 MiB/s blob load", maxBT, maxSingleBlockTime)
 
 	t.Log("Corto load test passed")
+}
+
+// newAuthedRPCClient returns an RPC client for the given endpoint that
+// attaches the token as an Authorization Bearer header when set.
+func newAuthedRPCClient(remote, token string) (*rpchttp.HTTP, error) {
+	httpClient, err := jsonrpcclient.DefaultHTTPClient(remote)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		httpClient.Transport = &bearerRoundTripper{token: token, base: httpClient.Transport}
+	}
+	return rpchttp.NewWithClient(remote, "/websocket", httpClient)
+}
+
+// bearerRoundTripper attaches an Authorization Bearer header to every request.
+type bearerRoundTripper struct {
+	token string
+	base  http.RoundTripper
+}
+
+func (b *bearerRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+b.token)
+	return b.base.RoundTrip(clone)
 }
 
 // fetchBlockTimes retrieves block timestamps between startHeight and endHeight

--- a/test/docker-e2e/e2e_corto_load_test.go
+++ b/test/docker-e2e/e2e_corto_load_test.go
@@ -76,9 +76,10 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 	cortoCfg, err := networks.NewCortoConfig()
 	require.NoError(t, err, "failed to build Corto config")
 
-	// Endpoints on port 443 sit behind a TLS-terminating proxy (e.g.
-	// grpc.celestia-corto.com:443), so dial them with TLS.
-	useTLS := strings.HasSuffix(cortoCfg.GRPCs[0], ":443")
+	// A configured token implies a TLS-terminating auth proxy, whatever the
+	// port. Unauthenticated endpoints on port 443 (e.g.
+	// grpc.celestia-corto.com:443) are also dialed with TLS.
+	useTLS := cortoCfg.GRPCToken != "" || strings.HasSuffix(cortoCfg.GRPCs[0], ":443")
 
 	t.Logf("Corto Load Test Configuration:")
 	t.Logf("  RPC:              %s", cortoCfg.RPCs[0])

--- a/test/docker-e2e/e2e_corto_load_test.go
+++ b/test/docker-e2e/e2e_corto_load_test.go
@@ -170,6 +170,9 @@ func (s *CelestiaTestSuite) TestCortoLoad() {
 // newAuthedRPCClient returns an RPC client for the given endpoint that
 // attaches the token as an Authorization Bearer header when set.
 func newAuthedRPCClient(remote, token string) (*rpchttp.HTTP, error) {
+	if token != "" && !strings.HasPrefix(remote, "https://") {
+		return nil, fmt.Errorf("an auth token is set but RPC endpoint %s is not https: refusing to send the token over plaintext", remote)
+	}
 	httpClient, err := jsonrpcclient.DefaultHTTPClient(remote)
 	if err != nil {
 		return nil, err

--- a/test/docker-e2e/latency_monitor_test.go
+++ b/test/docker-e2e/latency_monitor_test.go
@@ -116,6 +116,12 @@ func (s *CelestiaTestSuite) DeployLatencyMonitorForNetwork(
 ) (*tastoracontainertypes.Container, error) {
 	t := s.T()
 
+	// Fail here rather than minutes later in the monitor: a token on a
+	// plaintext connection would be sent unencrypted.
+	if cfg.AuthToken != "" && !cfg.TLS {
+		return nil, fmt.Errorf("AuthToken is set but TLS is disabled: refusing to send the token over plaintext")
+	}
+
 	networkName, err := getNetworkNameFromID(ctx, s.client, s.network)
 	if err != nil {
 		return nil, err

--- a/test/docker-e2e/latency_monitor_test.go
+++ b/test/docker-e2e/latency_monitor_test.go
@@ -39,6 +39,8 @@ type LatencyMonitorConfig struct {
 	Workers         int    // parallel worker accounts (0 or 1 = sequential)
 	PrivKeyHex      string // if set, creates a keyring from hex-encoded private key
 	KeyringDir      string // if set, bind-mounts this existing keyring directory
+	TLS             bool   // if set, the monitor dials the gRPC endpoint with TLS
+	AuthToken       string // if set, attached as an x-token header to every gRPC call
 }
 
 type LatencyMonitorResult struct {
@@ -151,12 +153,23 @@ func (s *CelestiaTestSuite) DeployLatencyMonitorForNetwork(
 	if cfg.Workers > 1 {
 		args = append(args, "--workers", strconv.Itoa(cfg.Workers))
 	}
+	if cfg.TLS {
+		args = append(args, "--tls")
+	}
+
+	// The auth token goes through the container environment rather than argv
+	// so it never appears in the logged args.
+	var env []string
+	if cfg.AuthToken != "" {
+		env = append(env, "AUTH_TOKEN="+cfg.AuthToken)
+	}
 
 	t.Logf("Starting latency-monitor for external network with args: %v", args)
 
 	container, err := image.Start(ctx, args, tastoracontainertypes.Options{
 		User:  "0:0",
 		Binds: []string{keyringDir + ":/celestia-home"},
+		Env:   env,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to start latency-monitor: %w", err)

--- a/test/docker-e2e/networks/config.go
+++ b/test/docker-e2e/networks/config.go
@@ -13,7 +13,9 @@ type Config struct {
 	ChainID string
 	RPCs    []string
 	GRPCs   []string
-	Seeds   string
+	// GRPCToken, if set, is attached as an x-token header to every gRPC call.
+	GRPCToken string
+	Seeds     string
 }
 
 // NewMochaConfig returns a Config for the mocha testnet
@@ -39,7 +41,9 @@ func NewMochaConfig() *Config {
 
 // NewCortoConfig returns a Config for the Corto internal testnet. Corto has
 // no public endpoints, so the RPC and gRPC endpoints must be provided via the
-// CORTO_RPC and CORTO_GRPC env vars.
+// CORTO_RPC and CORTO_GRPC env vars. If the gRPC endpoint requires
+// authentication, the token is provided via the optional CORTO_GRPC_TOKEN env
+// var.
 func NewCortoConfig() (*Config, error) {
 	rpc := os.Getenv("CORTO_RPC")
 	if rpc == "" {
@@ -50,10 +54,11 @@ func NewCortoConfig() (*Config, error) {
 		return nil, fmt.Errorf("CORTO_GRPC environment variable must be set")
 	}
 	return &Config{
-		Name:    "corto",
-		ChainID: appconsts.CortoChainID,
-		RPCs:    []string{rpc},
-		GRPCs:   []string{grpc},
+		Name:      "corto",
+		ChainID:   appconsts.CortoChainID,
+		RPCs:      []string{rpc},
+		GRPCs:     []string{grpc},
+		GRPCToken: os.Getenv("CORTO_GRPC_TOKEN"),
 	}, nil
 }
 

--- a/test/docker-e2e/networks/config.go
+++ b/test/docker-e2e/networks/config.go
@@ -13,8 +13,10 @@ type Config struct {
 	ChainID string
 	RPCs    []string
 	GRPCs   []string
-	// GRPCToken, if set, is attached as an x-token header to every gRPC call.
-	GRPCToken string
+	// AuthToken, if set, authenticates both connections: it is attached as an
+	// x-token header on gRPC calls and as an Authorization Bearer header on
+	// RPC requests.
+	AuthToken string
 	Seeds     string
 }
 
@@ -41,9 +43,8 @@ func NewMochaConfig() *Config {
 
 // NewCortoConfig returns a Config for the Corto internal testnet. Corto has
 // no public endpoints, so the RPC and gRPC endpoints must be provided via the
-// CORTO_RPC and CORTO_GRPC env vars. If the gRPC endpoint requires
-// authentication, the token is provided via the optional CORTO_GRPC_TOKEN env
-// var.
+// CORTO_RPC and CORTO_GRPC env vars. If the endpoints require authentication,
+// the token is provided via the optional CORTO_AUTH_TOKEN env var.
 func NewCortoConfig() (*Config, error) {
 	rpc := os.Getenv("CORTO_RPC")
 	if rpc == "" {
@@ -58,7 +59,7 @@ func NewCortoConfig() (*Config, error) {
 		ChainID:   appconsts.CortoChainID,
 		RPCs:      []string{rpc},
 		GRPCs:     []string{grpc},
-		GRPCToken: os.Getenv("CORTO_GRPC_TOKEN"),
+		AuthToken: os.Getenv("CORTO_AUTH_TOKEN"),
 	}, nil
 }
 

--- a/tools/latency-monitor/README.md
+++ b/tools/latency-monitor/README.md
@@ -37,7 +37,7 @@ A tool for monitoring and measuring transaction latency in Celestia networks. Th
 | `--namespace`        | `-n`      | `test`            | Namespace for blob submission                                                             |
 | `--disable-metrics`  | `-m`      | `false`           | Disable metrics collection                                                                |
 | `--tls`              |           | `false`           | Use TLS for the gRPC connection (required for TLS-terminating endpoints, e.g. port 443)   |
-| `--auth-token`       |           | `$AUTH_TOKEN`     | Auth token attached to every RPC as an `x-token` header                                   |
+| `--auth-token`       |           | `$AUTH_TOKEN`     | Auth token attached to every RPC as an `x-token` header (requires `--tls`)                |
 
 ### Example
 

--- a/tools/latency-monitor/README.md
+++ b/tools/latency-monitor/README.md
@@ -36,6 +36,8 @@ A tool for monitoring and measuring transaction latency in Celestia networks. Th
 | `--submission-delay` | `-d`      | `4000ms`          | Delay between transaction submissions                                                     |
 | `--namespace`        | `-n`      | `test`            | Namespace for blob submission                                                             |
 | `--disable-metrics`  | `-m`      | `false`           | Disable metrics collection                                                                |
+| `--tls`              |           | `false`           | Use TLS for the gRPC connection (required for TLS-terminating endpoints, e.g. port 443)   |
+| `--auth-token`       |           | `$AUTH_TOKEN`     | Auth token attached to every RPC as an `x-token` header                                   |
 
 ### Example
 

--- a/tools/latency-monitor/main.go
+++ b/tools/latency-monitor/main.go
@@ -59,9 +59,9 @@ func (t tokenCreds) GetRequestMetadata(context.Context, ...string) (map[string]s
 	return map[string]string{"x-token": string(t)}, nil
 }
 
-// RequireTransportSecurity returns false so a token can also be sent over
-// plaintext connections (e.g. local networks without a TLS proxy).
-func (t tokenCreds) RequireTransportSecurity() bool { return false }
+// RequireTransportSecurity returns true so gRPC refuses to send the token
+// over a plaintext connection, where it could be intercepted and reused.
+func (t tokenCreds) RequireTransportSecurity() bool { return true }
 
 type txResult struct {
 	submitTime time.Time
@@ -118,7 +118,7 @@ between submission and commitment, providing detailed latency statistics.`,
 	cmd.Flags().IntVar(&observabilityPort, "observability-port", defaultObservabilityPort, "Port for Prometheus observability HTTP server")
 	cmd.Flags().IntVarP(&numWorkers, "workers", "w", 1, "Number of parallel worker accounts for submission (1 = sequential, >1 = parallel)")
 	cmd.Flags().BoolVar(&useTLS, "tls", false, "Use TLS for the gRPC connection (required for TLS-terminating endpoints, e.g. port 443)")
-	cmd.Flags().StringVar(&authToken, "auth-token", os.Getenv("AUTH_TOKEN"), "Auth token attached to every RPC as an x-token header (defaults to the AUTH_TOKEN env var)")
+	cmd.Flags().StringVar(&authToken, "auth-token", os.Getenv("AUTH_TOKEN"), "Auth token attached to every RPC as an x-token header (requires --tls; defaults to the AUTH_TOKEN env var)")
 
 	return cmd
 }
@@ -143,6 +143,9 @@ func monitorLatency(
 	}
 	if blobSize < blobMinSize {
 		return fmt.Errorf("maximum blob size (%d) must be greater than or equal to minimum blob size (%d)", blobSize, blobMinSize)
+	}
+	if authToken != "" && !useTLS {
+		return fmt.Errorf("an auth token is set but --tls is disabled: refusing to send the token over plaintext")
 	}
 
 	fmt.Printf("Monitoring latency with min blob size: %d bytes, max blob size: %d bytes, submission delay: %s, namespace: %s\n",

--- a/tools/latency-monitor/main.go
+++ b/tools/latency-monitor/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/csv"
 	"errors"
 	"fmt"
@@ -21,6 +22,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
@@ -45,7 +47,21 @@ var (
 	submissionDelay      time.Duration
 	observabilityPort    int
 	numWorkers           int
+	useTLS               bool
+	authToken            string
 )
+
+// tokenCreds implements credentials.PerRPCCredentials, attaching a static
+// x-token header to every RPC on the connection.
+type tokenCreds string
+
+func (t tokenCreds) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{"x-token": string(t)}, nil
+}
+
+// RequireTransportSecurity returns false so a token can also be sent over
+// plaintext connections (e.g. local networks without a TLS proxy).
+func (t tokenCreds) RequireTransportSecurity() bool { return false }
 
 type txResult struct {
 	submitTime time.Time
@@ -87,7 +103,7 @@ between submission and commitment, providing detailed latency statistics.`,
 				cancel()
 			}()
 
-			return monitorLatency(ctx, endpoint, keyringDir, accountName, blobSize, minBlobSize, namespaceStr, disableObservability, submissionDelay, observabilityPort, numWorkers)
+			return monitorLatency(ctx, endpoint, keyringDir, accountName, blobSize, minBlobSize, namespaceStr, disableObservability, submissionDelay, observabilityPort, numWorkers, useTLS, authToken)
 		},
 	}
 
@@ -101,6 +117,8 @@ between submission and commitment, providing detailed latency statistics.`,
 	cmd.Flags().DurationVarP(&submissionDelay, "submission-delay", "d", defaultSubmissionDelay, "Delay between transaction submissions")
 	cmd.Flags().IntVar(&observabilityPort, "observability-port", defaultObservabilityPort, "Port for Prometheus observability HTTP server")
 	cmd.Flags().IntVarP(&numWorkers, "workers", "w", 1, "Number of parallel worker accounts for submission (1 = sequential, >1 = parallel)")
+	cmd.Flags().BoolVar(&useTLS, "tls", false, "Use TLS for the gRPC connection (required for TLS-terminating endpoints, e.g. port 443)")
+	cmd.Flags().StringVar(&authToken, "auth-token", os.Getenv("AUTH_TOKEN"), "Auth token attached to every RPC as an x-token header (defaults to the AUTH_TOKEN env var)")
 
 	return cmd
 }
@@ -117,6 +135,8 @@ func monitorLatency(
 	submissionDelay time.Duration,
 	observabilityPort int,
 	numWorkers int,
+	useTLS bool,
+	authToken string,
 ) error {
 	if blobMinSize < 1 {
 		return fmt.Errorf("minimum blob size must be at least 1 byte (got %d)", blobMinSize)
@@ -152,16 +172,26 @@ func monitorLatency(
 		return fmt.Errorf("failed to initialize keyring: %w", err)
 	}
 
-	fmt.Printf("Connecting to gRPC endpoint: %s (insecure)\n", endpoint)
+	transportCreds := insecure.NewCredentials()
+	transportDesc := "insecure"
+	if useTLS {
+		transportCreds = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
+		transportDesc = "tls"
+	}
+	fmt.Printf("Connecting to gRPC endpoint: %s (%s, auth=%v)\n", endpoint, transportDesc, authToken != "")
 
-	grpcConn, err := grpc.NewClient(
-		endpoint,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	dialOpts := []grpc.DialOption{
+		grpc.WithTransportCredentials(transportCreds),
 		grpc.WithDefaultCallOptions(
 			grpc.MaxCallSendMsgSize(math.MaxInt32),
 			grpc.MaxCallRecvMsgSize(math.MaxInt32),
 		),
-	)
+	}
+	if authToken != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(tokenCreds(authToken)))
+	}
+
+	grpcConn, err := grpc.NewClient(endpoint, dialOpts...)
 	if err != nil {
 		return fmt.Errorf("failed to create gRPC connection to %s: %w (note: this tool requires a gRPC endpoint, not REST)", endpoint, err)
 	}

--- a/tools/latency-monitor/main_test.go
+++ b/tools/latency-monitor/main_test.go
@@ -2,25 +2,69 @@ package main
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 )
 
-// TestTokenCredsAttachesHeader verifies that a connection dialed with
+// newTestTLSCreds generates a self-signed certificate for 127.0.0.1 and
+// returns matching server and client transport credentials.
+func newTestTLSCreds(t *testing.T) (server, client credentials.TransportCredentials) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "latency-monitor-test"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:           []net.IP{net.ParseIP("127.0.0.1")},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+
+	server = credentials.NewTLS(&tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: priv}},
+		MinVersion:   tls.VersionTLS12,
+	})
+	client = credentials.NewTLS(&tls.Config{RootCAs: pool, MinVersion: tls.VersionTLS12})
+	return server, client
+}
+
+// TestTokenCredsAttachesHeader verifies that a TLS connection dialed with
 // tokenCreds sends the x-token header on every RPC.
 func TestTokenCredsAttachesHeader(t *testing.T) {
+	serverCreds, clientCreds := newTestTLSCreds(t)
+
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 
 	var gotToken string
-	srv := grpc.NewServer(grpc.UnaryInterceptor(
+	srv := grpc.NewServer(grpc.Creds(serverCreds), grpc.UnaryInterceptor(
 		func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 			if md, ok := metadata.FromIncomingContext(ctx); ok {
 				if v := md.Get("x-token"); len(v) > 0 {
@@ -36,7 +80,7 @@ func TestTokenCredsAttachesHeader(t *testing.T) {
 
 	conn, err := grpc.NewClient(
 		lis.Addr().String(),
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithTransportCredentials(clientCreds),
 		grpc.WithPerRPCCredentials(tokenCreds("secret-token")),
 	)
 	require.NoError(t, err)
@@ -45,4 +89,16 @@ func TestTokenCredsAttachesHeader(t *testing.T) {
 	_, err = healthpb.NewHealthClient(conn).Check(context.Background(), &healthpb.HealthCheckRequest{})
 	require.NoError(t, err)
 	require.Equal(t, "secret-token", gotToken)
+}
+
+// TestTokenCredsRejectedWithoutTLS verifies that gRPC refuses to build a
+// plaintext connection carrying token credentials, so the token can never be
+// sent unencrypted.
+func TestTokenCredsRejectedWithoutTLS(t *testing.T) {
+	_, err := grpc.NewClient(
+		"127.0.0.1:0",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(tokenCreds("secret-token")),
+	)
+	require.ErrorContains(t, err, "transport level security")
 }

--- a/tools/latency-monitor/main_test.go
+++ b/tools/latency-monitor/main_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+)
+
+// TestTokenCredsAttachesHeader verifies that a connection dialed with
+// tokenCreds sends the x-token header on every RPC.
+func TestTokenCredsAttachesHeader(t *testing.T) {
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	var gotToken string
+	srv := grpc.NewServer(grpc.UnaryInterceptor(
+		func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+			if md, ok := metadata.FromIncomingContext(ctx); ok {
+				if v := md.Get("x-token"); len(v) > 0 {
+					gotToken = v[0]
+				}
+			}
+			return handler(ctx, req)
+		},
+	))
+	healthpb.RegisterHealthServer(srv, health.NewServer())
+	go func() { _ = srv.Serve(lis) }()
+	defer srv.Stop()
+
+	conn, err := grpc.NewClient(
+		lis.Addr().String(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithPerRPCCredentials(tokenCreds("secret-token")),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	_, err = healthpb.NewHealthClient(conn).Check(context.Background(), &healthpb.HealthCheckRequest{})
+	require.NoError(t, err)
+	require.Equal(t, "secret-token", gotToken)
+}


### PR DESCRIPTION
Closes [PROTOCO-2414](https://linear.app/celestia/issue/PROTOCO-2414)

The corto endpoints now sit behind a TLS-terminating auth proxy: gRPC requires an `x-token` header (`grpcurl -H "x-token: <token>" grpc.celestia-corto.com:443 list`) and RPC requires an `Authorization: Bearer` header. This adds support for both to the nightly `TestCortoLoad`:

- latency-monitor: new `--tls` flag and `--auth-token` flag (defaults from `AUTH_TOKEN` env var) that attaches `x-token` to every RPC via per-RPC credentials; sending the token over plaintext is refused
- `TestCortoLoad` reads the optional `CORTO_AUTH_TOKEN` env var, uses it as a Bearer token on the RPC client and as `x-token` on the monitor's gRPC connection, and enables TLS when a token is set or the endpoint is on port 443
- nightly workflow requires the new `CORTO_AUTH_TOKEN` secret and fails fast if unset

Verified against the live corto endpoints: authenticated `Status`/`BlockchainInfo` on RPC, and the latency-monitor connects through TLS + `x-token` on gRPC (tokenless calls fail with `Unauthenticated`).

Note for maintainers: the `CORTO_AUTH_TOKEN` repo secret must be added before the next nightly run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)