### PR TITLE
fix: bound the PFB tx cache with an LRU

### DIFF
--- a/app/check_tx.go
+++ b/app/check_tx.go
@@ -81,8 +81,6 @@ func (app *App) handleBlobCheckTx(req *abci.RequestCheckTx, btx *blobtx.BlobTx) 
 		if err := blobtypes.ValidateBlobTx(app.encodingConfig.TxConfig, btx, appconsts.SubtreeRootThreshold, appconsts.Version); err != nil {
 			return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 		}
-		// Cache the tx, so ProcessProposal will skip the validation step
-		app.txCache.Set(btx.Tx, btx.Blobs)
 	case abci.CheckTxType_Recheck:
 		// no need to re-validate a blob
 	default:
@@ -95,7 +93,18 @@ func (app *App) handleBlobCheckTx(req *abci.RequestCheckTx, btx *blobtx.BlobTx) 
 		return responseCheckTxWithEvents(err, 0, 0, []abci.Event{}, false), err
 	}
 
-	return app.forwardCheckTx(baseReq, sdkTx)
+	res, err := app.forwardCheckTx(baseReq, sdkTx)
+	if err != nil || res.Code != abci.CodeTypeOK {
+		return res, err
+	}
+
+	// Cache only txs that passed full CheckTx, so ProcessProposal skips
+	// re-validation and invalid spam cannot evict legitimate entries.
+	if req.Type == abci.CheckTxType_New {
+		app.txCache.Set(btx.Tx, btx.Blobs)
+	}
+
+	return res, nil
 }
 
 func (app *App) forwardCheckTx(req *abci.RequestCheckTx, sdkTx sdk.Tx) (*abci.ResponseCheckTx, error) {

--- a/app/pfb_tx_cache.go
+++ b/app/pfb_tx_cache.go
@@ -2,21 +2,28 @@ package app
 
 import (
 	"crypto/sha256"
-	"sync"
 
 	"github.com/celestiaorg/go-square/v4/share"
+	lru "github.com/hashicorp/golang-lru/v2"
 )
 
-// TxCache caches the transactions
+const defaultTxCacheCapacity = 10_000
+
+// TxCache remembers blob txs validated in CheckTx so ProcessProposal can skip
+// re-validating them. Its fixed capacity bounds memory use independently of
+// mempool eviction, and only txs that passed full CheckTx are admitted, so
+// invalid spam cannot evict legitimate entries.
 type TxCache struct {
-	cache sync.Map
+	entries *lru.Cache[string, string]
 }
 
 // NewTxCache creates a new transaction cache
 func NewTxCache() *TxCache {
-	return &TxCache{
-		cache: sync.Map{},
+	entries, err := lru.New[string, string](defaultTxCacheCapacity)
+	if err != nil {
+		panic(err)
 	}
+	return &TxCache{entries: entries}
 }
 
 // getTxKey generates a deterministic key for a transaction
@@ -28,13 +35,8 @@ func (c *TxCache) getTxKey(tx []byte) string {
 // Exists checks whether the Tx exists in the cache and the blobs match the cached blobs
 func (c *TxCache) Exists(tx []byte, blobs []*share.Blob) bool {
 	key := c.getTxKey(tx)
-	value, exists := c.cache.Load(key)
+	cachedBlobHash, exists := c.entries.Get(key)
 	if !exists {
-		return false
-	}
-
-	cachedBlobHash, ok := value.(string)
-	if !ok {
 		return false
 	}
 
@@ -46,7 +48,7 @@ func (c *TxCache) Exists(tx []byte, blobs []*share.Blob) bool {
 func (c *TxCache) Set(tx []byte, blobs []*share.Blob) {
 	key := c.getTxKey(tx)
 	blobsHash := c.getBlobsHash(blobs)
-	c.cache.Store(key, blobsHash)
+	c.entries.Add(key, blobsHash)
 }
 
 // getBlobsHash hashes the domain-separated, length-prefixed hash of each blob.
@@ -64,15 +66,10 @@ func (c *TxCache) getBlobsHash(blobs []*share.Blob) string {
 // RemoveTransaction removes specific transactions from the cache
 func (c *TxCache) RemoveTransaction(tx []byte) {
 	key := c.getTxKey(tx)
-	c.cache.Delete(key)
+	c.entries.Remove(key)
 }
 
 // Size returns the current number of entries in the cache
 func (c *TxCache) Size() int {
-	count := 0
-	c.cache.Range(func(key, value any) bool {
-		count++
-		return true
-	})
-	return count
+	return c.entries.Len()
 }

--- a/app/pfb_tx_cache_test.go
+++ b/app/pfb_tx_cache_test.go
@@ -128,6 +128,35 @@ func TestTxCache_RemoveTransactionNonExistent(t *testing.T) {
 	assert.True(t, exists)
 }
 
+func TestTxCache_Eviction(t *testing.T) {
+	cache := NewTxCache()
+	blobs := blobfactory.ManyRandBlobs(random.New(), 100)
+
+	for i := range defaultTxCacheCapacity + 1 {
+		cache.Set(fmt.Appendf(nil, "tx-%d", i), blobs)
+	}
+
+	assert.Equal(t, defaultTxCacheCapacity, cache.Size())
+	assert.False(t, cache.Exists([]byte("tx-0"), blobs), "oldest entry must be evicted")
+	assert.True(t, cache.Exists(fmt.Appendf(nil, "tx-%d", defaultTxCacheCapacity), blobs))
+}
+
+func TestTxCache_EvictionRecency(t *testing.T) {
+	cache := NewTxCache()
+	blobs := blobfactory.ManyRandBlobs(random.New(), 100)
+
+	for i := range defaultTxCacheCapacity {
+		cache.Set(fmt.Appendf(nil, "tx-%d", i), blobs)
+	}
+
+	// touch the oldest entry so the next insert evicts tx-1 instead
+	require.True(t, cache.Exists([]byte("tx-0"), blobs))
+	cache.Set([]byte("one more"), blobs)
+
+	assert.True(t, cache.Exists([]byte("tx-0"), blobs))
+	assert.False(t, cache.Exists([]byte("tx-1"), blobs))
+}
+
 func TestTxCache_GetTxKey(t *testing.T) {
 	cache := NewTxCache()
 	tx := []byte("test transaction")

--- a/app/test/check_tx_test.go
+++ b/app/test/check_tx_test.go
@@ -575,6 +575,43 @@ func TestCheckTxMalformedModeInfoDoesNotPanic(t *testing.T) {
 	})
 }
 
+// TestCheckTxBlobTxCacheAdmission verifies that only blob txs passing full
+// CheckTx are admitted to the cache consulted by ProcessProposal.
+func TestCheckTxBlobTxCacheAdmission(t *testing.T) {
+	encodingConfig := encoding.MakeConfig(app.ModuleEncodingRegisters...)
+	accounts := []string{"a"}
+	testApp, kr := testutil.SetupTestAppWithGenesisValSet(app.DefaultConsensusParams(), accounts...)
+
+	fetchedAcc := testutil.DirectQueryAccount(testApp, testfactory.GetAddress(kr, accounts[0]))
+	namespace, err := share.NewV0Namespace(bytes.Repeat([]byte{1}, share.NamespaceVersionZeroIDSize))
+	require.NoError(t, err)
+
+	fromCacheAfterCheckTx := func(rawTx []byte) bool {
+		blobTx, isBlob, err := tx.UnmarshalBlobTx(rawTx)
+		require.True(t, isBlob)
+		require.NoError(t, err)
+		fromCache, err := testApp.ValidateBlobTxWithCache(blobTx)
+		require.NoError(t, err)
+		return fromCache
+	}
+
+	// A blob tx signed with a wrong account number passes stateless blob
+	// validation but fails the stateful ante pass; it must not be cached.
+	badSigner := createSigner(t, kr, accounts[0], encodingConfig.TxConfig, fetchedAcc.GetAccountNumber()+1)
+	invalidTx := blobfactory.RandBlobTxsWithNamespacesAndSigner(badSigner, []share.Namespace{namespace}, []int{100})[0]
+	resp, err := testApp.CheckTx(&abci.RequestCheckTx{Type: abci.CheckTxType_New, Tx: invalidTx})
+	require.NoError(t, err)
+	require.NotEqual(t, abci.CodeTypeOK, resp.Code)
+	assert.False(t, fromCacheAfterCheckTx(invalidTx), "a blob tx failing CheckTx must not be cached")
+
+	signer := createSigner(t, kr, accounts[0], encodingConfig.TxConfig, fetchedAcc.GetAccountNumber())
+	validTx := blobfactory.RandBlobTxsWithNamespacesAndSigner(signer, []share.Namespace{namespace}, []int{100})[0]
+	resp, err = testApp.CheckTx(&abci.RequestCheckTx{Type: abci.CheckTxType_New, Tx: validTx})
+	require.NoError(t, err)
+	require.Equal(t, abci.CodeTypeOK, resp.Code, resp.Log)
+	assert.True(t, fromCacheAfterCheckTx(validTx), "a blob tx passing CheckTx must be cached")
+}
+
 func createSigner(t *testing.T, kr keyring.Keyring, accountName string, enc client.TxConfig, accNum uint64) *user.Signer {
 	t.Helper()
 


### PR DESCRIPTION
Bounds the CheckTx-to-ProcessProposal blob tx cache with a fixed-capacity LRU (10,000 entries), mirroring the PFF signature cache, and admits entries only after the tx passes full CheckTx. Previously the cache was an unbounded map populated before the ante pass, so entries for txs that never entered the mempool were retained forever.

A cache miss only falls back to full validation in ProcessProposal, so accept/reject results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)