### PR TITLE
docs: instruct Claude to write short godoc comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@ All branches use forked cosmos-sdk and celestia-core:
 ### Documentation
 
 - Aim for simplicity. Prefer short sentences.
+- Keep godoc comments short and easy to understand: one or two plain-language sentences saying what the thing does. Avoid big blocks of text — they are hard to read and reason about.
 - No unnecessary calculations unless specified.
 - No unnecessary explanations unless requested.
 


### PR DESCRIPTION
Adds a Documentation bullet to CLAUDE.md telling Claude to write short, plain-language godoc comments instead of big blocks of text. Same convention as celestiaorg/celestia-core#3246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015i7TBLnRkyYgAEGJx17Yp6