### PR TITLE
fix!: count ICA messages in MsgRecvPacket against the block message limit

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -55,7 +55,12 @@ func (app *App) CheckTx(req *abci.RequestCheckTx) (*abci.ResponseCheckTx, error)
 		}
 	}
 
-	if msgCount := countExecutableMsgs(sdkTx.GetMsgs()); msgCount > appconsts.MaxSDKMessages {
+	checkTxCtx, ok := app.CheckState()
+	if !ok {
+		err := fmt.Errorf("checkState not set")
+		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
+	}
+	if msgCount := countExecutableMsgs(checkTxCtx, app.IBCKeeper.ChannelKeeper, sdkTx.GetMsgs()); msgCount > appconsts.MaxSDKMessages {
 		err := errors.Wrapf(apperr.ErrTxExceedsMaxSDKMessages, "tx contains %d messages, limit is %d", msgCount, appconsts.MaxSDKMessages)
 		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), nil
 	}

--- a/app/filtered_square_builder.go
+++ b/app/filtered_square_builder.go
@@ -20,6 +20,7 @@ type FilteredSquareBuilder struct {
 	handler   sdk.AnteHandler
 	msgRouter baseapp.MessageRouter
 	txConfig  client.TxConfig
+	chanKeep  channelKeeper
 	builder   *square.Builder
 }
 
@@ -27,6 +28,7 @@ func NewFilteredSquareBuilder(
 	handler sdk.AnteHandler,
 	msgRouter baseapp.MessageRouter,
 	txConfig client.TxConfig,
+	chanKeep channelKeeper,
 	maxSquareSize,
 	subtreeRootThreshold int,
 ) (*FilteredSquareBuilder, error) {
@@ -38,6 +40,7 @@ func NewFilteredSquareBuilder(
 		handler:   handler,
 		msgRouter: msgRouter,
 		txConfig:  txConfig,
+		chanKeep:  chanKeep,
 		builder:   builder,
 	}, nil
 }
