### PR TITLE
chore: bump cosmossdk.io/store to v1.1.3-celestia.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -457,7 +457,7 @@ replace (
 	// from celestiaorg/cosmos-sdk#705, which closes a data race between
 	// BaseApp.LastBlockHeight and concurrent Commits. Upstream store/v1.1.2
 	// does not have this fix.
-	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1
+	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.2
 	// Pin to the celestia fork's x/evidence to ignore equivocation evidence
 	// for a deleted validator instead of returning an error from FinalizeBlock.
 	// See celestiaorg/cosmos-sdk#749.

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/C
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.3.0 h1:DfckA2UihWckeKHBQU3UXkF2G/qEmsPxd3LtGYB9HeM=
 github.com/celestiaorg/cosmos-sdk/log v1.3.0/go.mod h1:lQTBplaW3HQLKQdPaQq+ElW6zASAoo9r3bJ7pOr8SWo=
-github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1 h1:lEP9DjBMA5frZy/B1IYhAdbJrEwutwGQ+EiTOs4Lm8M=
-github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1/go.mod h1:7+G078fe9GK42pXdYGncWm820tEJkzk+jc6K333Q7aI=
+github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.2 h1:xktmuJ5AMiw4xuOPsWXwczeKpYu+uXR7P3HFw5PfhGo=
+github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.2/go.mod h1:7+G078fe9GK42pXdYGncWm820tEJkzk+jc6K333Q7aI=
 github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia h1:9U/5sE9D0TETd1pCKKHOHce3IDH31QzLvMMOLMyBsdM=
 github.com/celestiaorg/cosmos-sdk/x/evidence v0.1.2-celestia/go.mod h1:xa/Yd8nYr19cawsEby/hvyqKY1JwgTADkpeLoiQCp/M=
 github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9 h1:YELTe9/1YksoqSd+Hm1uDZ6auHFNhyJrk5jvli0lbT4=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -291,7 +291,7 @@ replace (
 	// from celestiaorg/cosmos-sdk#705, which closes a data race between
 	// BaseApp.LastBlockHeight and concurrent Commits. Upstream store/v1.1.2
 	// does not have this fix.
-	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1
+	cosmossdk.io/store => github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.2
 	cosmossdk.io/x/tx => github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9
 	cosmossdk.io/x/upgrade => github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0
 	github.com/bcp-innovations/hyperlane-cosmos => github.com/celestiaorg/hyperlane-cosmos v1.3.0

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -169,8 +169,8 @@ github.com/celestiaorg/cosmos-sdk/api v0.7.6 h1:81in9Zk+noz0ko+hZFSSK8L1aawFN8/C
 github.com/celestiaorg/cosmos-sdk/api v0.7.6/go.mod h1:1BgQSufu6ZQkst3YBIHDCo/TPUrhfU4fV7tOI0ftql8=
 github.com/celestiaorg/cosmos-sdk/log v1.3.0 h1:DfckA2UihWckeKHBQU3UXkF2G/qEmsPxd3LtGYB9HeM=
 github.com/celestiaorg/cosmos-sdk/log v1.3.0/go.mod h1:lQTBplaW3HQLKQdPaQq+ElW6zASAoo9r3bJ7pOr8SWo=
-github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1 h1:lEP9DjBMA5frZy/B1IYhAdbJrEwutwGQ+EiTOs4Lm8M=
-github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.1/go.mod h1:7+G078fe9GK42pXdYGncWm820tEJkzk+jc6K333Q7aI=
+github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.2 h1:xktmuJ5AMiw4xuOPsWXwczeKpYu+uXR7P3HFw5PfhGo=
+github.com/celestiaorg/cosmos-sdk/store v1.1.3-celestia.2/go.mod h1:7+G078fe9GK42pXdYGncWm820tEJkzk+jc6K333Q7aI=
 github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9 h1:YELTe9/1YksoqSd+Hm1uDZ6auHFNhyJrk5jvli0lbT4=
 github.com/celestiaorg/cosmos-sdk/x/tx v0.13.9/go.mod h1:V6DImnwJMTq5qFjeGWpXNiT/fjgE4HtmclRmTqRVM3w=
 github.com/celestiaorg/cosmos-sdk/x/upgrade v0.2.0 h1:GyDYfK8dLETlUI7F+w+3QYQgAszUegMXgB6cTbDm7CA=


### PR DESCRIPTION
Closes [PROTOCO-2359](https://linear.app/celestia/issue/PROTOCO-2359)

Bumps `cosmossdk.io/store` to [store/v1.1.3-celestia.2](https://github.com/celestiaorg/cosmos-sdk/releases/tag/store%2Fv1.1.3-celestia.2) to pick up the snapshot-Restore fix in [celestiaorg/cosmos-sdk#753](https://github.com/celestiaorg/cosmos-sdk/pull/753), which rejects a negative IAVL version that crashed state-syncing nodes.