### PR TITLE
ci: run tx submission before other nightly tests

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -104,11 +104,61 @@ jobs:
           path: /tmp/latency-monitor-image.tar.gz
           retention-days: 1
 
-  test-nightly:
+  # Run the latency test before the other nightly tests.
+  test-tx-submission:
     needs: [build-e2e-image, build-latency-monitor-image]
     runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e #v7.0.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Download Docker image artifact
+        if: ${{ inputs.tag == '' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: e2e-image
+          path: /tmp
+
+      - name: Load Docker image
+        if: ${{ inputs.tag == '' }}
+        run: docker load < /tmp/e2e-image.tar.gz
+
+      - name: Download latency-monitor image artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #v8.0.1
+        with:
+          name: latency-monitor-image
+          path: /tmp
+
+      - name: Load latency-monitor Docker image
+        run: docker load < /tmp/latency-monitor-image.tar.gz
+
+      - name: Run TestTxSubmission
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          command: make test-docker-e2e test=TestTxSubmission
+        env:
+          CELESTIA_IMAGE: ghcr.io/celestiaorg/celestia-app
+          CELESTIA_TAG: ${{ needs.build-e2e-image.outputs.tag }}
+          CELESTIA_APP_VERSION: ${{ needs.build-e2e-image.outputs.tag }}
+          PUSHGATEWAY_URL: ${{ secrets.PUSHGATEWAY_URL }}
+          PUSHGATEWAY_USERNAME: ${{ secrets.PUSHGATEWAY_USERNAME }}
+          PUSHGATEWAY_PASSWORD: ${{ secrets.PUSHGATEWAY_PASSWORD }}
+
+  test-nightly:
+    needs: [build-e2e-image, build-latency-monitor-image, test-tx-submission]
+    # Keep running the other tests if the latency test fails.
+    if: ${{ !cancelled() && needs.build-e2e-image.result == 'success' && needs.build-latency-monitor-image.result == 'success' }}
+    runs-on: ubuntu-latest
     # Generous budget so the retried sync test (up to 3 attempts) has headroom
-    # without prematurely killing the long-running upgrade/tx tests.
+    # without prematurely killing the long-running upgrade tests.
     timeout-minutes: 90
     strategy:
       fail-fast: false
@@ -125,15 +175,6 @@ jobs:
           # deadline, so retry once before failing the nightly.
           - test: TestAllUpgrades
             max-attempts: 2
-          # TestTxSubmission asserts a wall-clock average tx-inclusion latency
-          # bound. On shared GitHub-hosted runners a single run can occasionally
-          # see sustained CPU contention that inflates latency well above the
-          # threshold (e.g. 17s avg vs the usual ~4.6s). A genuine latency
-          # regression shifts the whole distribution and fails every attempt,
-          # so a retry de-flakes transient runner noise without masking it.
-          - test: TestTxSubmission
-            max-attempts: 2
-            extra-image: true
           - test: TestCortoLoad
             extra-image: true
     steps:
@@ -209,6 +250,8 @@ jobs:
           PUSHGATEWAY_PASSWORD: ${{ secrets.PUSHGATEWAY_PASSWORD }}
 
   test-race:
+    needs: test-tx-submission
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -225,6 +268,8 @@ jobs:
   # scripts/test_fuzz.sh. Do NOT remove or disable this job; doing so re-opens
   # https://github.com/celestiaorg/celestia-app/issues/7392.
   test-fuzz:
+    needs: test-tx-submission
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
@@ -239,8 +284,8 @@ jobs:
   notify-slack-on-failure:
     name: Notify Slack on failure
     runs-on: ubuntu-latest
-    needs: [test-nightly, test-race, test-fuzz]
-    if: ${{ always() && (needs.test-nightly.result == 'failure' || needs.test-race.result == 'failure' || needs.test-fuzz.result == 'failure') }}
+    needs: [test-tx-submission, test-nightly, test-race, test-fuzz]
+    if: ${{ always() && (needs.test-tx-submission.result == 'failure' || needs.test-nightly.result == 'failure' || needs.test-race.result == 'failure' || needs.test-fuzz.result == 'failure') }}
     steps:
       - name: Slack Notification
         uses: slackapi/slack-github-action@v4.0.0


### PR DESCRIPTION
Run `TestTxSubmission` before the remaining e2e, race, and fuzz tests to investigate [intermittent nightly latency failures](https://github.com/celestiaorg/celestia-app/actions/runs/33938424641/job/101232020242). The other tests start after it finishes, even if it fails. Existing retries, thresholds, and failure notifications are preserved.

Validation: `yamllint`, `actionlint`, and `git diff --check` passed. The isolated nightly experiment has not run yet.
