### PR TITLE
fix!: bump embedded v9 to v9.0.7-corto

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,10 +33,10 @@ before:
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v8_arm64.tar.gz v8.0.8
     - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v8_amd64.tar.gz v8.0.8
     - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v8_amd64.tar.gz v8.0.8
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v9_arm64.tar.gz v9.0.4
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v9_arm64.tar.gz v9.0.4
-    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v9_amd64.tar.gz v9.0.4
-    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v9_amd64.tar.gz v9.0.4
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_arm64.tar.gz celestia-app_darwin_v9_arm64.tar.gz v9.0.7-corto
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_arm64.tar.gz celestia-app_linux_v9_arm64.tar.gz v9.0.7-corto
+    - ./scripts/download_binary.sh celestia-app-standalone_Darwin_x86_64.tar.gz celestia-app_darwin_v9_amd64.tar.gz v9.0.7-corto
+    - ./scripts/download_binary.sh celestia-app-standalone_Linux_x86_64.tar.gz celestia-app_linux_v9_amd64.tar.gz v9.0.7-corto
 
 builds:
   - id: darwin-amd64-multiplexer

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ CELESTIA_V5_VERSION := v5.0.12
 CELESTIA_V6_VERSION := v6.4.4
 CELESTIA_V7_VERSION := v7.0.2-mocha
 CELESTIA_V8_VERSION := v8.0.8
-CELESTIA_V9_VERSION := v9.0.4
+CELESTIA_V9_VERSION := v9.0.7-corto
 
 ## help: Get more info on make commands.
 help: Makefile

--- a/docker/multiplexer.Dockerfile
+++ b/docker/multiplexer.Dockerfile
@@ -24,7 +24,7 @@ ARG CELESTIA_VERSION_V5="v5.0.12"
 ARG CELESTIA_VERSION_V6="v6.4.4"
 ARG CELESTIA_VERSION_V7="v7.0.2-mocha"
 ARG CELESTIA_VERSION_V8="v8.0.8"
-ARG CELESTIA_VERSION_V9="v9.0.4"
+ARG CELESTIA_VERSION_V9="v9.0.7-corto"
 
 # Stage 1: this base image contains already released v3 binaries which can be embedded in the multiplexer.
 FROM ${CELESTIA_APP_REPOSITORY}:${CELESTIA_VERSION_V3} AS base-v3

--- a/internal/embedding/data.go
+++ b/internal/embedding/data.go
@@ -16,7 +16,7 @@ const (
 	v6Version = "v6.4.4"
 	v7Version = "v7.0.2-mocha"
 	v8Version = "v8.0.8"
-	v9Version = "v9.0.4"
+	v9Version = "v9.0.7-corto"
 )
 
 // CelestiaAppV3 returns the compressed platform specific Celestia binary and


### PR DESCRIPTION
## Summary

Bumps the multiplexer's embedded v9 from `v9.0.4` to `v9.0.7-corto` in the Makefile and `.goreleaser.yaml`.

`v9.0.7-corto` reschedules the pending corto-1 v10 upgrade to the corto delay (height 1280695). Embedding it lets a multiplexer built from `main` sync corto-1 past that upgrade. See celestiaorg/celestia-app#7788 and release `v9.0.7-corto`.

## Note for reviewers

`v9.0.7-corto` carries the corto override, which is a no-op on every chain other than corto-1 (gated on chain-id, app version 10, and the exact stored height), so mainnet and mocha replay are unchanged. It is `v9.x` head, so it also includes the v9.0.5/v9.0.6 patches already released on that branch.

Depends on the `v9.0.7-corto` release artifacts; the build job is red until goreleaser finishes publishing them.
