### PR TITLE
fix!: apply fibre state transitions in proposal before pay-for-fibre  settlement

### DIFF
--- a/app/ante/nested_msg.go
+++ b/app/ante/nested_msg.go
@@ -12,10 +12,10 @@ import (
 var _ sdk.AnteDecorator = NestedMsgDecorator{}
 
 // NestedMsgDecorator rejects messages wrapped in a MsgExec or MsgSubmitProposal
-// that must not skip the ante handler: MsgPayForBlobs and MsgPayForFibre (which
-// would bypass checks like PFF signature verification). It also rejects a
-// MsgExec or MsgSubmitProposal wrapped in either container, so nesting can't be
-// used to smuggle those messages one level deeper.
+// that must not skip the ante handler: MsgPayForBlobs, MsgPayForFibre, and the
+// fibre escrow messages (which would otherwise bypass PFF signature verification
+// or the proposal-time settlement replay). It also rejects a nested MsgExec or
+// MsgSubmitProposal so those can't be smuggled one level deeper.
 type NestedMsgDecorator struct{}
 
 func NewNestedMsgDecorator() *NestedMsgDecorator {
@@ -54,6 +54,12 @@ func rejectWrapped(msgs []sdk.Msg, container string) error {
 			return sdkerrors.ErrNotSupported.Wrapf("MsgPayForBlobs inside %s is not supported", container)
 		case *fibretypes.MsgPayForFibre:
 			return sdkerrors.ErrNotSupported.Wrapf("MsgPayForFibre inside %s is not supported", container)
+		case *fibretypes.MsgPaymentPromiseTimeout:
+			return sdkerrors.ErrNotSupported.Wrapf("MsgPaymentPromiseTimeout inside %s is not supported", container)
+		case *fibretypes.MsgDepositToEscrow:
+			return sdkerrors.ErrNotSupported.Wrapf("MsgDepositToEscrow inside %s is not supported", container)
+		case *fibretypes.MsgRequestWithdrawal:
+			return sdkerrors.ErrNotSupported.Wrapf("MsgRequestWithdrawal inside %s is not supported", container)
 		case *authz.MsgExec:
 			return sdkerrors.ErrNotSupported.Wrapf("MsgExec inside %s is not supported", container)
 		case *govv1.MsgSubmitProposal:

--- a/app/ante/nested_msg_test.go
+++ b/app/ante/nested_msg_test.go
@@ -22,6 +22,9 @@ func TestNestedMsgDecorator(t *testing.T) {
 	nestedMsgExec := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&msgExec})
 	nestedMsgPayForBlobs := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&blobtypes.MsgPayForBlobs{}})
 	nestedMsgPayForFibre := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&fibretypes.MsgPayForFibre{}})
+	nestedMsgPaymentPromiseTimeout := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&fibretypes.MsgPaymentPromiseTimeout{}})
+	nestedMsgDepositToEscrow := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&fibretypes.MsgDepositToEscrow{}})
+	nestedMsgRequestWithdrawal := authz.NewMsgExec(sdk.AccAddress{}, []sdk.Msg{&fibretypes.MsgRequestWithdrawal{}})
 
 	proposalWithMsgSend := newMsgSubmitProposal(t, &banktypes.MsgSend{})
 	proposalWithMsgExec := newMsgSubmitProposal(t, &msgExec)
