### PR TITLE
refactor(fibre): extract local shard storage

### DIFF
--- a/docs/architecture/adr-030-fibre-elastic-shard-storage.md
+++ b/docs/architecture/adr-030-fibre-elastic-shard-storage.md
@@ -10,6 +10,7 @@
 - 2026-09-02: Batch object deletion during pruning
 - 2026-09-02: Make conditional object writes idempotent
 - 2026-09-02: Define the shard-marker binary format
+- 2026-09-07: Route shard operations through `routedStorage`
 
 ## Status
 
@@ -93,13 +94,16 @@ These rules apply to `Store.Get`, `Store.Has`, `Store.Size`, and `Store.PruneBef
 Fibre server
   └── Store
       ├── Pebble metadata and prune index
-      └── shardStorage
-          └── durable backend
-              ├── localBackend
-              └── objectBackend
+      └── routedStorage
+          ├── primary shardBackend
+          └── secondary shardBackend (optional)
 ```
 
-`Store` will continue to own Pebble metadata. `shardStorage` will own durable-backend routing.
+`localBackend` and `objectBackend` implement `shardBackend`.
+
+`Store` will own Pebble metadata and one `routedStorage`. The router will own the primary and optional secondary backends.
+
+`Store` will not hold or select a `shardBackend` directly. New writes will use the primary backend. Existing operations will use the marker tag.
 
 Fibre will write each new shard to one durable backend. Local mode will use `localBackend`, and object mode will use `objectBackend`.
 
