### PR TITLE
fix!: bump x/evidence to v0.1.2-celestia

### DIFF
--- a/app/test/evidence_test.go
+++ b/app/test/evidence_test.go
@@ -1,0 +1,50 @@
+package app_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/app"
+	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testfactory"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFinalizeBlockIgnoresEvidenceForUnknownValidator is a regression test for
+// CELESTIA-267: evidence naming a validator that is not in staking state must
+// be ignored rather than halting FinalizeBlock.
+func TestFinalizeBlockIgnoresEvidenceForUnknownValidator(t *testing.T) {
+	// A consensus address that was never (or is no longer) a validator.
+	unknownConsAddr := make([]byte, 20)
+	for i := range unknownConsAddr {
+		unknownConsAddr[i] = byte(i + 1)
+	}
+
+	for _, misbehaviorType := range []abci.MisbehaviorType{
+		abci.MisbehaviorType_DUPLICATE_VOTE,
+		abci.MisbehaviorType_LIGHT_CLIENT_ATTACK,
+	} {
+		t.Run(misbehaviorType.String(), func(t *testing.T) {
+			accounts := testfactory.GenerateAccounts(1)
+			testApp, _ := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+			misbehavior := abci.Misbehavior{
+				Type:             misbehaviorType,
+				Validator:        abci.Validator{Address: unknownConsAddr, Power: 100},
+				Height:           1,
+				Time:             time.Now(),
+				TotalVotingPower: 100,
+			}
+
+			resp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+				Time:        time.Now(),
+				Height:      testApp.LastBlockHeight() + 1,
+				Hash:        testApp.LastCommitID().Hash,
+				Misbehavior: []abci.Misbehavior{misbehavior},
+			})
+			require.NoError(t, err, "evidence for an unknown validator must not halt FinalizeBlock")
+			require.NotNil(t, resp)
+		})
+	}
+}

--- a/app/test/evidence_test.go
+++ b/app/test/evidence_test.go
@@ -13,7 +13,7 @@ import (
 
 // TestFinalizeBlockIgnoresEvidenceForUnknownValidator is a regression test for
 // CELESTIA-267: evidence naming a validator that is not in staking state must
-// be ignored rather than halting FinalizeBlock.
+// be ignored rather than returning an error from FinalizeBlock.
 func TestFinalizeBlockIgnoresEvidenceForUnknownValidator(t *testing.T) {
 	// A consensus address that was never (or is no longer) a validator.
 	unknownConsAddr := make([]byte, 20)
@@ -43,7 +43,7 @@ func TestFinalizeBlockIgnoresEvidenceForUnknownValidator(t *testing.T) {
 				Hash:        testApp.LastCommitID().Hash,
 				Misbehavior: []abci.Misbehavior{misbehavior},
 			})
-			require.NoError(t, err, "evidence for an unknown validator must not halt FinalizeBlock")
+			require.NoError(t, err, "evidence for an unknown validator must not cause FinalizeBlock to return an error")
 			require.NotNil(t, resp)
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -459,8 +459,8 @@ replace (
 	// does not have this fix.
 	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1
 	// Pin to the celestia fork's x/evidence to ignore equivocation evidence
-	// for a deleted validator instead of halting the chain. See
-	// celestiaorg/cosmos-sdk#749.
+	// for a deleted validator instead of returning an error from FinalizeBlock.
+	// See celestiaorg/cosmos-sdk#749.
 	cosmossdk.io/x/evidence => github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0

--- a/go.mod
+++ b/go.mod
@@ -458,6 +458,10 @@ replace (
 	// BaseApp.LastBlockHeight and concurrent Commits. Upstream store/v1.1.2
 	// does not have this fix.
 	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1
+	// Pin to the celestia fork's x/evidence to ignore equivocation evidence
+	// for a deleted validator instead of halting the chain. See
+	// celestiaorg/cosmos-sdk#749.
+	cosmossdk.io/x/evidence => github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/bcp-innovations/hyperlane-cosmos => github.com/celestiaorg/hyperlane-cosmos v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,6 @@ cosmossdk.io/tools/confix v0.1.2 h1:2hoM1oFCNisd0ltSAAZw2i4ponARPmlhuNu3yy0VwI4=
 cosmossdk.io/tools/confix v0.1.2/go.mod h1:7XfcbK9sC/KNgVGxgLM0BrFbVcR/+6Dg7MFfpx7duYo=
 cosmossdk.io/x/circuit v0.1.1 h1:KPJCnLChWrxD4jLwUiuQaf5mFD/1m7Omyo7oooefBVQ=
 cosmossdk.io/x/circuit v0.1.1/go.mod h1:B6f/urRuQH8gjt4eLIXfZJucrbreuYrKh5CSjaOxr+Q=
-cosmossdk.io/x/evidence v0.1.1 h1:Ks+BLTa3uftFpElLTDp9L76t2b58htjVbSZ86aoK/E4=
-cosmossdk.io/x/evidence v0.1.1/go.mod h1:OoDsWlbtuyqS70LY51aX8FBTvguQqvFrt78qL7UzeNc=
 cosmossdk.io/x/feegrant v0.1.1 h1:EKFWOeo/pup0yF0svDisWWKAA9Zags6Zd0P3nRvVvw8=
 cosmossdk.io/x/feegrant v0.1.1/go.mod h1:2GjVVxX6G2fta8LWj7pC/ytHjryA6MHAJroBWHFNiEQ=
 dev.gaijin.team/go/exhaustruct/v4 v4.0.0 h1:873r7aNneqoBB3IaFIzhvt2RFYTuHgmMjoKfwODoI1Y=
@@ -263,6 +261,8 @@ github.com/celestiaorg/cosmos-sdk/log v1.3.0 h1:DfckA2UihWckeKHBQU3UXkF2G/qEmsPx
 github.com/celestiaorg/cosmos-sdk/log v1.3.0/go.mod h1:lQTBplaW3HQLKQdPaQq+ElW6zASAoo9r3bJ7pOr8SWo=
 github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1 h1:lEP9DjBMA5frZy/B1IYhAdbJrEwutwGQ+EiTOs4Lm8M=
 github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1/go.mod h1:7+G078fe9GK42pXdYGncWm820tEJkzk+jc6K333Q7aI=
+github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia h1:9U/5sE9D0TETd1pCKKHOHce3IDH31QzLvMMOLMyBsdM=
+github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia/go.mod h1:xa/Yd8nYr19cawsEby/hvyqKY1JwgTADkpeLoiQCp/M=
 github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9 h1:YELTe9/1YksoqSd+Hm1uDZ6auHFNhyJrk5jvli0lbT4=
 github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0 h1:GyDYfK8dLETlUI7F+w+3QYQgAszUegMXgB6cTbDm7CA=


### PR DESCRIPTION
Closes [PROTOCO-2361](https://linear.app/celestia/issue/PROTOCO-2361/handle-celestia-267-equivocation-evidence-for-a-deleted-validator)

Bumps `cosmossdk.io/x/evidence` to the fork's [x/evidence/v0.1.2-celestia](https://github.com/celestiaorg/cosmos-sdk/releases/tag/x%2Fevidence%2Fv0.1.2-celestia), which ignores equivocation evidence naming a validator that no longer exists in staking state instead of erroring out of FinalizeBlock. Adds a regression test that fails on v0.1.1 and passes with the bump. Supersedes #7707.

Note for reviewers: consensus-affecting — evidence BeginBlocker behavior changes for a consensus address not found in staking state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)