### PR TITLE
fix(zkism)!: require compressed curve points in Groth16 vkey validation

### DIFF
--- a/x/zkism/types/keys.go
+++ b/x/zkism/types/keys.go
@@ -44,6 +44,11 @@ const (
 	// G1.Delta (32) + G2.Delta (64) = 288 bytes.
 	groth16VkeyCurvePointsSize = 288
 
+	// groth16PointCompressionMask isolates the two most significant bits of a
+	// serialized BN254 curve point, which encode whether the point is
+	// compressed. Uncompressed points have both bits clear.
+	groth16PointCompressionMask = 0b11 << 6
+
 	// Groth16VkeyG1KLength is the expected number of G1.K elements in the
 	// verifying key. For the SP1 v6 scheme with 5 public inputs (vkey_hash,
 	// committed_values_digest, exit_code, vk_root, proof_nonce) this is
@@ -76,6 +81,12 @@ var (
 	IsmsKeyPrefix               = collections.NewPrefix(0)
 	MessageKeyPrefix            = collections.NewPrefix(1)
 	MessageProofSubmittedPrefix = collections.NewPrefix(2)
+
+	// groth16VkeyPointOffsets are the byte offsets of the six leading curve
+	// points (G1.Alpha, G1.Beta, G2.Beta, G2.Gamma, G1.Delta, G2.Delta) in a
+	// serialized compressed BN254 verifying key. G1 points are 32 bytes and G2
+	// points are 64 bytes.
+	groth16VkeyPointOffsets = []int{0, 32, 64, 128, 192, 224}
 )
 
 // ValidateGroth16Vkey checks that a serialized Groth16 verifying key has the
@@ -86,6 +97,17 @@ var (
 func ValidateGroth16Vkey(vkey []byte) error {
 	if len(vkey) != Groth16VkeySize {
 		return fmt.Errorf("groth16 vkey must be exactly %d bytes, got %d", Groth16VkeySize, len(vkey))
+	}
+
+	// The length-prefix offsets below are only correct when every leading curve
+	// point uses the compressed encoding. gnark derives each point's width from
+	// its own compression-flag byte, so an uncompressed leading point would shift
+	// gnark's length reads past these fixed offsets, letting an inflated length
+	// slip through and trigger an unbounded allocation during deserialization.
+	for _, offset := range groth16VkeyPointOffsets {
+		if vkey[offset]&groth16PointCompressionMask == 0 {
+			return fmt.Errorf("groth16 vkey curve point at offset %d must be compressed", offset)
+		}
 	}
 
 	g1kLen := binary.BigEndian.Uint32(vkey[groth16VkeyCurvePointsSize : groth16VkeyCurvePointsSize+4])

--- a/x/zkism/types/keys_test.go
+++ b/x/zkism/types/keys_test.go
@@ -2,6 +2,7 @@ package types_test
 
 import (
 	"encoding/binary"
+	"fmt"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/x/zkism/types"
@@ -66,14 +67,16 @@ func TestValidateGroth16Vkey(t *testing.T) {
 		assert.ErrorContains(t, err, "PublicAndCommitmentCommitted length must be 0, got 1")
 	})
 
-	t.Run("uncompressed leading curve point is rejected", func(t *testing.T) {
-		malicious := make([]byte, types.Groth16VkeySize)
-		copy(malicious, validVK)
-		// Clear the compression-flag bits of G1.Delta's first byte (offset 192) so
-		// gnark would read it as an uncompressed 64-byte point, shifting its G1.K
-		// length read past the offset the validator checks (CELESTIA-269).
-		malicious[192] &= 0x3f
-		err := types.ValidateGroth16Vkey(malicious)
-		assert.ErrorContains(t, err, "must be compressed")
-	})
+	// Clearing the compression-flag bits of any leading curve point's first byte makes gnark
+	// read it as an uncompressed point, shifting its length-prefix reads past the offsets the
+	// validator checks (CELESTIA-269). Every leading point must be rejected.
+	for _, offset := range []int{0, 32, 64, 128, 192, 224} {
+		t.Run(fmt.Sprintf("uncompressed leading curve point at offset %d is rejected", offset), func(t *testing.T) {
+			malicious := make([]byte, types.Groth16VkeySize)
+			copy(malicious, validVK)
+			malicious[offset] &= 0x3f
+			err := types.ValidateGroth16Vkey(malicious)
+			assert.ErrorContains(t, err, "must be compressed")
+		})
+	}
 }

--- a/x/zkism/types/keys_test.go
+++ b/x/zkism/types/keys_test.go
@@ -65,4 +65,15 @@ func TestValidateGroth16Vkey(t *testing.T) {
 		err := types.ValidateGroth16Vkey(malicious)
 		assert.ErrorContains(t, err, "PublicAndCommitmentCommitted length must be 0, got 1")
 	})
+
+	t.Run("uncompressed leading curve point is rejected", func(t *testing.T) {
+		malicious := make([]byte, types.Groth16VkeySize)
+		copy(malicious, validVK)
+		// Clear the compression-flag bits of G1.Delta's first byte (offset 192) so
+		// gnark would read it as an uncompressed 64-byte point, shifting its G1.K
+		// length read past the offset the validator checks (CELESTIA-269).
+		malicious[192] &= 0x3f
+		err := types.ValidateGroth16Vkey(malicious)
+		assert.ErrorContains(t, err, "must be compressed")
+	})
 }


### PR DESCRIPTION
Closes [PROTOCO-2360](https://linear.app/celestia/issue/PROTOCO-2360)

`ValidateGroth16Vkey` reads the verifying key's length prefixes at fixed byte offsets that are only correct when every leading curve point uses the compressed encoding. This adds a check that all six leading points are compressed, keeping those offsets sound.

Note for reviewers: this changes the result of `MsgCreateInterchainSecurityModule` validation, so it is state-machine-affecting and should land in v10 before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)