### PR TITLE
fix: bound validator signatures in MsgPayForFibre

### DIFF
--- a/app/test/process_proposal_fibre_test.go
+++ b/app/test/process_proposal_fibre_test.go
@@ -323,7 +323,9 @@ func newSignedPayForFibreTxAt(
 		require.NoError(t, err)
 		msg.ValidatorSignatures = [][]byte{validatorSignature}
 	} else {
-		msg.ValidatorSignatures = [][]byte{{0x01}}
+		// A 64-byte but cryptographically invalid signature: passes stateless
+		// size validation, yet is rejected during signature verification.
+		msg.ValidatorSignatures = [][]byte{make([]byte, 64)}
 	}
 
 	txBytes, _, err := signer.CreateTx([]sdk.Msg{msg}, opts...)

--- a/pkg/appconsts/fibre_gas_consts.go
+++ b/pkg/appconsts/fibre_gas_consts.go
@@ -24,4 +24,8 @@ const (
 	// PFFibreGasPerValidatorSignature is the gas per validator signature.
 	// 828 for state reads + crypto.
 	PFFibreGasPerValidatorSignature uint64 = 1_000
+
+	// MaxFibreValidatorSignatures is a stateless ceiling on a MsgPayForFibre's
+	// signatures; keep it >= MaxValidators (the keeper enforces the exact bound).
+	MaxFibreValidatorSignatures = 1_000
 )

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -383,12 +383,15 @@ func (k Keeper) validateValidatorSignatures(ctx sdk.Context, signBytes []byte, h
 
 	// Add all provided signatures to the signature set
 	for i, signature := range signatures {
-		if len(signature) == 0 {
-			continue // Skip empty signatures
-		}
-
+		// Bound the index before skipping empties: the list is positional over
+		// the validator set, so an out-of-range index is always invalid and an
+		// empty entry must not slip past this check.
 		if i >= len(cmtValidators) {
 			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "signature index %d exceeds validator count %d", i, len(cmtValidators))
+		}
+
+		if len(signature) == 0 {
+			continue // Skip empty signatures
 		}
 
 		// Add signature to set (this validates the signature internally)

--- a/x/fibre/keeper/msg_server.go
+++ b/x/fibre/keeper/msg_server.go
@@ -381,15 +381,15 @@ func (k Keeper) validateValidatorSignatures(ctx sdk.Context, signBytes []byte, h
 	twoThirds := cmtmath.Fraction{Numerator: 2, Denominator: 3}
 	sigSet := valSet.NewSignatureSet(twoThirds, signBytes)
 
+	// The list is positional over the validator set, so more entries than
+	// validators is malformed. Rejecting up front also guarantees every index is
+	// in range, so the quorum short-circuit below cannot skip a trailing entry.
+	if len(signatures) > len(cmtValidators) {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "signature count %d exceeds validator count %d", len(signatures), len(cmtValidators))
+	}
+
 	// Add all provided signatures to the signature set
 	for i, signature := range signatures {
-		// Bound the index before skipping empties: the list is positional over
-		// the validator set, so an out-of-range index is always invalid and an
-		// empty entry must not slip past this check.
-		if i >= len(cmtValidators) {
-			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "signature index %d exceeds validator count %d", i, len(cmtValidators))
-		}
-
 		if len(signature) == 0 {
 			continue // Skip empty signatures
 		}

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -457,6 +457,18 @@ func (suite *MsgServerTestSuite) TestValidatePayForFibreSignatures() {
 		suite.Contains(err.Error(), "exceeds validator count")
 	})
 
