### PR TITLE
refactor: simplify getTxPriority to a single utia fee amount

### DIFF
--- a/app/ante/fee.go
+++ b/app/ante/fee.go
@@ -73,7 +73,7 @@ func ValidateTxFee(ctx sdk.Context, tx sdk.Tx, minfeeKeeper *minfeekeeper.Keeper
 		return nil, 0, err
 	}
 
-	priority := getTxPriority(fee, int64(gas))
+	priority := getTxPriority(fee, gas)
 
 	// Track actual gas price paid by users for congestion monitoring
 	gasPriceFloat := float64(fee.Int64()) / float64(gas)
@@ -113,13 +113,13 @@ func trimTrailingZeros(d math.LegacyDec) string {
 }
 
 // getTxPriority returns a naive tx priority based on the utia gas price of the
-// transaction. It returns zero if gas is not positive or the priority does not
-// fit in an int64.
-func getTxPriority(fee math.Int, gas int64) int64 {
-	if gas <= 0 {
+// transaction. It returns zero if gas is zero or the priority does not fit in
+// an int64.
+func getTxPriority(fee math.Int, gas uint64) int64 {
+	if gas == 0 {
 		return 0
 	}
-	priority := fee.Mul(math.NewInt(priorityScalingFactor)).QuoRaw(gas)
+	priority := fee.Mul(math.NewInt(priorityScalingFactor)).Quo(math.NewIntFromUint64(gas))
 	if !priority.IsInt64() {
 		return 0
 	}

--- a/app/ante/fee.go
+++ b/app/ante/fee.go
@@ -73,7 +73,7 @@ func ValidateTxFee(ctx sdk.Context, tx sdk.Tx, minfeeKeeper *minfeekeeper.Keeper
 		return nil, 0, err
 	}
 
-	priority := getTxPriority(feeTx.GetFee(), int64(gas))
+	priority := getTxPriority(fee, int64(gas))
 
 	// Track actual gas price paid by users for congestion monitoring
 	gasPriceFloat := float64(fee.Int64()) / float64(gas)
@@ -112,21 +112,16 @@ func trimTrailingZeros(d math.LegacyDec) string {
 	return s
 }
 
-// getTxPriority returns a naive tx priority based on the amount of the smallest denomination of the gas price
-// provided in a transaction.
-// NOTE: This implementation should not be used for txs with multiple coins.
-func getTxPriority(fee sdk.Coins, gas int64) int64 {
-	var priority int64
-	for _, c := range fee {
-		p := c.Amount.Mul(math.NewInt(priorityScalingFactor)).QuoRaw(gas)
-		if !p.IsInt64() {
-			continue
-		}
-		// take the lowest priority as the tx priority
-		if priority == 0 || p.Int64() < priority {
-			priority = p.Int64()
-		}
+// getTxPriority returns a naive tx priority based on the utia gas price of the
+// transaction. It returns zero if gas is not positive or the priority does not
+// fit in an int64.
+func getTxPriority(fee math.Int, gas int64) int64 {
+	if gas <= 0 {
+		return 0
 	}
-
-	return priority
+	priority := fee.Mul(math.NewInt(priorityScalingFactor)).QuoRaw(gas)
+	if !priority.IsInt64() {
+		return 0
+	}
+	return priority.Int64()
 }

--- a/app/ante/get_tx_priority_test.go
+++ b/app/ante/get_tx_priority_test.go
@@ -3,54 +3,70 @@ package ante
 import (
 	"testing"
 
-	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
-	sdk "github.com/cosmos/cosmos-sdk/types"
+	"cosmossdk.io/math"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetTxPriority(t *testing.T) {
 	cases := []struct {
 		name        string
-		fee         sdk.Coins
+		fee         math.Int
 		gas         int64
 		expectedPri int64
 	}{
 		{
 			name:        "1 TIA fee large gas",
-			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 1_000_000)),
+			fee:         math.NewInt(1_000_000),
 			gas:         1000000,
 			expectedPri: 1000000,
 		},
 		{
 			name:        "1 utia fee small gas",
-			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 1)),
+			fee:         math.NewInt(1),
 			gas:         1,
 			expectedPri: 1000000,
 		},
 		{
 			name:        "2 utia fee small gas",
-			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 2)),
+			fee:         math.NewInt(2),
 			gas:         1,
 			expectedPri: 2000000,
 		},
 		{
 			name:        "1_000_000 TIA fee normal gas tx",
-			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 1_000_000_000_000)),
+			fee:         math.NewInt(1_000_000_000_000),
 			gas:         75000,
 			expectedPri: 13333333333333,
 		},
 		{
 			name:        "0.001 utia gas price",
-			fee:         sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 1_000)),
+			fee:         math.NewInt(1_000),
 			gas:         1_000_000,
 			expectedPri: 1000,
+		},
+		{
+			name:        "zero fee",
+			fee:         math.ZeroInt(),
+			gas:         1_000_000,
+			expectedPri: 0,
+		},
+		{
+			name:        "zero gas returns zero priority instead of dividing by zero",
+			fee:         math.NewInt(1_000),
+			gas:         0,
+			expectedPri: 0,
+		},
+		{
+			name:        "priority that overflows int64 returns zero priority",
+			fee:         math.NewIntFromUint64(1 << 63),
+			gas:         1,
+			expectedPri: 0,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			pri := getTxPriority(tc.fee, tc.gas)
-			assert.Equal(t, tc.expectedPri, pri)
+			assert.Equal(t, tc.expectedPri, getTxPriority(tc.fee, tc.gas))
 		})
 	}
 }

--- a/app/ante/get_tx_priority_test.go
+++ b/app/ante/get_tx_priority_test.go
@@ -11,7 +11,7 @@ func TestGetTxPriority(t *testing.T) {
 	cases := []struct {
 		name        string
 		fee         math.Int
-		gas         int64
+		gas         uint64
 		expectedPri int64
 	}{
 		{
@@ -55,6 +55,12 @@ func TestGetTxPriority(t *testing.T) {
 			fee:         math.NewInt(1_000),
 			gas:         0,
 			expectedPri: 0,
+		},
+		{
+			name:        "gas limit above the max int64 is not narrowed to a negative value",
+			fee:         math.NewIntFromUint64(1 << 63),
+			gas:         1 << 63,
+			expectedPri: 1_000_000,
 		},
 		{
 			name:        "priority that overflows int64 returns zero priority",


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/7736
Closes [PROTOCO-2495](https://linear.app/celestia/issue/PROTOCO-2495)

Fees are single-denom (`utia`) since #7734, so the multi-coin loop and lowest-priority selection in `getTxPriority` were unreachable. It now takes the `utia` amount `ValidateTxFee` already computed, and keeps the gas limit unsigned so a limit above the max int64 is not narrowed to a negative divisor.

Also guards against a zero gas divisor, which would panic in the old code.

Not consensus-breaking: tx priority only affects mempool ordering.