### PR TITLE
fix(fibre): handle Store.Size cancellation consistently

### DIFF
--- a/fibre/store.go
+++ b/fibre/store.go
@@ -348,6 +348,10 @@ func (s *Store) hasShardMarker(commit Commitment, promiseHash []byte) bool {
 
 // Size returns the total on-disk bytes of stored shard files.
 func (s *Store) Size(ctx context.Context) (int64, error) {
+	if err := ctx.Err(); err != nil {
+		return 0, err
+	}
+
 	dir := filepath.Join(s.cfg.Path, shardsSubdir)
 	list, err := s.fs.List(dir)
 	if err != nil {
@@ -363,7 +367,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 		case err != nil:
 			return 0, fmt.Errorf("stat shard file %s: %w", name, err)
 		case ctx.Err() != nil:
-			return 0, err
+			return 0, ctx.Err()
 		}
 		totalSize += info.Size()
 	}

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -1,6 +1,7 @@
 package fibre_test
 
 import (
+	"context"
 	"encoding/hex"
 	"log/slog"
 	"os"
@@ -510,6 +511,12 @@ func testStoreSize(t *testing.T, store *fibre.Store, path string) {
 	require.NoError(t, err)
 	require.Zero(t, size, "empty store must report 0, not an error")
 
+	canceledEmptyCtx, cancelEmpty := context.WithCancel(ctx)
+	cancelEmpty()
+	size, err = store.Size(canceledEmptyCtx)
+	require.Zero(t, size)
+	require.ErrorIs(t, err, context.Canceled)
+
 	blob := makeTestBlobV0(t, 256)
 	commitment := blob.ID().Commitment()
 	var want int64
@@ -526,6 +533,12 @@ func testStoreSize(t *testing.T, store *fibre.Store, path string) {
 	size, err = store.Size(ctx)
 	require.NoError(t, err)
 	require.Equal(t, want, size)
+
+	canceledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+	size, err = store.Size(canceledCtx)
+	require.Zero(t, size)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 // PruneBefore reports the total on-disk bytes it freed.

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -539,6 +539,28 @@ func testStoreSize(t *testing.T, store *fibre.Store, path string) {
 	size, err = store.Size(canceledCtx)
 	require.Zero(t, size)
 	require.ErrorIs(t, err, context.Canceled)
+
+	// Cancelling mid-scan, after the entry guard has already passed, must also
+	// surface context.Canceled rather than a nil error and a partial total.
+	size, err = store.Size(&cancelAfterCtx{Context: ctx, live: 1})
+	require.Zero(t, size)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// cancelAfterCtx reports a live context for its first `live` Err checks and a
+// cancelled one from then on, so a test can land the cancellation between
+// Store.Size's entry guard and its shard scan deterministically.
+type cancelAfterCtx struct {
+	context.Context
+	live int
+}
+
+func (c *cancelAfterCtx) Err() error {
+	if c.live > 0 {
+		c.live--
+		return nil
+	}
+	return context.Canceled
 }
 
 // PruneBefore reports the total on-disk bytes it freed.


### PR DESCRIPTION
Closes #7683. Supersedes #7684 by @questfever, which spotted that `Store.Size` returned the local nil filesystem error instead of `ctx.Err()` when cancellation was observed mid-scan.

This carries that correction and adds an entry guard so an already-canceled context is rejected before any filesystem work, meaning an empty store also returns `context.Canceled` rather than a successful zero-byte result. Tests cover cancellation before the scan and during it.