### PR TITLE
feat(fibre): add object shard storage

### DIFF
--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -65,7 +65,11 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 	reader, writer := io.Pipe()
 	writeDone := make(chan error, 1)
 	go func() {
-		err := writeShardBinary(writer, shard)
+		buffer := bufio.NewWriterSize(writer, 1<<20)
+		err := writeShardBinary(buffer, shard)
+		if err == nil {
+			err = buffer.Flush()
+		}
 		_ = writer.CloseWithError(err)
 		writeDone <- err
 	}()
@@ -73,7 +77,7 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 	_, putErr := b.client.PutObject(ctx, &s3.PutObjectInput{
 		Bucket:        aws.String(b.bucket),
 		Key:           aws.String(b.objectKey(commitment, promiseHash)),
-		Body:          reader,
+		Body:          io.NopCloser(reader), // Preserve ContentLength; the SDK treats a bare pipe as unknown-length.
 		ContentLength: aws.Int64(shardBinarySize(shard)),
 		IfNoneMatch:   aws.String("*"),
 	}, func(options *s3.Options) {
@@ -83,6 +87,7 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 	writeErr := <-writeDone
 
 	if hasObjectErrorCode(putErr, "PreconditionFailed") {
+		// IfNoneMatch rejected an existing object; this call created nothing.
 		return false, nil
 	}
 	if putErr != nil {
@@ -168,6 +173,8 @@ func (b *objectBackend) DeleteObjects(ctx context.Context, ids []shardID) ([]err
 	}
 
 	objects := make([]s3types.ObjectIdentifier, len(ids))
+	// S3 returns failures by key; map each key back to its input positions.
+	// Keep every position so duplicate IDs receive the same error.
 	indices := make(map[string][]int, len(ids))
 	for i, id := range ids {
 		key := b.objectKey(id.commitment, id.promiseHash)
@@ -222,6 +229,7 @@ func isObjectNotFound(err error) bool {
 	return hasObjectErrorCode(err, "NoSuchKey") || hasObjectErrorCode(err, "NotFound")
 }
 
+// hasObjectErrorCode unwraps AWS SDK service errors and matches their API code.
 func hasObjectErrorCode(err error, code string) bool {
 	var apiErr smithy.APIError
 	return errors.As(err, &apiErr) && apiErr.ErrorCode() == code

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -117,9 +117,16 @@ func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseH
 	}
 	defer output.Body.Close()
 
-	shard, err := readShardBinary(bufio.NewReaderSize(output.Body, 1<<20))
+	reader := bufio.NewReaderSize(output.Body, 1<<20)
+	shard, err := readShardBinary(reader)
 	if err != nil {
 		return nil, fmt.Errorf("decoding shard object: %w", err)
+	}
+	if _, err := reader.ReadByte(); err != io.EOF {
+		if err != nil {
+			return nil, fmt.Errorf("reading shard object: %w", err)
+		}
+		return nil, errors.New("unexpected trailing data in shard object")
 	}
 	return shard, nil
 }

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -1,0 +1,228 @@
+package fibre
+
+import (
+	"bufio"
+	"context"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+)
+
+const maxObjectDeleteBatchSize = 1000
+
+type s3ObjectClient interface {
+	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	GetObject(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	HeadObject(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	DeleteObject(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	DeleteObjects(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
+}
+
+type shardID struct {
+	commitment  Commitment
+	promiseHash []byte
+}
+
+// objectBackend stores shard payloads in S3-compatible object storage.
+type objectBackend struct {
+	client           s3ObjectClient
+	bucket           string
+	prefix           string
+	chainID          string
+	validatorAddress string
+}
+
+var _ shardBackend = (*objectBackend)(nil)
+
+func (*objectBackend) backendTag() shardBackendTag {
+	return objectBackendTag
+}
+
+func newObjectBackend(client s3ObjectClient, bucket, prefix, chainID, validatorAddress string) *objectBackend {
+	return &objectBackend{
+		client:           client,
+		bucket:           bucket,
+		prefix:           strings.Trim(prefix, "/"),
+		chainID:          chainID,
+		validatorAddress: validatorAddress,
+	}
+}
+
+func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseHash []byte, shard *types.BlobShard) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	reader, writer := io.Pipe()
+	writeDone := make(chan error, 1)
+	go func() {
+		err := writeShardBinary(writer, shard)
+		_ = writer.CloseWithError(err)
+		writeDone <- err
+	}()
+
+	_, putErr := b.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:        aws.String(b.bucket),
+		Key:           aws.String(b.objectKey(commitment, promiseHash)),
+		Body:          reader,
+		ContentLength: aws.Int64(shardBinarySize(shard)),
+		IfNoneMatch:   aws.String("*"),
+	}, func(options *s3.Options) {
+		options.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+	})
+	_ = reader.CloseWithError(putErr)
+	writeErr := <-writeDone
+
+	if hasObjectErrorCode(putErr, "PreconditionFailed") {
+		return false, nil
+	}
+	if putErr != nil {
+		return false, fmt.Errorf("putting shard object: %w", putErr)
+	}
+	if writeErr != nil {
+		return false, fmt.Errorf("encoding shard object: %w", writeErr)
+	}
+	return true, nil
+}
+
+func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseHash []byte) (*types.BlobShard, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	output, err := b.client.GetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.objectKey(commitment, promiseHash)),
+	})
+	if isObjectNotFound(err) {
+		return nil, ErrStoreNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("getting shard object: %w", err)
+	}
+	defer output.Body.Close()
+
+	shard, err := readShardBinary(bufio.NewReaderSize(output.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("decoding shard object: %w", err)
+	}
+	return shard, nil
+}
+
+func (b *objectBackend) Has(ctx context.Context, commitment Commitment, promiseHash []byte) (bool, error) {
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
+	_, err := b.client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.objectKey(commitment, promiseHash)),
+	})
+	switch {
+	case isObjectNotFound(err):
+		return false, nil
+	case err != nil:
+		return false, fmt.Errorf("checking shard object: %w", err)
+	default:
+		return true, nil
+	}
+}
+
+func (b *objectBackend) Delete(ctx context.Context, commitment Commitment, promiseHash []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	_, err := b.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(b.bucket),
+		Key:    aws.String(b.objectKey(commitment, promiseHash)),
+	})
+	if isObjectNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("deleting shard object: %w", err)
+	}
+	return nil
+}
+
+// DeleteObjects deletes up to 1,000 objects. Returned errors align with ids.
+func (b *objectBackend) DeleteObjects(ctx context.Context, ids []shardID) ([]error, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if len(ids) > maxObjectDeleteBatchSize {
+		return nil, fmt.Errorf("object delete batch has %d entries, maximum is %d", len(ids), maxObjectDeleteBatchSize)
+	}
+	if len(ids) == 0 {
+		return []error{}, nil
+	}
+
+	objects := make([]s3types.ObjectIdentifier, len(ids))
+	indices := make(map[string][]int, len(ids))
+	for i, id := range ids {
+		key := b.objectKey(id.commitment, id.promiseHash)
+		objects[i].Key = aws.String(key)
+		indices[key] = append(indices[key], i)
+	}
+
+	output, err := b.client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(b.bucket),
+		Delete: &s3types.Delete{
+			Objects: objects,
+			Quiet:   aws.Bool(true),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("deleting shard objects: %w", err)
+	}
+
+	result := make([]error, len(ids))
+	for _, objectErr := range output.Errors {
+		if objectErr.Key == nil {
+			return nil, errors.New("object delete response contains an error without a key")
+		}
+		key := *objectErr.Key
+		keyIndices, ok := indices[key]
+		if !ok {
+			return nil, fmt.Errorf("object delete response contains unknown key %q", key)
+		}
+		code := aws.ToString(objectErr.Code)
+		if code == "NoSuchKey" || code == "NotFound" {
+			continue
+		}
+		deleteErr := fmt.Errorf("deleting object %q: %s: %s", key, code, aws.ToString(objectErr.Message))
+		for _, i := range keyIndices {
+			result[i] = deleteErr
+		}
+	}
+	return result, nil
+}
+
+func (b *objectBackend) objectKey(commitment Commitment, promiseHash []byte) string {
+	return path.Join(
+		b.prefix,
+		b.chainID,
+		b.validatorAddress,
+		shardsSubdir,
+		commitment.String()+"-"+hex.EncodeToString(promiseHash),
+	)
+}
+
+func isObjectNotFound(err error) bool {
+	return hasObjectErrorCode(err, "NoSuchKey") || hasObjectErrorCode(err, "NotFound")
+}
+
+func hasObjectErrorCode(err error, code string) bool {
+	var apiErr smithy.APIError
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == code
+}

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -87,7 +87,8 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 	writeErr := <-writeDone
 
 	if hasObjectErrorCode(putErr, "PreconditionFailed") {
-		// IfNoneMatch rejected an existing object; this call created nothing.
+		// IfNoneMatch: "*" rejected this upload because a shard already exists for this commitment and promise hash.
+		// Return created=false with no error: the payload exists, but this call did not create it.
 		return false, nil
 	}
 	if putErr != nil {

--- a/fibre/store_object_test.go
+++ b/fibre/store_object_test.go
@@ -1,0 +1,191 @@
+package fibre
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/smithy-go"
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectBackendPut(t *testing.T) {
+	var commitment Commitment
+	commitment[0] = 1
+	promiseHash := []byte{2, 3}
+	shard := &types.BlobShard{
+		Rlcs: []byte("rlcs"),
+		Rows: []*types.BlobRow{{Index: 4, Data: []byte("data")}},
+	}
+	wantKey := "fibre/test-chain/celestiavalcons1validator/shards/" + commitment.String() + "-0203"
+
+	t.Run("created", func(t *testing.T) {
+		client := &s3ObjectClientStub{
+			putObject: func(_ context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+				require.Equal(t, "bucket", aws.ToString(input.Bucket))
+				require.Equal(t, wantKey, aws.ToString(input.Key))
+				require.Equal(t, "*", aws.ToString(input.IfNoneMatch))
+				require.Equal(t, shardBinarySize(shard), aws.ToInt64(input.ContentLength))
+
+				var options s3.Options
+				for _, fn := range optFns {
+					fn(&options)
+				}
+				require.Equal(t, aws.RequestChecksumCalculationWhenRequired, options.RequestChecksumCalculation)
+
+				data, err := io.ReadAll(input.Body)
+				require.NoError(t, err)
+				got, err := readShardBinary(bytes.NewReader(data))
+				require.NoError(t, err)
+				require.Equal(t, shard, got)
+				return &s3.PutObjectOutput{}, nil
+			},
+		}
+		backend := newObjectBackend(client, "bucket", "/fibre/", "test-chain", "celestiavalcons1validator")
+
+		created, err := backend.Put(t.Context(), commitment, promiseHash, shard)
+		require.NoError(t, err)
+		require.True(t, created)
+	})
+
+	t.Run("existing", func(t *testing.T) {
+		client := &s3ObjectClientStub{
+			putObject: func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+				return nil, &smithy.GenericAPIError{Code: "PreconditionFailed", Fault: smithy.FaultClient}
+			},
+		}
+		backend := newObjectBackend(client, "bucket", "fibre", "test-chain", "celestiavalcons1validator")
+
+		created, err := backend.Put(t.Context(), commitment, promiseHash, shard)
+		require.NoError(t, err)
+		require.False(t, created)
+	})
+}
+
+func TestObjectBackendGet(t *testing.T) {
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}}}
+	var data bytes.Buffer
+	require.NoError(t, writeShardBinary(&data, shard))
+
+	client := &s3ObjectClientStub{
+		getObject: func(_ context.Context, input *s3.GetObjectInput, _ ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			require.Equal(t, "bucket", aws.ToString(input.Bucket))
+			return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data.Bytes()))}, nil
+		},
+	}
+	backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+
+	got, err := backend.Get(t.Context(), Commitment{}, []byte{1})
+	require.NoError(t, err)
+	require.Equal(t, shard, got)
+}
+
+func TestObjectBackendNormalisesMissingObject(t *testing.T) {
+	missing := &smithy.GenericAPIError{Code: "NoSuchKey", Fault: smithy.FaultClient}
+	client := &s3ObjectClientStub{
+		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return nil, missing
+		},
+		headObject: func(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+			return nil, missing
+		},
+		deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+			return nil, missing
+		},
+	}
+	backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+
+	_, err := backend.Get(t.Context(), Commitment{}, []byte{1})
+	require.ErrorIs(t, err, ErrStoreNotFound)
+	has, err := backend.Has(t.Context(), Commitment{}, []byte{1})
+	require.NoError(t, err)
+	require.False(t, has)
+	require.NoError(t, backend.Delete(t.Context(), Commitment{}, []byte{1}))
+}
+
+func TestObjectBackendDeleteObjects(t *testing.T) {
+	var (
+		first  Commitment
+		second Commitment
+	)
+	first[0] = 1
+	second[0] = 2
+	ids := []shardID{
+		{commitment: first, promiseHash: []byte{1}},
+		{commitment: second, promiseHash: []byte{2}},
+	}
+
+	t.Run("individual error", func(t *testing.T) {
+		client := &s3ObjectClientStub{
+			deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+				require.Len(t, input.Delete.Objects, 2)
+				require.True(t, aws.ToBool(input.Delete.Quiet))
+				return &s3.DeleteObjectsOutput{Errors: []s3types.Error{{
+					Key:     input.Delete.Objects[1].Key,
+					Code:    aws.String("AccessDenied"),
+					Message: aws.String("denied"),
+				}}}, nil
+			},
+		}
+		backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+
+		errs, err := backend.DeleteObjects(t.Context(), ids)
+		require.NoError(t, err)
+		require.NoError(t, errs[0])
+		require.ErrorContains(t, errs[1], "AccessDenied")
+	})
+
+	t.Run("request error", func(t *testing.T) {
+		requestErr := errors.New("request failed")
+		client := &s3ObjectClientStub{
+			deleteObjects: func(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+				return nil, requestErr
+			},
+		}
+		backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+
+		errs, err := backend.DeleteObjects(t.Context(), ids)
+		require.ErrorIs(t, err, requestErr)
+		require.Nil(t, errs)
+	})
+
+	t.Run("batch limit", func(t *testing.T) {
+		backend := newObjectBackend(&s3ObjectClientStub{}, "bucket", "prefix", "chain", "validator")
+		_, err := backend.DeleteObjects(t.Context(), make([]shardID, maxObjectDeleteBatchSize+1))
+		require.ErrorContains(t, err, "maximum is 1000")
+	})
+}
+
+type s3ObjectClientStub struct {
+	putObject     func(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+	getObject     func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	headObject    func(context.Context, *s3.HeadObjectInput, ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
+	deleteObject  func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error)
+	deleteObjects func(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error)
+}
+
+func (s *s3ObjectClientStub) PutObject(ctx context.Context, input *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	return s.putObject(ctx, input, optFns...)
+}
+
+func (s *s3ObjectClientStub) GetObject(ctx context.Context, input *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+	return s.getObject(ctx, input, optFns...)
+}
+
+func (s *s3ObjectClientStub) HeadObject(ctx context.Context, input *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	return s.headObject(ctx, input, optFns...)
+}
+
+func (s *s3ObjectClientStub) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+	return s.deleteObject(ctx, input, optFns...)
+}
+
+func (s *s3ObjectClientStub) DeleteObjects(ctx context.Context, input *s3.DeleteObjectsInput, optFns ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+	return s.deleteObjects(ctx, input, optFns...)
+}

