### PR TITLE
ci: retry TestAllUpgrades once in the nightly

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -120,7 +120,11 @@ jobs:
           # tests default to a single attempt so real failures aren't masked.
           - test: TestSyncToTipMocha
             max-attempts: 3
+          # TestAllUpgrades starts a fresh chain per upgrade step; on shared
+          # runners an older-version chain occasionally misses the startup
+          # deadline, so retry once before failing the nightly.
           - test: TestAllUpgrades
+            max-attempts: 2
           # TestTxSubmission asserts a wall-clock average tx-inclusion latency
           # bound. On shared GitHub-hosted runners a single run can occasionally
           # see sustained CPU contention that inflates latency well above the


### PR DESCRIPTION
TestAllUpgrades starts a fresh multi-validator chain per upgrade step. On shared runners an older-version chain occasionally misses tastora's chain-startup deadline and fails with `context deadline exceeded` (e.g. [this run](https://github.com/celestiaorg/celestia-app/actions/runs/32396906569/job/96518057367), where the same commit passed an hour earlier). Retry the test once before failing the nightly, same pattern as TestSyncToTipMocha and TestTxSubmission.

Two attempts fit the existing budgets: ~26 min per attempt against the 30 min per-attempt cap and the 90 min job timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)