### PR TITLE
fix: decide PFF signature verification by exec mode, not sig cache

### DIFF
--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -142,7 +142,11 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 			}
 
 			// Settle after ante so later promises see the updated state and the tx
-			// pays the same gas it would in FinalizeBlock.
+			// pays the same gas it would in FinalizeBlock. This ante pass is also
+			// the consensus enforcement point for PFF validator signatures:
+			// FinalizeBlock never re-verifies them (see
+			// FibreSignatureVerificationDecorator), so removing it would let a
+			// proposer settle promises without a validator quorum.
 			if isPFF {
 				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
 					logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("fibre settlement failed %d", idx), execErr)

--- a/app/test/finalize_block_test.go
+++ b/app/test/finalize_block_test.go
@@ -11,6 +11,7 @@ import (
 	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
 	"github.com/celestiaorg/celestia-app/v10/test/util/testfactory"
 	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
@@ -47,6 +48,58 @@ func TestPayForFibreReplayGasParity(t *testing.T) {
 	}
 	require.Equal(t, finalizeResp.TxResults[1].GasUsed, finalizeResp.TxResults[2].GasUsed,
 		"cached and uncached signature verification must consume identical gas")
+}
+
+// TestPayForFibreFinalizeBlockColdCacheWithPrunedHistory replays a committed
+// PFF tx on a node whose signature cache is cold (as after state sync or a
+// restart) once the promise height's historical info has been pruned. The
+// result must match the live network, which settled the tx with a warm cache.
+func TestPayForFibreFinalizeBlockColdCacheWithPrunedHistory(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(1)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	infos := queryAccountInfo(testApp, accounts, kr)
+	signer := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)(0)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[0]), pffTestEscrowAmount)
+
+	// Keep only the two most recent historical entries so the promise height
+	// (1) gets pruned while still inside PaymentPromiseHeightWindow.
+	setHistoricalEntries(t, testApp, 2)
+	for testApp.LastBlockHeight() < 5 {
+		execBlock(t, testApp, func(sdk.Context) {})
+	}
+	_, err := testApp.StakingKeeper.GetHistoricalInfo(uncachedContext(testApp), 1)
+	require.Error(t, err, "promise height must be pruned for this test")
+
+	// The tx never went through CheckTx or ProcessProposal on this node, so
+	// the signature cache is cold.
+	pffTx := newSignedPayForFibreTx(t, signer, accounts[0], true)
+	resp, err := testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
+		Time:   time.Now(),
+		Height: testApp.LastBlockHeight() + 1,
+		Hash:   testApp.LastCommitID().Hash,
+		Txs:    [][]byte{pffTx},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.TxResults, 1)
+	require.Equal(t, abci.CodeTypeOK, resp.TxResults[0].Code, resp.TxResults[0].Log)
+}
+
+func uncachedContext(testApp *app.App) sdk.Context {
+	return testApp.NewUncachedContext(false, cmtproto.Header{
+		ChainID: testutil.ChainID,
+		Height:  testApp.LastBlockHeight(),
+		Time:    time.Now(),
+	})
+}
+
+func setHistoricalEntries(t *testing.T, testApp *app.App, entries uint32) {
+	t.Helper()
+	ctx := uncachedContext(testApp)
+	params, err := testApp.StakingKeeper.GetParams(ctx)
+	require.NoError(t, err)
+	params.HistoricalEntries = entries
+	require.NoError(t, testApp.StakingKeeper.SetParams(ctx, params))
 }
 
 // buildGasParityTxs returns a MsgSend tx and two same-sized MsgPayForFibre txs.

--- a/x/fibre/README.md
+++ b/x/fibre/README.md
@@ -47,6 +47,8 @@ Settles a `PaymentPromise` against the promise signer's escrow account. The mess
 1. The promise's `height` must be within `payment_promise_height_window` of the current height, its `creation_timestamp` fresh (not older than the freshness floor, not further than 10 minutes in the future), and the promise not yet expired or already processed.
 1. The escrow account must exist and its total balance cover the payment.
 
+Validator signatures (check 2) are verified in CheckTx and ProcessProposal only: a committed block already had them verified by honest validators, so FinalizeBlock skips the check and the state machine alone does not enforce it — the same trust model as blob share commitments. All other checks run at settlement on every node.
+
 In practice the promise JSON and the signatures are produced by the fibre client's upload flow — a PFF is not constructed by hand. See [specs/src/fibre_module.md](../../specs/src/fibre_module.md) for the full promise format and verification rules.
 
 ### `MsgPaymentPromiseTimeout`