+	suite.T().Run("empty signatures beyond validator count", func(t *testing.T) {
+		// The set has one validator; an empty entry at index 1 must be rejected
+		// by the index bound rather than silently skipped.
+		msg := &types.MsgPayForFibre{
+			PaymentPromise:      paymentPromise,
+			ValidatorSignatures: [][]byte{{}, {}},
+		}
+		err := suite.keeper.ValidatePayForFibreSignatures(suite.ctx, msg)
+		suite.Error(err)
+		suite.Contains(err.Error(), "signature index 1 exceeds validator count 1")
+	})
+
 	suite.T().Run("missing historical info", func(t *testing.T) {
 		suite.stakingKeeper.GetHistoricalInfoFn = func(ctx context.Context, height int64) (stakingtypes.HistoricalInfo, error) {
 			return stakingtypes.HistoricalInfo{}, stakingtypes.ErrNoHistoricalInfo

--- a/x/fibre/keeper/msg_server_test.go
+++ b/x/fibre/keeper/msg_server_test.go
@@ -457,16 +457,16 @@ func (suite *MsgServerTestSuite) TestValidatePayForFibreSignatures() {
 		suite.Contains(err.Error(), "exceeds validator count")
 	})
 
-	suite.T().Run("empty signatures beyond validator count", func(t *testing.T) {
-		// The set has one validator; an empty entry at index 1 must be rejected
-		// by the index bound rather than silently skipped.
+	suite.T().Run("trailing entry beyond quorum is still rejected", func(t *testing.T) {
+		// One validator: index 0 alone meets quorum, but a trailing entry at
+		// index 1 exceeds the set and must be rejected despite the early quorum.
 		msg := &types.MsgPayForFibre{
 			PaymentPromise:      paymentPromise,
-			ValidatorSignatures: [][]byte{{}, {}},
+			ValidatorSignatures: [][]byte{validSignatures[0], {}},
 		}
 		err := suite.keeper.ValidatePayForFibreSignatures(suite.ctx, msg)
 		suite.Error(err)
-		suite.Contains(err.Error(), "signature index 1 exceeds validator count 1")
+		suite.Contains(err.Error(), "signature count 2 exceeds validator count 1")
 	})
 
 	suite.T().Run("missing historical info", func(t *testing.T) {

--- a/x/fibre/types/msgs.go
+++ b/x/fibre/types/msgs.go
@@ -2,7 +2,9 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/go-square/v4/share"
+	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -112,6 +114,16 @@ func (msg *MsgPayForFibre) ValidateBasic() error {
 
 	if len(msg.ValidatorSignatures) == 0 {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "must have at least one validator signature")
+	}
+
+	if len(msg.ValidatorSignatures) > appconsts.MaxFibreValidatorSignatures {
+		return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "too many validator signatures: %d exceeds maximum %d", len(msg.ValidatorSignatures), appconsts.MaxFibreValidatorSignatures)
+	}
+
+	for i, sig := range msg.ValidatorSignatures {
+		if l := len(sig); l != 0 && l != ed25519.SignatureSize {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidRequest, "validator signature %d must be empty or %d bytes, got %d", i, ed25519.SignatureSize, l)
+		}
 	}
 
 	return nil

--- a/x/fibre/types/msgs_test.go
+++ b/x/fibre/types/msgs_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"cosmossdk.io/math"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -363,7 +364,7 @@ func TestMsgPayForFibreValidateBasic(t *testing.T) {
 	// another test file in this binary sets the global bech32 prefix.
 	signer := sdk.AccAddress(bytes.Repeat([]byte{0x01}, 20)).String()
 	paymentPromise := generatePaymentPromise(t)
-	validatorSignatures := [][]byte{[]byte("sig1"), []byte("sig2")}
+	validatorSignatures := [][]byte{bytes.Repeat([]byte{0x01}, 64), bytes.Repeat([]byte{0x02}, 64)}
 
 	type testCase struct {
 		name    string
@@ -402,9 +403,27 @@ func TestMsgPayForFibreValidateBasic(t *testing.T) {
 			msg: &MsgPayForFibre{
 				Signer:              signer,
 				PaymentPromise:      paymentPromise,
-				ValidatorSignatures: [][]byte{[]byte("sig1"), {}},
+				ValidatorSignatures: [][]byte{bytes.Repeat([]byte{0x01}, 64), {}},
 			},
 			wantErr: nil,
+		},
+		{
+			name: "too many validator signatures",
+			msg: &MsgPayForFibre{
+				Signer:              signer,
+				PaymentPromise:      paymentPromise,
+				ValidatorSignatures: make([][]byte, appconsts.MaxFibreValidatorSignatures+1),
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
+		},
+		{
+			name: "validator signature of wrong size",
+			msg: &MsgPayForFibre{
+				Signer:              signer,
+				PaymentPromise:      paymentPromise,
+				ValidatorSignatures: [][]byte{bytes.Repeat([]byte{0x01}, 32)},
+			},
+			wantErr: sdkerrors.ErrInvalidRequest,
 		},
 	}
 


### PR DESCRIPTION
Resolves [PROTOCO-2417](https://linear.app/celestia/issue/PROTOCO-2417/empty-fibre-signature-fields-cause-unbounded-decoded-cardinality)

Bounded the ValidatorSignatures list on MsgPayForFibre: ValidateBasic now caps the count at MaxFibreValidatorSignatures (1000) and requires each element to be empty or 64 bytes, and the keeper checks the signature index before skipping empties so empty entries can no longer slip past the validator-count bound. This rejects the crafted transaction before the expensive verification instead of scanning millions of attacker-controlled entries under the infinite gas meter.