### PR TITLE
fix: verify downloaded genesis before replacing destination

### DIFF
--- a/cmd/celestia-appd/cmd/download_genesis.go
+++ b/cmd/celestia-appd/cmd/download_genesis.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
@@ -33,33 +34,18 @@ func downloadGenesisCommand() *cobra.Command {
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			chainID := getChainIDOrDefault(args)
-			if !isKnownChainID(chainID) {
+			knownHash, ok := chainIDToSha256[chainID]
+			if !ok {
 				return fmt.Errorf("unknown chain-id: %s. Must be: %s", chainID, chainIDs())
 			}
 			outputFile := server.GetServerContextFromCmd(cmd).Config.GenesisFile()
 			fmt.Printf("Downloading genesis file for %s to %s\n", chainID, outputFile)
 
 			url := fmt.Sprintf("https://raw.githubusercontent.com/celestiaorg/networks/master/%s/genesis.json", chainID)
-			if err := downloadFile(outputFile, url); err != nil {
+			if err := downloadFile(outputFile, url, knownHash); err != nil {
 				return fmt.Errorf("error downloading / persisting the genesis file: %s", err)
 			}
 			fmt.Printf("Downloaded genesis file for %s to %s\n", chainID, outputFile)
-
-			// Compute SHA-256 hash of the downloaded file
-			hash, err := computeSha256(outputFile)
-			if err != nil {
-				return fmt.Errorf("error computing sha256 hash: %s", err)
-			}
-
-			// Compare computed hash against known hash
-			knownHash, ok := chainIDToSha256[chainID]
-			if !ok {
-				return fmt.Errorf("unknown chain-id: %s", chainID)
-			}
-
-			if hash != knownHash {
-				return fmt.Errorf("sha256 hash mismatch: got %s, expected %s", hash, knownHash)
-			}
 
 			fmt.Printf("SHA-256 hash verified for %s\n", chainID)
 			return nil
@@ -88,8 +74,8 @@ func chainIDs() string {
 	return strings.Join(getKeys(chainIDToSha256), ", ")
 }
 
-// downloadFile will download a URL to a local file.
-func downloadFile(filepath, url string) error {
+// downloadFile downloads and verifies a URL before replacing the destination.
+func downloadFile(destination, url, expectedHash string) error {
 	resp, err := http.Get(url)
 	if err != nil {
 		return err
@@ -100,14 +86,32 @@ func downloadFile(filepath, url string) error {
 		return fmt.Errorf("unexpected HTTP status: %s", resp.Status)
 	}
 
-	out, err := os.Create(filepath)
+	out, err := os.CreateTemp(filepath.Dir(destination), ".genesis-*")
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	temporary := out.Name()
+	defer os.Remove(temporary)
 
-	_, err = io.Copy(out, resp.Body)
-	return err
+	if _, err := io.Copy(out, resp.Body); err != nil {
+		out.Close()
+		return err
+	}
+	if err := out.Close(); err != nil {
+		return err
+	}
+
+	hash, err := computeSha256(temporary)
+	if err != nil {
+		return err
+	}
+	if hash != expectedHash {
+		return fmt.Errorf("sha256 hash mismatch: got %s, expected %s", hash, expectedHash)
+	}
+	if err := os.Chmod(temporary, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(temporary, destination)
 }
 
 // computeSha256 computes the SHA-256 hash of a file.

--- a/cmd/celestia-appd/cmd/download_genesis_test.go
+++ b/cmd/celestia-appd/cmd/download_genesis_test.go
@@ -1,28 +1,77 @@
 package cmd
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
-	"github.com/stretchr/testify/assert"
 )
 
-func Test_isKnownChainID(t *testing.T) {
-	type testCase struct {
+func TestIsKnownChainID(t *testing.T) {
+	tests := []struct {
 		chainID string
 		want    bool
-	}
-	testCases := []testCase{
+	}{
 		{appconsts.MainnetChainID, true},
 		{appconsts.MochaChainID, true},
 		{appconsts.CortoChainID, true},
 		{"foo", false},
 	}
 
-	for _, tc := range testCases {
-		t.Run(tc.chainID, func(t *testing.T) {
-			got := isKnownChainID(tc.chainID)
-			assert.Equal(t, tc.want, got)
+	for _, tt := range tests {
+		t.Run(tt.chainID, func(t *testing.T) {
+			if got := isKnownChainID(tt.chainID); got != tt.want {
+				t.Fatalf("isKnownChainID(%q) = %v, want %v", tt.chainID, got, tt.want)
+			}
 		})
+	}
+}
+
+func TestDownloadFilePreservesDestinationOnHashMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("downloaded"))
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "genesis.json")
+	if err := os.WriteFile(destination, []byte("existing"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := downloadFile(destination, server.URL, "wrong hash"); err == nil {
+		t.Fatal("downloadFile returned nil, want hash mismatch")
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "existing" {
+		t.Fatalf("destination contains %q, want existing content", got)
+	}
+}
+
+func TestDownloadFileReplacesDestinationAfterVerification(t *testing.T) {
+	content := []byte("downloaded")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(content)
+	}))
+	defer server.Close()
+
+	destination := filepath.Join(t.TempDir(), "genesis.json")
+	hash := sha256.Sum256(content)
+	if err := downloadFile(destination, server.URL, hex.EncodeToString(hash[:])); err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(content) {
+		t.Fatalf("destination contains %q, want %q", got, content)
 	}
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview



The command currently writes directly to the configured genesis file and verifies its SHA-256 digest afterward.

If the download is interrupted or the downloaded content has an unexpected digest, the command returns an error but may leave an invalid genesis file in place. It can also overwrite an existing valid genesis before the failure is detected.

## Changes

- download genesis data into a temporary file in the destination directory
- verify its SHA-256 digest before replacing the configured genesis file
- preserve an existing genesis file when downloading or verification fails
- add regression tests for hash mismatch and successful replacement

## Testing

- `go test ./cmd/celestia-appd/cmd -run 'Test(IsKnownChainID|DownloadFile)' -count=1`