### PR TITLE
fix!: count MsgModuleQuerySafe queries against the block message limit

### DIFF
--- a/app/msg_count.go
+++ b/app/msg_count.go
@@ -3,21 +3,44 @@ package app
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
+	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 )
 
 // countExecutableMsgs counts messages the way a block executes them: a MsgExec
-// contributes the number of messages authz dispatches from it, not one. This
-// stops a tx from hiding many executable messages behind a single MsgExec to
-// bypass the per-block SDK message limit. Nested MsgExec is rejected by the ante
-// handler, so counting one level is enough.
+// contributes the messages authz dispatches from it and a MsgModuleQuerySafe
+// contributes the queries it dispatches, not one each. This stops a tx from
+// hiding many units of execution behind a single message to bypass the
+// per-block SDK message limit. Nested MsgExec is rejected by the ante handler,
+// so flattening one level is enough.
 func countExecutableMsgs(msgs []sdk.Msg) int {
 	count := 0
 	for _, msg := range msgs {
-		if exec, ok := msg.(*authz.MsgExec); ok {
+		exec, ok := msg.(*authz.MsgExec)
+		if !ok {
+			count += msgWeight(msg)
+			continue
+		}
+		nested, err := exec.GetMessages()
+		if err != nil {
+			// The ante handler rejects a tx with undecodable inner messages, so
+			// count the wrappers rather than treating the MsgExec as free.
 			count += len(exec.Msgs)
 			continue
 		}
-		count++
+		for _, inner := range nested {
+			count += msgWeight(inner)
+		}
 	}
 	return count
+}
+
+// msgWeight returns the number of executable units in a single message. It never
+// returns less than one: a message with an empty fan-out still costs a full ante
+// pass, and per-message ValidateBasic does not run in the ante chain that
+// ProcessProposal uses.
+func msgWeight(msg sdk.Msg) int {
+	if querySafe, ok := msg.(*icahosttypes.MsgModuleQuerySafe); ok {
+		return max(1, len(querySafe.Requests))
+	}
+	return 1
 }

--- a/app/msg_count_test.go
+++ b/app/msg_count_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -18,6 +19,19 @@ func TestCountExecutableMsgs(t *testing.T) {
 			inner[i] = send()
 		}
 		exec := authz.NewMsgExec(sdk.AccAddress{}, inner)
+		return &exec
+	}
+
+	moduleQuerySafeWith := func(n int) sdk.Msg {
+		requests := make([]*icahosttypes.QueryRequest, n)
+		for i := range requests {
+			requests[i] = &icahosttypes.QueryRequest{Path: "/cosmos.bank.v1beta1.Query/TotalSupply"}
+		}
+		return icahosttypes.NewMsgModuleQuerySafe("", requests)
+	}
+
+	msgExecWithMsgs := func(msgs ...sdk.Msg) sdk.Msg {
+		exec := authz.NewMsgExec(sdk.AccAddress{}, msgs)
 		return &exec
 	}
 
@@ -45,6 +59,26 @@ func TestCountExecutableMsgs(t *testing.T) {
 			name:     "empty MsgExec counts as zero",
 			msgs:     []sdk.Msg{msgExecWith(0)},
 			expected: 0,
+		},
+		{
+			name:     "MsgModuleQuerySafe counts its queries",
+			msgs:     []sdk.Msg{moduleQuerySafeWith(5)},
+			expected: 5,
+		},
+		{
+			name:     "MsgModuleQuerySafe inside MsgExec counts its queries",
+			msgs:     []sdk.Msg{msgExecWithMsgs(moduleQuerySafeWith(5))},
+			expected: 5,
+		},
+		{
+			name:     "MsgModuleQuerySafe with no queries still counts as one",
+			msgs:     []sdk.Msg{moduleQuerySafeWith(0)},
+			expected: 1,
+		},
+		{
+			name:     "mix of MsgModuleQuerySafe and plain messages",
+			msgs:     []sdk.Msg{moduleQuerySafeWith(3), send(), msgExecWithMsgs(moduleQuerySafeWith(2), send())},
+			expected: 7,
 		},
 	}
 

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -33,6 +33,7 @@ import (
 	vestingtypes "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -50,7 +51,7 @@ func TestCheckTx(t *testing.T) {
 	namespace1, err = share.NewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
 	require.NoError(t, err)
 
-	accounts := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n"}
+	accounts := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o"}
 	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
 
 	signers := make([]*user.Signer, len(accounts))
@@ -362,6 +363,25 @@ func TestCheckTx(t *testing.T) {
 					remaining -= n
 				}
 				tx, _, err := signer.CreateTx(msgs, user.SetGasLimitAndGasPrice(1e7, appconsts.DefaultMinGasPrice))
+				require.NoError(t, err)
+				return tx
+			},
+			expectedABCICode: apperr.ErrTxExceedsMaxSDKMessages.ABCICode(),
+		},
+		{
+			name:      "MsgModuleQuerySafe queries exceeding max SDK messages, CheckTxType_New",
+			checkType: abci.CheckTxType_New,
+			getTx: func() []byte {
+				signer := signers[14]
+				addr := signer.Account(accounts[14]).Address()
+				// A single MsgModuleQuerySafe dispatches one query per request, so
+				// counting it as one message would let it bypass the limit.
+				requests := make([]*icahosttypes.QueryRequest, appconsts.MaxSDKMessages+1)
+				for i := range requests {
+					requests[i] = &icahosttypes.QueryRequest{Path: "/cosmos.bank.v1beta1.Query/TotalSupply"}
+				}
+				msg := icahosttypes.NewMsgModuleQuerySafe(addr.String(), requests)
+				tx, _, err := signer.CreateTx([]sdk.Msg{msg}, user.SetGasLimitAndGasPrice(1e7, appconsts.DefaultMinGasPrice))
 				require.NoError(t, err)
 				return tx
 			},

--- a/app/test/process_proposal_test.go
+++ b/app/test/process_proposal_test.go
@@ -28,6 +28,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/authz"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	icahosttypes "github.com/cosmos/ibc-go/v8/modules/apps/27-interchain-accounts/host/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -395,8 +396,9 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 	}
 
 	// Create enough accounts so each sends exactly one tx (avoids sequence collisions).