--- a/fibre/store_object_test.go
+++ b/fibre/store_object_test.go
@@ -3,7 +3,10 @@ package fibre
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -119,6 +122,55 @@ func TestObjectBackendGet(t *testing.T) {
 	got, err := backend.Get(t.Context(), Commitment{}, []byte{1})
 	require.NoError(t, err)
 	require.Equal(t, shard, got)
+}
+
+// TestObjectBackendGetChecksum guards against accepting corrupt shards when decoding
+// finishes before the AWS SDK reports a checksum error at EOF.
+func TestObjectBackendGetChecksum(t *testing.T) {
+	for _, size := range []int{4, 2 << 20} {
+		for _, outcome := range []string{"valid", "corrupt", "trailing data"} {
+			t.Run(fmt.Sprintf("%d/%s", size, outcome), func(t *testing.T) {
+				shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: bytes.Repeat([]byte("a"), size)}}}
+				var encoded bytes.Buffer
+				require.NoError(t, writeShardBinary(&encoded, shard))
+				if outcome == "trailing data" {
+					encoded.WriteByte(0)
+				}
+				checksum := sha256.Sum256(encoded.Bytes())
+				if outcome == "corrupt" {
+					encoded.Bytes()[20] ^= 1 // First row data byte, after the length prefixes.
+				}
+				server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("X-Amz-Checksum-Sha256", base64.StdEncoding.EncodeToString(checksum[:]))
+					_, _ = w.Write(encoded.Bytes())
+				}))
+				defer server.Close()
+				client := s3.New(s3.Options{
+					Region:                     "us-east-1",
+					Credentials:                credentials.NewStaticCredentialsProvider("test", "test", ""),
+					BaseEndpoint:               aws.String(server.URL),
+					UsePathStyle:               true,
+					HTTPClient:                 server.Client(),
+					ResponseChecksumValidation: aws.ResponseChecksumValidationWhenSupported,
+				})
+				backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				defer cancel()
+				got, err := backend.Get(ctx, Commitment{}, []byte{1})
+				switch outcome {
+				case "valid":
+					require.NoError(t, err)
+					require.Equal(t, shard, got)
+				case "corrupt":
+					require.ErrorContains(t, err, "checksum did not match")
+					require.Nil(t, got)
+				case "trailing data":
+					require.ErrorContains(t, err, "unexpected trailing data")
+					require.Nil(t, got)
+				}
+			})
+		}
+	}
 }
 
 func TestObjectBackendNormalisesMissingObject(t *testing.T) {

--- a/fibre/store_object_test.go
+++ b/fibre/store_object_test.go
@@ -5,15 +5,50 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestObjectBackendPutContentLength(t *testing.T) {
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: bytes.Repeat([]byte("data"), 1<<19)}}}
+	var encoded bytes.Buffer
+	require.NoError(t, writeShardBinary(&encoded, shard))
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil || !bytes.Equal(encoded.Bytes(), body) {
+			t.Error("upload body does not match the encoded shard", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if r.ContentLength != int64(encoded.Len()) {
+			t.Errorf("content length: got %d, want %d", r.ContentLength, encoded.Len())
+		}
+	}))
+	defer server.Close()
+	client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		Credentials:  credentials.NewStaticCredentialsProvider("test", "test", ""),
+		BaseEndpoint: aws.String(server.URL),
+		UsePathStyle: true,
+		HTTPClient:   server.Client(),
+	})
+	backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	created, err := backend.Put(ctx, Commitment{}, []byte{1}, shard)
+	require.NoError(t, err)
+	require.True(t, created)
+}
 
 func TestObjectBackendPut(t *testing.T) {
 	var commitment Commitment

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.4.1
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.325.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.109.1
+	github.com/aws/smithy-go v1.28.1
 	github.com/bcp-innovations/hyperlane-cosmos v1.2.0
 	github.com/celestiaorg/go-square/v2 v2.3.3
 	github.com/celestiaorg/go-square/v3 v3.0.2
@@ -155,7 +156,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sso v1.35.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.40.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.47.1 // indirect
-	github.com/aws/smithy-go v1.28.1 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect


### PR DESCRIPTION
Closes [PROTOCO-2618](https://linear.app/celestia/issue/PROTOCO-2618)

Add the S3-compatible shard backend for R2 and AWS S3.

-----------------

FLUP (introduced in this PR) needed post implementation v1: https://linear.app/celestia/issue/PROTOCO-2650/make-object-uploads-retryable-after-temporary-s3r2-failures