@@ -102,7 +105,7 @@ func (fsb *FilteredSquareBuilder) Fill(ctx sdk.Context, txs [][]byte, maxTxBytes
 		ctx = ctx.WithTxBytes(tx)
 
 		msgTypes := msgTypes(sdkTx)
-		execMsgCount := countExecutableMsgs(sdkTx.GetMsgs())
+		execMsgCount := countExecutableMsgs(ctx, fsb.chanKeep, sdkTx.GetMsgs())
 		if sdkMessageCount+execMsgCount > appconsts.MaxSDKMessages {
 			logger.Debug("skipping tx because the max SDK message count was reached", "tx", tmbytes.HexBytes(coretypes.Tx(tx).Hash()))
 			continue

--- a/app/filtered_square_builder_fibre_test.go
+++ b/app/filtered_square_builder_fibre_test.go
@@ -228,7 +228,7 @@ func TestFilteredSquareBuilderFillWithPayForFibre(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fsb, err := NewFilteredSquareBuilder(tc.anteHandler, nil, txConfig, 64, 64)
+			fsb, err := NewFilteredSquareBuilder(tc.anteHandler, nil, txConfig, fakeChannelKeeper{}, 64, 64)
 			require.NoError(t, err)
 
 			db := dbm.NewMemDB()
@@ -279,7 +279,7 @@ func TestFilteredSquareBuilderFillMaxPayForFibreMessages(t *testing.T) {
 		pffTxs[i] = blobfactory.UnsignedPayForFibreTx(t, txConfig)
 	}
 
-	fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+	fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, fakeChannelKeeper{}, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 	require.NoError(t, err)
 
 	db := dbm.NewMemDB()

--- a/app/filtered_square_builder_test.go
+++ b/app/filtered_square_builder_test.go
@@ -254,7 +254,7 @@ func TestFilteredSquareBuilderFillMaxTxBytes(t *testing.T) {
 	// configured block max bytes.
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
+			fsb, err := NewFilteredSquareBuilder(alwaysPass, nil, txConfig, fakeChannelKeeper{}, appconsts.SquareSizeUpperBound, appconsts.SubtreeRootThreshold)
 			require.NoError(t, err)
 
 			db := dbm.NewMemDB()

--- a/app/ica_host.go
+++ b/app/ica_host.go
@@ -2,8 +2,11 @@ package app
 
 // IcaAllowMessages returns the list of messages that are allowed to be sent via ICA.
 //
-// Adding a message that dispatches further messages (e.g. MsgExec) would let one
-// ICA packet execute more messages than countExecutableMsgs counts.
+// Adding a message that dispatches further messages would let one ICA packet
+// execute more than countExecutableMsgs counts, which counts a payload's entries
+// without looking inside them. MsgModuleQuerySafe is the likeliest such message,
+// since it exists for ICA controllers to query the host, but it dispatches one
+// query per request. See TestIcaAllowMessagesExcludeFanOutMsgs.
 func IcaAllowMessages() []string {
 	return []string{
 		"/ibc.applications.transfer.v1.MsgTransfer",

--- a/app/ica_host.go
+++ b/app/ica_host.go
@@ -1,6 +1,9 @@
 package app
 
 // IcaAllowMessages returns the list of messages that are allowed to be sent via ICA.
+//
+// Adding a message that dispatches further messages (e.g. MsgExec) would let one
+// ICA packet execute more messages than countExecutableMsgs counts.
 func IcaAllowMessages() []string {
 	return []string{
 		"/ibc.applications.transfer.v1.MsgTransfer",

--- a/app/ica_host_test.go
+++ b/app/ica_host_test.go
@@ -3,7 +3,13 @@ package app
 import (
 	"testing"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/authz"
+	govv1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1"
+	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIcaAllowMessages(t *testing.T) {
@@ -23,4 +29,23 @@ func TestIcaAllowMessages(t *testing.T) {
 		"/cosmos.feegrant.v1beta1.MsgRevokeAllowance",
 	}
 	assert.Equal(t, want, got)
+}
+
+// TestIcaAllowMessagesExcludeFanOutMsgs guards the bound the per-block message
+// limit relies on. countICAPacketMsgs counts a packet payload's entries without
+// looking inside them, so a payload message that dispatches further messages
+// would execute more than the block limit counts.
+func TestIcaAllowMessagesExcludeFanOutMsgs(t *testing.T) {
+	fanOut := map[string]string{
+		sdk.MsgTypeURL(&authz.MsgExec{}):                   "dispatches the messages it wraps",
+		sdk.MsgTypeURL(&icahosttypes.MsgModuleQuerySafe{}): "dispatches one query per request",
+		sdk.MsgTypeURL(&channeltypes.MsgRecvPacket{}):      "dispatches the messages in its packet payload",
+		sdk.MsgTypeURL(&govv1.MsgSubmitProposal{}):         "dispatches its messages once the proposal passes",
+	}
+
+	for _, allowed := range IcaAllowMessages() {
+		reason, found := fanOut[allowed]
+		require.False(t, found,
+			"%s %s, so allowing it over ICA lets one packet execute more messages than countExecutableMsgs counts", allowed, reason)
+	}
 }

--- a/app/msg_count.go
+++ b/app/msg_count.go
@@ -23,13 +23,10 @@ type channelKeeper interface {
 	GetAppVersion(ctx sdk.Context, portID, channelID string) (string, bool)
 }
 
-// countExecutableMsgs counts messages the way a block executes them. A MsgExec
-// contributes the messages authz dispatches from it, a MsgModuleQuerySafe
-// contributes the queries it dispatches, and a MsgRecvPacket bound for the ICA
-// host contributes the messages the host dispatches from its payload. This stops
-// a tx from hiding many executable messages behind a single wrapper to bypass the
-// per-block SDK message limit. Nested MsgExec is rejected by the ante handler, so
-// counting one level is enough.
+// countExecutableMsgs counts messages the way a block executes them: every
+// message costs one, plus whatever it dispatches. This stops a tx from hiding
+// many executable messages behind a single wrapper to bypass the per-block SDK
+// message limit.
 func countExecutableMsgs(ctx sdk.Context, ck channelKeeper, msgs []sdk.Msg) int {
 	// Counting filters a proposal, it does not execute the tx, so reading the
 	// channel must not draw on the gas the previous tx left on the meter.
@@ -39,14 +36,7 @@ func countExecutableMsgs(ctx sdk.Context, ck channelKeeper, msgs []sdk.Msg) int 
 
 	count := 0
 	for _, msg := range msgs {
-		switch msg := msg.(type) {
-		case *authz.MsgExec:
-			count += countExecMsgs(ctx, ck, msg)
-		case *channeltypes.MsgRecvPacket:
-			count += 1 + countICAPacketMsgs(ctx, ck, msg.Packet)
-		default:
-			count += msgWeight(msg)
-		}
+		count += msgWeight(ctx, ck, msg)
 		// Callers only compare the count against the limit, so stop once it is
 		// past it rather than reading a channel for every remaining packet.
 		if count > appconsts.MaxSDKMessages {
@@ -56,33 +46,41 @@ func countExecutableMsgs(ctx sdk.Context, ck channelKeeper, msgs []sdk.Msg) int 
 	return count
 }
 
-// msgWeight returns the number of executable units in a single message that does
-// not expand further. It never returns less than one: a message with an empty
-// fan-out still costs a full ante pass, and per-message ValidateBasic does not
-// run in the ante chain that ProcessProposal uses.
-func msgWeight(msg sdk.Msg) int {
-	if querySafe, ok := msg.(*icahosttypes.MsgModuleQuerySafe); ok {
-		return max(1, len(querySafe.Requests))
+// msgWeight returns what a message costs: one for the message itself, plus the
+// messages it dispatches. A message with no fan-out, or an empty one, still
+// weighs one, since it costs a full ante pass either way.
+func msgWeight(ctx sdk.Context, ck channelKeeper, msg sdk.Msg) int {
+	if exec, ok := msg.(*authz.MsgExec); ok {
+		return 1 + execFanout(ctx, ck, exec)
+	}
+	return leafWeight(ctx, ck, msg)
+}
+
+// leafWeight is msgWeight for a message that is not a MsgExec.
+func leafWeight(ctx sdk.Context, ck channelKeeper, msg sdk.Msg) int {
+	switch msg := msg.(type) {
+	case *icahosttypes.MsgModuleQuerySafe:
+		return 1 + len(msg.Requests)
+	case *channeltypes.MsgRecvPacket:
+		return 1 + countICAPacketMsgs(ctx, ck, msg.Packet)
 	}
 	return 1
 }
 
-// countExecMsgs counts the messages a MsgExec dispatches. A wrapped
-// MsgRecvPacket expands further, so it is counted like a top level one.
-func countExecMsgs(ctx sdk.Context, ck channelKeeper, exec *authz.MsgExec) int {
+// execFanout counts the messages a MsgExec dispatches, not counting the MsgExec
+// itself. It does not recurse: the ante handler rejects a nested MsgExec, and
+// counting runs before the ante handler, so recursing on attacker controlled
+// nesting could exhaust the stack in PrepareProposal, which has no recover.
+func execFanout(ctx sdk.Context, ck channelKeeper, exec *authz.MsgExec) int {
 	nested, err := exec.GetMessages()
 	if err != nil {
 		// The ante handler rejects a tx with undecodable inner messages, so
-		// count the wrappers rather than treating the MsgExec as free.
+		// count the wrappers rather than treating them as free.
 		return len(exec.Msgs)
 	}
 	count := 0
 	for _, msg := range nested {
-		if recv, ok := msg.(*channeltypes.MsgRecvPacket); ok {
-			count += 1 + countICAPacketMsgs(ctx, ck, recv.Packet)
-			continue
-		}
-		count += msgWeight(msg)
+		count += leafWeight(ctx, ck, msg)
 	}
 	return count
 }

--- a/app/msg_count.go
+++ b/app/msg_count.go
@@ -1,46 +1,168 @@
 package app
 
 import (
+	"encoding/json"
+
+	storetypes "cosmossdk.io/store/types"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	"google.golang.org/protobuf/encoding/protowire"
 )
 
-// countExecutableMsgs counts messages the way a block executes them: a MsgExec
-// contributes the messages authz dispatches from it and a MsgModuleQuerySafe
-// contributes the queries it dispatches, not one each. This stops a tx from
-// hiding many units of execution behind a single message to bypass the
-// per-block SDK message limit. Nested MsgExec is rejected by the ante handler,
-// so flattening one level is enough.
-func countExecutableMsgs(msgs []sdk.Msg) int {
+// cosmosTxMsgsField is the field number of CosmosTx.messages.
+const cosmosTxMsgsField = 1
+
+// channelKeeper reads the version an ICA channel negotiated, which says how its
+// packet payloads are encoded.
+type channelKeeper interface {
+	GetAppVersion(ctx sdk.Context, portID, channelID string) (string, bool)
+}
+
+// countExecutableMsgs counts messages the way a block executes them. A MsgExec
+// contributes the messages authz dispatches from it, a MsgModuleQuerySafe
+// contributes the queries it dispatches, and a MsgRecvPacket bound for the ICA
+// host contributes the messages the host dispatches from its payload. This stops
+// a tx from hiding many executable messages behind a single wrapper to bypass the
+// per-block SDK message limit. Nested MsgExec is rejected by the ante handler, so
+// counting one level is enough.
+func countExecutableMsgs(ctx sdk.Context, ck channelKeeper, msgs []sdk.Msg) int {
+	// Counting filters a proposal, it does not execute the tx, so reading the
+	// channel must not draw on the gas the previous tx left on the meter.
+	// Otherwise an unrelated tx with a tight gas limit ahead of this one makes
+	// the read run out of gas and panic.
+	ctx = ctx.WithGasMeter(storetypes.NewInfiniteGasMeter())
+
 	count := 0
 	for _, msg := range msgs {
-		exec, ok := msg.(*authz.MsgExec)
-		if !ok {
+		switch msg := msg.(type) {
+		case *authz.MsgExec:
+			count += countExecMsgs(ctx, ck, msg)
+		case *channeltypes.MsgRecvPacket:
+			count += 1 + countICAPacketMsgs(ctx, ck, msg.Packet)
+		default:
 			count += msgWeight(msg)
-			continue
-		}
-		nested, err := exec.GetMessages()
-		if err != nil {
-			// The ante handler rejects a tx with undecodable inner messages, so
-			// count the wrappers rather than treating the MsgExec as free.
-			count += len(exec.Msgs)
-			continue
-		}
-		for _, inner := range nested {
-			count += msgWeight(inner)
 		}
 	}
 	return count
 }
 
-// msgWeight returns the number of executable units in a single message. It never
-// returns less than one: a message with an empty fan-out still costs a full ante
-// pass, and per-message ValidateBasic does not run in the ante chain that
-// ProcessProposal uses.
+// msgWeight returns the number of executable units in a single message that does
+// not expand further. It never returns less than one: a message with an empty
+// fan-out still costs a full ante pass, and per-message ValidateBasic does not
+// run in the ante chain that ProcessProposal uses.
 func msgWeight(msg sdk.Msg) int {
 	if querySafe, ok := msg.(*icahosttypes.MsgModuleQuerySafe); ok {
 		return max(1, len(querySafe.Requests))
 	}
 	return 1
+}
+
+// countExecMsgs counts the messages a MsgExec dispatches. A wrapped
+// MsgRecvPacket expands further, so it is counted like a top level one.
+func countExecMsgs(ctx sdk.Context, ck channelKeeper, exec *authz.MsgExec) int {
+	nested, err := exec.GetMessages()
+	if err != nil {
+		// The ante handler rejects a tx with undecodable inner messages, so
+		// count the wrappers rather than treating the MsgExec as free.
+		return len(exec.Msgs)
+	}
+	count := 0
+	for _, msg := range nested {
+		if recv, ok := msg.(*channeltypes.MsgRecvPacket); ok {
+			count += 1 + countICAPacketMsgs(ctx, ck, recv.Packet)
+			continue
+		}
+		count += msgWeight(msg)
+	}
+	return count
+}
+
+// countICAPacketMsgs returns how many messages the ICA host would dispatch from
+// packet: zero if the packet is not bound for the host or does not decode, or
+// MaxSDKMessages if the payload cannot be counted under the channel's encoding.
+func countICAPacketMsgs(ctx sdk.Context, ck channelKeeper, packet channeltypes.Packet) int {
+	if packet.DestinationPort != icatypes.HostPortID {
+		return 0
+	}
+
+	var data icatypes.InterchainAccountPacketData
+	if err := data.UnmarshalJSON(packet.Data); err != nil {
+		return 0
+	}
+	if data.Type != icatypes.EXECUTE_TX {
+		return 0
+	}
+
+	// Count with the encoding the channel negotiated, the same way the host
+	// picks its decoder.
+	version, ok := ck.GetAppVersion(ctx, packet.DestinationPort, packet.DestinationChannel)
+	if !ok {
+		return appconsts.MaxSDKMessages
+	}
+	metadata, err := icatypes.MetadataFromVersion(version)
+	if err != nil {
+		return appconsts.MaxSDKMessages
+	}
+
+	// Count the message list without materialising the messages in it. Counting
+	// runs before the ante handler charges any gas, so an 8 MiB payload of
+	// minimal messages would otherwise cost every node hundreds of MB for free.
+	count := -1
+	switch metadata.Encoding {
+	case icatypes.EncodingProtobuf:
+		count = countProtoMsgs(data.Data)
+	case icatypes.EncodingProto3JSON:
+		count = countJSONMsgs(data.Data)
+	}
+	if count < 0 {
+		// This is not the host's decoder, so bytes it rejects may still dispatch
+		// messages there. Counting such a payload as free would bypass the
+		// limit, so count it as over the limit instead.
+		return appconsts.MaxSDKMessages
+	}
+	return count
+}
+
+// countProtoMsgs counts the entries of a proto3 encoded CosmosTx, or -1 if the
+// bytes are not one. It walks the wire format instead of decoding, so the cost
+// does not depend on how many entries there are.
+func countProtoMsgs(bz []byte) int {
+	count := 0
+	for len(bz) > 0 {
+		num, typ, n := protowire.ConsumeTag(bz)
+		if n < 0 {
+			return -1
+		}
+		bz = bz[n:]
+		// Groups would make ConsumeFieldValue recurse as deep as the input is
+		// long. proto3 has no groups, so reject them rather than walk them.
+		if typ == protowire.StartGroupType || typ == protowire.EndGroupType {
+			return -1
+		}
+		if n = protowire.ConsumeFieldValue(num, typ, bz); n < 0 {
+			return -1
+		}
+		bz = bz[n:]
+		if num == cosmosTxMsgsField && typ == protowire.BytesType {
+			count++
+		}
+	}
+	return count
+}
+
+// countJSONMsgs counts the entries of a proto3json encoded CosmosTx, or -1 if
+// the bytes are not one. Entries decode into an empty struct, so only the list
+// length is retained.
+func countJSONMsgs(bz []byte) int {
+	var tx struct {
+		Messages []struct{} `json:"messages"`
+	}
+	if err := json.Unmarshal(bz, &tx); err != nil {
+		return -1
+	}
+	return len(tx.Messages)
 }

--- a/app/msg_count.go
+++ b/app/msg_count.go
@@ -10,6 +10,7 @@ import (
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
 	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
+	host "github.com/cosmos/ibc-go/v8/modules/core/24-host"
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
@@ -45,6 +46,11 @@ func countExecutableMsgs(ctx sdk.Context, ck channelKeeper, msgs []sdk.Msg) int 
 			count += 1 + countICAPacketMsgs(ctx, ck, msg.Packet)
 		default:
 			count += msgWeight(msg)
+		}
+		// Callers only compare the count against the limit, so stop once it is
+		// past it rather than reading a channel for every remaining packet.
+		if count > appconsts.MaxSDKMessages {
+			return count
 		}
 	}
 	return count
@@ -95,6 +101,13 @@ func countICAPacketMsgs(ctx sdk.Context, ck channelKeeper, packet channeltypes.P
 	}
 	if data.Type != icatypes.EXECUTE_TX {
 		return 0
+	}
+
+	// Bound the channel identifier before it reaches the store, which panics on
+	// an oversized key. The packet is attacker controlled and MsgRecvPacket's
+	// ValidateBasic only runs later, in the ante handler.
+	if err := host.ChannelIdentifierValidator(packet.DestinationChannel); err != nil {
+		return appconsts.MaxSDKMessages
 	}
 
 	// Count with the encoding the channel negotiated, the same way the host

--- a/app/msg_count_test.go
+++ b/app/msg_count_test.go
@@ -3,23 +3,67 @@ package app
 import (
 	"testing"
 
+	"github.com/celestiaorg/celestia-app/v10/app/encoding"
+	"github.com/celestiaorg/celestia-app/v10/pkg/appconsts"
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/gogoproto/proto"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/stretchr/testify/require"
 )
 
+// fakeChannelKeeper reports the encoding an ICA channel negotiated. An empty
+// encoding means the channel does not exist.
+type fakeChannelKeeper struct{ encoding string }
+
+func (f fakeChannelKeeper) GetAppVersion(sdk.Context, string, string) (string, bool) {
+	if f.encoding == "" {
+		return "", false
+	}
+	return string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{Encoding: f.encoding})), true
+}
+
 func TestCountExecutableMsgs(t *testing.T) {
+	cdc := encoding.MakeConfig(ModuleEncodingRegisters...).Codec
 	send := func() sdk.Msg { return &banktypes.MsgSend{} }
 
-	msgExecWith := func(n int) sdk.Msg {
-		inner := make([]sdk.Msg, n)
-		for i := range inner {
-			inner[i] = send()
-		}
-		exec := authz.NewMsgExec(sdk.AccAddress{}, inner)
+	msgExecWith := func(msgs ...sdk.Msg) sdk.Msg {
+		exec := authz.NewMsgExec(sdk.AccAddress{}, msgs)
 		return &exec
+	}
+	sends := func(n int) []sdk.Msg {
+		msgs := make([]sdk.Msg, n)
+		for i := range msgs {
+			msgs[i] = send()
+		}
+		return msgs
+	}
+
+	// icaPayload serializes n bank sends the way an ICA controller would.
+	icaPayload := func(n int, enc string) []byte {
+		msgs := make([]proto.Message, n)
+		for i := range msgs {
+			msgs[i] = &banktypes.MsgSend{}
+		}
+		bz, err := icatypes.SerializeCosmosTx(cdc, msgs, enc)
+		require.NoError(t, err)
+		return bz
+	}
+	// recvPacket wraps payload in a MsgRecvPacket addressed to destPort.
+	recvPacket := func(destPort string, data []byte) sdk.Msg {
+		packet := channeltypes.NewPacket(data, 1, "icacontroller-test", "channel-0", destPort, "channel-1", clienttypes.ZeroHeight(), 0)
+		return channeltypes.NewMsgRecvPacket(packet, nil, clienttypes.ZeroHeight(), "signer")
+	}
+	// icaRecvPacket builds a MsgRecvPacket the ICA host would execute n messages from.
+	icaRecvPacket := func(n int, enc string) sdk.Msg {
+		data := icatypes.InterchainAccountPacketData{Type: icatypes.EXECUTE_TX, Data: icaPayload(n, enc)}
+		return recvPacket(icatypes.HostPortID, data.GetBytes())
 	}
 
 	moduleQuerySafeWith := func(n int) sdk.Msg {
@@ -30,14 +74,11 @@ func TestCountExecutableMsgs(t *testing.T) {
 		return icahosttypes.NewMsgModuleQuerySafe("", requests)
 	}
 
-	msgExecWithMsgs := func(msgs ...sdk.Msg) sdk.Msg {
-		exec := authz.NewMsgExec(sdk.AccAddress{}, msgs)
-		return &exec
-	}
-
 	testCases := []struct {
-		name     string
-		msgs     []sdk.Msg
+		name string
+		msgs []sdk.Msg
+		// encoding the ICA channel negotiated; empty means no such channel.
+		encoding string
 		expected int
 	}{
 		{
@@ -47,17 +88,17 @@ func TestCountExecutableMsgs(t *testing.T) {
 		},
 		{
 			name:     "MsgExec counts its inner messages",
-			msgs:     []sdk.Msg{msgExecWith(99)},
+			msgs:     []sdk.Msg{msgExecWith(sends(99)...)},
 			expected: 99,
 		},
 		{
 			name:     "mix of plain and MsgExec",
-			msgs:     []sdk.Msg{msgExecWith(2), send(), msgExecWith(3)},
+			msgs:     []sdk.Msg{msgExecWith(sends(2)...), send(), msgExecWith(sends(3)...)},
 			expected: 6,
 		},
 		{
 			name:     "empty MsgExec counts as zero",
-			msgs:     []sdk.Msg{msgExecWith(0)},
+			msgs:     []sdk.Msg{msgExecWith()},
 			expected: 0,
 		},
 		{
@@ -67,7 +108,7 @@ func TestCountExecutableMsgs(t *testing.T) {
 		},
 		{
 			name:     "MsgModuleQuerySafe inside MsgExec counts its queries",
-			msgs:     []sdk.Msg{msgExecWithMsgs(moduleQuerySafeWith(5))},
+			msgs:     []sdk.Msg{msgExecWith(moduleQuerySafeWith(5))},
 			expected: 5,
 		},
 		{
@@ -77,14 +118,177 @@ func TestCountExecutableMsgs(t *testing.T) {
 		},
 		{
 			name:     "mix of MsgModuleQuerySafe and plain messages",
-			msgs:     []sdk.Msg{moduleQuerySafeWith(3), send(), msgExecWithMsgs(moduleQuerySafeWith(2), send())},
+			msgs:     []sdk.Msg{moduleQuerySafeWith(3), send(), msgExecWith(moduleQuerySafeWith(2), send())},
 			expected: 7,
+		},
+		{
+			name:     "proto3 ICA packet counts its payload messages plus the packet",
+			msgs:     []sdk.Msg{icaRecvPacket(50, icatypes.EncodingProtobuf)},
+			encoding: icatypes.EncodingProtobuf,
+			expected: 51,
+		},
+		{
+			name:     "proto3json ICA packet counts its payload messages plus the packet",
+			msgs:     []sdk.Msg{icaRecvPacket(50, icatypes.EncodingProto3JSON)},
+			encoding: icatypes.EncodingProto3JSON,
+			expected: 51,
+		},
+		{
+			name:     "empty ICA payload counts only the packet",
+			msgs:     []sdk.Msg{icaRecvPacket(0, icatypes.EncodingProtobuf)},
+			encoding: icatypes.EncodingProtobuf,
+			expected: 1,
+		},
+		{
+			name:     "packet to another port counts as one",
+			encoding: icatypes.EncodingProtobuf,
+			msgs:     []sdk.Msg{recvPacket("transfer", icaPayload(50, icatypes.EncodingProtobuf))},
+			expected: 1,
+		},
+		{
+			// Malformed packet data fails the same decode the host uses, so the
+			// host dispatches nothing and this is safe to count as just the packet.
+			name:     "malformed ICA packet data counts as one",
+			encoding: icatypes.EncodingProtobuf,
+			msgs:     []sdk.Msg{recvPacket(icatypes.HostPortID, []byte("not json"))},
+			expected: 1,
+		},
+		{
+			name:     "non executable ICA packet type counts as one",
+			encoding: icatypes.EncodingProtobuf,
+			msgs: []sdk.Msg{func() sdk.Msg {
+				data := icatypes.InterchainAccountPacketData{Type: icatypes.UNSPECIFIED, Data: icaPayload(50, icatypes.EncodingProtobuf)}
+				return recvPacket(icatypes.HostPortID, data.GetBytes())
+			}()},
+			expected: 1,
+		},
+		{
+			name:     "ICA packet inside a MsgExec counts its payload messages",
+			msgs:     []sdk.Msg{msgExecWith(icaRecvPacket(50, icatypes.EncodingProtobuf))},
+			encoding: icatypes.EncodingProtobuf,
+			expected: 51,
+		},
+		{
+			// Without the channel the encoding is unknown, so the payload cannot
+			// be counted and must not be counted as free.
+			name:     "ICA packet on an unknown channel counts as over the limit",
+			msgs:     []sdk.Msg{icaRecvPacket(50, icatypes.EncodingProtobuf)},
+			expected: 1 + appconsts.MaxSDKMessages,
+		},
+		{
+			// The payload is proto3json but the channel negotiated proto3, so the
+			// proto3 counter cannot read it and it fails closed.
+			name:     "ICA payload not matching the channel encoding counts as over the limit",
+			msgs:     []sdk.Msg{icaRecvPacket(50, icatypes.EncodingProto3JSON)},
+			encoding: icatypes.EncodingProtobuf,
+			expected: 1 + appconsts.MaxSDKMessages,
+		},
+		{
+			name: "undecodable message inside a MsgExec counts as one",
+			msgs: []sdk.Msg{&authz.MsgExec{Msgs: []*codectypes.Any{{
+				TypeUrl: sdk.MsgTypeURL(&channeltypes.MsgRecvPacket{}),
+				Value:   []byte("not a MsgRecvPacket"),
+			}}}},
+			expected: 1,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			require.Equal(t, tc.expected, countExecutableMsgs(tc.msgs))
+			ck := fakeChannelKeeper{encoding: tc.encoding}
+			require.Equal(t, tc.expected, countExecutableMsgs(sdk.Context{}, ck, tc.msgs))
 		})
+	}
+}
+
+// TestCountICAPacketMsgsNeverUndercounts checks the counter against the decoder
+// the ICA host actually uses. For any payload the host can decode, the count
+// must be at least the number of messages the host would dispatch, otherwise a
+// packet could execute more messages than the block limit accounts for.
+func TestCountICAPacketMsgsNeverUndercounts(t *testing.T) {
+	cdc := encoding.MakeConfig(ModuleEncodingRegisters...).Codec
+	send := &banktypes.MsgSend{}
+	msgs := []proto.Message{send, send, send}
+
+	protoPayload, err := icatypes.SerializeCosmosTx(cdc, msgs, icatypes.EncodingProtobuf)
+	require.NoError(t, err)
+	jsonPayload, err := icatypes.SerializeCosmosTx(cdc, msgs, icatypes.EncodingProto3JSON)
+	require.NoError(t, err)
+
+	// A proto3json payload laid out so its bytes are also a walkable proto wire
+	// stream: the leading "\n " is JSON whitespace and a proto field 1 tag of
+	// length 32, and the "*t" in each element is a field 5 tag whose length
+	// strides exactly one element. Counting it under proto3 yields 1 while the
+	// host, on a proto3json channel, dispatches every message.
+	element := `{"fromAddress":"AAA*tAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","@type":"/cosmos.bank.v1beta1.MsgSend"}`
+	crafted := []byte("\n {\"messages\":[")
+	for i := range 700 {
+		if i > 0 {
+			crafted = append(crafted, ',')
+		}
+		crafted = append(crafted, element...)
+	}
+	crafted = append(crafted, []byte("]}                  ")...)
+
+	payloads := map[string][]byte{
+		"proto3":                   protoPayload,
+		"proto3json":               jsonPayload,
+		"trailing byte":            append(append([]byte{}, jsonPayload...), 'X'),
+		"leading whitespace":       append([]byte{'\n', ' '}, jsonPayload...),
+		"duplicate key, number":    append([]byte(`{"messages":0,`), jsonPayload[1:]...),
+		"unknown sibling field":    append([]byte(`{"bogus":1,`), jsonPayload[1:]...),
+		"null messages":            []byte(`{"messages":null}`),
+		"empty":                    {},
+		"garbage":                  []byte("not a payload at all"),
+		"proto with group tag":     {0x0B, 0x0A, 0x00, 0x0C},
+		"proto truncated field":    {0x0A, 0x7F},
+		"json that walks as proto": crafted,
+	}
+
+	for name, payload := range payloads {
+		t.Run(name, func(t *testing.T) {
+			requireNoUndercount(t, cdc, payload)
+		})
+	}
+}
+
+// FuzzCountICAPacketMsgs is the same property as
+// TestCountICAPacketMsgsNeverUndercounts over generated payloads. The counter
+// does not use the host's decoders, so the two can disagree in ways a fixed
+// table does not anticipate; only an undercount is a bug.
+func FuzzCountICAPacketMsgs(f *testing.F) {
+	cdc := encoding.MakeConfig(ModuleEncodingRegisters...).Codec
+	f.Add([]byte{0x0A, 0x00})
+	f.Add([]byte{0x0B, 0x0A, 0x00, 0x0C})
+	f.Add([]byte(`{"messages":[]}`))
+	f.Add([]byte(`{"messages":[{"@type":"/cosmos.bank.v1beta1.MsgSend","amount":[]}]}`))
+	f.Add([]byte("\n {\"messages\":[{\"fromAddress\":\"AAA*tAA\",\"@type\":\"/cosmos.bank.v1beta1.MsgSend\"}]}  "))
+
+	f.Fuzz(func(t *testing.T, payload []byte) {
+		requireNoUndercount(t, cdc, payload)
+	})
+}
+
+// requireNoUndercount fails if either counter reports fewer messages than the
+// ICA host would dispatch from the same payload under that encoding. Counting
+// more is safe; counting fewer lets a packet execute messages the block limit
+// never accounted for.
+func requireNoUndercount(t *testing.T, cdc codec.Codec, payload []byte) {
+	t.Helper()
+	counters := map[string]func([]byte) int{
+		icatypes.EncodingProtobuf:   countProtoMsgs,
+		icatypes.EncodingProto3JSON: countJSONMsgs,
+	}
+	for enc, count := range counters {
+		dispatched, err := icatypes.DeserializeCosmosTx(cdc, payload, enc)
+		if err != nil {
+			continue // the host dispatches nothing under this encoding
+		}
+		counted := count(payload)
+		if counted < 0 {
+			continue // countICAPacketMsgs fails closed on this
+		}
+		require.GreaterOrEqual(t, counted, len(dispatched),
+			"counted %d but the host would dispatch %d under %s", counted, len(dispatched), enc)
 	}
 }

--- a/app/msg_count_test.go
+++ b/app/msg_count_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/app/encoding"
@@ -55,9 +56,14 @@ func TestCountExecutableMsgs(t *testing.T) {
 		require.NoError(t, err)
 		return bz
 	}
-	// recvPacket wraps payload in a MsgRecvPacket addressed to destPort.
-	recvPacket := func(destPort string, data []byte) sdk.Msg {
-		packet := channeltypes.NewPacket(data, 1, "icacontroller-test", "channel-0", destPort, "channel-1", clienttypes.ZeroHeight(), 0)
+	// recvPacket wraps payload in a MsgRecvPacket addressed to destPort on
+	// destChannel, defaulting to a valid channel id when none is given.
+	recvPacket := func(destPort string, data []byte, destChannel ...string) sdk.Msg {
+		channelID := "channel-1"
+		if len(destChannel) > 0 {
+			channelID = destChannel[0]
+		}
+		packet := channeltypes.NewPacket(data, 1, "icacontroller-test", "channel-0", destPort, channelID, clienttypes.ZeroHeight(), 0)
 		return channeltypes.NewMsgRecvPacket(packet, nil, clienttypes.ZeroHeight(), "signer")
 	}
 	// icaRecvPacket builds a MsgRecvPacket the ICA host would execute n messages from.
@@ -167,6 +173,14 @@ func TestCountExecutableMsgs(t *testing.T) {
 			msgs:     []sdk.Msg{msgExecWith(icaRecvPacket(50, icatypes.EncodingProtobuf))},
 			encoding: icatypes.EncodingProtobuf,
 			expected: 51,
+		},
+		{
+			// An oversized identifier would panic the store, whose keys are
+			// length bounded, before ValidateBasic ever rejects the packet.
+			name:     "ICA packet with an oversized channel id counts as over the limit",
+			msgs:     []sdk.Msg{recvPacket(icatypes.HostPortID, icatypes.InterchainAccountPacketData{Type: icatypes.EXECUTE_TX, Data: icaPayload(1, icatypes.EncodingProtobuf)}.GetBytes(), strings.Repeat("c", 200_000))},
+			encoding: icatypes.EncodingProtobuf,
+			expected: 1 + appconsts.MaxSDKMessages,
 		},
 		{
 			// Without the channel the encoding is unknown, so the payload cannot
@@ -291,4 +305,37 @@ func requireNoUndercount(t *testing.T, cdc codec.Codec, payload []byte) {
 		require.GreaterOrEqual(t, counted, len(dispatched),
 			"counted %d but the host would dispatch %d under %s", counted, len(dispatched), enc)
 	}
+}
+
+// TestCountExecutableMsgsBoundsChannelReads checks that counting stops once the
+// limit is passed. Without that, a transaction packed with ICA packets forces a
+// channel read per packet before the count is ever compared against the limit,
+// all of it before the ante handler charges any gas.
+func TestCountExecutableMsgsBoundsChannelReads(t *testing.T) {
+	cdc := encoding.MakeConfig(ModuleEncodingRegisters...).Codec
+	payload, err := icatypes.SerializeCosmosTx(cdc, nil, icatypes.EncodingProtobuf)
+	require.NoError(t, err)
+	data := icatypes.InterchainAccountPacketData{Type: icatypes.EXECUTE_TX, Data: payload}
+	packet := channeltypes.NewPacket(data.GetBytes(), 1, "icacontroller-test", "channel-0", icatypes.HostPortID, "channel-1", clienttypes.ZeroHeight(), 0)
+
+	msgs := make([]sdk.Msg, 50_000)
+	for i := range msgs {
+		msgs[i] = channeltypes.NewMsgRecvPacket(packet, nil, clienttypes.ZeroHeight(), "signer")
+	}
+
+	ck := &countingChannelKeeper{encoding: icatypes.EncodingProtobuf}
+	require.Greater(t, countExecutableMsgs(sdk.Context{}, ck, msgs), appconsts.MaxSDKMessages)
+	require.LessOrEqual(t, ck.reads, appconsts.MaxSDKMessages+1,
+		"counting read %d channels for %d packets", ck.reads, len(msgs))
+}
+
+// countingChannelKeeper records how many channel reads a count pass makes.
+type countingChannelKeeper struct {
+	encoding string
+	reads    int
+}
+
+func (k *countingChannelKeeper) GetAppVersion(sdk.Context, string, string) (string, bool) {
+	k.reads++
+	return string(icatypes.ModuleCdc.MustMarshalJSON(&icatypes.Metadata{Encoding: k.encoding})), true
 }

--- a/app/msg_count_test.go
+++ b/app/msg_count_test.go
@@ -93,29 +93,29 @@ func TestCountExecutableMsgs(t *testing.T) {
 			expected: 3,
 		},
 		{
-			name:     "MsgExec counts its inner messages",
+			name:     "MsgExec counts its inner messages plus itself",
 			msgs:     []sdk.Msg{msgExecWith(sends(99)...)},
-			expected: 99,
+			expected: 100,
 		},
 		{
 			name:     "mix of plain and MsgExec",
 			msgs:     []sdk.Msg{msgExecWith(sends(2)...), send(), msgExecWith(sends(3)...)},
-			expected: 6,
+			expected: 8,
 		},
 		{
-			name:     "empty MsgExec counts as zero",
+			name:     "empty MsgExec counts as one",
 			msgs:     []sdk.Msg{msgExecWith()},
-			expected: 0,
+			expected: 1,
 		},
 		{
-			name:     "MsgModuleQuerySafe counts its queries",
+			name:     "MsgModuleQuerySafe counts its queries plus itself",
 			msgs:     []sdk.Msg{moduleQuerySafeWith(5)},
-			expected: 5,
+			expected: 6,
 		},
 		{
 			name:     "MsgModuleQuerySafe inside MsgExec counts its queries",
 			msgs:     []sdk.Msg{msgExecWith(moduleQuerySafeWith(5))},
-			expected: 5,
+			expected: 7,
 		},
 		{
 			name:     "MsgModuleQuerySafe with no queries still counts as one",
@@ -125,7 +125,7 @@ func TestCountExecutableMsgs(t *testing.T) {
 		{
 			name:     "mix of MsgModuleQuerySafe and plain messages",
 			msgs:     []sdk.Msg{moduleQuerySafeWith(3), send(), msgExecWith(moduleQuerySafeWith(2), send())},
-			expected: 7,
+			expected: 10,
 		},
 		{
 			name:     "proto3 ICA packet counts its payload messages plus the packet",
@@ -172,7 +172,7 @@ func TestCountExecutableMsgs(t *testing.T) {
 			name:     "ICA packet inside a MsgExec counts its payload messages",
 			msgs:     []sdk.Msg{msgExecWith(icaRecvPacket(50, icatypes.EncodingProtobuf))},
 			encoding: icatypes.EncodingProtobuf,
-			expected: 51,
+			expected: 52,
 		},
 		{
 			// An oversized identifier would panic the store, whose keys are
@@ -198,12 +198,12 @@ func TestCountExecutableMsgs(t *testing.T) {
 			expected: 1 + appconsts.MaxSDKMessages,
 		},
 		{
-			name: "undecodable message inside a MsgExec counts as one",
+			name: "undecodable message inside a MsgExec counts the wrapper and the message",
 			msgs: []sdk.Msg{&authz.MsgExec{Msgs: []*codectypes.Any{{
 				TypeUrl: sdk.MsgTypeURL(&channeltypes.MsgRecvPacket{}),
 				Value:   []byte("not a MsgRecvPacket"),
 			}}}},
-			expected: 1,
+			expected: 2,
 		},
 	}
 

--- a/app/prepare_proposal.go
+++ b/app/prepare_proposal.go
@@ -39,6 +39,7 @@ func (app *App) PrepareProposalHandler(ctx sdk.Context, req *abci.RequestPrepare
 		handler,
 		app.MsgServiceRouter(),
 		app.encodingConfig.TxConfig,
+		app.IBCKeeper.ChannelKeeper,
 		app.MaxEffectiveSquareSize(ctx),
 		appconsts.SubtreeRootThreshold,
 	)

--- a/app/process_proposal.go
+++ b/app/process_proposal.go
@@ -134,7 +134,7 @@ func (app *App) ProcessProposalHandler(ctx sdk.Context, req *abci.RequestProcess
 					return reject(), nil
 				}
 			} else {
-				sdkMessageCount += countExecutableMsgs(msgs)
+				sdkMessageCount += countExecutableMsgs(ctx, app.IBCKeeper.ChannelKeeper, msgs)
 				if sdkMessageCount > appconsts.MaxSDKMessages {
 					logInvalidPropBlock(app.Logger(), blockHeader, fmt.Sprintf("block exceeds max SDK message count of %d", appconsts.MaxSDKMessages))
 					return reject(), nil

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -60,6 +60,10 @@ func TestCheckTx(t *testing.T) {
 		signers[i] = createSigner(t, kr, account, encodingConfig.TxConfig, fetchedAcc.GetAccountNumber())
 	}
 
+	// The message counter reads the payload encoding from the channel, so the
+	// channel the ICA packet below arrives on has to exist.
+	seedICAHostChannel(t, testApp)
+
 	opts := blobfactory.FeeTxOpts(1e9)
 	type test struct {
 		name             string
@@ -381,6 +385,22 @@ func TestCheckTx(t *testing.T) {
 					requests[i] = &icahosttypes.QueryRequest{Path: "/cosmos.bank.v1beta1.Query/TotalSupply"}
 				}
 				msg := icahosttypes.NewMsgModuleQuerySafe(addr.String(), requests)
+				tx, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimitAndGasPrice(1e7, appconsts.DefaultMinGasPrice))
+				require.NoError(t, err)
+				return tx
+			},
+			expectedABCICode: apperr.ErrTxExceedsMaxSDKMessages.ABCICode(),
+		},
+		{
+			name:      "ICA packet flattening exceeding max SDK messages, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				signer := signers[14]
+				addr := signer.Account(accounts[14]).Address()
+				// The ICA host dispatches every message in the packet payload,
+				// but only the packet is a top-level message, so this must still
+				// be rejected. The packet itself counts as one.
+				msg := icaHostRecvPacket(t, encodingConfig.Codec, addr, appconsts.MaxSDKMessages)
 				tx, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimitAndGasPrice(1e7, appconsts.DefaultMinGasPrice))
 				require.NoError(t, err)
 				return tx

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -38,6 +38,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestCheckTxICAPacketWithinLimit checks that CheckTx counts an ICA packet's
+// payload rather than falling back to the fail-closed count. Both paths reject a
+// packet over the limit with the same code, so only a packet under the limit
+// tells them apart: counted it passes the limit check, while a count that failed
+// closed would exceed it.
+func TestCheckTxICAPacketWithinLimit(t *testing.T) {
+	encodingConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := []string{"a"}
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+	seedICAHostChannel(t, testApp)
+
+	fetchedAcc := testutil.DirectQueryAccount(testApp, testfactory.GetAddress(kr, accounts[0]))
+	signer := createSigner(t, kr, accounts[0], encodingConfig.TxConfig, fetchedAcc.GetAccountNumber())
+	addr := signer.Account(accounts[0]).Address()
+
+	msg := icaHostRecvPacket(t, encodingConfig.Codec, addr, appconsts.MaxSDKMessages-1)
+	rawTx, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimitAndGasPrice(1e7, appconsts.DefaultMinGasPrice))
+	require.NoError(t, err)
+
+	resp, err := testApp.CheckTx(&abci.RequestCheckTx{Type: abci.CheckTxType_New, Tx: rawTx})
+	require.NoError(t, err)
+	// The packet still fails later in the ante handler, since the test only
+	// seeds the channel, but it must not fail on the message count.
+	require.NotEqual(t, apperr.ErrTxExceedsMaxSDKMessages.ABCICode(), resp.Code, resp.Log)
+}
+
 // Here we only need to check the functionality that is added to CheckTx. We
 // assume that the rest of CheckTx is tested by the cosmos-sdk.
 func TestCheckTx(t *testing.T) {

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -462,27 +462,34 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 		accountIndex++
 	}
 
-	// Build a tx that carries totalInner executable messages spread across authz
+	// Build a tx whose messages weigh totalWeight in total, spread across authz
 	// MsgExec wrappers. Each wrapper holds at most 99 inner messages to stay under
-	// the tx decoder's per-message unpack limit (MaxUnpackAnySubCalls). Only the
-	// wrappers are top-level messages, so a naive top-level count would let these
-	// bypass MaxSDKMessages.
-	buildMsgExecTx := func(accIdx, totalInner int) []byte {
+	// the tx decoder's per-message unpack limit (MaxUnpackAnySubCalls), and weighs
+	// one more than it holds. Plain sends make up any remainder. Only the wrappers
+	// are top-level messages, so a naive top-level count would let these bypass
+	// MaxSDKMessages.
+	buildMsgExecTx := func(accIdx, totalWeight int) []byte {
 		const perExec = 99
+		send := func() sdk.Msg {
+			return banktypes.NewMsgSend(
+				addrs[accIdx],
+				testnode.RandomAddress().(sdk.AccAddress),
+				sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 10)),
+			)
+		}
 		var msgs []sdk.Msg
-		for remaining := totalInner; remaining > 0; {
-			n := min(perExec, remaining)
-			inner := make([]sdk.Msg, n)
+		remaining := totalWeight
+		for remaining >= perExec+1 {
+			inner := make([]sdk.Msg, perExec)
 			for i := range inner {
-				inner[i] = banktypes.NewMsgSend(
-					addrs[accIdx],
-					testnode.RandomAddress().(sdk.AccAddress),
-					sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 10)),
-				)
+				inner[i] = send()
 			}
 			exec := authz.NewMsgExec(addrs[accIdx], inner)
 			msgs = append(msgs, &exec)
-			remaining -= n
+			remaining -= perExec + 1
+		}
+		for ; remaining > 0; remaining-- {
+			msgs = append(msgs, send())
 		}
 		rawTx, _, err := signers[accIdx].CreateTx(msgs, user.SetGasLimit(10000000), user.SetFee(10000))
 		require.NoError(t, err)
@@ -494,11 +501,12 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 	msgExecAtLimitTx := buildMsgExecTx(accountIndex, appconsts.MaxSDKMessages)
 	accountIndex++
 
-	// Build a tx with a single MsgModuleQuerySafe carrying numQueries requests.
-	// The message server dispatches one query per request, so a naive count of one
-	// message per MsgModuleQuerySafe would let these bypass MaxSDKMessages.
-	buildModuleQuerySafeTx := func(accIdx, numQueries int) []byte {
-		requests := make([]*icahosttypes.QueryRequest, numQueries)
+	// Build a tx with a single MsgModuleQuerySafe weighing totalWeight. The
+	// message server dispatches one query per request and the message itself
+	// weighs one, so a naive count of one message per MsgModuleQuerySafe would
+	// let these bypass MaxSDKMessages.
+	buildModuleQuerySafeTx := func(accIdx, totalWeight int) []byte {
+		requests := make([]*icahosttypes.QueryRequest, totalWeight-1)
 		for i := range requests {
 			requests[i] = &icahosttypes.QueryRequest{Path: "/cosmos.bank.v1beta1.Query/TotalSupply"}
 		}
@@ -508,16 +516,16 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 		return rawTx
 	}
 
-	// Build a tx carrying a single MsgRecvPacket whose ICA host payload holds
-	// totalInner messages. Only the packet is a top-level message, so a naive
-	// top-level count would let these bypass MaxSDKMessages. The packet itself
-	// counts as one, hence totalInner-1 messages in the payload.
+	// Build a tx carrying a single MsgRecvPacket weighing totalWeight. Only the
+	// packet is a top-level message, so a naive top-level count would let these
+	// bypass MaxSDKMessages. The packet itself weighs one, hence totalWeight-1
+	// messages in its payload.
 	// The counter reads the payload encoding from the channel, so the channel the
 	// packets arrive on has to exist.
 	seedICAHostChannel(t, testApp)
 
-	buildICATx := func(accIdx, totalInner int) []byte {
-		msg := icaHostRecvPacket(t, enc.Codec, addrs[accIdx], totalInner-1)
+	buildICATx := func(accIdx, totalWeight int) []byte {
+		msg := icaHostRecvPacket(t, enc.Codec, addrs[accIdx], totalWeight-1)
 		rawTx, _, err := signers[accIdx].CreateTx([]sdk.Msg{msg}, user.SetGasLimit(10000000), user.SetFee(10000))
 		require.NoError(t, err)
 		return rawTx

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -25,11 +25,24 @@ import (
 	abci "github.com/cometbft/cometbft/abci/types"
 	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	coretypes "github.com/cometbft/cometbft/types"
+	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	"github.com/cosmos/gogoproto/proto"
 	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
+	icatypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/types"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+	channeltypes "github.com/cosmos/ibc-go/v8/modules/core/04-channel/types"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	// icaChannelID and icaEncoding describe the ICA host channel the test packets
+	// arrive on. The encoding has to match how their payloads are serialized,
+	// since the counter reads it from the channel.
+	icaChannelID = "channel-1"
+	icaEncoding  = icatypes.EncodingProtobuf
 )
 
 func TestProcessProposal(t *testing.T) {
@@ -396,9 +409,9 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 	}
 
 	// Create enough accounts so each sends exactly one tx (avoids sequence collisions).
-	// +2 accounts are grantees for the authz MsgExec txs built below and +3 sign
-	// the MsgModuleQuerySafe txs.
-	numberOfAccounts := (appconsts.MaxSDKMessages + 1) + (appconsts.MaxPFBMessages + 1) + 5
+	// +2 accounts are grantees for the authz MsgExec txs built below, +3 sign the
+	// MsgModuleQuerySafe txs and +4 sign the ICA and tight-gas txs.
+	numberOfAccounts := (appconsts.MaxSDKMessages + 1) + (appconsts.MaxPFBMessages + 1) + 9
 	accounts := testfactory.GenerateAccounts(numberOfAccounts)
 	consensusParams := app.DefaultConsensusParams()
 	testApp, kr := testutil.SetupTestAppWithGenesisValSetAndMaxSquareSize(consensusParams, 128, accounts...)
@@ -495,6 +508,21 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 		return rawTx
 	}
 
+	// Build a tx carrying a single MsgRecvPacket whose ICA host payload holds
+	// totalInner messages. Only the packet is a top-level message, so a naive
+	// top-level count would let these bypass MaxSDKMessages. The packet itself
+	// counts as one, hence totalInner-1 messages in the payload.
+	// The counter reads the payload encoding from the channel, so the channel the
+	// packets arrive on has to exist.
+	seedICAHostChannel(t, testApp)
+
+	buildICATx := func(accIdx, totalInner int) []byte {
+		msg := icaHostRecvPacket(t, enc.Codec, addrs[accIdx], totalInner-1)
+		rawTx, _, err := signers[accIdx].CreateTx([]sdk.Msg{msg}, user.SetGasLimit(10000000), user.SetFee(10000))
+		require.NoError(t, err)
+		return rawTx
+	}
+
 	querySafeExceedsTx := buildModuleQuerySafeTx(accountIndex, appconsts.MaxSDKMessages+1)
 	accountIndex++
 	querySafeAtLimitTx := buildModuleQuerySafeTx(accountIndex, appconsts.MaxSDKMessages)
@@ -513,6 +541,22 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 		require.NoError(t, err)
 		return rawTx
 	}()
+	accountIndex++
+
+	icaExceedsTx := buildICATx(accountIndex, appconsts.MaxSDKMessages+1)
+	accountIndex++
+	icaAtLimitTx := buildICATx(accountIndex, appconsts.MaxSDKMessages)
+	accountIndex++
+
+	// A tx with a tight gas limit ahead of an ICA tx: counting reads the channel,
+	// which must not draw on the gas this tx leaves on the meter.
+	icaSmallTx := buildICATx(accountIndex, 10)
+	accountIndex++
+
+	tightGasTx, _, tightErr := signers[accountIndex].CreateTx(
+		[]sdk.Msg{banktypes.NewMsgSend(addrs[accountIndex], testnode.RandomAddress().(sdk.AccAddress), sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 10)))},
+		user.SetGasLimit(63000), user.SetFee(10000))
+	require.NoError(t, tightErr)
 
 	type testCase struct {
 		name           string
@@ -567,8 +611,22 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 			validSquare:    true,
 		},
 		{
+			// The ICA host dispatches every message in the packet payload, so
+			// they must count against MaxSDKMessages like any other message.
+			name:           "reject ICA packet flattening beyond MaxSDKMessages",
+			txs:            [][]byte{icaExceedsTx},
+			expectedResult: abci.ResponseProcessProposal_REJECT,
+			validSquare:    true,
+		},
+		{
 			name:           "accept MsgModuleQuerySafe queries at exactly MaxSDKMessages",
 			txs:            [][]byte{querySafeAtLimitTx},
+			expectedResult: abci.ResponseProcessProposal_ACCEPT,
+			validSquare:    true,
+		},
+		{
+			name:           "accept ICA packet flattening to exactly MaxSDKMessages",
+			txs:            [][]byte{icaAtLimitTx},
 			expectedResult: abci.ResponseProcessProposal_ACCEPT,
 			validSquare:    true,
 		},
@@ -576,6 +634,14 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 			name:           "reject MsgModuleQuerySafe with no queries beyond MaxSDKMessages",
 			txs:            [][]byte{emptyQuerySafeTx},
 			expectedResult: abci.ResponseProcessProposal_REJECT,
+			validSquare:    true,
+		},
+		{
+			// Counting must not consume the gas the preceding tx left, otherwise
+			// the channel read runs out of gas and panics.
+			name:           "accept ICA packet after a tx with a tight gas limit",
+			txs:            [][]byte{tightGasTx, icaSmallTx},
+			expectedResult: abci.ResponseProcessProposal_ACCEPT,
 			validSquare:    true,
 		},
 	}
@@ -608,4 +674,31 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 			require.Equal(t, tc.expectedResult, resp.Status)
 		})
 	}
+}
+
+// icaHostRecvPacket builds a MsgRecvPacket bound for the ICA host whose payload
+// holds numMsgs bank sends, i.e. a packet the host would dispatch numMsgs
+// messages from.
+func icaHostRecvPacket(t *testing.T, cdc codec.Codec, addr sdk.AccAddress, numMsgs int) sdk.Msg {
+	inner := make([]proto.Message, numMsgs)
+	for i := range inner {
+		inner[i] = banktypes.NewMsgSend(addr, addr, sdk.NewCoins(sdk.NewInt64Coin(appconsts.BondDenom, 1)))
+	}
+	payload, err := icatypes.SerializeCosmosTx(cdc, inner, icaEncoding)
+	require.NoError(t, err)
+
+	data := icatypes.InterchainAccountPacketData{Type: icatypes.EXECUTE_TX, Data: payload}
+	packet := channeltypes.NewPacket(data.GetBytes(), 1, "icacontroller-test", "channel-0", icatypes.HostPortID, icaChannelID, clienttypes.NewHeight(1, 1000000), 0)
+	return channeltypes.NewMsgRecvPacket(packet, []byte("proof"), clienttypes.NewHeight(1, 1), addr.String())
+}
+
+// seedICAHostChannel writes the ICA host channel the test packets arrive on, so
+// the message counter can read the encoding their payloads use.
+func seedICAHostChannel(t *testing.T, testApp *app.App) {
+	t.Helper()
+	metadata := icatypes.Metadata{Version: icatypes.Version, Encoding: icaEncoding, TxType: icatypes.TxTypeSDKMultiMsg}
+	testApp.IBCKeeper.ChannelKeeper.SetChannel(testApp.NewUncachedContext(false, tmproto.Header{}), icatypes.HostPortID, icaChannelID, channeltypes.Channel{
+		State:   channeltypes.OPEN,
+		Version: string(icatypes.ModuleCdc.MustMarshalJSON(&metadata)),
+	})
 }

--- a/scripts/test_fuzz.sh
+++ b/scripts/test_fuzz.sh
@@ -16,6 +16,7 @@ set -e
 
 echo "Running fuzz tests..."
 go test -fuzz=FuzzPFBGasEstimation -fuzztime 5m ./x/blob/types
+go test -fuzz=FuzzCountICAPacketMsgs -fuzztime 5m ./app
 go test -fuzz=FuzzScatterMarshalParity -fuzztime 5m ./fibre/internal/grpc
 go test -fuzz=FuzzShardCodecRoundTrip -fuzztime 5m ./fibre
 go test -fuzz=FuzzShardCodecReadNoPanic -fuzztime 5m ./fibre

--- a/test/util/malicious/out_of_order_prepare.go
+++ b/test/util/malicious/out_of_order_prepare.go
@@ -50,6 +50,7 @@ func (a *App) OutOfOrderPrepareProposal(req *abci.RequestPrepareProposal) (*abci
 		handler,
 		a.MsgServiceRouter(),
 		a.GetEncodingConfig().TxConfig,
+		a.IBCKeeper.ChannelKeeper,
 		a.MaxEffectiveSquareSize(sdkCtx),
 		appconsts.SubtreeRootThreshold,
 	)


### PR DESCRIPTION
Closes [#7752](https://github.com/celestiaorg/celestia-app/issues/7752)
Closes [PROTOCO-2534](https://linear.app/celestia/issue/PROTOCO-2534/check-whether-msgrecvpacket-also-needs-limiting)

## Problem

The ICA host dispatches every message in a packet payload through the msg router, with no cap, but `countExecutableMsgs` counted a `MsgRecvPacket` as one message. With `MaxGas: -1`, that count is the only bound on per-block work, so a single 8 MiB packet could execute tens of thousands of messages against a budget of 600.

ICA host is enabled, its allow list includes `MsgSend` and `MsgDelegate`, and opening a channel is permissionless.

## Change

A `MsgRecvPacket` bound for the ICA host counts the messages its payload holds, at the top level and inside a `MsgExec` (the ante handler does not reject that combination, so without it the fix is bypassable).

Counting is now one rule: **every message weighs one for itself, plus whatever it dispatches.** That also changes `MsgExec` (#7745) and `MsgModuleQuerySafe` (#7762), which previously dropped and subsumed their wrapper respectively. Subsuming it undercounts a packet — 600 `MsgRecvPacket`s each holding one message counted 600 while doing 600 proof verifications on top of the 600 dispatches — and overcounting the cheaper wrappers by one only ever rejects more. Neither is released, so no gate is needed.

Three details are load bearing:

- Counting reads the payload encoding from the channel the same way the host does and counts with only that decoder. Counting under both encodings undercounts: a proto3json payload can be laid out so its bytes also walk as valid proto wire.
- It never materialises the payload's messages, since it runs before the ante handler charges any gas. The proto path walks the wire format, the JSON path decodes into an empty struct.
- It fails closed. A payload its decoder rejects counts as `MaxSDKMessages`, as do an unknown channel and unparseable metadata.
- It bounds what the packet can reach before the ante handler validates it. The destination channel is checked against `ChannelIdentifierValidator` first, because the store panics on an oversized key and a 200 KB channel id in an unsigned tx otherwise crashed any node running `CheckTx`. Counting also stops once the running count passes `MaxSDKMessages`, so one tx forces at most one channel read per counted message rather than one per packet.

Counting swaps in an infinite gas meter. The proposal call sites run it before the tx's own ante handler, so the context still carries the previous tx's partially consumed meter, and the channel read would otherwise run out of gas and panic.

## Consensus impact

Adds a `ProcessProposal` rejection rule, matched in `PrepareProposal` and `CheckTx`. No app version gate: v10 is unreleased and #7745 shipped its counting change ungated.

Counting reads one piece of committed state. Both proposal handlers branch from the same committed state and neither executes channel handshakes or packets, so they cannot disagree. `countExecutableMsgs` is not reachable from `FinalizeBlock`, so the read cannot affect the app hash.

## Notes for reviewers

The bound holds only while `IcaAllowMessages` contains no message that dispatches further messages. That is a comment in `app/ica_host.go`, not a runtime check, so a governance param change could reopen it.

Out of scope: a gov `MsgSubmitProposal` wrapping a packet executes in the EndBlocker uncounted. (`icahosttypes.MsgModuleQuerySafe` was the other gap; #7762 closed it on main and this branch is rebased on top of it, so `msgWeight` and the ICA packet counting now compose.)

Counting still runs before signature verification in `CheckTx`, so it is unpaid; the early bail bounds it but does not make it free. Caching parsed channel metadata per count pass would cut it further and is worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