@@ -81,7 +83,7 @@ The module emits typed events (the event type is the proto message name, e.g. `c
 | ShardRetention             | time.Duration   | 4h                 | [10m, 168h]             |
 | FullStakeStorageBudget     | uint64          | 2199023255552 (2 TiB) | > 0                  |
 
-All parameters are changeable by governance. `WithdrawalDelay`'s lower bound is `MaxPaymentPromiseTimeout + 10m`, which guarantees every promise leaves a usable timeout-settlement window. `ShardRetention` is how long fibre servers keep uploaded shards on disk; `FullStakeStorageBudget` caps the fibre disk usage of a hypothetical 100%-stake validator over one retention window, from which each server derives its own stake-proportional budget.
+All parameters are changeable by governance. `WithdrawalDelay`'s lower bound is `MaxPaymentPromiseTimeout + 10m`, which guarantees every promise leaves a usable timeout-settlement window. `ShardRetention` is how long fibre servers keep uploaded shards on disk; `FullStakeStorageBudget` caps the fibre disk usage of a hypothetical 100%-stake validator over one retention window, from which each server derives its own stake-proportional budget. `PaymentPromiseHeightWindow` should stay well below the staking module's `HistoricalEntries` (default 10000): a promise whose height has been pruned from historical info can no longer be signature-verified, so such PFFs fail CheckTx on nodes that have not already verified them, risk split ProcessProposal votes, and can only settle via timeout.
 
 ## Usage
 

--- a/x/fibre/ante/ante.go
+++ b/x/fibre/ante/ante.go
@@ -32,7 +32,11 @@ func consumeDeterministicFibreSignatureGas(ctx sdk.Context, msg *fibretypes.MsgP
 	)
 }
 
-// FibreSignatureVerificationDecorator verifies uncached MsgPayForFibre signatures.
+// FibreSignatureVerificationDecorator verifies uncached MsgPayForFibre
+// signatures in CheckTx and ProcessProposal. FinalizeBlock always skips:
+// a committed block already had its PFF signatures verified by honest
+// validators in ProcessProposal, and the outcome must not depend on the
+// node-local cache.
 type FibreSignatureVerificationDecorator struct {
 	k           FibreKeeper
 	pffSigCache PffSigCache
@@ -59,7 +63,7 @@ func NewFibreSigVerificationDecorator(
 
 func (d FibreSignatureVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bool, next sdk.AnteHandler) (sdk.Context, error) {
 	msg := payForFibreMessage(tx)
-	if msg == nil || simulate {
+	if msg == nil || simulate || ctx.ExecMode() == sdk.ExecModeFinalize {
 		return next(ctx, tx, simulate)
 	}
 

--- a/x/fibre/ante/ante_test.go
+++ b/x/fibre/ante/ante_test.go
@@ -72,6 +72,30 @@ func TestFibreSignatureVerificationDecoratorSimulationSkipsVerification(t *testi
 	require.Zero(t, gotCtx.GasMeter().GasConsumed())
 }
 
+func TestFibreSignatureVerificationDecoratorFinalizeModeSkipsVerification(t *testing.T) {
+	tx := mockTx{msgs: []sdk.Msg{newPayForFibreMsgWithSignatures(1)}}
+	keeper := &fakeFibreSignatureKeeper{err: errors.New("verification must not run in finalize mode")}
+	cache := &fakeSigCache{
+		t:                 t,
+		failOnCacheLookup: true,
+		failOnCacheWrite:  true,
+	}
+	decorator := FibreSignatureVerificationDecorator{
+		k:           keeper,
+		pffSigCache: cache,
+	}
+	ctx := sdk.Context{}.
+		WithGasMeter(storetypes.NewGasMeter(1)).
+		WithTxBytes([]byte{0x01}).
+		WithExecMode(sdk.ExecModeFinalize)
+
+	gotCtx, err := decorator.AnteHandle(ctx, tx, false, nextNoop)
+
+	require.NoError(t, err)
+	require.Zero(t, keeper.calls)
+	require.Zero(t, gotCtx.GasMeter().GasConsumed())
+}
+
 func TestFibreSignatureVerificationDecoratorCacheHitSkipsVerification(t *testing.T) {
 	tx := mockTx{msgs: []sdk.Msg{newPayForFibreMsgWithSignatures(1)}}
 	keeper := &fakeFibreSignatureKeeper{}


### PR DESCRIPTION
Closes [PROTOCO-2497](https://linear.app/celestia/issue/PROTOCO-2497)
Closes https://github.com/celestiaorg/celestia-app/issues/7738

## Overview

`MsgPayForFibre` settlement in FinalizeBlock depended on the node-local `pffSigCache`: live nodes (warm cache) skipped validator-signature verification and settled, while replaying or state-syncing nodes (cold cache) re-verified and rejected once the staking historical info at the promise height was pruned — same block, different app hash, permanent sync halt.

FinalizeBlock now skips PFF signature verification unconditionally (exec-mode check instead of cache hit). Signatures are enforced in CheckTx and ProcessProposal and attested by the >2/3 commit — the same trust model as blob share commitments. The cache can no longer affect a consensus outcome, gas is unchanged in all modes, and sync no longer pays for PFF signature re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)