### PR TITLE
test(fibre): wait for settlement state visibility before asserting

### DIFF
--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -416,10 +416,7 @@ func (s *FibreE2ETestSuite) Test07DuplicatePayment() {
 
 	hash, err := signed.Hash()
 	require.NoError(t, err)
-	q := fibretypes.NewQueryClient(s.cctx.GRPCClient)
-	processed, err := q.IsPaymentProcessed(ctx, &fibretypes.QueryIsPaymentProcessedRequest{PromiseHash: hash})
-	require.NoError(t, err)
-	require.True(t, processed.Found, "payment promise should be recorded as processed after settlement")
+	waitForPaymentProcessed(t, s.cctx, hash)
 
 	resp, err = s.txClient.BroadcastTx(ctx, []sdk.Msg{msg})
 	if err == nil {

--- a/fibre/internal/e2e/fibre_stack_test.go
+++ b/fibre/internal/e2e/fibre_stack_test.go
@@ -66,6 +66,18 @@ func startFibreStack(t *testing.T, cctx testnode.Context, ecfg encoding.Config, 
 	return fibreStack{server: server, client: client, tx: txClient}
 }
 
+// waitForPaymentProcessed waits until the promise is recorded as processed.
+// A confirmed settlement tx can precede its state becoming visible to queries
+// by a moment, so assertions on settlement state must wait for it.
+func waitForPaymentProcessed(t *testing.T, cctx testnode.Context, promiseHash []byte) {
+	t.Helper()
+	q := fibretypes.NewQueryClient(cctx.GRPCClient)
+	require.Eventually(t, func() bool {
+		resp, err := q.IsPaymentProcessed(cctx.GoContext(), &fibretypes.QueryIsPaymentProcessedRequest{PromiseHash: promiseHash})
+		return err == nil && resp.Found
+	}, 30*time.Second, 250*time.Millisecond, "payment promise should be recorded as processed")
+}
+
 func fundEscrow(t *testing.T, cctx testnode.Context, tx *user.TxClient, amount sdk.Coin) {
 	t.Helper()
 	resp, err := tx.SubmitTx(cctx.GoContext(),

--- a/fibre/internal/e2e/fibre_timeout_e2e_test.go
+++ b/fibre/internal/e2e/fibre_timeout_e2e_test.go
@@ -123,14 +123,12 @@ func (s *FibreTimeoutTestSuite) TestTimeoutSettlement() {
 	require.NoError(t, s.cctx.WaitForNextBlock())
 	require.NoError(t, submit(), "timeout settlement should succeed once the promise has expired")
 
+	hash, err := signed.Hash()
+	require.NoError(t, err)
+	waitForPaymentProcessed(t, s.cctx, hash)
+
 	uploadSize := uint32(fibre.DefaultBlobConfigV0().UploadSize(len(data)))
 	wantDebit := fibretypes.PaymentAmount(uploadSize)
 	require.Equal(t, wantDebit, before.Sub(escrowBalance()),
 		"escrow should be debited by the payment amount on timeout settlement")
-
-	hash, err := signed.Hash()
-	require.NoError(t, err)
-	processed, err := fibreQ.IsPaymentProcessed(ctx, &fibretypes.QueryIsPaymentProcessedRequest{PromiseHash: hash})
-	require.NoError(t, err)
-	require.True(t, processed.Found, "timed-out promise should be recorded as processed")
 }


### PR DESCRIPTION
`TestFibreTimeoutTestSuite/TestTimeoutSettlement` and `TestFibreE2ETestSuite/Test07DuplicatePayment` intermittently fail in CI on unrelated PRs (e.g. [this run](https://github.com/celestiaorg/celestia-app/actions/runs/33716443974/job/100526516518) on a test-tooling PR, and [this one](https://github.com/celestiaorg/celestia-app/actions/runs/33633676885) on a docs-only merge-queue run — both passed on rerun).

Cause: both tests submit a settlement tx, confirm it, and immediately query settlement state over gRPC. A confirmed tx can precede its state becoming visible to queries by a moment; on loaded runners the query lands inside that window and sees pre-settlement state (escrow delta 0 / promise not processed) even though the tx succeeded on-chain.

Fix: add a `waitForPaymentProcessed` helper that polls `IsPaymentProcessed` with `require.Eventually` (matching the existing pattern in `fibre_withdrawal_e2e_test.go`) and use it in both tests before asserting on settlement effects.

Both suites pass locally with `-count=2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)