@@ -53,6 +56,21 @@ func TestNestedMsgDecorator(t *testing.T) {
 		{
 			name:    "Reject nestedMsgPayForFibre",
 			msg:     &nestedMsgPayForFibre,
+			wantErr: sdkerrors.ErrNotSupported,
+		},
+		{
+			name:    "Reject nestedMsgPaymentPromiseTimeout",
+			msg:     &nestedMsgPaymentPromiseTimeout,
+			wantErr: sdkerrors.ErrNotSupported,
+		},
+		{
+			name:    "Reject nestedMsgDepositToEscrow",
+			msg:     &nestedMsgDepositToEscrow,
+			wantErr: sdkerrors.ErrNotSupported,
+		},
+		{
+			name:    "Reject nestedMsgRequestWithdrawal",
+			msg:     &nestedMsgRequestWithdrawal,
 			wantErr: sdkerrors.ErrNotSupported,
 		},
 		{

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -190,3 +190,20 @@ func payForFibreMsg(tx sdk.Tx) (*fibretypes.MsgPayForFibre, bool) {
 	pff, ok := msgs[0].(*fibretypes.MsgPayForFibre)
 	return pff, ok
 }
+
+// containsFibreStateMsg reports whether the tx carries a fibre message that
+// mutates escrow / processed-payment state. These must be simulated during
+// proposal so later MsgPayForFibre settlement sees the same escrow balance it
+// would in FinalizeBlock. MsgPayForFibre is excluded: it is settled on its own
+// path.
+func containsFibreStateMsg(tx sdk.Tx) bool {
+	for _, msg := range tx.GetMsgs() {
+		switch msg.(type) {
+		case *fibretypes.MsgPaymentPromiseTimeout,
+			*fibretypes.MsgDepositToEscrow,
+			*fibretypes.MsgRequestWithdrawal:
+			return true
+		}
+	}
+	return false
+}

--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -192,16 +192,15 @@ func payForFibreMsg(tx sdk.Tx) (*fibretypes.MsgPayForFibre, bool) {
 }
 
 // containsFibreStateMsg reports whether the tx carries a fibre message that
-// mutates escrow / processed-payment state. These must be simulated during
-// proposal so later MsgPayForFibre settlement sees the same escrow balance it
-// would in FinalizeBlock. MsgPayForFibre is excluded: it is settled on its own
-// path.
+// lowers an escrow balance as soon as it executes, so proposal must replay it
+// before settling a later MsgPayForFibre. MsgPayForFibre (settled on its own
+// path) and MsgRequestWithdrawal (only locks funds, paid out later by the
+// BeginBlocker) are excluded.
 func containsFibreStateMsg(tx sdk.Tx) bool {
 	for _, msg := range tx.GetMsgs() {
 		switch msg.(type) {
 		case *fibretypes.MsgPaymentPromiseTimeout,
-			*fibretypes.MsgDepositToEscrow,
-			*fibretypes.MsgRequestWithdrawal:
+			*fibretypes.MsgDepositToEscrow:
 			return true
 		}
 	}

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -131,10 +131,9 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 			continue
 		}
 
-		// Apply fibre escrow effects (e.g. MsgPaymentPromiseTimeout debit) on the
-		// proposal branch so later pay-for-fibre settlement sees the same escrow
-		// balance it would in FinalizeBlock. On message failure the tx still stays
-		// in the block (it only pays gas), so keep it and leave escrow unchanged.
+		// Replay fibre escrow effects (e.g. a timeout debit) so later pay-for-fibre
+		// settlement sees the same balance it will in FinalizeBlock. A failed
+		// message keeps the tx (gas only), so ignore the error.
 		if containsFibreStateMsg(sdkTx) {
 			if err := executeTxMsgs(ctx, sdkTx, fsb.msgRouter); err != nil {
 				logger.Debug("fibre state msg did not settle in proposal; keeping tx", "tx", tmbytes.HexBytes(coretypes.Tx(tx).Hash()), "error", err)

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -131,6 +131,16 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 			continue
 		}
 
+		// Apply fibre escrow effects (e.g. MsgPaymentPromiseTimeout debit) on the
+		// proposal branch so later pay-for-fibre settlement sees the same escrow
+		// balance it would in FinalizeBlock. On message failure the tx still stays
+		// in the block (it only pays gas), so keep it and leave escrow unchanged.
+		if containsFibreStateMsg(sdkTx) {
+			if err := executeTxMsgs(ctx, sdkTx, fsb.msgRouter); err != nil {
+				logger.Debug("fibre state msg did not settle in proposal; keeping tx", "tx", tmbytes.HexBytes(coretypes.Tx(tx).Hash()), "error", err)
+			}
+		}
+
 		sdkMessageCount += len(sdkTx.GetMsgs())
 		normalTxs[n] = tx
 		n++

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -46,11 +46,10 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 		return nil, fmt.Errorf("failed to create FilteredSquareBuilder: %w", err)
 	}
 
-	// Apply the fibre BeginBlocker on the proposal branch before filling the
-	// square. FinalizeBlock runs it (paying out matured withdrawals, advancing
-	// the freshness floor) before any tx, so pay-for-fibre settlement in Fill
-	// must see the same escrow state or an underpaid promise could keep its
-	// system blob. The branch is discarded, so these writes never commit.
+	// Run the fibre BeginBlocker on the proposal branch, mirroring FinalizeBlock,
+	// which pays out matured withdrawals and advances the freshness floor before
+	// any tx. Pay-for-fibre settlement in Fill must see that escrow state. The
+	// branch is discarded, so nothing commits.
 	if err := app.FibreKeeper.BeginBlocker(ctx); err != nil {
 		return nil, fmt.Errorf("failed to run fibre begin blocker on proposal branch: %w", err)
 	}

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -46,6 +46,15 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 		return nil, fmt.Errorf("failed to create FilteredSquareBuilder: %w", err)
 	}
 
+	// Apply the fibre BeginBlocker on the proposal branch before filling the
+	// square. FinalizeBlock runs it (paying out matured withdrawals, advancing
+	// the freshness floor) before any tx, so pay-for-fibre settlement in Fill
+	// must see the same escrow state or an underpaid promise could keep its
+	// system blob. The branch is discarded, so these writes never commit.
+	if err := app.FibreKeeper.BeginBlocker(ctx); err != nil {
+		return nil, fmt.Errorf("failed to run fibre begin blocker on proposal branch: %w", err)
+	}
+
 	txs := fsb.Fill(ctx, req.Txs, req.MaxTxBytes)
 
 	// Build the square from the set of valid and prioritised transactions.

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -57,6 +57,16 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 	)
 	blockHeader := ctx.BlockHeader()
 
