### PR TITLE
chore: add itrocket seed, peer and RPC for mocha-5

### DIFF
--- a/docker/mocha/celestia/entrypoint.sh
+++ b/docker/mocha/celestia/entrypoint.sh
@@ -11,8 +11,8 @@ set -o pipefail
 
 CHAIN_ID="mocha-5"
 NODE_NAME="mocha-node"
-SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656"
-PEERS=""
+SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656,b402fe40f3474e9e208840702e1b7aa37f2edc4b@celestia-testnet-seed.itrocket.net:14656"
+PEERS="daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656"
 RPC="https://rpc-mocha.pops.one:443"
 
 CELESTIA_APP_HOME="/home/celestia/.celestia-app"

--- a/scripts/block-sync.sh
+++ b/scripts/block-sync.sh
@@ -25,8 +25,8 @@ fi
 case "$NETWORK" in
   mocha)
     CHAIN_ID="mocha-5"
-    SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656"
-    PEERS=""
+    SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656,b402fe40f3474e9e208840702e1b7aa37f2edc4b@celestia-testnet-seed.itrocket.net:14656"
+    PEERS="daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656"
     ;;
   mainnet)
     CHAIN_ID="celestia"

--- a/scripts/mocha-halt.sh
+++ b/scripts/mocha-halt.sh
@@ -7,7 +7,7 @@ set -o nounset
 
 NODE_NAME="node-name"
 CHAIN_ID="mocha-5"
-SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656"
+SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656,b402fe40f3474e9e208840702e1b7aa37f2edc4b@celestia-testnet-seed.itrocket.net:14656"
 
 CELESTIA_APP_HOME="${HOME}/.celestia-app"
 CELESTIA_APP_VERSION=$(celestia-appd version 2>&1)

--- a/scripts/mocha.sh
+++ b/scripts/mocha.sh
@@ -8,8 +8,8 @@ set -o nounset # Stop script execution if an undefined variable is used
 
 CHAIN_ID="mocha-5"
 NODE_NAME="node-name"
-SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656"
-PEERS=""
+SEEDS="ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656,b402fe40f3474e9e208840702e1b7aa37f2edc4b@celestia-testnet-seed.itrocket.net:14656"
+PEERS="daf2cecee2bd7f1b3bf94839f993f807c6b15fbf@celestia-testnet-peer.itrocket.net:11656"
 RPC="https://rpc-mocha.pops.one:443"
 
 CELESTIA_APP_HOME="${HOME}/.celestia-app"

--- a/test/docker-e2e/networks/config.go
+++ b/test/docker-e2e/networks/config.go
@@ -39,7 +39,7 @@ func NewMochaConfig() *Config {
 		// gets a fresh list of currently-alive peers, and connects. This is
 		// more resilient than hardcoded persistent peers which go stale.
 		// Keep in sync with https://github.com/celestiaorg/networks/blob/main/mocha-5/seeds.txt
-		Seeds: "ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656",
+		Seeds: "ee9f90974f85c59d3861fc7f7edb10894f6ac3c8@84.32.215.148:26656,b402fe40f3474e9e208840702e1b7aa37f2edc4b@celestia-testnet-seed.itrocket.net:14656",
 	}
 }
 

--- a/test/docker-e2e/networks/config.go
+++ b/test/docker-e2e/networks/config.go
@@ -26,14 +26,12 @@ func NewMochaConfig() *Config {
 		Name:    "mocha",
 		ChainID: appconsts.MochaChainID,
 		// State sync requires >= 2 RPC servers to cross-verify the app hash
-		// header. These should be distinct providers: listing one host twice
+		// header. These must be distinct providers: listing one host twice
 		// gives no redundancy, so a single slow/unavailable provider stalls
 		// state sync. Keep these in sync with the live mocha-5 testnet.
-		// TODO: replace the duplicate entry with a second distinct provider
-		// once more RPC providers serve mocha-5.
 		RPCs: []string{
 			"https://rpc-mocha.pops.one:443",
-			"https://rpc-mocha.pops.one:443",
+			"https://celestia-testnet-rpc.itrocket.net:443",
 		},
 		// seeds provide dynamic peer discovery — the node contacts a seed,
 		// gets a fresh list of currently-alive peers, and connects. This is

--- a/test/docker-e2e/networks/config_test.go
+++ b/test/docker-e2e/networks/config_test.go
@@ -15,18 +15,34 @@ func TestMochaConfigUpdate(t *testing.T) {
 	if !strings.HasPrefix(config.Seeds, "ee9f9097") {
 		t.Errorf("Expected seeds to start with ee9f9097, got: %s", config.Seeds)
 	}
+
+	seedList := strings.Split(config.Seeds, ",")
+	if len(seedList) < 2 {
+		t.Errorf("Expected at least 2 seeds, got %d", len(seedList))
+	}
 }
 
 // TestMochaConfigRPCsAreDistinct verifies that the mocha RPC list contains at
-// least two endpoints. CometBFT state sync requires >= 2 RPC servers to
-// cross-verify the app hash header; listing the same host twice satisfies
+// least two distinct endpoints. CometBFT state sync requires >= 2 RPC servers
+// to cross-verify the app hash header; listing the same host twice satisfies
 // the count but provides no redundancy, so a single slow or unavailable
 // provider stalls state sync (see flaky TestSyncToTipMocha nightly failures).
-// TODO: restore the distinctness check once more RPC providers serve mocha-5.
 func TestMochaConfigRPCsAreDistinct(t *testing.T) {
 	config := NewMochaConfig()
 
 	if len(config.RPCs) < 2 {
 		t.Fatalf("Expected at least 2 RPC servers for state sync, got %d", len(config.RPCs))
+	}
+
+	seen := make(map[string]bool)
+	for _, rpc := range config.RPCs {
+		if seen[rpc] {
+			t.Errorf("Duplicate RPC endpoint %q: state sync needs distinct servers for redundancy", rpc)
+		}
+		seen[rpc] = true
+	}
+
+	if len(seen) < 2 {
+		t.Errorf("Expected at least 2 distinct RPC endpoints, got %d distinct out of %d", len(seen), len(config.RPCs))
 	}
 }


### PR DESCRIPTION
Adds the itrocket seed and persistent peer for mocha-5 to the scripts, docker entrypoint, and docker-e2e networks config.

Also adds itrocket's RPC as a second distinct state sync provider and restores the seed count and RPC distinctness checks that were relaxed in #7709 when mocha-5 had a single provider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)