### PR TITLE
feat(fibre): add versioned shard markers

### DIFF
--- a/docs/architecture/adr-030-fibre-elastic-shard-storage.md
+++ b/docs/architecture/adr-030-fibre-elastic-shard-storage.md
@@ -142,14 +142,14 @@ For each matching shard marker, `Store` will use this flow:
 1. Select the durable backend from the shard marker.
 2. For a local marker, read the local flat file.
 3. For an object marker, read the object with `GetObject`.
-4. If local storage returns `NotFound`, remove the stale marker and try the next matching shard marker.
+4. If local storage returns `NotFound`, keep the marker for occupancy accounting and try the next matching shard marker.
 5. If object storage returns `NotFound`, keep the marker, record an integrity error, and try the next matching shard marker.
 6. If another durable-storage error occurs, record it and try the next matching shard marker.
 7. If no matching shard marker succeeds, return the recorded error.
 
 Every read of an object-backed shard accesses object storage.
 
-The current read flow scans all Pebble shard markers that match the requested commitment. It removes stale markers after missing-file errors ([`fibre/store.go:265`](../../fibre/store.go#L265), [`fibre/store.go:289`](../../fibre/store.go#L289)).
+The read flow keeps missing-file markers until pruning can release their recorded sizes.
 
 ### Read latency concerns
 

--- a/fibre/occupancy.go
+++ b/fibre/occupancy.go
@@ -2,10 +2,10 @@ package fibre
 
 import "sync/atomic"
 
-// occupancy tracks how many bytes of shards a validator holds against its disk
-// budget.
+// occupancy tracks marker-accounted and in-flight shard bytes against the
+// validator's storage budget.
 type occupancy struct {
-	used atomic.Int64 // on-disk plus in-flight bytes
+	used atomic.Int64 // marker-accounted plus in-flight bytes
 	// budget is the per-node cap in bytes. A non-positive value (<=0) disables
 	// the limiter.
 	budget atomic.Int64
@@ -25,7 +25,7 @@ func (o *occupancy) setBudget(newBudget int64) {
 	o.budget.Store(newBudget)
 }
 
-// usage returns the current tracked occupancy in bytes (on-disk plus in-flight).
+// usage returns the current marker-accounted and in-flight bytes.
 func (o *occupancy) usage() int64 {
 	return o.used.Load()
 }

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -146,11 +146,9 @@ func (s *Server) Start(ctx context.Context) (err error) {
 		return fmt.Errorf("opening store: %w", err)
 	}
 
-	size, err := s.store.Size(ctx)
-	if err != nil {
-		return fmt.Errorf("getting store size: %w", err)
+	if err := s.seedOccupancy(ctx); err != nil {
+		return err
 	}
-	s.occ.seed(size)
 
 	// Derive the budget once at startup.
 	if err := s.recomputeBudget(ctx); err != nil {
@@ -172,6 +170,18 @@ func (s *Server) Start(ctx context.Context) (err error) {
 
 	s.grpc.Serve()
 	s.log.Info("serving gRPC", "addr", s.grpc.ListenAddress())
+	return nil
+}
+
+func (s *Server) seedOccupancy(ctx context.Context) error {
+	size, err := s.store.Size(ctx)
+	if err != nil && !errors.Is(err, ErrStoreIntegrity) {
+		return fmt.Errorf("getting store size: %w", err)
+	}
+	if err != nil {
+		s.log.Warn("store size may be incorrect due to corrupt shard marker", "error", err)
+	}
+	s.occ.seed(size)
 	return nil
 }
 

--- a/fibre/server_prune.go
+++ b/fibre/server_prune.go
@@ -2,6 +2,7 @@ package fibre
 
 import (
 	"context"
+	"errors"
 	"time"
 )
 
@@ -32,18 +33,33 @@ func (s *Server) startPruneLoop(ctx context.Context) {
 
 func (s *Server) prune(ctx context.Context) {
 	start := time.Now()
+	var totalPruned int
+	var pruneErr error
 
-	pruned, freed, err := s.store.PruneBefore(ctx, start)
-	s.metrics.observePrune(ctx, start, pruned, err)
+	for {
+		pruned, freed, err := s.store.PruneBefore(ctx, start)
+		totalPruned += pruned
+		if freed > 0 {
+			s.occ.release(freed)
+		}
+		if err != nil && (pruneErr == nil || !errors.Is(err, ErrStoreIntegrity)) {
+			pruneErr = err
+		}
+		if pruned < maxPruneBatchSize || (err != nil && !errors.Is(err, ErrStoreIntegrity)) || ctx.Err() != nil {
+			break
+		}
+	}
+	metricErr := pruneErr
+	if errors.Is(pruneErr, ErrStoreIntegrity) {
+		s.log.WarnContext(ctx, "prune skipped corrupt shard markers", "error", pruneErr,
+			"elapsed (ms)", time.Since(start).Milliseconds())
+		metricErr = nil
+	} else if pruneErr != nil {
+		s.log.ErrorContext(ctx, "failed to prune store", "error", pruneErr, "elapsed (ms)", time.Since(start).Milliseconds())
+	}
+	s.metrics.observePrune(ctx, start, totalPruned, metricErr)
 
-	if freed > 0 {
-		s.occ.release(freed)
-	}
-	if err != nil {
-		s.log.ErrorContext(ctx, "failed to prune store", "error", err, "elapsed (ms)", time.Since(start).Milliseconds())
-		return
-	}
-	if pruned > 0 {
-		s.log.InfoContext(ctx, "pruned expired entries", "pruned", pruned, "elapsed (ms)", time.Since(start).Milliseconds())
+	if totalPruned > 0 {
+		s.log.InfoContext(ctx, "pruned expired entries", "pruned", totalPruned, "elapsed (ms)", time.Since(start).Milliseconds())
 	}
 }

--- a/fibre/server_prune.go
+++ b/fibre/server_prune.go
@@ -33,31 +33,38 @@ func (s *Server) startPruneLoop(ctx context.Context) {
 
 func (s *Server) prune(ctx context.Context) {
 	start := time.Now()
-	var totalPruned int
-	var pruneErr error
+	var (
+		totalPruned  int
+		integrityErr error
+	)
 
 	for {
 		pruned, freed, err := s.store.PruneBefore(ctx, start)
+		if err != nil {
+			if !errors.Is(err, ErrStoreIntegrity) {
+				s.metrics.observePrune(ctx, start, totalPruned, err)
+				s.log.ErrorContext(ctx, "failed to prune store", "error", err, "elapsed (ms)", time.Since(start).Milliseconds())
+				return
+			}
+			if integrityErr == nil {
+				integrityErr = err
+			}
+		}
+
 		totalPruned += pruned
 		if freed > 0 {
 			s.occ.release(freed)
 		}
-		if err != nil && (pruneErr == nil || !errors.Is(err, ErrStoreIntegrity)) {
-			pruneErr = err
-		}
-		if pruned < maxPruneBatchSize || (err != nil && !errors.Is(err, ErrStoreIntegrity)) || ctx.Err() != nil {
+		if pruned < maxPruneBatchSize || ctx.Err() != nil {
 			break
 		}
 	}
-	metricErr := pruneErr
-	if errors.Is(pruneErr, ErrStoreIntegrity) {
-		s.log.WarnContext(ctx, "prune skipped corrupt shard markers", "error", pruneErr,
+
+	if integrityErr != nil {
+		s.log.WarnContext(ctx, "prune skipped corrupt shard markers", "error", integrityErr,
 			"elapsed (ms)", time.Since(start).Milliseconds())
-		metricErr = nil
-	} else if pruneErr != nil {
-		s.log.ErrorContext(ctx, "failed to prune store", "error", pruneErr, "elapsed (ms)", time.Since(start).Milliseconds())
 	}
-	s.metrics.observePrune(ctx, start, totalPruned, metricErr)
+	s.metrics.observePrune(ctx, start, totalPruned, nil)
 
 	if totalPruned > 0 {
 		s.log.InfoContext(ctx, "pruned expired entries", "pruned", totalPruned, "elapsed (ms)", time.Since(start).Milliseconds())

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -99,8 +99,15 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 
 	if !has {
 		size := shardBinarySize(req.Shard)
-		reserved := s.occ.reserve(size)
-		if !reserved {
+		accounted, err := s.store.hasAccountedShardMarker(promise.Commitment, promiseHash)
+		if err != nil {
+			log.ErrorContext(ctx, "failed to check shard accounting", "error", err)
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "shard accounting check failed")
+			return nil, status.Error(grpccodes.Internal, fmt.Sprintf("checking shard accounting: %v", err))
+		}
+		newReservation := !accounted
+		if newReservation && !s.occ.reserve(size) {
 			s.metrics.uploadShardRejected.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "budget_exceeded")))
 			st := status.New(grpccodes.ResourceExhausted, "fibre storage budget exceeded")
 			st, _ = st.WithDetails(&errdetails.RetryInfo{
@@ -112,7 +119,9 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 		// store payment promise and shard with RLC roots
 		storePutStart := time.Now()
 		if err := s.store.Put(ctx, promise, req.Shard, pruneAt); err != nil {
-			s.occ.release(size)
+			if newReservation {
+				s.occ.release(size)
+			}
 			s.metrics.observeStoreOp(ctx, s.metrics.storePutDuration, storePutStart, false)
 			// A cancelled/expired client context means the store deliberately
 			// skipped the commit; report it as such rather than as an Internal

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -99,13 +99,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 
 	if !has {
 		size := shardBinarySize(req.Shard)
-		accounted, err := s.store.hasAccountedShardMarker(promise.Commitment, promiseHash)
-		if err != nil {
-			log.ErrorContext(ctx, "failed to check shard accounting", "error", err)
-			span.RecordError(err)
-			span.SetStatus(codes.Error, "shard accounting check failed")
-			return nil, status.Error(grpccodes.Internal, fmt.Sprintf("checking shard accounting: %v", err))
-		}
+		accounted := s.store.hasAccountedShardMarker(promise.Commitment, promiseHash)
 		newReservation := !accounted
 		if newReservation && !s.occ.reserve(size) {
 			s.metrics.uploadShardRejected.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "budget_exceeded")))

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -89,7 +89,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	mu.Lock()
 	defer mu.Unlock()
 
-	has, err := s.store.Has(ctx, promise.Commitment, promiseHash)
+	has, accounted, err := s.store.shardStatus(promise.Commitment, promiseHash)
 	if err != nil {
 		log.ErrorContext(ctx, "failed to check store for existing shard", "error", err)
 		span.RecordError(err)
@@ -99,7 +99,6 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 
 	if !has {
 		size := shardBinarySize(req.Shard)
-		accounted := s.store.hasAccountedShardMarker(promise.Commitment, promiseHash)
 		newReservation := !accounted
 		if newReservation && !s.occ.reserve(size) {
 			s.metrics.uploadShardRejected.Add(ctx, 1, metric.WithAttributes(attribute.String("reason", "budget_exceeded")))

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -33,8 +33,10 @@ import (
 // commits through a single goroutine, which becomes the upload bottleneck at
 // concurrency. Pebble only holds the small metadata.
 const (
-	shardsSubdir      = "shards"
-	stagingSubdir     = "staging"
+	shardsSubdir  = "shards"
+	stagingSubdir = "staging"
+	// maxPruneBatchSize bounds each Pebble commit. The server drains full
+	// batches during one prune pass.
 	maxPruneBatchSize = 1000
 )
 
@@ -347,23 +349,15 @@ func (s *Store) Has(_ context.Context, commitment Commitment, promiseHash []byte
 	return true, nil
 }
 
-// hasAccountedShardMarker reports whether a versioned marker already counts
-// the shard towards occupancy. Empty legacy markers require a local payload.
-func (s *Store) hasAccountedShardMarker(commitment Commitment, promiseHash []byte) (bool, error) {
+// hasAccountedShardMarker reports whether a marker validated by [Store.Has]
+// already counts the shard towards occupancy.
+func (s *Store) hasAccountedShardMarker(commitment Commitment, promiseHash []byte) bool {
 	markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
-	switch {
-	case errors.Is(err, pebbledb.ErrNotFound):
-		return false, nil
-	case err != nil:
-		return false, fmt.Errorf("getting shard marker: %w", err)
-	}
-
-	size, err := decodeShardMarker(markerData)
-	_ = closer.Close()
 	if err != nil {
-		return false, err
+		return false
 	}
-	return size > 0, nil
+	_ = closer.Close()
+	return len(markerData) > 0
 }
 
 // hasShardMarker reports whether a committed shard marker exists,
@@ -382,7 +376,10 @@ func (s *Store) hasShardMarker(commit Commitment, promiseHash []byte) bool {
 	}
 }
 
-// Size returns the total encoded size of stored shards.
+// Size returns the marker-accounted encoded size of stored shards. It stats
+// existing local payloads for empty legacy markers. If invalid metadata is
+// skipped, it returns the usable partial total with [ErrStoreIntegrity]. All
+// other errors return zero.
 func (s *Store) Size(ctx context.Context) (int64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
@@ -474,8 +471,10 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 // PruneBefore deletes all shards and payment promises with pruneAt before the given time
 // and returns the number of pruned entries and the freed bytes.
 //
-// It inspects at most [maxPruneBatchSize] expired entries per call. Invalid
-// markers remain unchanged while valid entries in the batch are pruned.
+// It deletes at most [maxPruneBatchSize] expired entries per call. If invalid
+// markers are skipped, it commits valid deletions and returns their count and
+// freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
+// do not consume deletion capacity.
 func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -492,9 +491,9 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 	var pruned int
 	var prunedBytes int64
 	var integrityErr error
-	var examined int
+	var corruptMarkers int
 	beforeStr := formatTimestamp(before.UTC())
-	for valid := iter.First(); valid && examined < maxPruneBatchSize; valid = iter.Next() {
+	for valid := iter.First(); valid && pruned < maxPruneBatchSize; valid = iter.Next() {
 		key := iter.Key()
 
 		// Keys are sorted; once the timestamp reaches the cutoff we're done.
@@ -503,8 +502,6 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 		if timestampStr >= beforeStr {
 			break
 		}
-		examined++
-
 		commitment, promiseHash, ok := parsePruneKey(keyStr)
 		if !ok {
 			continue
@@ -520,7 +517,10 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 			size, err = decodeShardMarker(markerData)
 			_ = closer.Close()
 			if err != nil {
-				integrityErr = errors.Join(integrityErr, fmt.Errorf("decoding shard marker %q: %w", key, err))
+				corruptMarkers++
+				if integrityErr == nil {
+					integrityErr = fmt.Errorf("decoding shard marker %q: %w", key, err)
+				}
 				continue
 			}
 		}
@@ -562,6 +562,9 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
 		return pruned, prunedBytes, fmt.Errorf("committing batch: %w", err)
+	}
+	if corruptMarkers > 1 {
+		integrityErr = fmt.Errorf("%w (%d corrupt shard markers)", integrityErr, corruptMarkers)
 	}
 	return pruned, prunedBytes, integrityErr
 }

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -157,14 +157,10 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 		return fmt.Errorf("getting promise hash: %w", err)
 	}
 
+	marker := encodeShardMarker(shardBinarySize(shard))
 	tmp, err := s.writeTmpShard(shard)
 	if err != nil {
 		return fmt.Errorf("writing shard tmp: %w", err)
-	}
-	marker, err := encodeShardMarker(shardBinarySize(shard))
-	if err != nil {
-		_ = s.fs.Remove(tmp)
-		return fmt.Errorf("encoding shard marker: %w", err)
 	}
 	if err := s.commitAndPublish(ctx, promise, promiseHash, tmp, marker, pruneAt); err != nil {
 		_ = s.fs.Remove(tmp)
@@ -395,8 +391,11 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 	}
 	defer iter.Close()
 
-	var totalSize int64
-	var integrityErr error
+	var (
+		totalSize      int64
+		integrityErr   error
+		invalidEntries int
+	)
 	for valid := iter.First(); valid; valid = iter.Next() {
 		if err := ctx.Err(); err != nil {
 			return 0, err
@@ -404,14 +403,19 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 
 		size, err := decodeShardMarker(iter.Value())
 		if err != nil {
-			integrityErr = errors.Join(integrityErr, fmt.Errorf("decoding shard marker %q: %w", iter.Key(), err))
+			invalidEntries++
+			if integrityErr == nil {
+				integrityErr = fmt.Errorf("decoding shard marker %q: %w", iter.Key(), err)
+			}
 			continue
 		}
 		if size == 0 {
 			commitment, promiseHash, ok := parseShardKey(string(iter.Key()))
 			if !ok {
-				integrityErr = errors.Join(integrityErr,
-					fmt.Errorf("%w: invalid shard key %q", ErrStoreIntegrity, iter.Key()))
+				invalidEntries++
+				if integrityErr == nil {
+					integrityErr = fmt.Errorf("%w: invalid shard key %q", ErrStoreIntegrity, iter.Key())
+				}
 				continue
 			}
 			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
@@ -434,6 +438,9 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 	}
 	if err := ctx.Err(); err != nil {
 		return 0, ctx.Err()
+	}
+	if invalidEntries > 1 {
+		integrityErr = fmt.Errorf("%w (%d invalid shard metadata entries)", integrityErr, invalidEntries)
 	}
 	return totalSize, integrityErr
 }
@@ -488,10 +495,12 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 
 	batch := s.db.NewBatch()
 	defer batch.Close()
-	var pruned int
-	var prunedBytes int64
-	var integrityErr error
-	var corruptMarkers int
+	var (
+		pruned         int
+		prunedBytes    int64
+		integrityErr   error
+		corruptMarkers int
+	)
 	beforeStr := formatTimestamp(before.UTC())
 	for valid := iter.First(); valid && pruned < maxPruneBatchSize; valid = iter.Next() {
 		key := iter.Key()

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -4,10 +4,12 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
+	"math"
 	"os"
 	"path/filepath"
 	"slices"
@@ -31,12 +33,16 @@ import (
 // commits through a single goroutine, which becomes the upload bottleneck at
 // concurrency. Pebble only holds the small metadata.
 const (
-	shardsSubdir  = "shards"
-	stagingSubdir = "staging"
+	shardsSubdir      = "shards"
+	stagingSubdir     = "staging"
+	maxPruneBatchSize = 1000
 )
 
 // ErrStoreNotFound is returned when no shard is found for a [Commitment] in the [Store].
 var ErrStoreNotFound = errors.New("no shard found in store")
+
+// ErrStoreIntegrity is returned when stored metadata is invalid.
+var ErrStoreIntegrity = errors.New("store integrity error")
 
 // StoreConfig contains configuration options for the [Store].
 type StoreConfig struct {
@@ -94,8 +100,8 @@ func NewMemoryStore(cfg StoreConfig) *Store {
 }
 
 // NewStore opens a [Store] backed by an on-disk pebble database and flat
-// shard files at cfg.Path. On open, [Store.reconcile] drops any leftover
-// staging files from a previous crash.
+// shard files at cfg.Path. On open, [Store.reconcile] drops leftover staging
+// files and shard files without markers.
 func NewStore(cfg StoreConfig) (*Store, error) {
 	return openStore(cfg, vfs.Default)
 }
@@ -133,9 +139,8 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 
 // Put stores a [PaymentPromise] and [types.BlobShard] using a stage → publish
 // → commit pattern: write tmp under staging/, rename into shards/<commit>-<hash>,
-// then commit pebble metadata. A crash between rename and commit
-// leaves a phantom marker that [Store.Get] cleans lazily and [PruneBefore]
-// sweeps at pruneAt.
+// then commit pebble metadata. A crash between rename and commit can leave an
+// orphan file that [Store.reconcile] removes on the next open.
 // Puts for the same commitment but different promises are stored independently
 // without deduplication.
 func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.BlobShard, pruneAt time.Time) error {
@@ -154,7 +159,12 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 	if err != nil {
 		return fmt.Errorf("writing shard tmp: %w", err)
 	}
-	if err := s.commitAndPublish(ctx, promise, promiseHash, tmp, pruneAt); err != nil {
+	marker, err := encodeShardMarker(shardBinarySize(shard))
+	if err != nil {
+		_ = s.fs.Remove(tmp)
+		return fmt.Errorf("encoding shard marker: %w", err)
+	}
+	if err := s.commitAndPublish(ctx, promise, promiseHash, tmp, marker, pruneAt); err != nil {
 		_ = s.fs.Remove(tmp)
 		return err
 	}
@@ -164,7 +174,7 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 // commitAndPublish renames tmp into the canonical shards/ path, then writes
 // pebble metadata for the published shard. On any error tmp is left in
 // place for the caller to remove.
-func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, promiseHash []byte, tmp string, pruneAt time.Time) error {
+func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, promiseHash []byte, tmp string, marker []byte, pruneAt time.Time) error {
 	promiseProto, err := promise.ToProto()
 	if err != nil {
 		return fmt.Errorf("converting payment promise to proto: %w", err)
@@ -179,8 +189,7 @@ func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, p
 	if err := batch.Set(promiseKey(promiseHash), ppData, pebbledb.NoSync); err != nil {
 		return fmt.Errorf("putting payment promise: %w", err)
 	}
-	// Empty value: the marker only exists so [Get] can iterate by commitment.
-	if err := batch.Set(shardKey(promise.Commitment, promiseHash), nil, pebbledb.NoSync); err != nil {
+	if err := batch.Set(shardKey(promise.Commitment, promiseHash), marker, pebbledb.NoSync); err != nil {
 		return fmt.Errorf("putting shard marker: %w", err)
 	}
 	if err := batch.Set(pruneKey(pruneAt, promise.Commitment, promiseHash), nil, pebbledb.NoSync); err != nil {
@@ -275,6 +284,10 @@ func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard,
 
 	var rerr error
 	for valid := iter.First(); valid; valid = iter.Next() {
+		if _, err := decodeShardMarker(iter.Value()); err != nil {
+			rerr = errors.Join(rerr, err)
+			continue
+		}
 		promiseHashHex := string(iter.Key()[len(prefix):])
 		promiseHash, err := hex.DecodeString(promiseHashHex)
 		if err != nil {
@@ -310,14 +323,18 @@ func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard,
 
 // Has verifies that shard exists without reading the whole file
 func (s *Store) Has(_ context.Context, commitment Commitment, promiseHash []byte) (bool, error) {
-	_, closer, err := s.db.Get(shardKey(commitment, promiseHash))
+	markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
 	switch {
 	case errors.Is(err, pebbledb.ErrNotFound):
 		return false, nil
 	case err != nil:
 		return false, fmt.Errorf("checking if shard exists failed: %w", err)
 	default:
+		_, err = decodeShardMarker(markerData)
 		_ = closer.Close()
+		if err != nil {
+			return false, err
+		}
 	}
 
 	_, err = s.fs.Stat(s.shardFilePath(commitment, promiseHash))
@@ -328,6 +345,25 @@ func (s *Store) Has(_ context.Context, commitment Commitment, promiseHash []byte
 		return false, fmt.Errorf("stat shard file: %w", err)
 	}
 	return true, nil
+}
+
+// hasAccountedShardMarker reports whether a versioned marker already counts
+// the shard towards occupancy. Empty legacy markers require a local payload.
+func (s *Store) hasAccountedShardMarker(commitment Commitment, promiseHash []byte) (bool, error) {
+	markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
+	switch {
+	case errors.Is(err, pebbledb.ErrNotFound):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("getting shard marker: %w", err)
+	}
+
+	size, err := decodeShardMarker(markerData)
+	_ = closer.Close()
+	if err != nil {
+		return false, err
+	}
+	return size > 0, nil
 }
 
 // hasShardMarker reports whether a committed shard marker exists,
@@ -346,32 +382,63 @@ func (s *Store) hasShardMarker(commit Commitment, promiseHash []byte) bool {
 	}
 }
 
-// Size returns the total on-disk bytes of stored shard files.
+// Size returns the total encoded size of stored shards.
 func (s *Store) Size(ctx context.Context) (int64, error) {
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
 
-	dir := filepath.Join(s.cfg.Path, shardsSubdir)
-	list, err := s.fs.List(dir)
+	prefix := []byte("/shard/")
+	iter, err := s.db.NewIter(&pebbledb.IterOptions{
+		LowerBound: prefix,
+		UpperBound: prefixUpperBound(prefix),
+	})
 	if err != nil {
-		return 0, fmt.Errorf("accessing shards dir: %w", err)
+		return 0, fmt.Errorf("creating iterator: %w", err)
 	}
+	defer iter.Close()
 
 	var totalSize int64
-	for _, name := range list {
-		info, err := s.fs.Stat(filepath.Join(dir, name))
-		switch {
-		case errors.Is(err, os.ErrNotExist):
-			continue // pruned concurrently between List and Stat
-		case err != nil:
-			return 0, fmt.Errorf("stat shard file %s: %w", name, err)
-		case ctx.Err() != nil:
-			return 0, ctx.Err()
+	var integrityErr error
+	for valid := iter.First(); valid; valid = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return 0, err
 		}
-		totalSize += info.Size()
+
+		size, err := decodeShardMarker(iter.Value())
+		if err != nil {
+			integrityErr = errors.Join(integrityErr, fmt.Errorf("decoding shard marker %q: %w", iter.Key(), err))
+			continue
+		}
+		if size == 0 {
+			commitment, promiseHash, ok := parseShardKey(string(iter.Key()))
+			if !ok {
+				integrityErr = errors.Join(integrityErr,
+					fmt.Errorf("%w: invalid shard key %q", ErrStoreIntegrity, iter.Key()))
+				continue
+			}
+			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
+			switch {
+			case errors.Is(err, os.ErrNotExist):
+				continue
+			case err != nil:
+				return 0, fmt.Errorf("stat legacy shard file: %w", err)
+			default:
+				size = info.Size()
+			}
+		}
+		if size > math.MaxInt64-totalSize {
+			return 0, fmt.Errorf("%w: total shard size overflows int64", ErrStoreIntegrity)
+		}
+		totalSize += size
 	}
-	return totalSize, nil
+	if err := iter.Error(); err != nil {
+		return 0, fmt.Errorf("iterating shards: %w", err)
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, ctx.Err()
+	}
+	return totalSize, integrityErr
 }
 
 // DiskAvailable returns the free bytes on the filesystem backing the store.
@@ -407,9 +474,8 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 // PruneBefore deletes all shards and payment promises with pruneAt before the given time
 // and returns the number of pruned entries and the freed bytes.
 //
-// It works by iterating over the ordered prune index and deleting each entry until the given time,
-// so it iterates exactly over the entries that need to be pruned. The order is guaranteed by the
-// underlying database and enforced with query.OrderByKey{}.
+// It inspects at most [maxPruneBatchSize] expired entries per call. Invalid
+// markers remain unchanged while valid entries in the batch are pruned.
 func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -423,13 +489,12 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 
 	batch := s.db.NewBatch()
 	defer batch.Close()
-
-	var (
-		pruned      int
-		prunedBytes int64
-	)
+	var pruned int
+	var prunedBytes int64
+	var integrityErr error
+	var examined int
 	beforeStr := formatTimestamp(before.UTC())
-	for valid := iter.First(); valid; valid = iter.Next() {
+	for valid := iter.First(); valid && examined < maxPruneBatchSize; valid = iter.Next() {
 		key := iter.Key()
 
 		// Keys are sorted; once the timestamp reaches the cutoff we're done.
@@ -438,20 +503,40 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 		if timestampStr >= beforeStr {
 			break
 		}
+		examined++
 
 		commitment, promiseHash, ok := parsePruneKey(keyStr)
 		if !ok {
 			continue
 		}
 
+		markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
 		var size int64
-		info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
 		switch {
-		case errors.Is(err, os.ErrNotExist):
+		case errors.Is(err, pebbledb.ErrNotFound):
 		case err != nil:
-			return pruned, prunedBytes, fmt.Errorf("getting shard file stats: %w", err)
+			return pruned, prunedBytes, fmt.Errorf("getting shard marker: %w", err)
 		default:
-			size = info.Size()
+			size, err = decodeShardMarker(markerData)
+			_ = closer.Close()
+			if err != nil {
+				integrityErr = errors.Join(integrityErr, fmt.Errorf("decoding shard marker %q: %w", key, err))
+				continue
+			}
+		}
+
+		if size == 0 {
+			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
+			switch {
+			case errors.Is(err, os.ErrNotExist):
+			case err != nil:
+				return pruned, prunedBytes, fmt.Errorf("getting shard file stats: %w", err)
+			default:
+				size = info.Size()
+			}
+		}
+		if size > math.MaxInt64-prunedBytes {
+			return pruned, prunedBytes, fmt.Errorf("%w: pruned shard size overflows int64", ErrStoreIntegrity)
 		}
 
 		// Missing file is fine (orphan marker from a crashed Put).
@@ -474,27 +559,62 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 	if err := iter.Error(); err != nil {
 		return pruned, prunedBytes, fmt.Errorf("iterating prune index: %w", err)
 	}
+
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
 		return pruned, prunedBytes, fmt.Errorf("committing batch: %w", err)
 	}
-	return pruned, prunedBytes, nil
+	return pruned, prunedBytes, integrityErr
 }
 
-// reconcile drops everything under <store>/staging/. Anything there at open
-// time is a leftover from a Put that crashed before the rename. Orphan
-// markers and orphan files in shards/ are intentionally not cleaned here:
-// markers self-heal in [Store.Get] and at pruneAt via [Store.PruneBefore];
-// rare orphan files (pebble.NoSync power loss after rename) are accepted.
+// reconcile drops incomplete staging files and canonical shard files without
+// markers. Markers without files self-heal in [Store.Get] and at pruneAt.
 func (s *Store) reconcile() error {
 	start := time.Now()
-	n, err := s.resetStaging()
-	elapsedMs := time.Since(start).Milliseconds()
+	stagingRemoved, err := s.resetStaging()
 	if err != nil {
-		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", elapsedMs)
+		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", time.Since(start).Milliseconds())
 		return err
 	}
-	s.log.Info("store reconcile complete", "staging_files_removed", n, "elapsed_ms", elapsedMs)
+	orphansRemoved, err := s.removeOrphanShards()
+	if err != nil {
+		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", time.Since(start).Milliseconds())
+		return err
+	}
+	s.log.Info("store reconcile complete", "staging_files_removed", stagingRemoved,
+		"orphan_files_removed", orphansRemoved, "elapsed_ms", time.Since(start).Milliseconds())
 	return nil
+}
+
+func (s *Store) removeOrphanShards() (int, error) {
+	dir := filepath.Join(s.cfg.Path, shardsSubdir)
+	names, err := s.fs.List(dir)
+	if err != nil {
+		return 0, fmt.Errorf("listing shard files: %w", err)
+	}
+
+	var removed int
+	for _, name := range names {
+		commitmentHex, promiseHashHex, ok := strings.Cut(name, "-")
+		commitment, commitmentErr := CommitmentFromString(commitmentHex)
+		promiseHash, hashErr := hex.DecodeString(promiseHashHex)
+		if !ok || commitmentErr != nil || hashErr != nil || len(promiseHash) != sha256.Size {
+			continue
+		}
+
+		_, closer, err := s.db.Get(shardKey(commitment, promiseHash))
+		switch {
+		case err == nil:
+			_ = closer.Close()
+			continue
+		case !errors.Is(err, pebbledb.ErrNotFound):
+			return removed, fmt.Errorf("checking shard marker: %w", err)
+		}
+		if err := s.fs.Remove(filepath.Join(dir, name)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return removed, fmt.Errorf("removing orphan shard file: %w", err)
+		}
+		removed++
+	}
+	return removed, nil
 }
 
 // resetStaging removes and recreates <store>/staging/, returning the number
@@ -532,6 +652,23 @@ func promiseKey(promiseHash []byte) []byte {
 
 func shardKey(commitment Commitment, promiseHash []byte) []byte {
 	return fmt.Appendf(nil, "/shard/%s/%s", commitment.String(), hex.EncodeToString(promiseHash))
+}
+
+func parseShardKey(key string) (Commitment, []byte, bool) {
+	parts := strings.Split(key, "/")
+	if len(parts) != 4 || parts[1] != "shard" {
+		return Commitment{}, nil, false
+	}
+
+	commitment, err := CommitmentFromString(parts[2])
+	if err != nil {
+		return Commitment{}, nil, false
+	}
+	promiseHash, err := hex.DecodeString(parts[3])
+	if err != nil {
+		return Commitment{}, nil, false
+	}
+	return commitment, promiseHash, true
 }
 
 // pruneKey is keyed by the pruneAt computed during upload (see shardPruneAt)

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -321,39 +321,36 @@ func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard,
 
 // Has verifies that shard exists without reading the whole file
 func (s *Store) Has(_ context.Context, commitment Commitment, promiseHash []byte) (bool, error) {
+	has, _, err := s.shardStatus(commitment, promiseHash)
+	return has, err
+}
+
+// shardStatus reports whether the payload exists and its marker counts towards occupancy.
+func (s *Store) shardStatus(commitment Commitment, promiseHash []byte) (bool, bool, error) {
 	markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
+	var accounted bool
 	switch {
 	case errors.Is(err, pebbledb.ErrNotFound):
-		return false, nil
+		return false, false, nil
 	case err != nil:
-		return false, fmt.Errorf("checking if shard exists failed: %w", err)
+		return false, false, fmt.Errorf("checking if shard exists failed: %w", err)
 	default:
+		accounted = len(markerData) > 0
 		_, err = decodeShardMarker(markerData)
 		_ = closer.Close()
 		if err != nil {
-			return false, err
+			return false, false, err
 		}
 	}
 
 	_, err = s.fs.Stat(s.shardFilePath(commitment, promiseHash))
 	switch {
 	case errors.Is(err, os.ErrNotExist):
-		return false, nil
+		return false, accounted, nil
 	case err != nil:
-		return false, fmt.Errorf("stat shard file: %w", err)
+		return false, false, fmt.Errorf("stat shard file: %w", err)
 	}
-	return true, nil
-}
-
-// hasAccountedShardMarker reports whether a marker validated by [Store.Has]
-// already counts the shard towards occupancy.
-func (s *Store) hasAccountedShardMarker(commitment Commitment, promiseHash []byte) bool {
-	markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
-	if err != nil {
-		return false
-	}
-	_ = closer.Close()
-	return len(markerData) > 0
+	return true, accounted, nil
 }
 
 // hasShardMarker reports whether a committed shard marker exists,

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -481,7 +481,7 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 // It deletes at most [maxPruneBatchSize] expired entries per call. If invalid
 // markers are skipped, it commits valid deletions and returns their count and
 // freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
-// do not consume deletion capacity.
+// do not consume deletion capacity. Fatal errors return no uncommitted counts.
 func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -521,7 +521,7 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 		switch {
 		case errors.Is(err, pebbledb.ErrNotFound):
 		case err != nil:
-			return pruned, prunedBytes, fmt.Errorf("getting shard marker: %w", err)
+			return 0, 0, fmt.Errorf("getting shard marker: %w", err)
 		default:
 			size, err = decodeShardMarker(markerData)
 			_ = closer.Close()
@@ -539,38 +539,38 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 			switch {
 			case errors.Is(err, os.ErrNotExist):
 			case err != nil:
-				return pruned, prunedBytes, fmt.Errorf("getting shard file stats: %w", err)
+				return 0, 0, fmt.Errorf("getting shard file stats: %w", err)
 			default:
 				size = info.Size()
 			}
 		}
 		if size > math.MaxInt64-prunedBytes {
-			return pruned, prunedBytes, fmt.Errorf("%w: pruned shard size overflows int64", ErrStoreIntegrity)
+			return 0, 0, errors.New("pruned shard size overflows int64")
 		}
 
 		// Missing file is fine (orphan marker from a crashed Put).
 		if err := s.fs.Remove(s.shardFilePath(commitment, promiseHash)); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return pruned, prunedBytes, fmt.Errorf("removing shard file: %w", err)
+			return 0, 0, fmt.Errorf("removing shard file: %w", err)
 		}
 		if err := batch.Delete(key, pebbledb.NoSync); err != nil {
-			return pruned, prunedBytes, fmt.Errorf("deleting prune index: %w", err)
+			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
 		}
 		if err := batch.Delete(shardKey(commitment, promiseHash), pebbledb.NoSync); err != nil {
-			return pruned, prunedBytes, fmt.Errorf("deleting shard marker: %w", err)
+			return 0, 0, fmt.Errorf("deleting shard marker: %w", err)
 		}
 		if err := batch.Delete(promiseKey(promiseHash), pebbledb.NoSync); err != nil {
-			return pruned, prunedBytes, fmt.Errorf("deleting payment promise: %w", err)
+			return 0, 0, fmt.Errorf("deleting payment promise: %w", err)
 		}
 		pruned++
 		prunedBytes += size
 	}
 
 	if err := iter.Error(); err != nil {
-		return pruned, prunedBytes, fmt.Errorf("iterating prune index: %w", err)
+		return 0, 0, fmt.Errorf("iterating prune index: %w", err)
 	}
 
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
-		return pruned, prunedBytes, fmt.Errorf("committing batch: %w", err)
+		return 0, 0, fmt.Errorf("committing batch: %w", err)
 	}
 	if corruptMarkers > 1 {
 		integrityErr = fmt.Errorf("%w (%d corrupt shard markers)", integrityErr, corruptMarkers)

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -103,7 +103,7 @@ func NewMemoryStore(cfg StoreConfig) *Store {
 
 // NewStore opens a [Store] backed by an on-disk pebble database and flat
 // shard files at cfg.Path. On open, [Store.reconcile] drops leftover staging
-// files and shard files without markers.
+// files from a previous crash.
 func NewStore(cfg StoreConfig) (*Store, error) {
 	return openStore(cfg, vfs.Default)
 }
@@ -390,6 +390,14 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 			return 0, err
 		}
 
+		commitment, promiseHash, ok := parseShardKey(string(iter.Key()))
+		if !ok {
+			invalidEntries++
+			if integrityErr == nil {
+				integrityErr = fmt.Errorf("%w: invalid shard key %q", ErrStoreIntegrity, iter.Key())
+			}
+			continue
+		}
 		size, err := decodeShardMarker(iter.Value())
 		if err != nil {
 			// Keep one representative error and count all invalid markers.
@@ -401,14 +409,6 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 		}
 		if size == 0 {
 			// Empty markers predate encoded sizes, so read the local file size.
-			commitment, promiseHash, ok := parseShardKey(string(iter.Key()))
-			if !ok {
-				invalidEntries++
-				if integrityErr == nil {
-					integrityErr = fmt.Errorf("%w: invalid shard key %q", ErrStoreIntegrity, iter.Key())
-				}
-				continue
-			}
 			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
 			switch {
 			case errors.Is(err, os.ErrNotExist):

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -143,7 +142,7 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 // Put stores a [PaymentPromise] and [types.BlobShard] using a stage → publish
 // → commit pattern: write tmp under staging/, rename into shards/<commit>-<hash>,
 // then commit pebble metadata. A crash between rename and commit can leave an
-// orphan file that [Store.reconcile] removes on the next open.
+// orphan file.
 // Puts for the same commitment but different promises are stored independently
 // without deduplication.
 func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.BlobShard, pruneAt time.Time) error {
@@ -579,8 +578,11 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 	return pruned, prunedBytes, integrityErr
 }
 
-// reconcile drops incomplete staging files and canonical shard files without
-// markers. Markers without files self-heal in [Store.Get] and at pruneAt.
+// reconcile drops everything under <store>/staging/. Anything there at open
+// time is a leftover from a Put that crashed before the rename. Orphan
+// markers and orphan files in shards/ are intentionally not cleaned here:
+// markers self-heal in [Store.Get] and at pruneAt via [Store.PruneBefore];
+// rare orphan files (pebble.NoSync power loss after rename) are accepted.
 func (s *Store) reconcile() error {
 	start := time.Now()
 	stagingRemoved, err := s.resetStaging()
@@ -588,48 +590,9 @@ func (s *Store) reconcile() error {
 		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", time.Since(start).Milliseconds())
 		return err
 	}
-	orphansRemoved, err := s.removeOrphanShards()
-	if err != nil {
-		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", time.Since(start).Milliseconds())
-		return err
-	}
 	s.log.Info("store reconcile complete", "staging_files_removed", stagingRemoved,
-		"orphan_files_removed", orphansRemoved, "elapsed_ms", time.Since(start).Milliseconds())
+		"elapsed_ms", time.Since(start).Milliseconds())
 	return nil
-}
-
-// removeOrphanShards deletes canonical shard files that have no Pebble marker.
-func (s *Store) removeOrphanShards() (int, error) {
-	dir := filepath.Join(s.cfg.Path, shardsSubdir)
-	names, err := s.fs.List(dir)
-	if err != nil {
-		return 0, fmt.Errorf("listing shard files: %w", err)
-	}
-
-	var removed int
-	for _, name := range names {
-		// Ignore unrelated files; only canonical shard names are safe to remove.
-		commitmentHex, promiseHashHex, ok := strings.Cut(name, "-")
-		commitment, commitmentErr := CommitmentFromString(commitmentHex)
-		promiseHash, hashErr := hex.DecodeString(promiseHashHex)
-		if !ok || commitmentErr != nil || hashErr != nil || len(promiseHash) != sha256.Size {
-			continue
-		}
-
-		_, closer, err := s.db.Get(shardKey(commitment, promiseHash))
-		switch {
-		case err == nil:
-			_ = closer.Close()
-			continue
-		case !errors.Is(err, pebbledb.ErrNotFound):
-			return removed, fmt.Errorf("checking shard marker: %w", err)
-		}
-		if err := s.fs.Remove(filepath.Join(dir, name)); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return removed, fmt.Errorf("removing orphan shard file: %w", err)
-		}
-		removed++
-	}
-	return removed, nil
 }
 
 // resetStaging removes and recreates <store>/staging/, returning the number

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -266,9 +266,8 @@ func (s *Store) shardFilePath(commit Commitment, promiseHash []byte) string {
 // first prevents unbounded message sizes; pebble's deterministic key order
 // makes the choice consistent across validators.
 //
-// Get may write to pebble: if a /shard/ marker is found but the backing file
-// is missing (crash leftover or pebble.NoSync power loss), the marker is
-// deleted inline so future Gets stop paying the missed lookup.
+// A marker with a missing payload remains until pruning so its recorded size
+// can be released from occupancy.
 func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard, error) {
 	prefix := fmt.Appendf(nil, "%s%s/", shardKeyPrefix, commitment.String())
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -298,13 +297,6 @@ func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard,
 			return shard, nil
 		}
 		if errors.Is(err, ErrStoreNotFound) {
-			// Orphan marker — drop it. The /prune/ entry self-cleans at TTL.
-			if delErr := s.db.Delete(shardKey(commitment, promiseHash), pebbledb.NoSync); delErr != nil {
-				s.log.Warn("failed to clean orphan shard marker",
-					"commitment", commitment.String(),
-					"error", delErr,
-				)
-			}
 			continue
 		}
 		rerr = errors.Join(rerr, fmt.Errorf("reading shard file: %w", err))

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -33,8 +33,9 @@ import (
 // commits through a single goroutine, which becomes the upload bottleneck at
 // concurrency. Pebble only holds the small metadata.
 const (
-	shardsSubdir  = "shards"
-	stagingSubdir = "staging"
+	shardsSubdir   = "shards"
+	stagingSubdir  = "staging"
+	shardKeyPrefix = "/shard/"
 	// maxPruneBatchSize bounds each Pebble commit. The server drains full
 	// batches during one prune pass.
 	maxPruneBatchSize = 1000
@@ -270,7 +271,7 @@ func (s *Store) shardFilePath(commit Commitment, promiseHash []byte) string {
 // is missing (crash leftover or pebble.NoSync power loss), the marker is
 // deleted inline so future Gets stop paying the missed lookup.
 func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard, error) {
-	prefix := fmt.Appendf(nil, "/shard/%s/", commitment.String())
+	prefix := fmt.Appendf(nil, "%s%s/", shardKeyPrefix, commitment.String())
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
 		LowerBound: prefix,
 		UpperBound: prefixUpperBound(prefix),
@@ -378,7 +379,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 		return 0, err
 	}
 
-	prefix := []byte("/shard/")
+	prefix := []byte(shardKeyPrefix)
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
 		LowerBound: prefix,
 		UpperBound: prefixUpperBound(prefix),
@@ -400,6 +401,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 
 		size, err := decodeShardMarker(iter.Value())
 		if err != nil {
+			// Keep one representative error and count all invalid markers.
 			invalidEntries++
 			if integrityErr == nil {
 				integrityErr = fmt.Errorf("decoding shard marker %q: %w", iter.Key(), err)
@@ -407,6 +409,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 			continue
 		}
 		if size == 0 {
+			// Empty markers predate encoded sizes, so read the local file size.
 			commitment, promiseHash, ok := parseShardKey(string(iter.Key()))
 			if !ok {
 				invalidEntries++
@@ -532,6 +535,7 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 		}
 
 		if size == 0 {
+			// Empty markers predate encoded sizes, so read the local file size.
 			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
 			switch {
 			case errors.Is(err, os.ErrNotExist):
@@ -594,6 +598,7 @@ func (s *Store) reconcile() error {
 	return nil
 }
 
+// removeOrphanShards deletes canonical shard files that have no Pebble marker.
 func (s *Store) removeOrphanShards() (int, error) {
 	dir := filepath.Join(s.cfg.Path, shardsSubdir)
 	names, err := s.fs.List(dir)
@@ -603,6 +608,7 @@ func (s *Store) removeOrphanShards() (int, error) {
 
 	var removed int
 	for _, name := range names {
+		// Ignore unrelated files; only canonical shard names are safe to remove.
 		commitmentHex, promiseHashHex, ok := strings.Cut(name, "-")
 		commitment, commitmentErr := CommitmentFromString(commitmentHex)
 		promiseHash, hashErr := hex.DecodeString(promiseHashHex)
@@ -660,20 +666,24 @@ func promiseKey(promiseHash []byte) []byte {
 }
 
 func shardKey(commitment Commitment, promiseHash []byte) []byte {
-	return fmt.Appendf(nil, "/shard/%s/%s", commitment.String(), hex.EncodeToString(promiseHash))
+	return fmt.Appendf(nil, "%s%s/%s", shardKeyPrefix, commitment.String(), hex.EncodeToString(promiseHash))
 }
 
 func parseShardKey(key string) (Commitment, []byte, bool) {
-	parts := strings.Split(key, "/")
-	if len(parts) != 4 || parts[1] != "shard" {
+	suffix, ok := strings.CutPrefix(key, shardKeyPrefix)
+	if !ok {
+		return Commitment{}, nil, false
+	}
+	parts := strings.Split(suffix, "/")
+	if len(parts) != 2 {
 		return Commitment{}, nil, false
 	}
 
-	commitment, err := CommitmentFromString(parts[2])
+	commitment, err := CommitmentFromString(parts[0])
 	if err != nil {
 		return Commitment{}, nil, false
 	}
-	promiseHash, err := hex.DecodeString(parts[3])
+	promiseHash, err := hex.DecodeString(parts[1])
 	if err != nil {
 		return Commitment{}, nil, false
 	}

--- a/fibre/store_marker.go
+++ b/fibre/store_marker.go
@@ -1,0 +1,49 @@
+package fibre
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+)
+
+const (
+	shardMarkerVersion = 1
+	shardMarkerSize    = 10
+)
+
+type shardBackendTag byte
+
+const localBackendTag shardBackendTag = 0x01
+
+func encodeShardMarker(size int64) ([]byte, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid shard size %d", size)
+	}
+
+	marker := make([]byte, shardMarkerSize)
+	marker[0] = shardMarkerVersion
+	marker[1] = byte(localBackendTag)
+	binary.BigEndian.PutUint64(marker[2:], uint64(size))
+	return marker, nil
+}
+
+func decodeShardMarker(data []byte) (int64, error) {
+	if len(data) == 0 {
+		return 0, nil
+	}
+	if len(data) != shardMarkerSize {
+		return 0, fmt.Errorf("%w: shard marker length %d, want %d", ErrStoreIntegrity, len(data), shardMarkerSize)
+	}
+	if data[0] != shardMarkerVersion {
+		return 0, fmt.Errorf("%w: unsupported shard marker version %d", ErrStoreIntegrity, data[0])
+	}
+	if shardBackendTag(data[1]) != localBackendTag {
+		return 0, fmt.Errorf("%w: unsupported shard backend tag 0x%02x", ErrStoreIntegrity, data[1])
+	}
+
+	size := binary.BigEndian.Uint64(data[2:])
+	if size == 0 || size > math.MaxInt64 {
+		return 0, fmt.Errorf("%w: invalid shard size %d", ErrStoreIntegrity, size)
+	}
+	return int64(size), nil
+}

--- a/fibre/store_marker.go
+++ b/fibre/store_marker.go
@@ -11,22 +11,19 @@ const (
 	shardMarkerSize    = 10
 )
 
-type shardBackendTag byte
+const localBackendTag byte = 0x01
 
-const localBackendTag shardBackendTag = 0x01
-
-func encodeShardMarker(size int64) ([]byte, error) {
-	if size <= 0 {
-		return nil, fmt.Errorf("invalid shard size %d", size)
-	}
-
+// encodeShardMarker encodes a local shard size.
+func encodeShardMarker(size int64) []byte {
 	marker := make([]byte, shardMarkerSize)
 	marker[0] = shardMarkerVersion
-	marker[1] = byte(localBackendTag)
+	marker[1] = localBackendTag
 	binary.BigEndian.PutUint64(marker[2:], uint64(size))
-	return marker, nil
+	return marker
 }
 
+// decodeShardMarker returns the encoded shard size. An empty marker returns
+// zero without an error and identifies a legacy local shard.
 func decodeShardMarker(data []byte) (int64, error) {
 	if len(data) == 0 {
 		return 0, nil
@@ -37,7 +34,7 @@ func decodeShardMarker(data []byte) (int64, error) {
 	if data[0] != shardMarkerVersion {
 		return 0, fmt.Errorf("%w: unsupported shard marker version %d", ErrStoreIntegrity, data[0])
 	}
-	if shardBackendTag(data[1]) != localBackendTag {
+	if data[1] != localBackendTag {
 		return 0, fmt.Errorf("%w: unsupported shard backend tag 0x%02x", ErrStoreIntegrity, data[1])
 	}
 

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -273,6 +273,23 @@ func TestPruneBeforeLimitsBatchSize(t *testing.T) {
 	require.Equal(t, int64(1), freed)
 }
 
+func TestPruneBeforeOverflowReturnsNoUncommittedCounts(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	for i, size := range []int64{math.MaxInt64, 1} {
+		promiseHash := []byte{byte(i)}
+		require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
+		require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+	}
+
+	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrStoreIntegrity)
+	require.Zero(t, pruned)
+	require.Zero(t, freed)
+}
+
 func TestServerPruneDrainsBacklog(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestShardMarkerCodec(t *testing.T) {
-	marker, err := encodeShardMarker(42)
-	require.NoError(t, err)
+	marker := encodeShardMarker(42)
 	require.Equal(t, []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 42}, marker)
 
 	size, err := decodeShardMarker(marker)
@@ -31,8 +30,7 @@ func TestShardMarkerCodec(t *testing.T) {
 }
 
 func TestShardMarkerRejectsInvalidData(t *testing.T) {
-	valid, err := encodeShardMarker(1)
-	require.NoError(t, err)
+	valid := encodeShardMarker(1)
 
 	overflow := append([]byte(nil), valid...)
 	binary.BigEndian.PutUint64(overflow[2:], uint64(math.MaxInt64)+1)
@@ -140,8 +138,7 @@ func TestGetSkipsInvalidMarkerAndReturnsValidShard(t *testing.T) {
 	invalidMarker := []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}
 	writeMarkerTestShard(t, store, commitment, invalidHash)
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
-	validMarker, err := encodeShardMarker(validSize)
-	require.NoError(t, err)
+	validMarker := encodeShardMarker(validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), invalidMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 
@@ -173,14 +170,16 @@ func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
 	commitment := generateCommitment()
 	validHash := []byte{1}
 	invalidHash := []byte{2}
+	secondInvalidHash := []byte{3}
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
-	validMarker, err := encodeShardMarker(validSize)
-	require.NoError(t, err)
+	validMarker := encodeShardMarker(validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), []byte{1, 2}, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, secondInvalidHash), []byte{1, 2}, pebbledb.NoSync))
 
 	size, err := store.Size(t.Context())
 	require.ErrorIs(t, err, ErrStoreIntegrity)
+	require.Contains(t, err.Error(), "2 invalid shard metadata entries")
 	require.Equal(t, validSize, size)
 }
 
@@ -189,8 +188,7 @@ func TestServerSeedsPartialSizeAfterIntegrityError(t *testing.T) {
 	commitment := generateCommitment()
 	validHash := []byte{1}
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
-	validMarker, err := encodeShardMarker(validSize)
-	require.NoError(t, err)
+	validMarker := encodeShardMarker(validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, []byte{2}), []byte{1, 2}, pebbledb.NoSync))
 
@@ -215,8 +213,7 @@ func TestHasAccountedShardMarker(t *testing.T) {
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), nil, pebbledb.NoSync))
 	accounted = store.hasAccountedShardMarker(commitment, promiseHash)
 	require.False(t, accounted)
-	marker, err := encodeShardMarker(1)
-	require.NoError(t, err)
+	marker := encodeShardMarker(1)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
 	accounted = store.hasAccountedShardMarker(commitment, promiseHash)
 	require.True(t, accounted)
@@ -230,8 +227,7 @@ func TestPruneBeforeSkipsInvalidMarkerAndPrunesValidEntry(t *testing.T) {
 	invalidHash := []byte{2}
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
 	writeMarkerTestShard(t, store, commitment, invalidHash)
-	validMarker, err := encodeShardMarker(validSize)
-	require.NoError(t, err)
+	validMarker := encodeShardMarker(validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, validHash), nil, pebbledb.NoSync))
@@ -257,8 +253,7 @@ func TestPruneBeforeLimitsBatchSize(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	marker, err := encodeShardMarker(1)
-	require.NoError(t, err)
+	marker := encodeShardMarker(1)
 	require.NoError(t, store.db.Set(shardKey(commitment, nil), []byte{1, 2}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, nil), nil, pebbledb.NoSync))
 	for i := range maxPruneBatchSize + 1 {
@@ -282,8 +277,7 @@ func TestServerPruneDrainsBacklog(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	marker, err := encodeShardMarker(1)
-	require.NoError(t, err)
+	marker := encodeShardMarker(1)
 	require.NoError(t, store.db.Set(shardKey(commitment, nil), []byte{1, 2}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, nil), nil, pebbledb.NoSync))
 	for i := range maxPruneBatchSize + 1 {

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -1,0 +1,299 @@
+package fibre
+
+import (
+	"encoding/binary"
+	"log/slog"
+	"math"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	pebbledb "github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardMarkerCodec(t *testing.T) {
+	marker, err := encodeShardMarker(42)
+	require.NoError(t, err)
+	require.Equal(t, []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 42}, marker)
+
+	size, err := decodeShardMarker(marker)
+	require.NoError(t, err)
+	require.Equal(t, int64(42), size)
+
+	size, err = decodeShardMarker(nil)
+	require.NoError(t, err)
+	require.Zero(t, size)
+}
+
+func TestShardMarkerRejectsInvalidData(t *testing.T) {
+	valid, err := encodeShardMarker(1)
+	require.NoError(t, err)
+
+	overflow := append([]byte(nil), valid...)
+	binary.BigEndian.PutUint64(overflow[2:], uint64(math.MaxInt64)+1)
+	zeroBackend := append([]byte(nil), valid...)
+	zeroBackend[1] = 0
+	objectBackend := append([]byte(nil), valid...)
+	objectBackend[1] = 2
+	tests := []struct {
+		name string
+		data []byte
+	}{
+		{"truncated", valid[:9]},
+		{"overlong", append(valid, 0)},
+		{"zero version", append([]byte{0}, valid[1:]...)},
+		{"unsupported version", append([]byte{2}, valid[1:]...)},
+		{"zero backend", zeroBackend},
+		{"object backend", objectBackend},
+		{"zero size", []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{"size overflow", overflow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decodeShardMarker(tt.data)
+			require.ErrorIs(t, err, ErrStoreIntegrity)
+		})
+	}
+}
+
+func TestStoreSupportsLegacyShardMarker(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	promiseHash := []byte{1, 2, 3}
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	wantSize := writeMarkerTestShard(t, store, commitment, promiseHash)
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), nil, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+
+	shard, err := store.Get(t.Context(), commitment)
+	require.NoError(t, err)
+	require.Len(t, shard.Rows, 1)
+	has, err := store.Has(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.True(t, has)
+	size, err := store.Size(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, wantSize, size)
+
+	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+	require.Equal(t, wantSize, freed)
+}
+
+func TestStoreRejectsInvalidShardMarkerWithoutDeletingItsData(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Store, Commitment, []byte, time.Time) error
+	}{
+		{"Get", func(s *Store, c Commitment, _ []byte, _ time.Time) error {
+			_, err := s.Get(t.Context(), c)
+			return err
+		}},
+		{"Has", func(s *Store, c Commitment, h []byte, _ time.Time) error {
+			_, err := s.Has(t.Context(), c, h)
+			return err
+		}},
+		{"Size", func(s *Store, _ Commitment, _ []byte, _ time.Time) error {
+			_, err := s.Size(t.Context())
+			return err
+		}},
+		{"PruneBefore", func(s *Store, _ Commitment, _ []byte, pruneAt time.Time) error {
+			_, _, err := s.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := newMarkerTestStore(t)
+			commitment := generateCommitment()
+			promiseHash := []byte{1, 2, 3}
+			pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+			writeMarkerTestShard(t, store, commitment, promiseHash)
+			invalidMarker := []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}
+			require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), invalidMarker, pebbledb.NoSync))
+			require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+
+			require.ErrorIs(t, tt.call(store, commitment, promiseHash, pruneAt), ErrStoreIntegrity)
+			_, err := store.fs.Stat(store.shardFilePath(commitment, promiseHash))
+			require.NoError(t, err)
+			data, closer, err := store.db.Get(shardKey(commitment, promiseHash))
+			require.NoError(t, err)
+			require.Equal(t, invalidMarker, data)
+			require.NoError(t, closer.Close())
+		})
+	}
+}
+
+func TestGetSkipsInvalidMarkerAndReturnsValidShard(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	invalidHash := []byte{1}
+	validHash := []byte{2}
+	invalidMarker := []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}
+	writeMarkerTestShard(t, store, commitment, invalidHash)
+	validSize := writeMarkerTestShard(t, store, commitment, validHash)
+	validMarker, err := encodeShardMarker(validSize)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), invalidMarker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
+
+	shard, err := store.Get(t.Context(), commitment)
+	require.NoError(t, err)
+	require.Equal(t, []byte("data"), shard.Rows[0].Data)
+	data, closer, err := store.db.Get(shardKey(commitment, invalidHash))
+	require.NoError(t, err)
+	require.Equal(t, invalidMarker, data)
+	require.NoError(t, closer.Close())
+}
+
+func TestRemoveOrphanShardsPreservesInvalidMarker(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	promiseHash := make([]byte, 32)
+	writeMarkerTestShard(t, store, commitment, promiseHash)
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), []byte{1, 2}, pebbledb.NoSync))
+
+	removed, err := store.removeOrphanShards()
+	require.NoError(t, err)
+	require.Zero(t, removed)
+	_, err = store.fs.Stat(store.shardFilePath(commitment, promiseHash))
+	require.NoError(t, err)
+}
+
+func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	validHash := []byte{1}
+	invalidHash := []byte{2}
+	validSize := writeMarkerTestShard(t, store, commitment, validHash)
+	validMarker, err := encodeShardMarker(validSize)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), []byte{1, 2}, pebbledb.NoSync))
+
+	size, err := store.Size(t.Context())
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+	require.Equal(t, validSize, size)
+}
+
+func TestServerSeedsPartialSizeAfterIntegrityError(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	validHash := []byte{1}
+	validSize := writeMarkerTestShard(t, store, commitment, validHash)
+	validMarker, err := encodeShardMarker(validSize)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, []byte{2}), []byte{1, 2}, pebbledb.NoSync))
+
+	var logs strings.Builder
+	server := &Server{
+		store: store,
+		occ:   newOccupancy(0),
+		log:   slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	require.NoError(t, server.seedOccupancy(t.Context()))
+	require.Equal(t, validSize, server.occ.usage())
+	require.Contains(t, logs.String(), "store size may be incorrect due to corrupt shard marker")
+}
+
+func TestHasAccountedShardMarker(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	promiseHash := []byte{1}
+
+	accounted, err := store.hasAccountedShardMarker(commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, accounted)
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), nil, pebbledb.NoSync))
+	accounted, err = store.hasAccountedShardMarker(commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, accounted)
+	marker, err := encodeShardMarker(1)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
+	accounted, err = store.hasAccountedShardMarker(commitment, promiseHash)
+	require.NoError(t, err)
+	require.True(t, accounted)
+}
+
+func TestPruneBeforeSkipsInvalidMarkerAndPrunesValidEntry(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	validHash := []byte{1}
+	invalidHash := []byte{2}
+	validSize := writeMarkerTestShard(t, store, commitment, validHash)
+	writeMarkerTestShard(t, store, commitment, invalidHash)
+	validMarker, err := encodeShardMarker(validSize)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, validHash), nil, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, invalidHash), nil, pebbledb.NoSync))
+
+	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+	require.Equal(t, 1, pruned)
+	require.Equal(t, validSize, freed)
+	_, closer, err := store.db.Get(shardKey(commitment, validHash))
+	require.ErrorIs(t, err, pebbledb.ErrNotFound)
+	require.Nil(t, closer)
+	_, err = store.fs.Stat(store.shardFilePath(commitment, validHash))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	_, closer, err = store.db.Get(shardKey(commitment, invalidHash))
+	require.NoError(t, err)
+	require.NoError(t, closer.Close())
+	_, err = store.fs.Stat(store.shardFilePath(commitment, invalidHash))
+	require.NoError(t, err)
+}
+
+func TestPruneBeforeLimitsBatchSize(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	marker, err := encodeShardMarker(1)
+	require.NoError(t, err)
+	for i := range maxPruneBatchSize + 1 {
+		promiseHash := binary.BigEndian.AppendUint64(nil, uint64(i))
+		require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
+		require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+	}
+
+	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, maxPruneBatchSize, pruned)
+	require.Equal(t, int64(maxPruneBatchSize), freed)
+
+	pruned, freed, err = store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+	require.Equal(t, int64(1), freed)
+}
+
+func newMarkerTestStore(t *testing.T) *Store {
+	t.Helper()
+	store := NewMemoryStore(DefaultStoreConfig())
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	return store
+}
+
+func writeMarkerTestShard(t *testing.T, store *Store, commitment Commitment, promiseHash []byte) int64 {
+	t.Helper()
+	path := store.shardFilePath(commitment, promiseHash)
+	f, err := store.fs.Create(path, shardWriteCategory)
+	require.NoError(t, err)
+	require.NoError(t, writeShardBinary(f, &types.BlobShard{
+		Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}},
+	}))
+	require.NoError(t, f.Close())
+	info, err := store.fs.Stat(path)
+	require.NoError(t, err)
+	return info.Size()
+}

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -203,19 +203,25 @@ func TestServerSeedsPartialSizeAfterIntegrityError(t *testing.T) {
 	require.Contains(t, logs.String(), "store size may be incorrect due to corrupt shard marker")
 }
 
-func TestHasAccountedShardMarker(t *testing.T) {
+func TestShardStatus(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()
 	promiseHash := []byte{1}
 
-	accounted := store.hasAccountedShardMarker(commitment, promiseHash)
+	has, accounted, err := store.shardStatus(commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
 	require.False(t, accounted)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), nil, pebbledb.NoSync))
-	accounted = store.hasAccountedShardMarker(commitment, promiseHash)
+	has, accounted, err = store.shardStatus(commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
 	require.False(t, accounted)
 	marker := encodeShardMarker(1)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
-	accounted = store.hasAccountedShardMarker(commitment, promiseHash)
+	has, accounted, err = store.shardStatus(commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
 	require.True(t, accounted)
 }
 

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	pebbledb "github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestShardMarkerCodec(t *testing.T) {
@@ -208,18 +210,15 @@ func TestHasAccountedShardMarker(t *testing.T) {
 	commitment := generateCommitment()
 	promiseHash := []byte{1}
 
-	accounted, err := store.hasAccountedShardMarker(commitment, promiseHash)
-	require.NoError(t, err)
+	accounted := store.hasAccountedShardMarker(commitment, promiseHash)
 	require.False(t, accounted)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), nil, pebbledb.NoSync))
-	accounted, err = store.hasAccountedShardMarker(commitment, promiseHash)
-	require.NoError(t, err)
+	accounted = store.hasAccountedShardMarker(commitment, promiseHash)
 	require.False(t, accounted)
 	marker, err := encodeShardMarker(1)
 	require.NoError(t, err)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
-	accounted, err = store.hasAccountedShardMarker(commitment, promiseHash)
-	require.NoError(t, err)
+	accounted = store.hasAccountedShardMarker(commitment, promiseHash)
 	require.True(t, accounted)
 }
 
@@ -260,6 +259,8 @@ func TestPruneBeforeLimitsBatchSize(t *testing.T) {
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	marker, err := encodeShardMarker(1)
 	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, nil), []byte{1, 2}, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, nil), nil, pebbledb.NoSync))
 	for i := range maxPruneBatchSize + 1 {
 		promiseHash := binary.BigEndian.AppendUint64(nil, uint64(i))
 		require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
@@ -267,14 +268,59 @@ func TestPruneBeforeLimitsBatchSize(t *testing.T) {
 	}
 
 	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrStoreIntegrity)
 	require.Equal(t, maxPruneBatchSize, pruned)
 	require.Equal(t, int64(maxPruneBatchSize), freed)
 
 	pruned, freed, err = store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
-	require.NoError(t, err)
+	require.ErrorIs(t, err, ErrStoreIntegrity)
 	require.Equal(t, 1, pruned)
 	require.Equal(t, int64(1), freed)
+}
+
+func TestServerPruneDrainsBacklog(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	marker, err := encodeShardMarker(1)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(commitment, nil), []byte{1, 2}, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, nil), nil, pebbledb.NoSync))
+	for i := range maxPruneBatchSize + 1 {
+		promiseHash := binary.BigEndian.AppendUint64(nil, uint64(i))
+		require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
+		require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+	}
+
+	occ := newOccupancy(0)
+	occ.seed(maxPruneBatchSize + 1)
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	metrics, err := newServerMetrics(provider.Meter("prune-test"), occ)
+	require.NoError(t, err)
+	var logs strings.Builder
+	server := &Server{store: store, occ: occ, metrics: metrics, log: slog.New(slog.NewTextHandler(&logs, nil))}
+	server.prune(t.Context())
+
+	require.Zero(t, occ.usage())
+	size, err := store.Size(t.Context())
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+	require.Zero(t, size)
+	require.Contains(t, logs.String(), "prune skipped corrupt shard markers")
+	require.Contains(t, logs.String(), "pruned expired entries")
+	require.NotContains(t, logs.String(), "level=ERROR")
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &collected))
+	var pruneEntries int64
+	for _, scope := range collected.ScopeMetrics {
+		for _, metric := range scope.Metrics {
+			if metric.Name == "fibre.server.prune.entries" {
+				pruneEntries = metric.Data.(metricdata.Sum[int64]).DataPoints[0].Value
+			}
+		}
+	}
+	require.Equal(t, int64(maxPruneBatchSize+1), pruneEntries)
 }
 
 func newMarkerTestStore(t *testing.T) *Store {

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -150,6 +150,25 @@ func TestGetSkipsInvalidMarkerAndReturnsValidShard(t *testing.T) {
 	require.NoError(t, closer.Close())
 }
 
+func TestGetMissingPayloadKeepsPruneAccounting(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	promiseHash := []byte{1}
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	size := writeMarkerTestShard(t, store, commitment, promiseHash)
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+	require.NoError(t, store.fs.Remove(store.shardFilePath(commitment, promiseHash)))
+
+	_, err := store.Get(t.Context(), commitment)
+	require.ErrorIs(t, err, ErrStoreNotFound)
+
+	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+	require.NoError(t, err)
+	require.Equal(t, 1, pruned)
+	require.Equal(t, size, freed)
+}
+
 func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -13,7 +13,6 @@ import (
 	pebbledb "github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestShardMarkerCodec(t *testing.T) {
@@ -311,8 +310,7 @@ func TestServerPruneDrainsBacklog(t *testing.T) {
 
 	occ := newOccupancy(0)
 	occ.seed(maxPruneBatchSize + 1)
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	provider := sdkmetric.NewMeterProvider()
 	metrics, err := newServerMetrics(provider.Meter("prune-test"), occ)
 	require.NoError(t, err)
 	var logs strings.Builder
@@ -326,18 +324,6 @@ func TestServerPruneDrainsBacklog(t *testing.T) {
 	require.Contains(t, logs.String(), "prune skipped corrupt shard markers")
 	require.Contains(t, logs.String(), "pruned expired entries")
 	require.NotContains(t, logs.String(), "level=ERROR")
-
-	var collected metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(t.Context(), &collected))
-	var pruneEntries int64
-	for _, scope := range collected.ScopeMetrics {
-		for _, metric := range scope.Metrics {
-			if metric.Name == "fibre.server.prune.entries" {
-				pruneEntries = metric.Data.(metricdata.Sum[int64]).DataPoints[0].Value
-			}
-		}
-	}
-	require.Equal(t, int64(maxPruneBatchSize+1), pruneEntries)
 }
 
 func newMarkerTestStore(t *testing.T) *Store {

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -187,6 +187,15 @@ func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
 	require.Equal(t, validSize, size)
 }
 
+func TestSizeRejectsMalformedShardKeyWithValidMarker(t *testing.T) {
+	store := newMarkerTestStore(t)
+	require.NoError(t, store.db.Set([]byte(shardKeyPrefix+"malformed"), encodeShardMarker(37), pebbledb.NoSync))
+
+	size, err := store.Size(t.Context())
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+	require.Zero(t, size)
+}
+
 func TestServerSeedsPartialSizeAfterIntegrityError(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -150,20 +150,6 @@ func TestGetSkipsInvalidMarkerAndReturnsValidShard(t *testing.T) {
 	require.NoError(t, closer.Close())
 }
 
-func TestRemoveOrphanShardsPreservesInvalidMarker(t *testing.T) {
-	store := newMarkerTestStore(t)
-	commitment := generateCommitment()
-	promiseHash := make([]byte, 32)
-	writeMarkerTestShard(t, store, commitment, promiseHash)
-	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), []byte{1, 2}, pebbledb.NoSync))
-
-	removed, err := store.removeOrphanShards()
-	require.NoError(t, err)
-	require.Zero(t, removed)
-	_, err = store.fs.Stat(store.shardFilePath(commitment, promiseHash))
-	require.NoError(t, err)
-}
-
 func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -355,9 +355,8 @@ func testStoreGetDeterministicOrdering(t *testing.T, store *fibre.Store, _ strin
 	}
 }
 