+	// Apply the fibre BeginBlocker on the proposal branch before validating txs.
+	// FinalizeBlock runs it (paying out matured withdrawals, advancing the
+	// freshness floor) before any tx, so pay-for-fibre settlement below must see
+	// the same escrow state or an underpaid promise could keep its system blob.
+	// The branch is discarded, so these writes never commit.
+	if err := app.FibreKeeper.BeginBlocker(ctx); err != nil {
+		logInvalidPropBlockError(app.Logger(), blockHeader, "failed to run fibre begin blocker on proposal branch", err)
+		return reject(), nil
+	}
+
 	var (
 		sdkMessageCount int
 		pfbMessageCount int
@@ -147,6 +157,14 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
 					logInvalidPropBlockError(app.Logger(), blockHeader, fmt.Sprintf("fibre settlement failed %d", idx), execErr)
 					return reject(), nil
+				}
+			} else if containsFibreStateMsg(sdkTx) {
+				// Apply fibre escrow effects (e.g. MsgPaymentPromiseTimeout debit)
+				// in block order so later settlement sees the FinalizeBlock balance.
+				// A failed message keeps the tx in the block (gas only), so do not
+				// reject on error.
+				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
+					app.Logger().Debug("fibre state msg did not settle in proposal; keeping tx", "idx", idx, "err", execErr)
 				}
 			}
 

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -57,11 +57,10 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 	)
 	blockHeader := ctx.BlockHeader()
 
