### PR TITLE
docs: add AI context-efficiency guideline and context-gatherer agent

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -19,7 +19,7 @@ When in doubt, treat as the higher tier. Light tier: skip Phase 1 and Phase 3 en
 
 ## Phase 1 — Align (risky only, hard gate)
 
-1. Explore the code involved. Answer every question the codebase can answer before asking the engineer.
+1. Explore the code involved — delegate token-heavy exploration to read-only sub-agents that return conclusions, not transcripts. Answer every question the codebase can answer before asking the engineer.
 2. Interview the engineer about every unclear or under-defined aspect. Give a recommended answer for each question.
 3. Write an assumptions note to `docs/plans/<task>.md`: goal, stated assumptions, invariants in play (by INV number), design decisions, open questions, and an implementation plan (ordered steps, files to touch, tests to add — as short as the task allows). Never commit this file.
 4. Present the note and wait for explicit confirmation. Do not write code before the engineer confirms.
@@ -32,7 +32,12 @@ When in doubt, treat as the higher tier. Light tier: skip Phase 1 and Phase 3 en
 
 ## Phase 3 — Review loop
 
-1. Get the full diff (`git diff` plus untracked files) and spawn these agents from `.claude/agents/` in parallel on it: `determinism-reviewer`, `adversarial-input-reviewer`, `consensus-reviewer`, `compat-reviewer`, `simplicity-reviewer`. Give each the diff and the path to the assumptions note if one exists.
+Model guideline — cheap models gather, frontier models think:
+
+- Gathering (`context-gatherer`, Phase 1 exploration) runs on a cheap model: Claude `sonnet` (pinned via `model:` in `.claude/agents/`); Codex low reasoning effort; any other LLM a mid-tier model.
+- Judgment (all reviewers and `finding-verifier`) is thinking: spawn these on the orchestrator's frontier model (no override). Deciding whether a finding is real never runs on a cheap model.
+
+1. Get the full diff (`git diff` plus untracked files). Spawn `context-gatherer` on it to build the evidence package, then spawn these agents from `.claude/agents/` in parallel: `determinism-reviewer`, `adversarial-input-reviewer`, `consensus-reviewer`, `compat-reviewer`, `simplicity-reviewer`. Give each the diff, the evidence package, and the path to the assumptions note if one exists.
 2. Consensus-critical tier: also spawn `adversarial-reviewer` in the first round. In later rounds, re-run it only on state transitions whose code changed during fixes. The engineer can request it for any change or skip it for a provably trivial one; record a skip in the report.
 3. For every finding, spawn a `finding-verifier` agent to try to refute it. Discard refuted findings. Escalate unproven findings to the engineer — never fix them on your own.
 4. Fix all confirmed findings, then run the reviewers again.

--- a/.claude/agents/context-gatherer.md
+++ b/.claude/agents/context-gatherer.md
@@ -1,0 +1,20 @@
+---
+name: context-gatherer
+description: Gathers the code context reviewers need to judge a diff - surrounding code, ABCI reachability, callers and callees, input origins. Makes no judgments. Use before spawning reviewers in the /implement review loop.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Context gatherer
+
+You gather information about a celestia-app diff so that reviewer agents can judge it. You make no judgments yourself: no findings, no verdicts, no opinions on whether code is safe. Facts only, over-inclusive.
+
+For each changed function or code path in the diff:
+
+- Quote the changed code with enough surrounding context to read it standalone.
+- State whether it is reachable from ABCI (`PrepareProposal`, `ProcessProposal`, `FinalizeBlock`, `BeginBlocker`/`EndBlocker`, upgrades, migrations) and via which call path.
+- List its direct callers and the callees it delegates to, with file:line.
+- Identify values that originate from a transaction, message, or proposed block, and where, if anywhere, each is validated.
+- Note anything a reviewer would otherwise have to search for: related helpers, protocol bounds and constants in play, existing tests covering the code.
+
+Output: one section per changed function or path with the facts above, each backed by file:line. Do not flag, rank, or interpret — the reviewers decide what matters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,9 @@ Every code change must respect the invariants in [docs/ai/invariants.md](docs/ai
 - **Interactive gate**: before implementing or reviewing any change, triage the tier, then ask the engineer whether to run the invariant workflow (the `/implement` skill, or the reviewer agents in `.claude/agents/` for a review). Give a 2–3 line overview — tier, paths touched, what the workflow would add — and a recommendation: run it for risky and consensus-critical changes, skip it for light ones. Skip the question when the engineer invoked `/implement` directly. In non-interactive runs, follow the recommendation.
 - **Declined workflow on a risky change**: still state assumptions and get engineer confirmation before writing code; no reviewer agents unless the engineer asks.
 - **Assumptions notes** live in `docs/plans/` and are never committed.
+- **Cheap models gather, frontier models think**: codebase exploration, log digging, and web research go to sub-agents on cheap models, which report conclusions — not transcripts — back to the frontier model; the frontier model orchestrates and keeps design, hard debugging, synthesis, and judgment calls (details in `.agents/skills/implement/SKILL.md`).
+- **Persist findings to files**: on long tasks, write durable findings into the `docs/plans/` note as they are established instead of relying on chat history.
+- **Context hygiene**: per-developer guidance in [docs/ai/context.md](docs/ai/context.md).
 
 ## Simplicity Rules
 

--- a/docs/ai/context.md
+++ b/docs/ai/context.md
@@ -1,0 +1,19 @@
+# AI Context Efficiency
+
+Per-developer guidance for keeping AI tool context lean in this repo. Repo-level rules are in [AGENTS.md](../../AGENTS.md).
+
+## What loads into every session
+
+- `AGENTS.md` and its import `docs/ai/invariants.md` load into the main loop and into every spawned sub-agent. Anything added there is paid once per agent. Keep additions short; link to other docs instead of `@`-importing them.
+- Periodically audit what loads at session start — connectors, global skills, memory files — and remove what your current work does not need.
+
+## Tool configuration
+
+- With 10 or more connectors enabled, switch tool access from Auto to On demand. Tool definitions are context paid on every turn.
+- Disable global skills that are irrelevant to this repo. Always-included skills pollute every session.
+
+## Model choice
+
+- One rule: cheap models explore and gather; frontier models think and orchestrate. Token-heavy research — codebase exploration, log digging, web searches — goes to sub-agents on a cheap model that report conclusions back.
+- Keep the frontier model for orchestration, design, hard debugging, final synthesis, and judgment — including review: reviewer agents run on the frontier model, fed by the cheap `context-gatherer` (see `.agents/skills/implement/SKILL.md`).
+- Store durable context in files (`docs/plans/` notes, memory) instead of long chat history.


### PR DESCRIPTION
[Attempt to improve token usage in the AI workflow defined in this repo]
Encodes the model-usage guideline for AI agents: cheap models explore and gather, frontier models think and orchestrate.

- `AGENTS.md`: AI Workflow gains delegation and context rules — sub-agents gather and report conclusions back to the frontier model; durable findings persist to the `docs/plans/` note instead of chat history.
- `docs/ai/context.md` (new): per-developer context hygiene — connector tool access, global skills, model choice.
- `.claude/agents/context-gatherer.md` (new): sonnet-pinned agent that assembles the evidence package for reviewers (code context, ABCI reachability, callers/callees, input origins). Facts only, no judgments.
- `/implement` skill: Phase 1 delegates exploration to read-only sub-agents; Phase 3 spawns `context-gatherer` first and states the model guideline — gathering on cheap models, judgment (reviewers, `finding-verifier`) on the orchestrator's frontier model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)