-// Reconcile drops staging/ leftovers on open, leaves real shards alone, and
-// logs the cleanup count.
-func TestStoreReconcileStaging(t *testing.T) {
+// Reconcile drops staging leftovers and orphan shard files on open.
+func TestStoreReconcile(t *testing.T) {
 	cfg := fibre.DefaultStoreConfig()
 	cfg.Path = t.TempDir()
 	store, err := fibre.NewStore(cfg)
@@ -375,6 +374,10 @@ func TestStoreReconcileStaging(t *testing.T) {
 	staleB := filepath.Join(stagingDir, "bbb")
 	require.NoError(t, os.WriteFile(staleA, []byte("partial-a"), 0o644))
 	require.NoError(t, os.WriteFile(staleB, []byte("partial-b"), 0o644))
+	orphan := filepath.Join(cfg.Path, "shards", strings.Repeat("0", 64)+"-"+strings.Repeat("1", 64))
+	unknown := filepath.Join(cfg.Path, "shards", "unknown")
+	require.NoError(t, os.WriteFile(orphan, []byte("orphan"), 0o644))
+	require.NoError(t, os.WriteFile(unknown, []byte("unknown"), 0o644))
 
 	var buf strings.Builder
 	cfg.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -387,6 +390,10 @@ func TestStoreReconcileStaging(t *testing.T) {
 		_, err := os.Stat(p)
 		require.True(t, os.IsNotExist(err), "%s should be removed by reconcile", p)
 	}
+	_, err = os.Stat(orphan)
+	require.True(t, os.IsNotExist(err), "%s should be removed by reconcile", orphan)
+	_, err = os.Stat(unknown)
+	require.NoError(t, err)
 	st, err := os.Stat(stagingDir)
 	require.NoError(t, err)
 	require.True(t, st.IsDir())
@@ -394,6 +401,7 @@ func TestStoreReconcileStaging(t *testing.T) {
 	out := buf.String()
 	require.Contains(t, out, "store reconcile complete")
 	require.Contains(t, out, "staging_files_removed=2")
+	require.Contains(t, out, "orphan_files_removed=1")
 
 	got, err := store.Get(t.Context(), blob.ID().Commitment())
 	require.NoError(t, err)
@@ -503,7 +511,7 @@ func testStoreHas(t *testing.T, store *fibre.Store, path string) {
 	require.False(t, has, "orphan marker without a file must report absent, not error")
 }
 
-// Size is 0 for an empty store and the sum of on-disk shard file sizes otherwise.
+// Size is 0 for an empty store and otherwise sums shard marker sizes.
 func testStoreSize(t *testing.T, store *fibre.Store, path string) {
 	ctx := t.Context()
 
@@ -530,6 +538,14 @@ func testStoreSize(t *testing.T, store *fibre.Store, path string) {
 		want += info.Size()
 	}
 
+	size, err = store.Size(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, size)
+
+	// Versioned markers remain accounted when a local payload is missing.
+	h, err := makeTestPaymentPromise(100, blob.ID()).Hash()
+	require.NoError(t, err)
+	require.NoError(t, os.Remove(filepath.Join(path, "shards", commitment.String()+"-"+hex.EncodeToString(h))))
 	size, err = store.Size(ctx)
 	require.NoError(t, err)
 	require.Equal(t, want, size)
@@ -563,7 +579,7 @@ func (c *cancelAfterCtx) Err() error {
 	return context.Canceled
 }
 
-// PruneBefore reports the total on-disk bytes it freed.
+// PruneBefore reports the total marker-accounted bytes it freed.
 func testStorePruneBeforeReturnsFreedBytes(t *testing.T, store *fibre.Store, path string) {
 	ctx := t.Context()
 	blob := makeTestBlobV0(t, 256)

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -29,7 +29,7 @@ func TestStore(t *testing.T) {
 		{"Put_ConcurrentSameKey", testStorePutConcurrentSameKey},
 		{"Get_NotFound", testStoreGetNotFound},
 		{"Get_DeterministicOrdering", testStoreGetDeterministicOrdering},
-		{"Get_CleansOrphanMarker", testStoreGetCleansOrphanMarker},
+		{"Get_SkipsMissingPayload", testStoreGetSkipsMissingPayload},
 		{"Get_SkipsOrphanToSibling", testStoreGetSkipsOrphanToSibling},
 		{"Get_AllOrphans", testStoreGetAllOrphans},
 		{"PutGet_PreservesRLCs", testStorePutGetPreservesRLCs},
@@ -400,9 +400,8 @@ func TestStoreReconcileStaging(t *testing.T) {
 	require.Len(t, got.Rows, 2)
 }
 
-// Get drops a /shard/ marker whose backing file is missing (crash between
-// pebble commit and rename) so future Gets stop paying the missed lookup.
-func testStoreGetCleansOrphanMarker(t *testing.T, store *fibre.Store, path string) {
+// Get skips a marker whose backing file is missing.
+func testStoreGetSkipsMissingPayload(t *testing.T, store *fibre.Store, path string) {
 	blob := makeTestBlobV0(t, 256)
 	shard := makeShardFrom(t, blob, 0, 1)
 	promise := makeTestPaymentPromise(100, blob.ID())
@@ -417,8 +416,7 @@ func testStoreGetCleansOrphanMarker(t *testing.T, store *fibre.Store, path strin
 	_, err = store.Get(t.Context(), blob.ID().Commitment())
 	require.ErrorIs(t, err, fibre.ErrStoreNotFound)
 
-	// After the first Get drops the marker, a fresh Put with a different
-	// promise must be the one Get finds, proving the orphan slot is gone.
+	// A fresh Put with a different promise must still be the one Get finds.
 	promise2 := makeTestPaymentPromise(101, blob.ID())
 	shard2 := makeShardFrom(t, blob, 2, 3)
 	require.NoError(t, store.Put(t.Context(), promise2, shard2, promise2.CreationTimestamp))
@@ -456,8 +454,7 @@ func testStoreGetSkipsOrphanToSibling(t *testing.T, store *fibre.Store, path str
 	require.Equal(t, validRow, got.Rows[0].Index)
 }
 
-// All shards for a commit are orphans, so Get returns NotFound (and cleans
-// the markers along the way).
+// If all payloads for a commitment are missing, Get returns NotFound.
 func testStoreGetAllOrphans(t *testing.T, store *fibre.Store, path string) {
 	blob := makeTestBlobV0(t, 256)
 	for i := range 3 {

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -355,8 +355,9 @@ func testStoreGetDeterministicOrdering(t *testing.T, store *fibre.Store, _ strin
 	}
 }
 
-// Reconcile drops staging leftovers and orphan shard files on open.
-func TestStoreReconcile(t *testing.T) {
+// Reconcile drops staging/ leftovers on open, leaves real shards alone, and
+// logs the cleanup count.
+func TestStoreReconcileStaging(t *testing.T) {
 	cfg := fibre.DefaultStoreConfig()
 	cfg.Path = t.TempDir()
 	store, err := fibre.NewStore(cfg)
@@ -374,10 +375,6 @@ func TestStoreReconcile(t *testing.T) {
 	staleB := filepath.Join(stagingDir, "bbb")
 	require.NoError(t, os.WriteFile(staleA, []byte("partial-a"), 0o644))
 	require.NoError(t, os.WriteFile(staleB, []byte("partial-b"), 0o644))
-	orphan := filepath.Join(cfg.Path, "shards", strings.Repeat("0", 64)+"-"+strings.Repeat("1", 64))
-	unknown := filepath.Join(cfg.Path, "shards", "unknown")
-	require.NoError(t, os.WriteFile(orphan, []byte("orphan"), 0o644))
-	require.NoError(t, os.WriteFile(unknown, []byte("unknown"), 0o644))
 
 	var buf strings.Builder
 	cfg.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -390,10 +387,6 @@ func TestStoreReconcile(t *testing.T) {
 		_, err := os.Stat(p)
 		require.True(t, os.IsNotExist(err), "%s should be removed by reconcile", p)
 	}
-	_, err = os.Stat(orphan)
-	require.True(t, os.IsNotExist(err), "%s should be removed by reconcile", orphan)
-	_, err = os.Stat(unknown)
-	require.NoError(t, err)
 	st, err := os.Stat(stagingDir)
 	require.NoError(t, err)
 	require.True(t, st.IsDir())
@@ -401,7 +394,6 @@ func TestStoreReconcile(t *testing.T) {
 	out := buf.String()
 	require.Contains(t, out, "store reconcile complete")
 	require.Contains(t, out, "staging_files_removed=2")
-	require.Contains(t, out, "orphan_files_removed=1")
 
 	got, err := store.Get(t.Context(), blob.ID().Commitment())
 	require.NoError(t, err)


### PR DESCRIPTION
This PR is the first PR in a stack of PRs intended to provide Fibre support for object storage backends (R2, S3)

It: 
* adds versioned Fibre shard markers with backend and size metadata.
* uses marker sizes for storage accounting while supporting legacy empty markers.

Ref: https://linear.app/celestia/issue/PROTOCO-2616/add-versioned-fibre-shard-markers