### PR TITLE
fix(signal)!: reschedule corto-1 v10 upgrade to the corto delay

### DIFF
--- a/pkg/appconsts/chain_ids.go
+++ b/pkg/appconsts/chain_ids.go
@@ -2,6 +2,7 @@ package appconsts
 
 const (
 	ArabicaChainID = "arabica-11"
+	CortoChainID   = "corto-1"
 	MochaChainID   = "mocha-5"
 	MainnetChainID = "celestia"
 	// TestChainID is the chain ID used for testing.

--- a/x/signal/keeper.go
+++ b/x/signal/keeper.go
@@ -368,7 +368,25 @@ func (k *Keeper) getUpgrade(ctx sdk.Context) (upgrade types.Upgrade, ok bool) {
 		return types.Upgrade{}, false
 	}
 	k.binaryCodec.MustUnmarshal(value, &upgrade)
-	return upgrade, true
+	return overrideCortoUpgradeHeight(ctx.ChainID(), upgrade), true
+}
+
+const (
+	// CortoV10ScheduledUpgradeHeight is the v10 upgrade height stored on
+	// corto-1. v9 computed it with the mainnet delay because it did not know
+	// corto-1.
+	CortoV10ScheduledUpgradeHeight = int64(1_480_080)
+	// CortoV10UpgradeHeight replaces CortoV10ScheduledUpgradeHeight on corto-1.
+	CortoV10UpgradeHeight = int64(1_280_695)
+)
+
+// overrideCortoUpgradeHeight moves the v10 upgrade on corto-1 to
+// CortoV10UpgradeHeight. It is a no-op on other chains and other upgrades.
+func overrideCortoUpgradeHeight(chainID string, upgrade types.Upgrade) types.Upgrade {
+	if chainID == appconsts.CortoChainID && upgrade.AppVersion == 10 && upgrade.UpgradeHeight == CortoV10ScheduledUpgradeHeight {
+		upgrade.UpgradeHeight = CortoV10UpgradeHeight
+	}
+	return upgrade
 }
 
 // setUpgrade sets the upgrade in the store.

--- a/x/signal/keeper_test.go
+++ b/x/signal/keeper_test.go
@@ -573,6 +573,63 @@ func TestTallyAfterTryUpgrade(t *testing.T) {
 	require.EqualValues(t, 120, res.TotalVotingPower)
 }
 
+func TestCortoV10UpgradeHeightOverride(t *testing.T) {
+	// The v10 upgrade on corto-1 was scheduled at height 1480080 because v9
+	// used the mainnet delay. Reproduce that state and check the override.
+	const scheduledHeight = int64(1_480_080)
+	const tryUpgradeHeight = scheduledHeight - appconsts.MainnetUpgradeHeightDelay
+
+	signalAndTryUpgrade := func(t *testing.T, chainID string, height int64) (signal.Keeper, sdk.Context) {
+		upgradeKeeper, ctx, _ := setup(t)
+		ctx = ctx.WithChainID(chainID).WithHeaderInfo(header.Info{ChainID: chainID, Height: height})
+		for _, valAddr := range testutil.ValAddrs[:4] {
+			_, err := upgradeKeeper.SignalVersion(ctx, &types.MsgSignalVersion{ValidatorAddress: valAddr.String(), Version: 10})
+			require.NoError(t, err)
+		}
+		_, err := upgradeKeeper.TryUpgrade(ctx, &types.MsgTryUpgrade{})
+		require.NoError(t, err)
+		return upgradeKeeper, ctx
+	}
+
+	t.Run("override is earlier than the scheduled height", func(t *testing.T) {
+		assert.Equal(t, scheduledHeight, signal.CortoV10ScheduledUpgradeHeight)
+		assert.Less(t, signal.CortoV10UpgradeHeight, scheduledHeight)
+	})
+
+	t.Run("moves the v10 upgrade on corto-1", func(t *testing.T) {
+		upgradeKeeper, ctx := signalAndTryUpgrade(t, appconsts.CortoChainID, tryUpgradeHeight)
+
+		got, err := upgradeKeeper.GetUpgrade(ctx, &types.QueryGetUpgradeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, uint64(10), got.Upgrade.AppVersion)
+		assert.Equal(t, signal.CortoV10UpgradeHeight, got.Upgrade.UpgradeHeight)
+
+		shouldUpgrade, _ := upgradeKeeper.ShouldUpgrade(ctx.WithBlockHeight(signal.CortoV10UpgradeHeight - 1))
+		assert.False(t, shouldUpgrade)
+
+		shouldUpgrade, upgrade := upgradeKeeper.ShouldUpgrade(ctx.WithBlockHeight(signal.CortoV10UpgradeHeight))
+		assert.True(t, shouldUpgrade)
+		assert.Equal(t, uint64(10), upgrade.AppVersion)
+		assert.Equal(t, signal.CortoV10UpgradeHeight, upgrade.UpgradeHeight)
+	})
+
+	t.Run("does not move other upgrades on corto-1", func(t *testing.T) {
+		upgradeKeeper, ctx := signalAndTryUpgrade(t, appconsts.CortoChainID, tryUpgradeHeight+1)
+
+		got, err := upgradeKeeper.GetUpgrade(ctx, &types.QueryGetUpgradeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, scheduledHeight+1, got.Upgrade.UpgradeHeight)
+	})
+
+	t.Run("does not move the same upgrade on mainnet", func(t *testing.T) {
+		upgradeKeeper, ctx := signalAndTryUpgrade(t, appconsts.MainnetChainID, tryUpgradeHeight)
+
+		got, err := upgradeKeeper.GetUpgrade(ctx, &types.QueryGetUpgradeRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, scheduledHeight, got.Upgrade.UpgradeHeight)
+	})
+}
+
 func setup(t *testing.T) (signal.Keeper, sdk.Context, *mockStakingKeeper) {
 	signalStore := storetypes.NewKVStoreKey(types.StoreKey)
 	db := dbm.NewMemDB()


### PR DESCRIPTION
## Summary

Moves the pending v10 upgrade on corto-1 from height 1480080 to 1280695.

v9 has no corto-1 entry in `GetUpgradeHeightDelay`, so the try-upgrade at height 1247464 scheduled v10 with the mainnet delay (232616 blocks, ~7 days) instead of the corto delay (33231 blocks, ~1 day). The height is persisted in the signal store and cannot be changed on-chain.

The signal keeper now rewrites the upgrade height when reading it from the store, gated on chain-id `corto-1`, app version 10, and the exact stored height 1480080. Every other chain and every other upgrade is untouched, so this binary stays consensus-compatible with unpatched v9 nodes on mainnet and mocha.

This is a coordinated hard fork of corto-1. All corto validators must run this release before height 1280695. `celestia-appd query signal upgrade` prints 1280695 on patched nodes and 1480080 on unpatched ones.

## Testing

- Unit: `TestCortoV10UpgradeHeightOverride` in `x/signal` covers the corto rewrite, a different corto upgrade (unchanged), and the same stored height on mainnet (unchanged).
- Local 2-node network (1 validator + 1 full node) on chain-id corto-1: scheduled v10 with the unpatched binary (landed at 1480080), swapped both nodes to the patched binary, both then reported 1280695 and the chain kept advancing.

## Follow-up (not in this PR)

Bump `CELESTIA_V9_VERSION` in the Makefile and `.goreleaser.yaml` on `main` to the tag cut from this PR, then release a new multiplexer.