-	// Apply the fibre BeginBlocker on the proposal branch before validating txs.
-	// FinalizeBlock runs it (paying out matured withdrawals, advancing the
-	// freshness floor) before any tx, so pay-for-fibre settlement below must see
-	// the same escrow state or an underpaid promise could keep its system blob.
-	// The branch is discarded, so these writes never commit.
+	// Run the fibre BeginBlocker on the proposal branch, mirroring FinalizeBlock,
+	// which pays out matured withdrawals and advances the freshness floor before
+	// any tx. Pay-for-fibre settlement below must see that escrow state. The
+	// branch is discarded, so nothing commits.
 	if err := app.FibreKeeper.BeginBlocker(ctx); err != nil {
 		logInvalidPropBlockError(app.Logger(), blockHeader, "failed to run fibre begin blocker on proposal branch", err)
 		return reject(), nil
@@ -159,10 +158,9 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 					return reject(), nil
 				}
 			} else if containsFibreStateMsg(sdkTx) {
-				// Apply fibre escrow effects (e.g. MsgPaymentPromiseTimeout debit)
-				// in block order so later settlement sees the FinalizeBlock balance.
-				// A failed message keeps the tx in the block (gas only), so do not
-				// reject on error.
+				// Replay fibre escrow effects in block order so later settlement
+				// sees the FinalizeBlock balance. A failed message keeps the tx
+				// (gas only), so don't reject.
 				if execErr := executeTxMsgs(ctx, sdkTx, app.MsgServiceRouter()); execErr != nil {
 					app.Logger().Debug("fibre state msg did not settle in proposal; keeping tx", "idx", idx, "err", execErr)
 				}

--- a/app/test/process_proposal_fibre_bench_test.go
+++ b/app/test/process_proposal_fibre_bench_test.go
@@ -100,7 +100,7 @@ func BenchmarkProcessProposalUnderLoad(b *testing.B) {
 func benchSendTxs(tb testing.TB, signer *user.Signer, account, fromAddr string, n int) [][]byte {
 	tb.Helper()
 	txs := make([][]byte, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		msg := &banktypes.MsgSend{
 			FromAddress: fromAddr,
 			ToAddress:   fromAddr,
@@ -138,7 +138,7 @@ func seedManyMaturedWithdrawals(tb testing.TB, testApp *app.App, owner sdk.AccAd
 	// available = requested + delay stays in the past so all mature this block.
 	base := time.Now().Add(-time.Duration(n) * time.Second).Add(-25 * time.Hour)
 	delay := fibretypes.DefaultWithdrawalDelay
-	for i := 0; i < n; i++ {
+	for i := range n {
 		requested := base.Add(time.Duration(i) * time.Second)
 		testApp.FibreKeeper.SetWithdrawal(ctx, fibretypes.Withdrawal{
 			Signer:             owner.String(),

--- a/app/test/process_proposal_fibre_bench_test.go
+++ b/app/test/process_proposal_fibre_bench_test.go
@@ -1,0 +1,150 @@
+package app_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/app"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
+	"github.com/celestiaorg/celestia-app/v10/pkg/user"
+	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testfactory"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/stretchr/testify/require"
+)
+
+// maturingWithdrawalCounts spans the common case (0) to a worst-case burst of
+// many withdrawals maturing in one block, isolating the BeginBlocker cost.
+var maturingWithdrawalCounts = []int{0, 100, 1000, 10000}
+
+// BenchmarkProcessProposalMaturingWithdrawals measures ProcessProposal on an
+// empty block while N withdrawals mature at block start. N=0 is the baseline,
+// where the added BeginBlocker only opens empty iterators.
+func BenchmarkProcessProposalMaturingWithdrawals(b *testing.B) {
+	for _, n := range maturingWithdrawalCounts {
+		b.Run(fmt.Sprintf("withdrawals=%d", n), func(b *testing.B) {
+			accounts := testfactory.GenerateAccounts(1)
+			testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+			seedManyMaturedWithdrawals(b, testApp, testfactory.GetAddress(kr, accounts[0]), n)
+			req := processProposalRequest(b, testApp, [][]byte{})
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resp, err := testApp.ProcessProposal(req)
+				require.NoError(b, err)
+				require.Equal(b, abci.ResponseProcessProposal_ACCEPT, resp.Status)
+			}
+		})
+	}
+}
+
+// BenchmarkPrepareProposalMaturingWithdrawals is the proposer-side counterpart.
+func BenchmarkPrepareProposalMaturingWithdrawals(b *testing.B) {
+	for _, n := range maturingWithdrawalCounts {
+		b.Run(fmt.Sprintf("withdrawals=%d", n), func(b *testing.B) {
+			accounts := testfactory.GenerateAccounts(1)
+			testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+			seedManyMaturedWithdrawals(b, testApp, testfactory.GetAddress(kr, accounts[0]), n)
+			height := testApp.LastBlockHeight() + 1
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, err := testApp.PrepareProposal(&abci.RequestPrepareProposal{
+					Txs:    [][]byte{},
+					Height: height,
+					Time:   time.Now(),
+				})
+				require.NoError(b, err)
+			}
+		})
+	}
+}
+
+// BenchmarkProcessProposalUnderLoad measures ProcessProposal on a full 512-tx
+// block, showing the added BeginBlocker cost as a fraction of a busy block.
+func BenchmarkProcessProposalUnderLoad(b *testing.B) {
+	const blockTxs = 512
+	for _, n := range []int{0, 50, 200} {
+		b.Run(fmt.Sprintf("txs=%d/withdrawals=%d", blockTxs, n), func(b *testing.B) {
+			enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+			accounts := testfactory.GenerateAccounts(1)
+			testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+			infos := queryAccountInfo(testApp, accounts, kr)
+			signer, err := user.NewSigner(kr, enc.TxConfig, testutil.ChainID, user.NewAccount(accounts[0], infos[0].AccountNum, infos[0].Sequence))
+			require.NoError(b, err)
+
+			seedManyMaturedWithdrawals(b, testApp, testfactory.GetAddress(kr, accounts[0]), n)
+			txs := benchSendTxs(b, signer, accounts[0], testfactory.GetAddress(kr, accounts[0]).String(), blockTxs)
+			req := processProposalRequest(b, testApp, txs)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				resp, err := testApp.ProcessProposal(req)
+				require.NoError(b, err)
+				require.Equal(b, abci.ResponseProcessProposal_ACCEPT, resp.Status)
+			}
+		})
+	}
+}
+
+// benchSendTxs builds n sequential self-transfer MsgSend txs from the account.
+func benchSendTxs(tb testing.TB, signer *user.Signer, account, fromAddr string, n int) [][]byte {
+	tb.Helper()
+	txs := make([][]byte, n)
+	for i := 0; i < n; i++ {
+		msg := &banktypes.MsgSend{
+			FromAddress: fromAddr,
+			ToAddress:   fromAddr,
+			Amount:      sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 1)),
+		}
+		txBytes, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimit(100_000), user.SetFee(10_000))
+		require.NoError(tb, err)
+		txs[i] = txBytes
+		require.NoError(tb, signer.IncrementSequence(account))
+	}
+	return txs
+}
+
+// seedManyMaturedWithdrawals seeds n already-available withdrawals of 1 utia
+// each on the owner's escrow, funding the module so the next BeginBlocker can
+// pay them all out.
+func seedManyMaturedWithdrawals(tb testing.TB, testApp *app.App, owner sdk.AccAddress, n int) {
+	tb.Helper()
+	if n == 0 {
+		return
+	}
+	ctx := testApp.NewUncachedContext(false, cmtproto.Header{
+		ChainID: testutil.ChainID,
+		Height:  testApp.LastBlockHeight(),
+		Time:    time.Now(),
+	})
+	total := sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, int64(n)))
+	require.NoError(tb, testApp.BankKeeper.SendCoinsFromAccountToModule(ctx, owner, fibretypes.ModuleName, total))
+	testApp.FibreKeeper.SetEscrowAccount(ctx, fibretypes.EscrowAccount{
+		Signer:           owner.String(),
+		Balance:          total[0],
+		AvailableBalance: sdk.NewInt64Coin(appconsts.BondDenom, 0),
+	})
+	// Distinct requested timestamps (1s apart) keep the withdrawal keys unique;
+	// available = requested + delay stays in the past so all mature this block.
+	base := time.Now().Add(-time.Duration(n) * time.Second).Add(-25 * time.Hour)
+	delay := fibretypes.DefaultWithdrawalDelay
+	for i := 0; i < n; i++ {
+		requested := base.Add(time.Duration(i) * time.Second)
+		testApp.FibreKeeper.SetWithdrawal(ctx, fibretypes.Withdrawal{
+			Signer:             owner.String(),
+			Amount:             sdk.NewInt64Coin(appconsts.BondDenom, 1),
+			RequestedTimestamp: requested,
+			AvailableTimestamp: requested.Add(delay),
+		})
+	}
+}

--- a/app/test/process_proposal_fibre_ordering_test.go
+++ b/app/test/process_proposal_fibre_ordering_test.go
@@ -1,0 +1,126 @@
+package app_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/app"
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/fibre"
+	"github.com/celestiaorg/celestia-app/v10/pkg/user"
+	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
+	"github.com/celestiaorg/celestia-app/v10/test/util/testfactory"
+	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/celestiaorg/go-square/v4/share"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessProposalTimeoutThenPayForFibre guards against an underpaid
+// pay-for-fibre: a MsgPaymentPromiseTimeout ordered before a MsgPayForFibre on
+// the same escrow debits it in FinalizeBlock, so the pay-for-fibre must not be
+// accepted (and keep its system blob) unless the escrow still covers it after
+// the timeout. ProcessProposal simulates the timeout's escrow debit before
+// settling the pay-for-fibre, so it rejects the block the same way.
+func TestProcessProposalTimeoutThenPayForFibre(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(3)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	infos := queryAccountInfo(testApp, accounts, kr)
+	newSigner := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)
+
+	// Every factory promise has BlobSize=100 and costs one payment.
+	payment := fibretypes.PaymentAmount(100).Amount.Int64()
+
+	// accounts[0]: exactly one payment -> the timeout drains it, so the
+	// pay-for-fibre can no longer settle and the block must be rejected.
+	// accounts[1]: two payments -> the timeout and the pay-for-fibre both settle.
+	// accounts[2]: one payment, pay-for-fibre alone -> accepted (control).
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[0]), payment)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[1]), 2*payment)
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[2]), payment)
+
+	// Default params: WithdrawalDelay=24h, PaymentPromiseTimeout=1h. A creation
+	// timestamp 2h in the past is both fresh (after now-24h) and expired (before
+	// now-1h), so the timeout path accepts it.
+	timeoutCreation := time.Now().Add(-2 * time.Hour)
+
+	sig0 := newSigner(0)
+	timeout0 := newSignedPaymentPromiseTimeoutTx(t, sig0, accounts[0], timeoutCreation)
+	require.NoError(t, sig0.IncrementSequence(accounts[0]))
+	pff0 := newSignedPayForFibreTxAt(t, sig0, accounts[0], true, time.Now(), user.SetGasLimit(1_000_000), user.SetFee(4_000))
+
+	sig1 := newSigner(1)
+	timeout1 := newSignedPaymentPromiseTimeoutTx(t, sig1, accounts[1], timeoutCreation)
+	require.NoError(t, sig1.IncrementSequence(accounts[1]))
+	pff1 := newSignedPayForFibreTxAt(t, sig1, accounts[1], true, time.Now(), user.SetGasLimit(1_000_000), user.SetFee(4_000))
+
+	pff2 := newSignedPayForFibreTx(t, newSigner(2), accounts[2], true)
+
+	tests := []struct {
+		name           string
+		txs            [][]byte
+		expectedStatus abci.ResponseProcessProposal_ProposalStatus
+	}{
+		{
+			name:           "reject: timeout drains escrow below the pay-for-fibre charge",
+			txs:            [][]byte{timeout0, pff0},
+			expectedStatus: abci.ResponseProcessProposal_REJECT,
+		},
+		{
+			name:           "accept: escrow covers both the timeout and the pay-for-fibre",
+			txs:            [][]byte{timeout1, pff1},
+			expectedStatus: abci.ResponseProcessProposal_ACCEPT,
+		},
+		{
+			name:           "accept: pay-for-fibre alone fits the escrow",
+			txs:            [][]byte{pff2},
+			expectedStatus: abci.ResponseProcessProposal_ACCEPT,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, tc.txs))
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedStatus, resp.Status)
+		})
+	}
+}
+
+// newSignedPaymentPromiseTimeoutTx builds a signed MsgPaymentPromiseTimeout tx
+// for an expired, owner-signed promise on the account's escrow.
+func newSignedPaymentPromiseTimeoutTx(t *testing.T, signer *user.Signer, account string, creation time.Time) []byte {
+	t.Helper()
+	ownerPub := signer.Account(account).PubKey().(*secp256k1.PubKey)
+	promise := fibretypes.PaymentPromise{
+		ChainId:           testutil.ChainID,
+		Height:            1,
+		Namespace:         share.MustNewV0Namespace(bytes.Repeat([]byte{0x2}, share.NamespaceVersionZeroIDSize)).Bytes(),
+		BlobSize:          100,
+		BlobVersion:       0,
+		Commitment:        make([]byte, 32),
+		CreationTimestamp: creation.Truncate(time.Second),
+		SignerPublicKey:   *ownerPub,
+		Signature:         make([]byte, 64),
+	}
+
+	pp := fibre.PaymentPromise{}
+	require.NoError(t, pp.FromProto(&promise))
+	signBytes, err := pp.SignBytes()
+	require.NoError(t, err)
+	promise.Signature, _, err = signer.Keyring().Sign(account, signBytes, signing.SignMode_SIGN_MODE_DIRECT)
+	require.NoError(t, err)
+
+	msg := &fibretypes.MsgPaymentPromiseTimeout{
+		Signer:         sdk.AccAddress(ownerPub.Address()).String(),
+		PaymentPromise: promise,
+	}
+	txBytes, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimit(1_000_000), user.SetFee(4_000))
+	require.NoError(t, err)
+	return txBytes
+}