-	// +2 accounts are grantees for the authz MsgExec txs built below.
-	numberOfAccounts := (appconsts.MaxSDKMessages + 1) + (appconsts.MaxPFBMessages + 1) + 2
+	// +2 accounts are grantees for the authz MsgExec txs built below and +3 sign
+	// the MsgModuleQuerySafe txs.
+	numberOfAccounts := (appconsts.MaxSDKMessages + 1) + (appconsts.MaxPFBMessages + 1) + 5
 	accounts := testfactory.GenerateAccounts(numberOfAccounts)
 	consensusParams := app.DefaultConsensusParams()
 	testApp, kr := testutil.SetupTestAppWithGenesisValSetAndMaxSquareSize(consensusParams, 128, accounts...)
@@ -477,6 +479,40 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 	msgExecExceedsTx := buildMsgExecTx(accountIndex, appconsts.MaxSDKMessages+1)
 	accountIndex++
 	msgExecAtLimitTx := buildMsgExecTx(accountIndex, appconsts.MaxSDKMessages)
+	accountIndex++
+
+	// Build a tx with a single MsgModuleQuerySafe carrying numQueries requests.
+	// The message server dispatches one query per request, so a naive count of one
+	// message per MsgModuleQuerySafe would let these bypass MaxSDKMessages.
+	buildModuleQuerySafeTx := func(accIdx, numQueries int) []byte {
+		requests := make([]*icahosttypes.QueryRequest, numQueries)
+		for i := range requests {
+			requests[i] = &icahosttypes.QueryRequest{Path: "/cosmos.bank.v1beta1.Query/TotalSupply"}
+		}
+		msg := icahosttypes.NewMsgModuleQuerySafe(addrs[accIdx].String(), requests)
+		rawTx, _, err := signers[accIdx].CreateTx([]sdk.Msg{msg}, user.SetGasLimit(10000000), user.SetFee(10000))
+		require.NoError(t, err)
+		return rawTx
+	}
+
+	querySafeExceedsTx := buildModuleQuerySafeTx(accountIndex, appconsts.MaxSDKMessages+1)
+	accountIndex++
+	querySafeAtLimitTx := buildModuleQuerySafeTx(accountIndex, appconsts.MaxSDKMessages)
+	accountIndex++
+
+	// A MsgModuleQuerySafe with no queries dispatches nothing, but the tx still
+	// costs a full ante pass, so it must not be weightless. Per-message
+	// ValidateBasic, which rejects an empty request list, does not run in the
+	// ante chain ProcessProposal uses.
+	emptyQuerySafeTx := func() []byte {
+		msgs := make([]sdk.Msg, appconsts.MaxSDKMessages+1)
+		for i := range msgs {
+			msgs[i] = icahosttypes.NewMsgModuleQuerySafe(addrs[accountIndex].String(), nil)
+		}
+		rawTx, _, err := signers[accountIndex].CreateTx(msgs, user.SetGasLimit(10000000), user.SetFee(10000))
+		require.NoError(t, err)
+		return rawTx
+	}()
 
 	type testCase struct {
 		name           string
@@ -522,6 +558,24 @@ func TestProcessProposalCappingNumberOfMessages(t *testing.T) {
 			name:           "accept authz MsgExec flattening to exactly MaxSDKMessages",
 			txs:            [][]byte{msgExecAtLimitTx},
 			expectedResult: abci.ResponseProcessProposal_ACCEPT,
+			validSquare:    true,
+		},
+		{
+			name:           "reject MsgModuleQuerySafe queries beyond MaxSDKMessages",
+			txs:            [][]byte{querySafeExceedsTx},
+			expectedResult: abci.ResponseProcessProposal_REJECT,
+			validSquare:    true,
+		},
+		{
+			name:           "accept MsgModuleQuerySafe queries at exactly MaxSDKMessages",
+			txs:            [][]byte{querySafeAtLimitTx},
+			expectedResult: abci.ResponseProcessProposal_ACCEPT,
+			validSquare:    true,
+		},
+		{
+			name:           "reject MsgModuleQuerySafe with no queries beyond MaxSDKMessages",
+			txs:            [][]byte{emptyQuerySafeTx},
+			expectedResult: abci.ResponseProcessProposal_REJECT,
 			validSquare:    true,
 		},
 	}


### PR DESCRIPTION
`MsgModuleQuerySafe` dispatches one query per entry in its `Requests` slice, but `countExecutableMsgs` counted the whole message as 1 against `MaxSDKMessages`. Its `ValidateBasic` only rejects an empty request list, and the handler ignores the signer, so any funded account can send one in a plain tx.

Count `len(Requests)`, and flatten one level of authz `MsgExec` so a nested `MsgModuleQuerySafe` is counted too. The weight is never less than 1: an empty request list dispatches nothing but still costs a full ante pass, and per-message `ValidateBasic` does not run in the ante chain `ProcessProposal` uses.

This applies in `CheckTx`, `PrepareProposal` and `ProcessProposal`, which already call `countExecutableMsgs`.

Consensus-breaking: changes `ProcessProposal` accept/reject. Not version-gated, matching #7745 and the existing ungated `MaxSDKMessages` checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)