@@ -111,27 +115,29 @@ Both durable backends will use the existing shard binary codec. One payload cont
 
 1. The server validates the upload, payment promise, assignment, and shard.
 2. `Store` calculates the exact encoded size without encoding the shard ([`fibre/store_codec.go:90`](../../fibre/store_codec.go#L90)).
-3. `Store` streams `writeShardBinary` directly into the `PutObject` request body ([`fibre/store_codec.go:33`](../../fibre/store_codec.go#L33)).
-4. The request uses `If-None-Match: *` to prevent an overwrite.
-5. If `PutObject` succeeds, the object write is complete.
-6. If `PutObject` returns `PreconditionFailed` because `If-None-Match: *` found an existing object, `Store` treats the object as already written.
-7. Any other object-write error fails the upload.
-8. `Store` commits the Pebble metadata with the `object` backend and encoded payload size.
-9. The server signs and returns the storage promise.
+3. `Store` gets a marker for the primary backend from `routedStorage`.
+4. `Store` passes the marker and shard to `routedStorage.Put`.
+5. `objectBackend` streams `writeShardBinary` into the `PutObject` request body ([`fibre/store_codec.go:33`](../../fibre/store_codec.go#L33)).
+6. The request uses `If-None-Match: *` to prevent an overwrite.
+7. If `PutObject` succeeds, the object write is complete.
+8. If `PutObject` returns `PreconditionFailed`, `objectBackend` treats the object as already written.
+9. Any other object-write error fails the upload.
+10. `Store` commits the Pebble metadata with the `object` backend and encoded payload size.
+11. The server signs and returns the storage promise.
 
 Object storage is authoritative in object mode. Object mode does not write shard payloads to local disk.
 
 If the object write fails with an error other than `PreconditionFailed`, `Store` does not commit metadata or sign the storage promise.
 
-If the Pebble commit fails, `Store` attempts to remove the object. It returns an error after the cleanup attempt.
+If the Pebble commit fails, `Store` passes the same marker to `routedStorage.Delete`. This routes cleanup to the backend that handled the write.
 
 #### Local mode
 
-Local mode will keep the current stage, publish, and Pebble commit flow ([`fibre/store.go:134`](../../fibre/store.go#L134)).
+Local mode will keep the current stage, publish, and Pebble commit flow ([`fibre/store.go:146`](../../fibre/store.go#L146)).
 
 The publish step atomically renames the staging file to its final path. The Pebble marker will record `local` and the encoded payload size.
 
-At startup, `Store` removes incomplete local-mode staging files.
+At startup, `routedStorage` removes incomplete local-mode staging files.
 
 ### Read flow
 
@@ -139,13 +145,14 @@ Pebble will return all shard markers that match the requested commitment. Each m
 
 For each matching shard marker, `Store` will use this flow:
 
-1. Select the durable backend from the shard marker.
-2. For a local marker, read the local flat file.
-3. For an object marker, read the object with `GetObject`.
-4. If local storage returns `NotFound`, keep the marker for occupancy accounting and try the next matching shard marker.
-5. If object storage returns `NotFound`, keep the marker, record an integrity error, and try the next matching shard marker.
-6. If another durable-storage error occurs, record it and try the next matching shard marker.
-7. If no matching shard marker succeeds, return the recorded error.
+1. Pass the marker to `routedStorage.Get`.
+2. `routedStorage` selects the configured backend from the marker tag.
+3. For a local marker, `localBackend` reads the local flat file.
+4. For an object marker, `objectBackend` reads the object with `GetObject`.
+5. If local storage returns `NotFound`, keep the marker for occupancy accounting and try the next matching shard marker.
+6. If object storage returns `NotFound`, keep the marker, record an integrity error, and try the next matching shard marker.
+7. If another durable-storage error occurs, record it and try the next matching shard marker.
+8. If no matching shard marker succeeds, return the recorded error.
 
 Every read of an object-backed shard accesses object storage.
 
@@ -161,7 +168,7 @@ This ADR does not define the cache design or its storage medium.
 
 ### Store integration
 
-The `Store` API will not change. Its methods will delegate shard payload operations to `shardStorage`.
+The `Store` API will not change. `Store` will contain `routedStorage` and delegate shard payload operations to it.
 
 | Method | Behavior |
 |---|---|
@@ -169,10 +176,10 @@ The `Store` API will not change. Its methods will delegate shard payload operati
 | `Store.Get` | Get matching shard markers from Pebble, then call `shards.Get` for each matching shard marker. |
 | `Store.Has` | Read Pebble first, then call `shards.Has` for the recorded durable backend. |
 | `Store.PruneBefore` | Call `shards.Delete` before removing the Pebble entries. |
-| `Store.Size` | Sum the sizes in shard markers and stat empty legacy markers. |
+| `Store.Size` | Sum the sizes returned by `shards.size`; the router stats empty legacy markers. |
 | `Store.DiskAvailable` | Report local space for Pebble, local payloads, and local staging files. |
 
-The current `Store` directly owns Pebble and its filesystem ([`fibre/store.go:68`](../../fibre/store.go#L68)). The new `shardStorage` field will replace only direct shard-payload operations.
+`Store` owns Pebble and `routedStorage` ([`fibre/store.go:63`](../../fibre/store.go#L63)). The router contains backends and hides marker routing from `Store`.
 
 ### Backend construction
 
@@ -180,12 +187,16 @@ The current `Store` directly owns Pebble and its filesystem ([`fibre/store.go:68
 
 `NewStore` will open `objectBackend` in object mode. It will also open this backend while live markers record `object`.
 
+In local mode, `routedStorage` will use `localBackend` as primary. It will use `objectBackend` as secondary when object access is configured.
+
+In object mode, `routedStorage` will use `objectBackend` as primary and `localBackend` as secondary. Startup reconciliation will still clear local staging files.
+
 The primary backend will support these values:
 
 - `local`: Store new shards in `localBackend`. This value is the default.
 - `object`: Stream new shards to `objectBackend`.
 
-Tests can inject durable backends directly. `NewMemoryStore` will use `localBackend` with the existing in-memory filesystem.
+Tests can inject `shardBackend` implementations into `routedStorage`. `NewMemoryStore` will use `localBackend` with the existing in-memory filesystem.
 
 The object backend will use provider-neutral configuration:
 
@@ -221,9 +232,9 @@ The validator consensus address prevents collisions when one operator uses the b
 
 ### Prune flow
 
-Pebble will continue to select expired entries from its prune index ([`fibre/store.go:410`](../../fibre/store.go#L410)).
+Pebble will continue to select expired entries from its prune index ([`fibre/store.go:388`](../../fibre/store.go#L388)).
 
-`Store` will group expired entries by durable backend.
+`Store` will pass expired markers to `routedStorage`. The router will group the payloads by durable backend.
 
 1. Delete local payloads individually.
 2. Delete object payloads with `DeleteObjects` in batches of up to 1,000 keys.
@@ -232,7 +243,7 @@ Pebble will continue to select expired entries from its prune index ([`fibre/sto
 
 `DeleteObjects` can report errors for individual keys. `Store` will keep the corresponding Pebble entries so a later prune cycle can retry them.
 
-For a legacy empty marker, `Store` will get the size from the local file before deletion.
+For a legacy empty marker, `routedStorage` will get the size from the local file before deletion.
 
 Fibre protocol pruning will remain responsible for normal shard expiration. Operators should configure a provider lifecycle rule that deletes objects after at least 30 days.
 
@@ -265,7 +276,7 @@ Before a downgrade, an external utility must copy each live object to its legacy
 
 ### Preserve empty Pebble marker values
 
-`shardStorage` could keep all marker values empty. It could use a primary durable backend and an optional secondary durable backend.
+A router could keep all marker values empty. It could use a primary durable backend and an optional secondary durable backend.
 
 Reads would use the primary backend. They would use the secondary backend after `NotFound` from the primary backend.
 

--- a/fibre/internal/e2e/fibre_withdrawal_e2e_test.go
+++ b/fibre/internal/e2e/fibre_withdrawal_e2e_test.go
@@ -51,11 +51,17 @@ func TestFibreWithdrawalLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		return *resp.Balance
 	}
-	escrow := func() *fibretypes.EscrowAccount {
-		resp, err := fibreQ.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{Signer: signer})
-		require.NoError(t, err)
-		require.True(t, resp.Found)
-		return resp.EscrowAccount
+	escrow := func(balance, available sdk.Coin) *fibretypes.EscrowAccount {
+		var acc *fibretypes.EscrowAccount
+		require.Eventually(t, func() bool {
+			resp, err := fibreQ.EscrowAccount(ctx, &fibretypes.QueryEscrowAccountRequest{Signer: signer})
+			if err != nil || !resp.Found {
+				return false
+			}
+			acc = resp.EscrowAccount
+			return acc.Balance.Equal(balance) && acc.AvailableBalance.Equal(available)
+		}, 5*time.Second, 100*time.Millisecond, "escrow balances should become visible to queries")
+		return acc
 	}
 	pendingWithdrawals := func() []fibretypes.Withdrawal {
 		resp, err := fibreQ.Withdrawals(ctx, &fibretypes.QueryWithdrawalsRequest{Signer: signer})
@@ -72,7 +78,7 @@ func TestFibreWithdrawalLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), depositResp.Code)
 
-	acc := escrow()
+	acc := escrow(deposit, deposit)
 	require.Equal(t, deposit, acc.Balance)
 	require.Equal(t, deposit, acc.AvailableBalance)
 
@@ -82,7 +88,7 @@ func TestFibreWithdrawalLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), reqResp.Code)
 
-	acc = escrow()
+	acc = escrow(deposit, deposit.Sub(withdraw))
 	require.Equal(t, deposit, acc.Balance, "total balance stays locked until the withdrawal executes")
 	require.Equal(t, deposit.Sub(withdraw), acc.AvailableBalance, "available balance drops by the requested amount")
 
@@ -96,7 +102,7 @@ func TestFibreWithdrawalLifecycle(t *testing.T) {
 		return len(pendingWithdrawals()) == 0
 	}, 60*time.Second, 500*time.Millisecond, "withdrawal should be auto-executed after the delay")
 
-	acc = escrow()
+	acc = escrow(deposit.Sub(withdraw), deposit.Sub(withdraw))
 	require.Equal(t, deposit.Sub(withdraw), acc.Balance, "total balance should drop by the withdrawn amount after execution")
 	require.Equal(t, deposit.Sub(withdraw), acc.AvailableBalance)
 

--- a/fibre/server_prune.go
+++ b/fibre/server_prune.go
@@ -40,6 +40,10 @@ func (s *Server) prune(ctx context.Context) {
 
 	for {
 		pruned, freed, err := s.store.PruneBefore(ctx, start)
+		totalPruned += pruned
+		if freed > 0 {
+			s.occ.release(freed)
+		}
 		if err != nil {
 			if !errors.Is(err, ErrStoreIntegrity) {
 				s.metrics.observePrune(ctx, start, totalPruned, err)
@@ -51,10 +55,6 @@ func (s *Server) prune(ctx context.Context) {
 			}
 		}
 
-		totalPruned += pruned
-		if freed > 0 {
-			s.occ.release(freed)
-		}
 		if pruned < maxPruneBatchSize || ctx.Err() != nil {
 			break
 		}

--- a/fibre/server_upload.go
+++ b/fibre/server_upload.go
@@ -89,7 +89,7 @@ func (s *Server) UploadShard(ctx context.Context, req *types.UploadShardRequest)
 	mu.Lock()
 	defer mu.Unlock()
 
-	has, accounted, err := s.store.shardStatus(promise.Commitment, promiseHash)
+	has, accounted, err := s.store.shardStatus(ctx, promise.Commitment, promiseHash)
 	if err != nil {
 		log.ErrorContext(ctx, "failed to check store for existing shard", "error", err)
 		span.RecordError(err)

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -385,6 +385,8 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 // markers are skipped, it commits valid deletions and returns their count and
 // freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
 // do not consume deletion capacity. Fatal errors return no uncommitted counts.
+// If a payload deletion fails, completed cleanup is committed and returned
+// with the deletion error.
 func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -449,7 +451,10 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 
 		// Missing file is fine (orphan marker from a crashed Put).
 		if err := s.shards.Delete(ctx, markerData, commitment, promiseHash); err != nil {
-			return 0, 0, err
+			if commitErr := batch.Commit(pebbledb.NoSync); commitErr != nil {
+				return 0, 0, errors.Join(err, fmt.Errorf("committing batch: %w", commitErr))
+			}
+			return pruned, prunedBytes, err
 		}
 		if err := batch.Delete(key, pebbledb.NoSync); err != nil {
 			return 0, 0, fmt.Errorf("deleting prune index: %w", err)

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -17,9 +17,8 @@ import (
 	gogoproto "github.com/cosmos/gogoproto/proto"
 )
 
-// Bulk shard data is kept off pebble because pebble serializes large-value
-// commits through a single goroutine, which becomes the upload bottleneck at
-// concurrency. Pebble only holds the small metadata.
+// Pebble stores promises, prune indexes, and shard markers. Each marker
+// identifies the backend and size of its shard payload; legacy markers use local storage.
 const (
 	shardKeyPrefix = "/shard/"
 	// maxPruneBatchSize bounds each Pebble commit. The server drains full
@@ -64,7 +63,6 @@ type Store struct {
 	db     *pebbledb.DB
 	log    *slog.Logger
 	shards shardStorage
-	local  *localBackend
 }
 
 // memStorePath is an arbitrary location inside the in-memory FS used by
@@ -113,7 +111,7 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 		return nil, fmt.Errorf("opening pebble database: %w", err)
 	}
 
-	s := &Store{db: db, log: cfg.Log, shards: local, local: local}
+	s := &Store{db: db, log: cfg.Log, shards: newRoutedStorage(local, nil)}
 	if err := s.reconcile(); err != nil {
 		_ = s.db.Close()
 		return nil, fmt.Errorf("reconciling store: %w", err)
@@ -139,7 +137,7 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 		return fmt.Errorf("getting promise hash: %w", err)
 	}
 
-	marker := encodeShardMarker(shardBinarySize(shard))
+	marker := s.shards.marker(shardBinarySize(shard))
 	return s.commitAndStore(ctx, promise, promiseHash, shard, marker, pruneAt)
 }
 
@@ -171,13 +169,13 @@ func (s *Store) commitAndStore(ctx context.Context, promise *PaymentPromise, pro
 		return fmt.Errorf("aborting store commit: %w", err)
 	}
 
-	created, err := s.shards.Put(ctx, promise.Commitment, promiseHash, shard)
+	created, err := s.shards.Put(ctx, marker, promise.Commitment, promiseHash, shard)
 	if err != nil {
 		return fmt.Errorf("storing shard payload: %w", err)
 	}
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
 		if created && !s.hasShardMarker(promise.Commitment, promiseHash) {
-			if rmErr := s.shards.Delete(context.Background(), promise.Commitment, promiseHash); rmErr != nil {
+			if rmErr := s.shards.Delete(context.Background(), marker, promise.Commitment, promiseHash); rmErr != nil {
 				s.log.Warn("failed to remove orphaned shard after commit failure",
 					"commitment", promise.Commitment.String(), "error", rmErr)
 			}
@@ -208,10 +206,6 @@ func (s *Store) Get(ctx context.Context, commitment Commitment) (*types.BlobShar
 
 	var rerr error
 	for valid := iter.First(); valid; valid = iter.Next() {
-		if _, err := decodeShardMarker(iter.Value()); err != nil {
-			rerr = errors.Join(rerr, err)
-			continue
-		}
 		promiseHashHex := string(iter.Key()[len(prefix):])
 		promiseHash, err := hex.DecodeString(promiseHashHex)
 		if err != nil {
@@ -219,14 +213,14 @@ func (s *Store) Get(ctx context.Context, commitment Commitment) (*types.BlobShar
 			continue
 		}
 
-		shard, err := s.shards.Get(ctx, commitment, promiseHash)
+		shard, err := s.shards.Get(ctx, iter.Value(), commitment, promiseHash)
 		if err == nil {
 			return shard, nil
 		}
 		if errors.Is(err, ErrStoreNotFound) {
 			continue
 		}
-		rerr = errors.Join(rerr, fmt.Errorf("reading shard file: %w", err))
+		rerr = errors.Join(rerr, fmt.Errorf("reading shard payload: %w", err))
 	}
 
 	if err := iter.Error(); err != nil {
@@ -255,14 +249,11 @@ func (s *Store) shardStatus(ctx context.Context, commitment Commitment, promiseH
 		return false, false, fmt.Errorf("checking if shard exists failed: %w", err)
 	default:
 		accounted = len(markerData) > 0
-		_, err = decodeShardMarker(markerData)
+		markerData = slices.Clone(markerData)
 		_ = closer.Close()
-		if err != nil {
-			return false, false, err
-		}
 	}
 
-	has, err := s.shards.Has(ctx, commitment, promiseHash)
+	has, err := s.shards.Has(ctx, markerData, commitment, promiseHash)
 	if err != nil {
 		return false, false, err
 	}
@@ -322,8 +313,11 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 			}
 			continue
 		}
-		size, err := decodeShardMarker(iter.Value())
+		size, err := s.shards.size(iter.Value(), commitment, promiseHash)
 		if err != nil {
+			if !errors.Is(err, ErrStoreIntegrity) {
+				return 0, fmt.Errorf("stat legacy shard file: %w", err)
+			}
 			// Keep one representative error and count all invalid markers.
 			invalidEntries++
 			if integrityErr == nil {
@@ -332,14 +326,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 			continue
 		}
 		if size == 0 {
-			// Empty markers predate encoded sizes, so read the local file size.
-			size, err = s.local.size(commitment, promiseHash)
-			if err != nil {
-				return 0, fmt.Errorf("stat legacy shard file: %w", err)
-			}
-			if size == 0 {
-				continue
-			}
+			continue
 		}
 		if size > math.MaxInt64-totalSize {
 			return 0, fmt.Errorf("%w: total shard size overflows int64", ErrStoreIntegrity)
@@ -360,7 +347,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 
 // DiskAvailable returns the free bytes on the filesystem backing the store.
 func (s *Store) DiskAvailable() (int64, error) {
-	return s.local.diskAvailable()
+	return s.shards.diskAvailable()
 }
 
 // GetPaymentPromise retrieves a [PaymentPromise] by its hash.
@@ -432,30 +419,27 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 		case err != nil:
 			return 0, 0, fmt.Errorf("getting shard marker: %w", err)
 		default:
-			size, err = decodeShardMarker(markerData)
+			markerData = slices.Clone(markerData)
 			_ = closer.Close()
-			if err != nil {
-				corruptMarkers++
-				if integrityErr == nil {
-					integrityErr = fmt.Errorf("decoding shard marker %q: %w", key, err)
-				}
-				continue
-			}
 		}
 
-		if size == 0 {
-			// Empty markers predate encoded sizes, so read the local file size.
-			size, err = s.local.size(commitment, promiseHash)
-			if err != nil {
+		size, err = s.shards.size(markerData, commitment, promiseHash)
+		if err != nil {
+			if !errors.Is(err, ErrStoreIntegrity) {
 				return 0, 0, fmt.Errorf("getting shard file stats: %w", err)
 			}
+			corruptMarkers++
+			if integrityErr == nil {
+				integrityErr = fmt.Errorf("decoding shard marker %q: %w", key, err)
+			}
+			continue
 		}
 		if size > math.MaxInt64-prunedBytes {
 			return 0, 0, errors.New("pruned shard size overflows int64")
 		}
 
 		// Missing file is fine (orphan marker from a crashed Put).
-		if err := s.shards.Delete(ctx, commitment, promiseHash); err != nil {
+		if err := s.shards.Delete(ctx, markerData, commitment, promiseHash); err != nil {
 			return 0, 0, err
 		}
 		if err := batch.Delete(key, pebbledb.NoSync); err != nil {
@@ -491,7 +475,7 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 // rare orphan files (pebble.NoSync power loss after rename) are accepted.
 func (s *Store) reconcile() error {
 	start := time.Now()
-	stagingRemoved, err := s.local.resetStaging()
+	stagingRemoved, err := s.shards.resetStaging()
 	if err != nil {
 		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", time.Since(start).Milliseconds())
 		return err

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -1,16 +1,12 @@
 package fibre
 
 import (
-	"bufio"
 	"context"
-	"crypto/rand"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"log/slog"
 	"math"
-	"os"
-	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -21,19 +17,10 @@ import (
 	gogoproto "github.com/cosmos/gogoproto/proto"
 )
 
-// Layout under [StoreConfig.Path]:
-//
-//	shards/<commit>-<hash>  finalized shard payloads (flat files).
-//	staging/<rand>          in-flight Put writes; renamed into shards/ on
-//	                        success, dropped wholesale by [Store.reconcile]
-//	                        on next open.
-//
 // Bulk shard data is kept off pebble because pebble serializes large-value
 // commits through a single goroutine, which becomes the upload bottleneck at
 // concurrency. Pebble only holds the small metadata.
 const (
-	shardsSubdir   = "shards"
-	stagingSubdir  = "staging"
 	shardKeyPrefix = "/shard/"
 	// maxPruneBatchSize bounds each Pebble commit. The server drains full
 	// batches during one prune pass.
@@ -74,15 +61,11 @@ func (cfg *StoreConfig) Validate() error {
 // Store manages persistent storage of [PaymentPromise] and row data.
 // It provides indexed access by [Commitment], promise hash, and timestamp.
 type Store struct {
-	cfg StoreConfig
-	db  *pebbledb.DB
-	fs  vfs.FS
-	log *slog.Logger
+	db     *pebbledb.DB
+	log    *slog.Logger
+	shards shardStorage
+	local  *localBackend
 }
-
-// shardWriteCategory identifies our shard-file writes in pebble's vfs disk
-// I/O telemetry.
-const shardWriteCategory vfs.DiskWriteCategory = "fibre-shard"
 
 // memStorePath is an arbitrary location inside the in-memory FS used by
 // [NewMemoryStore]; both pebble's files and our shards/staging subdirs live
@@ -113,10 +96,9 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 		return nil, fmt.Errorf("validating store config: %w", err)
 	}
 
-	for _, sub := range []string{shardsSubdir, stagingSubdir} {
-		if err := filesystem.MkdirAll(filepath.Join(cfg.Path, sub), 0o755); err != nil {
-			return nil, fmt.Errorf("creating %s directory: %w", sub, err)
-		}
+	local, err := newLocalBackend(cfg.Path, filesystem)
+	if err != nil {
+		return nil, fmt.Errorf("opening local shard storage: %w", err)
 	}
 
 	opts := &pebbledb.Options{FS: filesystem}
@@ -131,7 +113,7 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 		return nil, fmt.Errorf("opening pebble database: %w", err)
 	}
 
-	s := &Store{cfg: cfg, db: db, fs: filesystem, log: cfg.Log}
+	s := &Store{db: db, log: cfg.Log, shards: local, local: local}
 	if err := s.reconcile(); err != nil {
 		_ = s.db.Close()
 		return nil, fmt.Errorf("reconciling store: %w", err)
@@ -158,21 +140,11 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 	}
 
 	marker := encodeShardMarker(shardBinarySize(shard))
-	tmp, err := s.writeTmpShard(shard)
-	if err != nil {
-		return fmt.Errorf("writing shard tmp: %w", err)
-	}
-	if err := s.commitAndPublish(ctx, promise, promiseHash, tmp, marker, pruneAt); err != nil {
-		_ = s.fs.Remove(tmp)
-		return err
-	}
-	return nil
+	return s.commitAndStore(ctx, promise, promiseHash, shard, marker, pruneAt)
 }
 
-// commitAndPublish renames tmp into the canonical shards/ path, then writes
-// pebble metadata for the published shard. On any error tmp is left in
-// place for the caller to remove.
-func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, promiseHash []byte, tmp string, marker []byte, pruneAt time.Time) error {
+// commitAndStore writes the shard payload, then commits its Pebble metadata.
+func (s *Store) commitAndStore(ctx context.Context, promise *PaymentPromise, promiseHash []byte, shard *types.BlobShard, marker []byte, pruneAt time.Time) error {
 	promiseProto, err := promise.ToProto()
 	if err != nil {
 		return fmt.Errorf("converting payment promise to proto: %w", err)
@@ -194,22 +166,18 @@ func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, p
 		return fmt.Errorf("putting prune index: %w", err)
 	}
 
-	// Last safe point to honor a client cancellation: the batch is still only
-	// staged in memory and the tmp file is still unpublished, so we can drop
-	// both cleanly. Past the Rename+Commit below the write is durable and
-	// cannot be undone.
+	// Last safe point to honour cancellation before the durable payload write.
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("aborting store commit: %w", err)
 	}
 
-	// Publish the file, then commit the marker that makes it discoverable.
-	shardPath := s.shardFilePath(promise.Commitment, promiseHash)
-	if err := s.fs.Rename(tmp, shardPath); err != nil {
-		return fmt.Errorf("renaming shard tmp to final: %w", err)
+	created, err := s.shards.Put(ctx, promise.Commitment, promiseHash, shard)
+	if err != nil {
+		return fmt.Errorf("storing shard payload: %w", err)
 	}
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
-		if !s.hasShardMarker(promise.Commitment, promiseHash) {
-			if rmErr := s.fs.Remove(shardPath); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+		if created && !s.hasShardMarker(promise.Commitment, promiseHash) {
+			if rmErr := s.shards.Delete(context.Background(), promise.Commitment, promiseHash); rmErr != nil {
 				s.log.Warn("failed to remove orphaned shard after commit failure",
 					"commitment", promise.Commitment.String(), "error", rmErr)
 			}
@@ -220,47 +188,6 @@ func (s *Store) commitAndPublish(ctx context.Context, promise *PaymentPromise, p
 	return nil
 }
 
-// writeTmpShard stages a shard under <store>/staging/ at a randomly named
-// file. Random (not canonical staging/<commit>-<hash>) because vfs.FS.Create
-// truncates on collision rather than failing — no O_EXCL — so two concurrent
-// same-key writers would clobber each other's tmp. Random per-writer names
-// sidestep that; the rename in [Store.Put] picks one winner.
-func (s *Store) writeTmpShard(shard *types.BlobShard) (string, error) {
-	var rnd [16]byte
-	if _, err := rand.Read(rnd[:]); err != nil {
-		return "", fmt.Errorf("generating tmp name: %w", err)
-	}
-	tmp := filepath.Join(s.cfg.Path, stagingSubdir, hex.EncodeToString(rnd[:]))
-
-	f, err := s.fs.Create(tmp, shardWriteCategory)
-	if err != nil {
-		return "", fmt.Errorf("creating tmp shard file: %w", err)
-	}
-	bw := bufio.NewWriterSize(f, 1<<20)
-	if err := writeShardBinary(bw, shard); err != nil {
-		f.Close()
-		_ = s.fs.Remove(tmp)
-		return "", err
-	}
-	if err := bw.Flush(); err != nil {
-		f.Close()
-		_ = s.fs.Remove(tmp)
-		return "", err
-	}
-	if err := f.Close(); err != nil {
-		_ = s.fs.Remove(tmp)
-		return "", err
-	}
-	return tmp, nil
-}
-
-// shardFilePath returns the canonical flat-file path for (commit, hash). All
-// shard files live as siblings under <store>/shards/; the (commit, hash) pair
-// is encoded in the filename as <commit-hex>-<hash-hex>.
-func (s *Store) shardFilePath(commit Commitment, promiseHash []byte) string {
-	return filepath.Join(s.cfg.Path, shardsSubdir, commit.String()+"-"+hex.EncodeToString(promiseHash))
-}
-
 // Get returns the first [types.BlobShard] found for the given [Commitment].
 // When multiple promises exist for the same commitment, returning only the
 // first prevents unbounded message sizes; pebble's deterministic key order
@@ -268,7 +195,7 @@ func (s *Store) shardFilePath(commit Commitment, promiseHash []byte) string {
 //
 // A marker with a missing payload remains until pruning so its recorded size
 // can be released from occupancy.
-func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard, error) {
+func (s *Store) Get(ctx context.Context, commitment Commitment) (*types.BlobShard, error) {
 	prefix := fmt.Appendf(nil, "%s%s/", shardKeyPrefix, commitment.String())
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
 		LowerBound: prefix,
@@ -292,7 +219,7 @@ func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard,
 			continue
 		}
 
-		shard, err := readShardFile(s.fs, s.shardFilePath(commitment, promiseHash))
+		shard, err := s.shards.Get(ctx, commitment, promiseHash)
 		if err == nil {
 			return shard, nil
 		}
@@ -312,13 +239,13 @@ func (s *Store) Get(_ context.Context, commitment Commitment) (*types.BlobShard,
 }
 
 // Has verifies that shard exists without reading the whole file
-func (s *Store) Has(_ context.Context, commitment Commitment, promiseHash []byte) (bool, error) {
-	has, _, err := s.shardStatus(commitment, promiseHash)
+func (s *Store) Has(ctx context.Context, commitment Commitment, promiseHash []byte) (bool, error) {
+	has, _, err := s.shardStatus(ctx, commitment, promiseHash)
 	return has, err
 }
 
 // shardStatus reports whether the payload exists and its marker counts towards occupancy.
-func (s *Store) shardStatus(commitment Commitment, promiseHash []byte) (bool, bool, error) {
+func (s *Store) shardStatus(ctx context.Context, commitment Commitment, promiseHash []byte) (bool, bool, error) {
 	markerData, closer, err := s.db.Get(shardKey(commitment, promiseHash))
 	var accounted bool
 	switch {
@@ -335,14 +262,11 @@ func (s *Store) shardStatus(commitment Commitment, promiseHash []byte) (bool, bo
 		}
 	}
 
-	_, err = s.fs.Stat(s.shardFilePath(commitment, promiseHash))
-	switch {
-	case errors.Is(err, os.ErrNotExist):
-		return false, accounted, nil
-	case err != nil:
-		return false, false, fmt.Errorf("stat shard file: %w", err)
+	has, err := s.shards.Has(ctx, commitment, promiseHash)
+	if err != nil {
+		return false, false, err
 	}
-	return true, accounted, nil
+	return has, accounted, nil
 }
 
 // hasShardMarker reports whether a committed shard marker exists,
@@ -409,14 +333,12 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 		}
 		if size == 0 {
 			// Empty markers predate encoded sizes, so read the local file size.
-			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
-			switch {
-			case errors.Is(err, os.ErrNotExist):
-				continue
-			case err != nil:
+			size, err = s.local.size(commitment, promiseHash)
+			if err != nil {
 				return 0, fmt.Errorf("stat legacy shard file: %w", err)
-			default:
-				size = info.Size()
+			}
+			if size == 0 {
+				continue
 			}
 		}
 		if size > math.MaxInt64-totalSize {
@@ -438,11 +360,7 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 
 // DiskAvailable returns the free bytes on the filesystem backing the store.
 func (s *Store) DiskAvailable() (int64, error) {
-	du, err := s.fs.GetDiskUsage(s.cfg.Path)
-	if err != nil {
-		return 0, fmt.Errorf("getting disk usage: %w", err)
-	}
-	return int64(du.AvailBytes), nil
+	return s.local.diskAvailable()
 }
 
 // GetPaymentPromise retrieves a [PaymentPromise] by its hash.
@@ -473,7 +391,7 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 // markers are skipped, it commits valid deletions and returns their count and
 // freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
 // do not consume deletion capacity. Fatal errors return no uncommitted counts.
-func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, error) {
+func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
 		LowerBound: prefix,
@@ -527,13 +445,9 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 
 		if size == 0 {
 			// Empty markers predate encoded sizes, so read the local file size.
-			info, err := s.fs.Stat(s.shardFilePath(commitment, promiseHash))
-			switch {
-			case errors.Is(err, os.ErrNotExist):
-			case err != nil:
+			size, err = s.local.size(commitment, promiseHash)
+			if err != nil {
 				return 0, 0, fmt.Errorf("getting shard file stats: %w", err)
-			default:
-				size = info.Size()
 			}
 		}
 		if size > math.MaxInt64-prunedBytes {
@@ -541,8 +455,8 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 		}
 
 		// Missing file is fine (orphan marker from a crashed Put).
-		if err := s.fs.Remove(s.shardFilePath(commitment, promiseHash)); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return 0, 0, fmt.Errorf("removing shard file: %w", err)
+		if err := s.shards.Delete(ctx, commitment, promiseHash); err != nil {
+			return 0, 0, err
 		}
 		if err := batch.Delete(key, pebbledb.NoSync); err != nil {
 			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
@@ -577,7 +491,7 @@ func (s *Store) PruneBefore(_ context.Context, before time.Time) (int, int64, er
 // rare orphan files (pebble.NoSync power loss after rename) are accepted.
 func (s *Store) reconcile() error {
 	start := time.Now()
-	stagingRemoved, err := s.resetStaging()
+	stagingRemoved, err := s.local.resetStaging()
 	if err != nil {
 		s.log.Error("store reconcile failed", "error", err, "elapsed_ms", time.Since(start).Milliseconds())
 		return err
@@ -585,23 +499,6 @@ func (s *Store) reconcile() error {
 	s.log.Info("store reconcile complete", "staging_files_removed", stagingRemoved,
 		"elapsed_ms", time.Since(start).Milliseconds())
 	return nil
-}
-
-// resetStaging removes and recreates <store>/staging/, returning the number
-// of entries that were dropped. A missing dir is treated as zero.
-func (s *Store) resetStaging() (int, error) {
-	stagingDir := filepath.Join(s.cfg.Path, stagingSubdir)
-	entries, err := s.fs.List(stagingDir)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return 0, fmt.Errorf("reading staging: %w", err)
-	}
-	if err := s.fs.RemoveAll(stagingDir); err != nil {
-		return len(entries), fmt.Errorf("removing staging: %w", err)
-	}
-	if err := s.fs.MkdirAll(stagingDir, 0o755); err != nil {
-		return len(entries), fmt.Errorf("recreating staging: %w", err)
-	}
-	return len(entries), nil
 }
 
 // Close closes the underlying pebble database. For [NewMemoryStore] the

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -18,7 +18,8 @@ import (
 )
 
 // Pebble stores promises, prune indexes, and shard markers. Each marker
-// identifies the backend and size of its shard payload; legacy markers use local storage.
+// identifies the backend (local || object) and size of its shard payload;
+// legacy markers use local storage.
 const (
 	shardKeyPrefix = "/shard/"
 	// maxPruneBatchSize bounds each Pebble commit. The server drains full
@@ -62,7 +63,7 @@ func (cfg *StoreConfig) Validate() error {
 type Store struct {
 	db     *pebbledb.DB
 	log    *slog.Logger
-	shards shardStorage
+	shards *routedStorage
 }
 
 // memStorePath is an arbitrary location inside the in-memory FS used by
@@ -142,7 +143,14 @@ func (s *Store) Put(ctx context.Context, promise *PaymentPromise, shard *types.B
 }
 
 // commitAndStore writes the shard payload, then commits its Pebble metadata.
-func (s *Store) commitAndStore(ctx context.Context, promise *PaymentPromise, promiseHash []byte, shard *types.BlobShard, marker []byte, pruneAt time.Time) error {
+func (s *Store) commitAndStore(
+	ctx context.Context,
+	promise *PaymentPromise,
+	promiseHash []byte,
+	shard *types.BlobShard,
+	marker []byte,
+	pruneAt time.Time,
+) error {
 	promiseProto, err := promise.ToProto()
 	if err != nil {
 		return fmt.Errorf("converting payment promise to proto: %w", err)
@@ -169,6 +177,7 @@ func (s *Store) commitAndStore(ctx context.Context, promise *PaymentPromise, pro
 		return fmt.Errorf("aborting store commit: %w", err)
 	}
 
+	// The marker routes the write and any commit-failure cleanup to the same backend.
 	created, err := s.shards.Put(ctx, marker, promise.Commitment, promiseHash, shard)
 	if err != nil {
 		return fmt.Errorf("storing shard payload: %w", err)
@@ -249,6 +258,7 @@ func (s *Store) shardStatus(ctx context.Context, commitment Commitment, promiseH
 		return false, false, fmt.Errorf("checking if shard exists failed: %w", err)
 	default:
 		accounted = len(markerData) > 0
+		// Pebble owns markerData until the closer closes.
 		markerData = slices.Clone(markerData)
 		_ = closer.Close()
 	}
@@ -323,9 +333,6 @@ func (s *Store) Size(ctx context.Context) (int64, error) {
 			if integrityErr == nil {
 				integrityErr = fmt.Errorf("decoding shard marker %q: %w", iter.Key(), err)
 			}
-			continue
-		}
-		if size == 0 {
 			continue
 		}
 		if size > math.MaxInt64-totalSize {
@@ -419,6 +426,7 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 		case err != nil:
 			return 0, 0, fmt.Errorf("getting shard marker: %w", err)
 		default:
+			// Pebble owns markerData until the closer closes.
 			markerData = slices.Clone(markerData)
 			_ = closer.Close()
 		}
@@ -429,6 +437,7 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 				return 0, 0, fmt.Errorf("getting shard file stats: %w", err)
 			}
 			corruptMarkers++
+			// Keep the first integrity error and count every corrupt marker.
 			if integrityErr == nil {
 				integrityErr = fmt.Errorf("decoding shard marker %q: %w", key, err)
 			}

--- a/fibre/store_local.go
+++ b/fibre/store_local.go
@@ -28,7 +28,7 @@ type localBackend struct {
 // shardPayloadWriteCategory labels shard payload bytes in VFS disk-write metrics.
 const shardPayloadWriteCategory vfs.DiskWriteCategory = "fibre-shard"
 
-func (*localBackend) backendTag() byte {
+func (*localBackend) backendTag() shardBackendTag {
 	return localBackendTag
 }
 

--- a/fibre/store_local.go
+++ b/fibre/store_local.go
@@ -1,0 +1,161 @@
+package fibre
+
+import (
+	"bufio"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/cockroachdb/pebble/v2/vfs"
+)
+
+const (
+	shardsSubdir  = "shards"
+	stagingSubdir = "staging"
+)
+
+// shardStorage stores durable shard payloads.
+type shardStorage interface {
+	Put(context.Context, Commitment, []byte, *types.BlobShard) (bool, error)
+	Get(context.Context, Commitment, []byte) (*types.BlobShard, error)
+	Has(context.Context, Commitment, []byte) (bool, error)
+	Delete(context.Context, Commitment, []byte) error
+}
+
+// localBackend stores shard payloads as flat files.
+type localBackend struct {
+	path string
+	fs   vfs.FS
+}
+
+// shardWriteCategory identifies shard-file writes in Pebble's vfs telemetry.
+const shardWriteCategory vfs.DiskWriteCategory = "fibre-shard"
+
+func newLocalBackend(path string, filesystem vfs.FS) (*localBackend, error) {
+	for _, sub := range []string{shardsSubdir, stagingSubdir} {
+		if err := filesystem.MkdirAll(filepath.Join(path, sub), 0o755); err != nil {
+			return nil, fmt.Errorf("creating %s directory: %w", sub, err)
+		}
+	}
+	return &localBackend{path: path, fs: filesystem}, nil
+}
+
+func (b *localBackend) Put(ctx context.Context, commitment Commitment, promiseHash []byte, shard *types.BlobShard) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	tmp, err := b.writeTmp(shard)
+	if err != nil {
+		return false, fmt.Errorf("writing shard tmp: %w", err)
+	}
+	defer func() { _ = b.fs.Remove(tmp) }()
+
+	if err := ctx.Err(); err != nil {
+		return false, fmt.Errorf("aborting shard publish: %w", err)
+	}
+	if err := b.fs.Rename(tmp, b.shardPath(commitment, promiseHash)); err != nil {
+		return false, fmt.Errorf("renaming shard tmp to final: %w", err)
+	}
+	return true, nil
+}
+
+func (b *localBackend) Get(_ context.Context, commitment Commitment, promiseHash []byte) (*types.BlobShard, error) {
+	return readShardFile(b.fs, b.shardPath(commitment, promiseHash))
+}
+
+func (b *localBackend) Has(_ context.Context, commitment Commitment, promiseHash []byte) (bool, error) {
+	_, err := b.fs.Stat(b.shardPath(commitment, promiseHash))
+	switch {
+	case errors.Is(err, os.ErrNotExist):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("stat shard file: %w", err)
+	default:
+		return true, nil
+	}
+}
+
+func (b *localBackend) Delete(ctx context.Context, commitment Commitment, promiseHash []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := b.fs.Remove(b.shardPath(commitment, promiseHash)); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("removing shard file: %w", err)
+	}
+	return nil
+}
+
+func (b *localBackend) size(commitment Commitment, promiseHash []byte) (int64, error) {
+	info, err := b.fs.Stat(b.shardPath(commitment, promiseHash))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, err
+	}
+	return info.Size(), nil
+}
+
+func (b *localBackend) diskAvailable() (int64, error) {
+	du, err := b.fs.GetDiskUsage(b.path)
+	if err != nil {
+		return 0, fmt.Errorf("getting disk usage: %w", err)
+	}
+	return int64(du.AvailBytes), nil
+}
+
+// writeTmp uses a random per-writer name because vfs.FS.Create truncates
+// colliding files. The final rename selects the same-key winner.
+func (b *localBackend) writeTmp(shard *types.BlobShard) (string, error) {
+	var rnd [16]byte
+	if _, err := rand.Read(rnd[:]); err != nil {
+		return "", fmt.Errorf("generating tmp name: %w", err)
+	}
+	tmp := filepath.Join(b.path, stagingSubdir, hex.EncodeToString(rnd[:]))
+
+	f, err := b.fs.Create(tmp, shardWriteCategory)
+	if err != nil {
+		return "", fmt.Errorf("creating tmp shard file: %w", err)
+	}
+	bw := bufio.NewWriterSize(f, 1<<20)
+	if err := writeShardBinary(bw, shard); err != nil {
+		f.Close()
+		_ = b.fs.Remove(tmp)
+		return "", err
+	}
+	if err := bw.Flush(); err != nil {
+		f.Close()
+		_ = b.fs.Remove(tmp)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = b.fs.Remove(tmp)
+		return "", err
+	}
+	return tmp, nil
+}
+
+func (b *localBackend) shardPath(commitment Commitment, promiseHash []byte) string {
+	return filepath.Join(b.path, shardsSubdir, commitment.String()+"-"+hex.EncodeToString(promiseHash))
+}
+
+func (b *localBackend) resetStaging() (int, error) {
+	stagingDir := filepath.Join(b.path, stagingSubdir)
+	entries, err := b.fs.List(stagingDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return 0, fmt.Errorf("reading staging: %w", err)
+	}
+	if err := b.fs.RemoveAll(stagingDir); err != nil {
+		return len(entries), fmt.Errorf("removing staging: %w", err)
+	}
+	if err := b.fs.MkdirAll(stagingDir, 0o755); err != nil {
+		return len(entries), fmt.Errorf("recreating staging: %w", err)
+	}
+	return len(entries), nil
+}

--- a/fibre/store_local.go
+++ b/fibre/store_local.go
@@ -19,22 +19,18 @@ const (
 	stagingSubdir = "staging"
 )
 
-// shardStorage stores durable shard payloads.
-type shardStorage interface {
-	Put(context.Context, Commitment, []byte, *types.BlobShard) (bool, error)
-	Get(context.Context, Commitment, []byte) (*types.BlobShard, error)
-	Has(context.Context, Commitment, []byte) (bool, error)
-	Delete(context.Context, Commitment, []byte) error
-}
-
 // localBackend stores shard payloads as flat files.
 type localBackend struct {
 	path string
 	fs   vfs.FS
 }
 
-// shardWriteCategory identifies shard-file writes in Pebble's vfs telemetry.
-const shardWriteCategory vfs.DiskWriteCategory = "fibre-shard"
+// shardPayloadWriteCategory labels shard payload bytes in VFS disk-write metrics.
+const shardPayloadWriteCategory vfs.DiskWriteCategory = "fibre-shard"
+
+func (*localBackend) backendTag() byte {
+	return localBackendTag
+}
 
 func newLocalBackend(path string, filesystem vfs.FS) (*localBackend, error) {
 	for _, sub := range []string{shardsSubdir, stagingSubdir} {
@@ -119,7 +115,7 @@ func (b *localBackend) writeTmp(shard *types.BlobShard) (string, error) {
 	}
 	tmp := filepath.Join(b.path, stagingSubdir, hex.EncodeToString(rnd[:]))
 
-	f, err := b.fs.Create(tmp, shardWriteCategory)
+	f, err := b.fs.Create(tmp, shardPayloadWriteCategory)
 	if err != nil {
 		return "", fmt.Errorf("creating tmp shard file: %w", err)
 	}

--- a/fibre/store_local_test.go
+++ b/fibre/store_local_test.go
@@ -1,0 +1,60 @@
+package fibre
+
+import (
+	"context"
+	"testing"
+
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/cockroachdb/pebble/v2/vfs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalBackendPayloadLifecycle(t *testing.T) {
+	backend, err := newLocalBackend("/store", vfs.NewMem())
+	require.NoError(t, err)
+
+	var commitment Commitment
+	commitment[0] = 1
+	promiseHash := []byte{2}
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Index: 3, Data: []byte("data")}}}
+
+	has, err := backend.Has(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
+	_, err = backend.Get(t.Context(), commitment, promiseHash)
+	require.ErrorIs(t, err, ErrStoreNotFound)
+	require.NoError(t, backend.Delete(t.Context(), commitment, promiseHash))
+
+	created, err := backend.Put(t.Context(), commitment, promiseHash, shard)
+	require.NoError(t, err)
+	require.True(t, created)
+	created, err = backend.Put(t.Context(), commitment, promiseHash, shard)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	got, err := backend.Get(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.Equal(t, shard, got)
+	has, err = backend.Has(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.True(t, has)
+
+	require.NoError(t, backend.Delete(t.Context(), commitment, promiseHash))
+	has, err = backend.Has(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestLocalBackendPutHonoursCancellation(t *testing.T) {
+	backend, err := newLocalBackend("/store", vfs.NewMem())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	created, err := backend.Put(ctx, Commitment{}, []byte{1}, &types.BlobShard{})
+	require.ErrorIs(t, err, context.Canceled)
+	require.False(t, created)
+	has, err := backend.Has(t.Context(), Commitment{}, []byte{1})
+	require.NoError(t, err)
+	require.False(t, has)
+}

--- a/fibre/store_marker.go
+++ b/fibre/store_marker.go
@@ -15,32 +15,30 @@ const localBackendTag byte = 0x01
 
 // encodeShardMarker encodes a local shard size.
 func encodeShardMarker(size int64) []byte {
+	return encodeShardMarkerForBackend(localBackendTag, size)
+}
+
+func encodeShardMarkerForBackend(backend byte, size int64) []byte {
 	marker := make([]byte, shardMarkerSize)
 	marker[0] = shardMarkerVersion
-	marker[1] = localBackendTag
+	marker[1] = backend
 	binary.BigEndian.PutUint64(marker[2:], uint64(size))
 	return marker
 }
 
-// decodeShardMarker returns the encoded shard size. An empty marker returns
-// zero without an error and identifies a legacy local shard.
-func decodeShardMarker(data []byte) (int64, error) {
+func decodeShardMarkerBackend(data []byte) (byte, int64, error) {
 	if len(data) == 0 {
-		return 0, nil
+		return localBackendTag, 0, nil
 	}
 	if len(data) != shardMarkerSize {
-		return 0, fmt.Errorf("%w: shard marker length %d, want %d", ErrStoreIntegrity, len(data), shardMarkerSize)
+		return 0, 0, fmt.Errorf("%w: shard marker length %d, want %d", ErrStoreIntegrity, len(data), shardMarkerSize)
 	}
 	if data[0] != shardMarkerVersion {
-		return 0, fmt.Errorf("%w: unsupported shard marker version %d", ErrStoreIntegrity, data[0])
+		return 0, 0, fmt.Errorf("%w: unsupported shard marker version %d", ErrStoreIntegrity, data[0])
 	}
-	if data[1] != localBackendTag {
-		return 0, fmt.Errorf("%w: unsupported shard backend tag 0x%02x", ErrStoreIntegrity, data[1])
-	}
-
 	size := binary.BigEndian.Uint64(data[2:])
 	if size == 0 || size > math.MaxInt64 {
-		return 0, fmt.Errorf("%w: invalid shard size %d", ErrStoreIntegrity, size)
+		return 0, 0, fmt.Errorf("%w: invalid shard size %d", ErrStoreIntegrity, size)
 	}
-	return int64(size), nil
+	return data[1], int64(size), nil
 }

--- a/fibre/store_marker.go
+++ b/fibre/store_marker.go
@@ -11,23 +11,26 @@ const (
 	shardMarkerSize    = 10
 )
 
-const localBackendTag byte = 0x01
+type shardBackendTag byte
 
-// encodeShardMarker encodes a local shard size.
-func encodeShardMarker(size int64) []byte {
-	return encodeShardMarkerForBackend(localBackendTag, size)
-}
+const (
+	localBackendTag  shardBackendTag = 0x01
+	objectBackendTag shardBackendTag = 0x02
+)
 
-func encodeShardMarkerForBackend(backend byte, size int64) []byte {
+// encodeShardMarkerForBackend encodes a backend and shard size in a versioned marker.
+func encodeShardMarkerForBackend(backend shardBackendTag, size int64) []byte {
 	marker := make([]byte, shardMarkerSize)
 	marker[0] = shardMarkerVersion
-	marker[1] = backend
+	marker[1] = byte(backend)
 	binary.BigEndian.PutUint64(marker[2:], uint64(size))
 	return marker
 }
 
-func decodeShardMarkerBackend(data []byte) (byte, int64, error) {
+// decodeShardMarkerBackend returns the backend and size from a shard marker.
+func decodeShardMarkerBackend(data []byte) (shardBackendTag, int64, error) {
 	if len(data) == 0 {
+		// Remove this legacy path after all stored shards use versioned markers.
 		return localBackendTag, 0, nil
 	}
 	if len(data) != shardMarkerSize {
@@ -36,9 +39,13 @@ func decodeShardMarkerBackend(data []byte) (byte, int64, error) {
 	if data[0] != shardMarkerVersion {
 		return 0, 0, fmt.Errorf("%w: unsupported shard marker version %d", ErrStoreIntegrity, data[0])
 	}
+	backend := shardBackendTag(data[1])
+	if backend != localBackendTag && backend != objectBackendTag {
+		return 0, 0, fmt.Errorf("%w: unsupported shard backend tag 0x%02x", ErrStoreIntegrity, data[1])
+	}
 	size := binary.BigEndian.Uint64(data[2:])
 	if size == 0 || size > math.MaxInt64 {
 		return 0, 0, fmt.Errorf("%w: invalid shard size %d", ErrStoreIntegrity, size)
 	}
-	return data[1], int64(size), nil
+	return backend, int64(size), nil
 }

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -20,12 +20,14 @@ func TestShardMarkerCodec(t *testing.T) {
 	marker := encodeShardMarker(42)
 	require.Equal(t, []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 42}, marker)
 
-	size, err := decodeShardMarker(marker)
+	backend, size, err := decodeShardMarkerBackend(marker)
 	require.NoError(t, err)
+	require.Equal(t, localBackendTag, backend)
 	require.Equal(t, int64(42), size)
 
-	size, err = decodeShardMarker(nil)
+	backend, size, err = decodeShardMarkerBackend(nil)
 	require.NoError(t, err)
+	require.Equal(t, localBackendTag, backend)
 	require.Zero(t, size)
 }
 
@@ -34,10 +36,6 @@ func TestShardMarkerRejectsInvalidData(t *testing.T) {
 
 	overflow := append([]byte(nil), valid...)
 	binary.BigEndian.PutUint64(overflow[2:], uint64(math.MaxInt64)+1)
-	zeroBackend := append([]byte(nil), valid...)
-	zeroBackend[1] = 0
-	objectBackend := append([]byte(nil), valid...)
-	objectBackend[1] = 2
 	tests := []struct {
 		name string
 		data []byte
@@ -46,15 +44,13 @@ func TestShardMarkerRejectsInvalidData(t *testing.T) {
 		{"overlong", append(valid, 0)},
 		{"zero version", append([]byte{0}, valid[1:]...)},
 		{"unsupported version", append([]byte{2}, valid[1:]...)},
-		{"zero backend", zeroBackend},
-		{"object backend", objectBackend},
 		{"zero size", []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
 		{"size overflow", overflow},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := decodeShardMarker(tt.data)
+			_, _, err := decodeShardMarkerBackend(tt.data)
 			require.ErrorIs(t, err, ErrStoreIntegrity)
 		})
 	}
@@ -120,7 +116,8 @@ func TestStoreRejectsInvalidShardMarkerWithoutDeletingItsData(t *testing.T) {
 			require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
 
 			require.ErrorIs(t, tt.call(store, commitment, promiseHash, pruneAt), ErrStoreIntegrity)
-			_, err := store.local.fs.Stat(store.local.shardPath(commitment, promiseHash))
+			local := storeLocalBackend(t, store)
+			_, err := local.fs.Stat(local.shardPath(commitment, promiseHash))
 			require.NoError(t, err)
 			data, closer, err := store.db.Get(shardKey(commitment, promiseHash))
 			require.NoError(t, err)
@@ -159,7 +156,8 @@ func TestGetMissingPayloadKeepsPruneAccounting(t *testing.T) {
 	size := writeMarkerTestShard(t, store, commitment, promiseHash)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
-	require.NoError(t, store.local.fs.Remove(store.local.shardPath(commitment, promiseHash)))
+	local := storeLocalBackend(t, store)
+	require.NoError(t, local.fs.Remove(local.shardPath(commitment, promiseHash)))
 
 	_, err := store.Get(t.Context(), commitment)
 	require.ErrorIs(t, err, ErrStoreNotFound)
@@ -260,12 +258,13 @@ func TestPruneBeforeSkipsInvalidMarkerAndPrunesValidEntry(t *testing.T) {
 	_, closer, err := store.db.Get(shardKey(commitment, validHash))
 	require.ErrorIs(t, err, pebbledb.ErrNotFound)
 	require.Nil(t, closer)
-	_, err = store.local.fs.Stat(store.local.shardPath(commitment, validHash))
+	local := storeLocalBackend(t, store)
+	_, err = local.fs.Stat(local.shardPath(commitment, validHash))
 	require.ErrorIs(t, err, os.ErrNotExist)
 	_, closer, err = store.db.Get(shardKey(commitment, invalidHash))
 	require.NoError(t, err)
 	require.NoError(t, closer.Close())
-	_, err = store.local.fs.Stat(store.local.shardPath(commitment, invalidHash))
+	_, err = local.fs.Stat(local.shardPath(commitment, invalidHash))
 	require.NoError(t, err)
 }
 
@@ -284,7 +283,8 @@ func TestPruneBeforeHonoursCancellation(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	require.Zero(t, pruned)
 	require.Zero(t, freed)
-	_, err = store.local.fs.Stat(store.local.shardPath(commitment, promiseHash))
+	local := storeLocalBackend(t, store)
+	_, err = local.fs.Stat(local.shardPath(commitment, promiseHash))
 	require.NoError(t, err)
 }
 
@@ -369,14 +369,24 @@ func newMarkerTestStore(t *testing.T) *Store {
 
 func writeMarkerTestShard(t *testing.T, store *Store, commitment Commitment, promiseHash []byte) int64 {
 	t.Helper()
-	path := store.local.shardPath(commitment, promiseHash)
-	f, err := store.local.fs.Create(path, shardWriteCategory)
+	local := storeLocalBackend(t, store)
+	path := local.shardPath(commitment, promiseHash)
+	f, err := local.fs.Create(path, shardPayloadWriteCategory)
 	require.NoError(t, err)
 	require.NoError(t, writeShardBinary(f, &types.BlobShard{
 		Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}},
 	}))
 	require.NoError(t, f.Close())
-	info, err := store.local.fs.Stat(path)
+	info, err := local.fs.Stat(path)
 	require.NoError(t, err)
 	return info.Size()
+}
+
+func storeLocalBackend(t *testing.T, store *Store) *localBackend {
+	t.Helper()
+	storage, ok := store.shards.(*routedStorage)
+	require.True(t, ok)
+	local, err := storage.localBackend()
+	require.NoError(t, err)
+	return local
 }

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestShardMarkerCodec(t *testing.T) {
-	marker := encodeShardMarker(42)
+	marker := encodeShardMarkerForBackend(localBackendTag, 42)
 	require.Equal(t, []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 42}, marker)
 
 	backend, size, err := decodeShardMarkerBackend(marker)
@@ -29,13 +29,23 @@ func TestShardMarkerCodec(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, localBackendTag, backend)
 	require.Zero(t, size)
+
+	marker = encodeShardMarkerForBackend(objectBackendTag, 42)
+	backend, size, err = decodeShardMarkerBackend(marker)
+	require.NoError(t, err)
+	require.Equal(t, objectBackendTag, backend)
+	require.Equal(t, int64(42), size)
 }
 
 func TestShardMarkerRejectsInvalidData(t *testing.T) {
-	valid := encodeShardMarker(1)
+	valid := encodeShardMarkerForBackend(localBackendTag, 1)
 
 	overflow := append([]byte(nil), valid...)
 	binary.BigEndian.PutUint64(overflow[2:], uint64(math.MaxInt64)+1)
+	zeroBackend := append([]byte(nil), valid...)
+	zeroBackend[1] = 0
+	unknownBackend := append([]byte(nil), valid...)
+	unknownBackend[1] = 3
 	tests := []struct {
 		name string
 		data []byte
@@ -44,6 +54,8 @@ func TestShardMarkerRejectsInvalidData(t *testing.T) {
 		{"overlong", append(valid, 0)},
 		{"zero version", append([]byte{0}, valid[1:]...)},
 		{"unsupported version", append([]byte{2}, valid[1:]...)},
+		{"zero backend", zeroBackend},
+		{"unknown backend", unknownBackend},
 		{"zero size", []byte{1, 1, 0, 0, 0, 0, 0, 0, 0, 0}},
 		{"size overflow", overflow},
 	}
@@ -135,7 +147,7 @@ func TestGetSkipsInvalidMarkerAndReturnsValidShard(t *testing.T) {
 	invalidMarker := []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}
 	writeMarkerTestShard(t, store, commitment, invalidHash)
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
-	validMarker := encodeShardMarker(validSize)
+	validMarker := encodeShardMarkerForBackend(localBackendTag, validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), invalidMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 
@@ -154,7 +166,7 @@ func TestGetMissingPayloadKeepsPruneAccounting(t *testing.T) {
 	promiseHash := []byte{1}
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	size := writeMarkerTestShard(t, store, commitment, promiseHash)
-	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarkerForBackend(localBackendTag, size), pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
 	local := storeLocalBackend(t, store)
 	require.NoError(t, local.fs.Remove(local.shardPath(commitment, promiseHash)))
@@ -175,7 +187,7 @@ func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
 	invalidHash := []byte{2}
 	secondInvalidHash := []byte{3}
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
-	validMarker := encodeShardMarker(validSize)
+	validMarker := encodeShardMarkerForBackend(localBackendTag, validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), []byte{1, 2}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, secondInvalidHash), []byte{1, 2}, pebbledb.NoSync))
@@ -188,7 +200,7 @@ func TestSizeReturnsValidTotalWithInvalidMarker(t *testing.T) {
 
 func TestSizeRejectsMalformedShardKeyWithValidMarker(t *testing.T) {
 	store := newMarkerTestStore(t)
-	require.NoError(t, store.db.Set([]byte(shardKeyPrefix+"malformed"), encodeShardMarker(37), pebbledb.NoSync))
+	require.NoError(t, store.db.Set([]byte(shardKeyPrefix+"malformed"), encodeShardMarkerForBackend(localBackendTag, 37), pebbledb.NoSync))
 
 	size, err := store.Size(t.Context())
 	require.ErrorIs(t, err, ErrStoreIntegrity)
@@ -200,7 +212,7 @@ func TestServerSeedsPartialSizeAfterIntegrityError(t *testing.T) {
 	commitment := generateCommitment()
 	validHash := []byte{1}
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
-	validMarker := encodeShardMarker(validSize)
+	validMarker := encodeShardMarkerForBackend(localBackendTag, validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, []byte{2}), []byte{1, 2}, pebbledb.NoSync))
 
@@ -229,7 +241,7 @@ func TestShardStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.False(t, has)
 	require.False(t, accounted)
-	marker := encodeShardMarker(1)
+	marker := encodeShardMarkerForBackend(localBackendTag, 1)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
 	has, accounted, err = store.shardStatus(t.Context(), commitment, promiseHash)
 	require.NoError(t, err)
@@ -245,7 +257,7 @@ func TestPruneBeforeSkipsInvalidMarkerAndPrunesValidEntry(t *testing.T) {
 	invalidHash := []byte{2}
 	validSize := writeMarkerTestShard(t, store, commitment, validHash)
 	writeMarkerTestShard(t, store, commitment, invalidHash)
-	validMarker := encodeShardMarker(validSize)
+	validMarker := encodeShardMarkerForBackend(localBackendTag, validSize)
 	require.NoError(t, store.db.Set(shardKey(commitment, validHash), validMarker, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(shardKey(commitment, invalidHash), []byte{1, 2, 0, 0, 0, 0, 0, 0, 0, 1}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, validHash), nil, pebbledb.NoSync))
@@ -274,7 +286,7 @@ func TestPruneBeforeHonoursCancellation(t *testing.T) {
 	promiseHash := []byte{1}
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	size := writeMarkerTestShard(t, store, commitment, promiseHash)
-	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarkerForBackend(localBackendTag, size), pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
 
 	ctx, cancel := context.WithCancel(t.Context())
@@ -292,7 +304,7 @@ func TestPruneBeforeLimitsBatchSize(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	marker := encodeShardMarker(1)
+	marker := encodeShardMarkerForBackend(localBackendTag, 1)
 	require.NoError(t, store.db.Set(shardKey(commitment, nil), []byte{1, 2}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, nil), nil, pebbledb.NoSync))
 	for i := range maxPruneBatchSize + 1 {
@@ -318,7 +330,7 @@ func TestPruneBeforeOverflowReturnsNoUncommittedCounts(t *testing.T) {
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	for i, size := range []int64{math.MaxInt64, 1} {
 		promiseHash := []byte{byte(i)}
-		require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
+		require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarkerForBackend(localBackendTag, size), pebbledb.NoSync))
 		require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
 	}
 
@@ -333,7 +345,7 @@ func TestServerPruneDrainsBacklog(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()
 	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	marker := encodeShardMarker(1)
+	marker := encodeShardMarkerForBackend(localBackendTag, 1)
 	require.NoError(t, store.db.Set(shardKey(commitment, nil), []byte{1, 2}, pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, nil), nil, pebbledb.NoSync))
 	for i := range maxPruneBatchSize + 1 {
@@ -384,9 +396,7 @@ func writeMarkerTestShard(t *testing.T, store *Store, commitment Commitment, pro
 
 func storeLocalBackend(t *testing.T, store *Store) *localBackend {
 	t.Helper()
-	storage, ok := store.shards.(*routedStorage)
-	require.True(t, ok)
-	local, err := storage.localBackend()
+	local, err := store.shards.localBackend()
 	require.NoError(t, err)
 	return local
 }

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -324,6 +324,80 @@ func TestPruneBeforeLimitsBatchSize(t *testing.T) {
 	require.Equal(t, int64(1), freed)
 }
 
+func TestPruneCommitsProgressOnCancellation(t *testing.T) {
+	for _, throughServer := range []bool{false, true} {
+		name := "store"
+		if throughServer {
+			name = "server"
+		}
+		t.Run(name, func(t *testing.T) {
+			store := newMarkerTestStore(t)
+			local := storeLocalBackend(t, store)
+			commitment := generateCommitment()
+			pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+			var size int64
+			for _, hash := range [][]byte{{1}, {2}} {
+				size = writeMarkerTestShard(t, store, commitment, hash)
+				require.NoError(t, store.db.Set(shardKey(commitment, hash), encodeShardMarkerForBackend(localBackendTag, size), pebbledb.NoSync))
+				require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, hash), nil, pebbledb.NoSync))
+				require.NoError(t, store.db.Set(promiseKey(hash), []byte("promise"), pebbledb.NoSync))
+			}
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			store.shards.primary = &cancelAfterDeleteBackend{shardBackend: local, cancel: cancel}
+			if throughServer {
+				occ := newOccupancy(0)
+				occ.seed(2 * size)
+				provider := sdkmetric.NewMeterProvider()
+				metrics, err := newServerMetrics(provider.Meter("prune-test"), occ)
+				require.NoError(t, err)
+				server := &Server{store: store, occ: occ, metrics: metrics, log: slog.Default()}
+				server.prune(ctx)
+				require.Equal(t, size, occ.usage())
+			} else {
+				pruned, freed, err := store.PruneBefore(ctx, pruneAt.Add(time.Hour))
+				require.ErrorIs(t, err, context.Canceled)
+				require.Equal(t, 1, pruned)
+				require.Equal(t, size, freed)
+			}
+			for _, hash := range [][]byte{{1}, {2}} {
+				for _, key := range [][]byte{shardKey(commitment, hash), pruneKey(pruneAt, commitment, hash), promiseKey(hash)} {
+					_, closer, err := store.db.Get(key)
+					if hash[0] == 1 {
+						require.ErrorIs(t, err, pebbledb.ErrNotFound)
+					} else {
+						require.NoError(t, err)
+						require.NoError(t, closer.Close())
+					}
+				}
+				_, err := local.fs.Stat(local.shardPath(commitment, hash))
+				if hash[0] == 1 {
+					require.ErrorIs(t, err, os.ErrNotExist)
+				} else {
+					require.NoError(t, err)
+				}
+			}
+			pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+			require.NoError(t, err)
+			require.Equal(t, 1, pruned)
+			require.Equal(t, size, freed)
+		})
+	}
+}
+
+type cancelAfterDeleteBackend struct {
+	shardBackend
+	cancel context.CancelFunc
+}
+
+func (b *cancelAfterDeleteBackend) Delete(ctx context.Context, commitment Commitment, hash []byte) error {
+	if err := b.shardBackend.Delete(ctx, commitment, hash); err != nil {
+		return err
+	}
+	b.cancel()
+	return nil
+}
+
 func TestPruneBeforeOverflowReturnsNoUncommittedCounts(t *testing.T) {
 	store := newMarkerTestStore(t)
 	commitment := generateCommitment()

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -1,6 +1,7 @@
 package fibre
 
 import (
+	"context"
 	"encoding/binary"
 	"log/slog"
 	"math"
@@ -119,7 +120,7 @@ func TestStoreRejectsInvalidShardMarkerWithoutDeletingItsData(t *testing.T) {
 			require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
 
 			require.ErrorIs(t, tt.call(store, commitment, promiseHash, pruneAt), ErrStoreIntegrity)
-			_, err := store.fs.Stat(store.shardFilePath(commitment, promiseHash))
+			_, err := store.local.fs.Stat(store.local.shardPath(commitment, promiseHash))
 			require.NoError(t, err)
 			data, closer, err := store.db.Get(shardKey(commitment, promiseHash))
 			require.NoError(t, err)
@@ -158,7 +159,7 @@ func TestGetMissingPayloadKeepsPruneAccounting(t *testing.T) {
 	size := writeMarkerTestShard(t, store, commitment, promiseHash)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
 	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
-	require.NoError(t, store.fs.Remove(store.shardFilePath(commitment, promiseHash)))
+	require.NoError(t, store.local.fs.Remove(store.local.shardPath(commitment, promiseHash)))
 
 	_, err := store.Get(t.Context(), commitment)
 	require.ErrorIs(t, err, ErrStoreNotFound)
@@ -221,18 +222,18 @@ func TestShardStatus(t *testing.T) {
 	commitment := generateCommitment()
 	promiseHash := []byte{1}
 
-	has, accounted, err := store.shardStatus(commitment, promiseHash)
+	has, accounted, err := store.shardStatus(t.Context(), commitment, promiseHash)
 	require.NoError(t, err)
 	require.False(t, has)
 	require.False(t, accounted)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), nil, pebbledb.NoSync))
-	has, accounted, err = store.shardStatus(commitment, promiseHash)
+	has, accounted, err = store.shardStatus(t.Context(), commitment, promiseHash)
 	require.NoError(t, err)
 	require.False(t, has)
 	require.False(t, accounted)
 	marker := encodeShardMarker(1)
 	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
-	has, accounted, err = store.shardStatus(commitment, promiseHash)
+	has, accounted, err = store.shardStatus(t.Context(), commitment, promiseHash)
 	require.NoError(t, err)
 	require.False(t, has)
 	require.True(t, accounted)
@@ -259,12 +260,31 @@ func TestPruneBeforeSkipsInvalidMarkerAndPrunesValidEntry(t *testing.T) {
 	_, closer, err := store.db.Get(shardKey(commitment, validHash))
 	require.ErrorIs(t, err, pebbledb.ErrNotFound)
 	require.Nil(t, closer)
-	_, err = store.fs.Stat(store.shardFilePath(commitment, validHash))
+	_, err = store.local.fs.Stat(store.local.shardPath(commitment, validHash))
 	require.ErrorIs(t, err, os.ErrNotExist)
 	_, closer, err = store.db.Get(shardKey(commitment, invalidHash))
 	require.NoError(t, err)
 	require.NoError(t, closer.Close())
-	_, err = store.fs.Stat(store.shardFilePath(commitment, invalidHash))
+	_, err = store.local.fs.Stat(store.local.shardPath(commitment, invalidHash))
+	require.NoError(t, err)
+}
+
+func TestPruneBeforeHonoursCancellation(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	promiseHash := []byte{1}
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	size := writeMarkerTestShard(t, store, commitment, promiseHash)
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), encodeShardMarker(size), pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, promiseHash), nil, pebbledb.NoSync))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	pruned, freed, err := store.PruneBefore(ctx, pruneAt.Add(time.Hour))
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, pruned)
+	require.Zero(t, freed)
+	_, err = store.local.fs.Stat(store.local.shardPath(commitment, promiseHash))
 	require.NoError(t, err)
 }
 
@@ -349,14 +369,14 @@ func newMarkerTestStore(t *testing.T) *Store {
 
 func writeMarkerTestShard(t *testing.T, store *Store, commitment Commitment, promiseHash []byte) int64 {
 	t.Helper()
-	path := store.shardFilePath(commitment, promiseHash)
-	f, err := store.fs.Create(path, shardWriteCategory)
+	path := store.local.shardPath(commitment, promiseHash)
+	f, err := store.local.fs.Create(path, shardWriteCategory)
 	require.NoError(t, err)
 	require.NoError(t, writeShardBinary(f, &types.BlobShard{
 		Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}},
 	}))
 	require.NoError(t, f.Close())
-	info, err := store.fs.Stat(path)
+	info, err := store.local.fs.Stat(path)
 	require.NoError(t, err)
 	return info.Size()
 }

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -9,23 +9,11 @@ import (
 
 // shardBackend stores shard payloads in one storage backend.
 type shardBackend interface {
-	backendTag() byte
+	backendTag() shardBackendTag
 	Put(context.Context, Commitment, []byte, *types.BlobShard) (bool, error)
 	Get(context.Context, Commitment, []byte) (*types.BlobShard, error)
 	Has(context.Context, Commitment, []byte) (bool, error)
 	Delete(context.Context, Commitment, []byte) error
-}
-
-// shardStorage stores shard payloads and routes each marker to its backend.
-type shardStorage interface {
-	marker(int64) []byte
-	Put(context.Context, []byte, Commitment, []byte, *types.BlobShard) (bool, error)
-	Get(context.Context, []byte, Commitment, []byte) (*types.BlobShard, error)
-	Has(context.Context, []byte, Commitment, []byte) (bool, error)
-	Delete(context.Context, []byte, Commitment, []byte) error
-	size([]byte, Commitment, []byte) (int64, error)
-	diskAvailable() (int64, error)
-	resetStaging() (int, error)
 }
 
 // routedStorage writes to its primary backend and routes existing markers by tag.
@@ -83,7 +71,7 @@ func (s *routedStorage) size(marker []byte, commitment Commitment, promiseHash [
 		return 0, err
 	}
 	if size > 0 {
-		return size, err
+		return size, nil
 	}
 	local, err := s.localBackend()
 	if err != nil {
@@ -100,6 +88,8 @@ func (s *routedStorage) diskAvailable() (int64, error) {
 	return local.diskAvailable()
 }
 
+// resetStaging removes incomplete local writes, including writes left before a switch to object mode.
+// Object backends do not use the local staging directory.
 func (s *routedStorage) resetStaging() (int, error) {
 	local, err := s.localBackend()
 	if err != nil {
@@ -116,7 +106,7 @@ func (s *routedStorage) backendForMarker(marker []byte) (shardBackend, error) {
 	return s.backend(tag)
 }
 
-func (s *routedStorage) backend(tag byte) (shardBackend, error) {
+func (s *routedStorage) backend(tag shardBackendTag) (shardBackend, error) {
 	if s.primary.backendTag() == tag {
 		return s.primary, nil
 	}

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -1,0 +1,137 @@
+package fibre
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+)
+
+// shardBackend stores shard payloads in one storage backend.
+type shardBackend interface {
+	backendTag() byte
+	Put(context.Context, Commitment, []byte, *types.BlobShard) (bool, error)
+	Get(context.Context, Commitment, []byte) (*types.BlobShard, error)
+	Has(context.Context, Commitment, []byte) (bool, error)
+	Delete(context.Context, Commitment, []byte) error
+}
+
+// shardStorage stores shard payloads and routes each marker to its backend.
+type shardStorage interface {
+	marker(int64) []byte
+	Put(context.Context, []byte, Commitment, []byte, *types.BlobShard) (bool, error)
+	Get(context.Context, []byte, Commitment, []byte) (*types.BlobShard, error)
+	Has(context.Context, []byte, Commitment, []byte) (bool, error)
+	Delete(context.Context, []byte, Commitment, []byte) error
+	size([]byte, Commitment, []byte) (int64, error)
+	diskAvailable() (int64, error)
+	resetStaging() (int, error)
+}
+
+// routedStorage writes to its primary backend and routes existing markers by tag.
+type routedStorage struct {
+	primary   shardBackend
+	secondary shardBackend
+}
+
+func newRoutedStorage(primary, secondary shardBackend) *routedStorage {
+	return &routedStorage{primary: primary, secondary: secondary}
+}
+
+func (s *routedStorage) marker(size int64) []byte {
+	return encodeShardMarkerForBackend(s.primary.backendTag(), size)
+}
+
+func (s *routedStorage) Put(ctx context.Context, marker []byte, commitment Commitment, promiseHash []byte, shard *types.BlobShard) (bool, error) {
+	backend, err := s.backendForMarker(marker)
+	if err != nil {
+		return false, err
+	}
+	return backend.Put(ctx, commitment, promiseHash, shard)
+}
+
+func (s *routedStorage) Get(ctx context.Context, marker []byte, commitment Commitment, promiseHash []byte) (*types.BlobShard, error) {
+	backend, err := s.backendForMarker(marker)
+	if err != nil {
+		return nil, err
+	}
+	return backend.Get(ctx, commitment, promiseHash)
+}
+
+func (s *routedStorage) Has(ctx context.Context, marker []byte, commitment Commitment, promiseHash []byte) (bool, error) {
+	backend, err := s.backendForMarker(marker)
+	if err != nil {
+		return false, err
+	}
+	return backend.Has(ctx, commitment, promiseHash)
+}
+
+func (s *routedStorage) Delete(ctx context.Context, marker []byte, commitment Commitment, promiseHash []byte) error {
+	backend, err := s.backendForMarker(marker)
+	if err != nil {
+		return err
+	}
+	return backend.Delete(ctx, commitment, promiseHash)
+}
+
+func (s *routedStorage) size(marker []byte, commitment Commitment, promiseHash []byte) (int64, error) {
+	tag, size, err := decodeShardMarkerBackend(marker)
+	if err != nil {
+		return 0, err
+	}
+	if _, err := s.backend(tag); err != nil {
+		return 0, err
+	}
+	if size > 0 {
+		return size, err
+	}
+	local, err := s.localBackend()
+	if err != nil {
+		return 0, err
+	}
+	return local.size(commitment, promiseHash)
+}
+
+func (s *routedStorage) diskAvailable() (int64, error) {
+	local, err := s.localBackend()
+	if err != nil {
+		return 0, err
+	}
+	return local.diskAvailable()
+}
+
+func (s *routedStorage) resetStaging() (int, error) {
+	local, err := s.localBackend()
+	if err != nil {
+		return 0, err
+	}
+	return local.resetStaging()
+}
+
+func (s *routedStorage) backendForMarker(marker []byte) (shardBackend, error) {
+	tag, _, err := decodeShardMarkerBackend(marker)
+	if err != nil {
+		return nil, err
+	}
+	return s.backend(tag)
+}
+
+func (s *routedStorage) backend(tag byte) (shardBackend, error) {
+	if s.primary.backendTag() == tag {
+		return s.primary, nil
+	}
+	if s.secondary != nil && s.secondary.backendTag() == tag {
+		return s.secondary, nil
+	}
+	return nil, fmt.Errorf("%w: shard backend 0x%02x is unavailable", ErrStoreIntegrity, tag)
+}
+
+func (s *routedStorage) localBackend() (*localBackend, error) {
+	if local, ok := s.primary.(*localBackend); ok {
+		return local, nil
+	}
+	if local, ok := s.secondary.(*localBackend); ok {
+		return local, nil
+	}
+	return nil, fmt.Errorf("%w: local shard backend is unavailable", ErrStoreIntegrity)
+}

--- a/fibre/store_shard_test.go
+++ b/fibre/store_shard_test.go
@@ -1,0 +1,42 @@
+package fibre
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoutedStorageBackend(t *testing.T) {
+	primary := &taggedShardBackend{tag: 1}
+	secondary := &taggedShardBackend{tag: 2}
+	storage := newRoutedStorage(primary, secondary)
+
+	marker := storage.marker(42)
+	tag, size, err := decodeShardMarkerBackend(marker)
+	require.NoError(t, err)
+	require.Equal(t, byte(1), tag)
+	require.EqualValues(t, 42, size)
+
+	backend, err := storage.backend(1)
+	require.NoError(t, err)
+	require.Same(t, primary, backend)
+
+	backend, err = storage.backend(2)
+	require.NoError(t, err)
+	require.Same(t, secondary, backend)
+	backend, err = storage.backendForMarker(encodeShardMarkerForBackend(2, 42))
+	require.NoError(t, err)
+	require.Same(t, secondary, backend)
+
+	_, err = storage.backend(3)
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+}
+
+type taggedShardBackend struct {
+	shardBackend
+	tag byte
+}
+
+func (b *taggedShardBackend) backendTag() byte {
+	return b.tag
+}

--- a/fibre/store_shard_test.go
+++ b/fibre/store_shard_test.go
@@ -6,37 +6,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRoutedStorageBackend verifies that markers select the configured backend.
 func TestRoutedStorageBackend(t *testing.T) {
-	primary := &taggedShardBackend{tag: 1}
-	secondary := &taggedShardBackend{tag: 2}
+	primary := &taggedShardBackend{tag: localBackendTag}
+	secondary := &taggedShardBackend{tag: objectBackendTag}
 	storage := newRoutedStorage(primary, secondary)
 
 	marker := storage.marker(42)
 	tag, size, err := decodeShardMarkerBackend(marker)
 	require.NoError(t, err)
-	require.Equal(t, byte(1), tag)
+	require.Equal(t, localBackendTag, tag)
 	require.EqualValues(t, 42, size)
 
-	backend, err := storage.backend(1)
+	backend, err := storage.backend(localBackendTag)
 	require.NoError(t, err)
 	require.Same(t, primary, backend)
 
-	backend, err = storage.backend(2)
+	backend, err = storage.backend(objectBackendTag)
 	require.NoError(t, err)
 	require.Same(t, secondary, backend)
-	backend, err = storage.backendForMarker(encodeShardMarkerForBackend(2, 42))
+	backend, err = storage.backendForMarker(encodeShardMarkerForBackend(objectBackendTag, 42))
 	require.NoError(t, err)
 	require.Same(t, secondary, backend)
 
-	_, err = storage.backend(3)
+	_, err = storage.backend(shardBackendTag(3))
 	require.ErrorIs(t, err, ErrStoreIntegrity)
 }
 
 type taggedShardBackend struct {
 	shardBackend
-	tag byte
+	tag shardBackendTag
 }
 
-func (b *taggedShardBackend) backendTag() byte {
+func (b *taggedShardBackend) backendTag() shardBackendTag {
 	return b.tag
 }


### PR DESCRIPTION
Closes [PROTOCO-2617](https://linear.app/celestia/issue/PROTOCO-2617)

Extract local shard payload operations behind the shared storage interface.

## Open questions

- Should local mode fail to start when object markers exist but object storage is not configured? Proposed: yes, because live object payloads would be unavailable.
- How should available capacity be reported when object storage is primary? This PR retains `DiskAvailable`. Proposed follow-up: `CapacityAvailable() (bytes int64, known bool, err error)`, with unknown capacity for object storage.