--- a/app/test/process_proposal_fibre_ordering_test.go
+++ b/app/test/process_proposal_fibre_ordering_test.go
@@ -8,12 +8,14 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/app"
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
 	"github.com/celestiaorg/celestia-app/v10/fibre"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	"github.com/celestiaorg/celestia-app/v10/pkg/user"
 	testutil "github.com/celestiaorg/celestia-app/v10/test/util"
 	"github.com/celestiaorg/celestia-app/v10/test/util/testfactory"
 	fibretypes "github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"github.com/celestiaorg/go-square/v4/share"
 	abci "github.com/cometbft/cometbft/abci/types"
+	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
@@ -21,11 +23,9 @@ import (
 )
 
 // TestProcessProposalTimeoutThenPayForFibre guards against an underpaid
-// pay-for-fibre: a MsgPaymentPromiseTimeout ordered before a MsgPayForFibre on
-// the same escrow debits it in FinalizeBlock, so the pay-for-fibre must not be
-// accepted (and keep its system blob) unless the escrow still covers it after
-// the timeout. ProcessProposal simulates the timeout's escrow debit before
-// settling the pay-for-fibre, so it rejects the block the same way.
+// pay-for-fibre: a timeout ordered before it debits the same escrow in
+// FinalizeBlock. ProcessProposal replays that debit, so it rejects the block
+// unless the escrow still covers the pay-for-fibre.
 func TestProcessProposalTimeoutThenPayForFibre(t *testing.T) {
 	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	accounts := testfactory.GenerateAccounts(3)
@@ -123,4 +123,125 @@ func newSignedPaymentPromiseTimeoutTx(t *testing.T, signer *user.Signer, account
 	txBytes, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimit(1_000_000), user.SetFee(4_000))
 	require.NoError(t, err)
 	return txBytes
+}
+
+// TestPrepareProposalTimeoutThenPayForFibre checks that the proposer drops a
+// pay-for-fibre a preceding timeout makes unpayable, so its system blob never
+// reaches the square.
+func TestPrepareProposalTimeoutThenPayForFibre(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(2)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	infos := queryAccountInfo(testApp, accounts, kr)
+	newSigner := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)
+
+	payment := fibretypes.PaymentAmount(100).Amount.Int64()
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[0]), payment)   // one payment
+	seedFibreEscrow(t, testApp, testfactory.GetAddress(kr, accounts[1]), 2*payment) // two payments
+
+	timeoutCreation := time.Now().Add(-2 * time.Hour)
+
+	sig0 := newSigner(0)
+	timeout0 := newSignedPaymentPromiseTimeoutTx(t, sig0, accounts[0], timeoutCreation)
+	require.NoError(t, sig0.IncrementSequence(accounts[0]))
+	pff0 := newSignedPayForFibreTxAt(t, sig0, accounts[0], true, time.Now(), user.SetGasLimit(1_000_000), user.SetFee(4_000))
+
+	sig1 := newSigner(1)
+	timeout1 := newSignedPaymentPromiseTimeoutTx(t, sig1, accounts[1], timeoutCreation)
+	require.NoError(t, sig1.IncrementSequence(accounts[1]))
+	pff1 := newSignedPayForFibreTxAt(t, sig1, accounts[1], true, time.Now(), user.SetGasLimit(1_000_000), user.SetFee(4_000))
+
+	t.Run("drops the pay-for-fibre the timeout makes unpayable", func(t *testing.T) {
+		resp, err := testApp.PrepareProposal(&abci.RequestPrepareProposal{
+			Txs:    [][]byte{timeout0, pff0},
+			Height: testApp.LastBlockHeight() + 1,
+			Time:   time.Now(),
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.Txs, timeout0, "the timeout tx should be kept")
+		require.NotContains(t, resp.Txs, pff0, "the unpayable pay-for-fibre must be dropped")
+	})
+
+	t.Run("keeps both when the escrow covers them", func(t *testing.T) {
+		resp, err := testApp.PrepareProposal(&abci.RequestPrepareProposal{
+			Txs:    [][]byte{timeout1, pff1},
+			Height: testApp.LastBlockHeight() + 1,
+			Time:   time.Now(),
+		})
+		require.NoError(t, err)
+		require.Contains(t, resp.Txs, timeout1)
+		require.Contains(t, resp.Txs, pff1)
+	})
+}
+
+// TestProcessProposalMaturingWithdrawalThenPayForFibre guards PROTOCO-2429: a
+// withdrawal paid out by the BeginBlocker debits escrow before any tx, so a
+// pay-for-fibre it leaves underfunded must be rejected.
+func TestProcessProposalMaturingWithdrawalThenPayForFibre(t *testing.T) {
+	enc := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := testfactory.GenerateAccounts(2)
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	infos := queryAccountInfo(testApp, accounts, kr)
+	newSigner := newSignerFactory(t, kr, enc.TxConfig, accounts, infos)
+
+	payment := fibretypes.PaymentAmount(100).Amount.Int64()
+	// accounts[0]: one payment, all locked in a matured withdrawal -> the payout
+	// drains the escrow and the pay-for-fibre can no longer settle.
+	// accounts[1]: two payments, one locked -> one payment survives the payout so
+	// the pay-for-fibre still settles.
+	seedMaturedWithdrawal(t, testApp, testfactory.GetAddress(kr, accounts[0]), payment, payment)
+	seedMaturedWithdrawal(t, testApp, testfactory.GetAddress(kr, accounts[1]), 2*payment, payment)
+
+	pff0 := newSignedPayForFibreTx(t, newSigner(0), accounts[0], true)
+	pff1 := newSignedPayForFibreTx(t, newSigner(1), accounts[1], true)
+
+	tests := []struct {
+		name           string
+		txs            [][]byte
+		expectedStatus abci.ResponseProcessProposal_ProposalStatus
+	}{
+		{
+			name:           "reject: matured withdrawal drains escrow below the charge",
+			txs:            [][]byte{pff0},
+			expectedStatus: abci.ResponseProcessProposal_REJECT,
+		},
+		{
+			name:           "accept: escrow still covers the charge after the payout",
+			txs:            [][]byte{pff1},
+			expectedStatus: abci.ResponseProcessProposal_ACCEPT,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := testApp.ProcessProposal(processProposalRequest(t, testApp, tc.txs))
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedStatus, resp.Status)
+		})
+	}
+}
+
+// seedMaturedWithdrawal seeds an escrow holding balance coins with amount of
+// them locked in a withdrawal that is already available, so the next
+// BeginBlocker pays it out and lowers the balance by amount.
+func seedMaturedWithdrawal(t *testing.T, testApp *app.App, owner sdk.AccAddress, balance, amount int64) {
+	t.Helper()
+	ctx := testApp.NewUncachedContext(false, cmtproto.Header{
+		ChainID: testutil.ChainID,
+		Height:  testApp.LastBlockHeight(),
+		Time:    time.Now(),
+	})
+	coins := sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, balance))
+	require.NoError(t, testApp.BankKeeper.SendCoinsFromAccountToModule(ctx, owner, fibretypes.ModuleName, coins))
+	testApp.FibreKeeper.SetEscrowAccount(ctx, fibretypes.EscrowAccount{
+		Signer:           owner.String(),
+		Balance:          sdk.NewInt64Coin(appconsts.BondDenom, balance),
+		AvailableBalance: sdk.NewInt64Coin(appconsts.BondDenom, balance-amount),
+	})
+	testApp.FibreKeeper.SetWithdrawal(ctx, fibretypes.Withdrawal{
+		Signer:             owner.String(),
+		Amount:             sdk.NewInt64Coin(appconsts.BondDenom, amount),
+		RequestedTimestamp: time.Now().Add(-48 * time.Hour),
+		AvailableTimestamp: time.Now().Add(-24 * time.Hour),
+	})
 }

