### PR TITLE
fix: skip signerDataFromTx when CheckTx fails

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -93,6 +93,14 @@ func (app *App) forwardCheckTx(req *abci.RequestCheckTx, sdkTx sdk.Tx) (*abci.Re
 		return res, err
 	}
 
+	// BaseApp.CheckTx reports a failed tx via the response code with a nil
+	// error. A failed tx may be malformed in ways that make signerDataFromTx
+	// panic (e.g. a SignerInfo with an unset ModeInfo oneof), so skip it and
+	// return the failure as-is.
+	if res.Code != abci.CodeTypeOK {
+		return res, nil
+	}
+
 	signerAddr, signerSeq, err := signerDataFromTx(sdkTx)
 	if err != nil {
 		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -123,11 +123,20 @@ func responseCheckTxWithEvents(err error, gw, gu uint64, events []abci.Event, de
 	}
 }
 
-func signerDataFromTx(tx sdk.Tx) ([]byte, uint64, error) {
+func signerDataFromTx(tx sdk.Tx) (addr []byte, seq uint64, err error) {
 	sigTx, ok := tx.(authsigning.SigVerifiableTx)
 	if !ok {
 		return nil, 0, fmt.Errorf("tx of type %T does not implement SigVerifiableTx", tx)
 	}
+
+	// GetSignaturesV2 panics on a malformed SignerInfo (e.g. an unset ModeInfo
+	// oneof). Recover so a bad tx returns an error rather than crashing the
+	// process, which is not always running under a recover (e.g. the mempool).
+	defer func() {
+		if r := recover(); r != nil {
+			addr, seq, err = nil, 0, fmt.Errorf("failed to get signer data: %v", r)
+		}
+	}()
 
 	sigs, err := sigTx.GetSignaturesV2()
 	if err != nil {

--- a/app/check_tx_internal_test.go
+++ b/app/check_tx_internal_test.go
@@ -1,0 +1,45 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSignerDataFromTxMalformedModeInfo verifies that signerDataFromTx returns
+// an error instead of panicking on a tx whose SignerInfo has a ModeInfo with
+// its oneof (Sum) unset. GetSignaturesV2 panics on such a ModeInfo, so this
+// exercises the recover directly, independent of CheckTx's response-code guard.
+func TestSignerDataFromTxMalformedModeInfo(t *testing.T) {
+	encodingConfig := encoding.MakeConfig(ModuleEncodingRegisters...)
+
+	sendMsg := banktypes.NewMsgSend(nil, nil, nil)
+	msgAny, err := codectypes.NewAnyWithValue(sendMsg)
+	require.NoError(t, err)
+
+	rawTx := &txtypes.Tx{
+		Body: &txtypes.TxBody{Messages: []*codectypes.Any{msgAny}},
+		AuthInfo: &txtypes.AuthInfo{
+			SignerInfos: []*txtypes.SignerInfo{{
+				ModeInfo: &txtypes.ModeInfo{}, // present but oneof (Sum) unset
+				Sequence: 0,
+			}},
+			Fee: &txtypes.Fee{},
+		},
+		Signatures: [][]byte{{}},
+	}
+	txBz, err := rawTx.Marshal()
+	require.NoError(t, err)
+
+	sdkTx, err := encodingConfig.TxConfig.TxDecoder()(txBz)
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		_, _, err := signerDataFromTx(sdkTx)
+		require.Error(t, err)
+	})
+}

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -417,11 +417,9 @@ func TestCheckTx_UnknownRequestType(t *testing.T) {
 	}
 }
 
-// TestCheckTxMalformedModeInfoDoesNotPanic verifies that a transaction whose
-// single SignerInfo has a ModeInfo present with its oneof (Sum) unset is
-// rejected without panicking. Such a ModeInfo decodes cleanly but makes
-// GetSignaturesV2 panic, and CheckTx must not propagate that panic (it runs on
-// an unrecovered mempool goroutine, so a panic here crashes the node).
+// TestCheckTxMalformedModeInfoDoesNotPanic verifies that a tx with a SignerInfo
+// whose ModeInfo oneof is unset is rejected without panicking. Such a ModeInfo
+// decodes cleanly but makes GetSignaturesV2 panic.
 func TestCheckTxMalformedModeInfoDoesNotPanic(t *testing.T) {
 	accounts := []string{"a"}
 	testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -23,9 +23,11 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
@@ -413,6 +415,40 @@ func TestCheckTx_UnknownRequestType(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestCheckTxMalformedModeInfoDoesNotPanic verifies that a transaction whose
+// single SignerInfo has a ModeInfo present with its oneof (Sum) unset is
+// rejected without panicking. Such a ModeInfo decodes cleanly but makes
+// GetSignaturesV2 panic, and CheckTx must not propagate that panic (it runs on
+// an unrecovered mempool goroutine, so a panic here crashes the node).
+func TestCheckTxMalformedModeInfoDoesNotPanic(t *testing.T) {
+	accounts := []string{"a"}
+	testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	addr := testnode.RandomAddress().(sdk.AccAddress)
+	sendMsg := banktypes.NewMsgSend(addr, addr, sdk.NewCoins(sdk.NewCoin(appconsts.BondDenom, sdkmath.NewInt(1))))
+	msgAny, err := codectypes.NewAnyWithValue(sendMsg)
+	require.NoError(t, err)
+
+	rawTx := &txtypes.Tx{
+		Body: &txtypes.TxBody{Messages: []*codectypes.Any{msgAny}},
+		AuthInfo: &txtypes.AuthInfo{
+			SignerInfos: []*txtypes.SignerInfo{{
+				ModeInfo: &txtypes.ModeInfo{}, // present but oneof (Sum) unset
+				Sequence: 0,
+			}},
+			Fee: &txtypes.Fee{},
+		},
+		Signatures: [][]byte{{}},
+	}
+	txBz, err := rawTx.Marshal()
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		resp, _ := testApp.CheckTx(&abci.RequestCheckTx{Type: abci.CheckTxType_New, Tx: txBz})
+		require.NotEqual(t, abci.CodeTypeOK, resp.Code)
+	})
 }
 
 func createSigner(t *testing.T, kr keyring.Keyring, accountName string, enc client.TxConfig, accNum uint64) *user.Signer {


### PR DESCRIPTION
Closes [PROTOCO-2423](https://linear.app/celestia/issue/PROTOCO-2423)

`forwardCheckTx` continued into `signerDataFromTx` even when `BaseApp.CheckTx` had already failed the tx (failure is reported via the response code with a nil error), where a malformed tx could trigger an unrecovered panic reachable from the mempool. This guards on the response code and, as defense-in-depth, recovers inside `signerDataFromTx` so it can't panic regardless of the call path. See the linked Linear issue for details.

Note for reviewers: touches `CheckTx`, the mempool admission path.