### PR TITLE
fix: force inter-block cache on for embedded v3 app

### DIFF
--- a/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
+++ b/cmd/celestia-appd/cmd/modify_root_command_multiplexer.go
@@ -27,9 +27,15 @@ var defaultArgs = []string{
 }
 
 // interBlockCacheOffArgs disables the SDK inter-block cache for the embedded
-// v3-v8 apps. Appended after the operator's own args, it overrides an
+// v4-v8 apps. Appended after the operator's own args, it overrides an
 // explicit --inter-block-cache=true.
 var interBlockCacheOffArgs = append([]string{"--inter-block-cache=false"}, defaultArgs...)
+
+// interBlockCacheOnArgs forces the inter-block cache on for the embedded v3
+// app. v3's upgrade-height Commit reloads the store mid-commit and relies on
+// the cache to preserve the upgrade block's writes; running v3 with the cache
+// disabled discards those writes and forks replay. See issue #7770.
+var interBlockCacheOnArgs = append([]string{"--inter-block-cache=true"}, defaultArgs...)
 
 // modifyRootCommand enhances the root command with the pass through and multiplexer.
 func modifyRootCommand(rootCommand *cobra.Command) {
@@ -103,7 +109,7 @@ func modifyRootCommand(rootCommand *cobra.Command) {
 		panic(err)
 	}
 
-	v3Args := interBlockCacheOffArgs
+	v3Args := interBlockCacheOnArgs
 	if v2UpgradeHeight != "" && v2UpgradeHeight != "0" {
 		v3Args = append(v3Args, "--v2-upgrade-height="+v2UpgradeHeight)
 	}


### PR DESCRIPTION
Closes https://github.com/celestiaorg/celestia-app/issues/7770 PROTOCO-2612

## Root cause

At an upgrade height, the v3 binary's cosmos-sdk fork (`v0.46.x-celestia`) reloads the root multistore in the middle of `Commit()` (`LoadLatestVersionAndUpgrade`), after the block's writes are flushed to the stores' working trees but before they are committed to disk.

- With the inter-block cache **on**, `CommitKVStoreCacheManager.GetStoreCache` returns the existing store instances, so the reload is a no-op and the upgrade block's writes survive. This is the behavior that produced mainnet/mocha state at the historical v2→v3 upgrade height.
- With the cache **off** (#7750), freshly loaded stores replace the instances holding the pending writes, so the upgrade block's writes — including the `SetAppVersion` param-store write and the signal tally reset — are silently discarded. The v2→v3 upgrade never activates, and replaying history forks at the upgrade height.

Only v3 has this mid-commit reload; v4+ upgrade via the upgrade module and a binary switch, so they keep the cache disabled per #7750.

## Fix

Force `--inter-block-cache=true` for the embedded v3 app. Forcing the flag (rather than just dropping the override) also protects nodes whose `app.toml` sets `inter-block-cache = false`, which would fork replay the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)