### PR TITLE
test(fibre): clarify idle timer cancellation comment

### DIFF
--- a/fibre/internal/row/pool_test.go
+++ b/fibre/internal/row/pool_test.go
@@ -323,7 +323,7 @@ func TestPool_IdleTimerArmedAndCancelled(t *testing.T) {
 
 	b := p.Get(rc, 64)
 	defer p.Put(b)
-	// Get's cancelIdle should have stopped the timer; a redundant Stop
+	// The call to Get should have stopped the timer through cancelIdle; a redundant Stop
 	// returns false because the timer is no longer active.
 	if bk.idleTimer.Stop() {
 		t.Fatal("idle timer should already be stopped after Get")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->


Clarifies the idle-timer assertion comment by stating explicitly that `Get` stops the timer through `cancelIdle`, which is why a subsequent redundant `Stop` returns false. This removes the awkward possessive wording and documents the causal path exercised by the test.

The test logic is unchanged

