### PR TITLE
fix!: reject transaction fees denominated in non-utia denoms

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ All branches use forked cosmos-sdk and celestia-core:
 ## Development Workflow
 
 1. **Multi-module repo**: Copy `go.work.example` to `go.work` and run `go work sync`
-2. **Conventional commits**: PR titles must follow [conventionalcommits.org](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `chore:`, `feat!:` for breaking changes)
+2. **Conventional commits**: PR titles must follow [conventionalcommits.org](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `chore:`, `feat!:` for breaking changes). Any consensus-breaking change (one that alters deterministic state-machine behavior and requires a coordinated network upgrade) must include a `!` in the PR title, e.g. `fix!:`.
 3. **Validate inputs** in message handlers; be cautious with arithmetic overflow and gas consumption
 4. **Linking issues**: PR descriptions must start with a `Closes <link>` line when an issue exists, and the link must be clickable. Linear issues use `Closes [PROTOCO-1234](https://linear.app/celestia/issue/PROTOCO-1234)` — a bare `Closes PROTOCO-1234` is not acceptable because GitHub does not linkify it.
 5. **Hacken bug bounty PRs**: When creating a PR that resolves a Hacken bug bounty report, do NOT include details about the bug in the PR description. Instead, link to a Linear issue (as a clickable link, per the previous item) that contains more details on the bug and the link to the Hacken bug bounty report.

--- a/app/ante/fee.go
+++ b/app/ante/fee.go
@@ -36,6 +36,15 @@ func ValidateTxFee(ctx sdk.Context, tx sdk.Tx, minfeeKeeper *minfeekeeper.Keeper
 		return nil, 0, errors.Wrap(sdkerror.ErrTxDecode, "Tx must be a FeeTx")
 	}
 
+	// Fees may only be paid in utia. Only the utia component is checked against
+	// the minimum gas price, so any other denom would be deducted unchecked.
+	for _, coin := range feeTx.GetFee() {
+		if coin.Denom != appconsts.BondDenom {
+			return nil, 0, errors.Wrapf(sdkerror.ErrInvalidCoins,
+				"fee must be denominated in %s, got %s", appconsts.BondDenom, coin.Denom)
+		}
+	}
+
 	fee := feeTx.GetFee().AmountOf(appconsts.BondDenom)
 	gas := feeTx.GetGas()
 

--- a/app/ante/fee_test.go
+++ b/app/ante/fee_test.go
@@ -143,6 +143,25 @@ func TestValidateTxFee(t *testing.T) {
 			expErr:      false,
 			minGasPrice: "0utia",
 		},
+		{
+			name: "bad tx; fee contains a non-utia denom",
+			fee: sdk.NewCoins(
+				sdk.NewInt64Coin(appconsts.BondDenom, feeAmount),
+				sdk.NewInt64Coin("ibc/FEED", 1),
+			),
+			gasLimit:    uint64(float64(feeAmount) / appconsts.DefaultNetworkMinGasPrice),
+			isCheckTx:   false,
+			expErr:      true,
+			minGasPrice: validatorMinGasPriceCoin,
+		},
+		{
+			name:        "bad tx; fee is denominated only in a non-utia denom",
+			fee:         sdk.NewCoins(sdk.NewInt64Coin("ibc/FEED", feeAmount)),
+			gasLimit:    uint64(float64(feeAmount) / appconsts.DefaultNetworkMinGasPrice),
+			isCheckTx:   false,
+			expErr:      true,
+			minGasPrice: validatorMinGasPriceCoin,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes [PROTOCO-2362](https://linear.app/celestia/issue/PROTOCO-2362)

`ValidateTxFee` only compares the `utia` component of a fee against the minimum gas price but returned the whole multi-denom fee for deduction. This adds a check that rejects any transaction whose fee carries a denom other than `utia`.

Also documents in CLAUDE.md that consensus-breaking PRs must carry a `!` in the title.

Note for reviewers: consensus-breaking (changes ante-handler behavior), so it targets the next app version.