--- a/app/test/process_proposal_fibre_test.go
+++ b/app/test/process_proposal_fibre_test.go
@@ -516,7 +516,7 @@ func TestProcessProposalChargesTxSizeGas(t *testing.T) {
 }
 
 // processProposalRequest builds a valid ProcessProposal request for the txs.
-func processProposalRequest(t *testing.T, testApp *app.App, txs [][]byte) *abci.RequestProcessProposal {
+func processProposalRequest(t testing.TB, testApp *app.App, txs [][]byte) *abci.RequestProcessProposal {
 	t.Helper()
 	classifiedTxs, err := fibretypes.ClassifyTxs(txs)
 	require.NoError(t, err)

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -325,7 +325,7 @@ func TestProcessProposal(t *testing.T) {
 	}
 }
 
-func calculateNewDataHash(t *testing.T, txs [][]byte) []byte {
+func calculateNewDataHash(t testing.TB, txs [][]byte) []byte {
 	classifiedTxs, err := fibretypes.ClassifyTxs(txs)
 	require.NoError(t, err)
 	dataSquare, err := square.Construct(classifiedTxs, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)


### PR DESCRIPTION
Resolves [PROTOCO-2419](https://linear.app/celestia/issue/PROTOCO-2419/omitted-timeout-settlement-allows-underpaid-fibre-publication)

Also fixes https://linear.app/celestia/issue/PROTOCO-2429/proposal-settlement-omits-maturing-fibre-withdrawals

Before settling pay-for-fibre txs during proposal, run the fibre BeginBlocker and execute the escrow-changing fibre messages of preceding normal txs, in block order. This way settlement sees the exact escrow balance it will see in FinalizeBlock, and an unpayable promise is dropped instead of leaving an unpaid blob behind. These simulated writes are applied only to the throwaway proposal state, so nothing is committed twice.