### PR TITLE
fix(fibre): bound DownloadShard request size in the server codec

### DIFF
--- a/fibre/internal/grpc/codec.go
+++ b/fibre/internal/grpc/codec.go
@@ -12,6 +12,10 @@ import (
 // grpc.CallContentSubtype.
 const codecName = "fibre-proto"
 
+// maxDownloadShardRequestSize bounds the wire size of a DownloadShardRequest.
+// A valid request is 35 bytes; the slack leaves room for small future fields.
+const maxDownloadShardRequestSize = 1024
+
 type sizedBufferMarshaler interface {
 	Size() int
 	MarshalToSizedBuffer([]byte) (int, error)
@@ -89,6 +93,10 @@ func (c *pooledCodec) Unmarshal(data mem.BufferSlice, v any) error {
 	}
 	if data.Len() == 0 {
 		return msg.Unmarshal(nil)
+	}
+	// Reject oversized download requests before Materialize copies them.
+	if _, ok := v.(*types.DownloadShardRequest); ok && data.Len() > maxDownloadShardRequestSize {
+		return fmt.Errorf("fibre-proto codec: download request exceeds %d bytes", maxDownloadShardRequestSize)
 	}
 	buf := data.Materialize()
 	// Check row and proof counts before the generated decoder allocates for them.

--- a/fibre/internal/grpc/codec_decode_test.go
+++ b/fibre/internal/grpc/codec_decode_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"bytes"
 	"math/rand"
+	"runtime"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
@@ -227,5 +228,33 @@ func TestCountingAllocations(t *testing.T) {
 			var stub types.ProofCountUploadShard
 			return stub.Unmarshal(buf)
 		})
+	})
+}
+
+// TestCodecUnmarshalDownloadShardLimit checks that oversized download requests
+// are rejected before the codec copies them.
+func TestCodecUnmarshalDownloadShardLimit(t *testing.T) {
+	codec := NewServerCodec(testMaxRows, testMaxProofs)
+
+	t.Run("round-trips a valid request", func(t *testing.T) {
+		wire, err := codec.Marshal(&types.DownloadShardRequest{BlobId: bytes.Repeat([]byte{1}, 33)})
+		require.NoError(t, err)
+
+		var got types.DownloadShardRequest
+		require.NoError(t, codec.Unmarshal(wire, &got))
+		require.Equal(t, bytes.Repeat([]byte{1}, 33), got.BlobId)
+	})
+
+	t.Run("rejects an oversized request before copying it", func(t *testing.T) {
+		buf, err := (&types.DownloadShardRequest{BlobId: make([]byte, 1<<20)}).Marshal()
+		require.NoError(t, err)
+
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		err = codec.Unmarshal(mem.BufferSlice{mem.SliceBuffer(buf)}, &types.DownloadShardRequest{})
+		runtime.ReadMemStats(&after)
+
+		require.ErrorContains(t, err, "download request")
+		require.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(len(buf)), "rejection must not copy the message")
 	})
 }

--- a/fibre/internal/grpc/codec_decode_test.go
+++ b/fibre/internal/grpc/codec_decode_test.go
@@ -3,7 +3,6 @@ package grpc
 import (
 	"bytes"
 	"math/rand"
-	"runtime"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
@@ -245,16 +244,25 @@ func TestCodecUnmarshalDownloadShardLimit(t *testing.T) {
 		require.Equal(t, bytes.Repeat([]byte{1}, 33), got.BlobId)
 	})
 
-	t.Run("rejects an oversized request before copying it", func(t *testing.T) {
-		buf, err := (&types.DownloadShardRequest{BlobId: make([]byte, 1<<20)}).Marshal()
+	t.Run("rejects an oversized request without reading it", func(t *testing.T) {
+		buf, err := (&types.DownloadShardRequest{BlobId: make([]byte, maxDownloadShardRequestSize)}).Marshal()
 		require.NoError(t, err)
 
-		var before, after runtime.MemStats
-		runtime.ReadMemStats(&before)
-		err = codec.Unmarshal(mem.BufferSlice{mem.SliceBuffer(buf)}, &types.DownloadShardRequest{})
-		runtime.ReadMemStats(&after)
-
+		tracked := &readCountingBuffer{Buffer: mem.SliceBuffer(buf)}
+		err = codec.Unmarshal(mem.BufferSlice{tracked}, &types.DownloadShardRequest{})
 		require.ErrorContains(t, err, "download request")
-		require.Less(t, after.TotalAlloc-before.TotalAlloc, uint64(len(buf)), "rejection must not copy the message")
+		require.Zero(t, tracked.reads, "rejection must not read or copy the message")
 	})
+}
+
+// readCountingBuffer counts how often the codec reads the buffer contents.
+// Materialize copies through ReadOnlyData, so zero reads means zero copies.
+type readCountingBuffer struct {
+	mem.Buffer
+	reads int
+}
+
+func (b *readCountingBuffer) ReadOnlyData() []byte {
+	b.reads++
+	return b.Buffer.ReadOnlyData()
 }

--- a/fibre/internal/grpc/server.go
+++ b/fibre/internal/grpc/server.go
@@ -23,7 +23,8 @@ import (
 // staking power, or adding a per-peer connection policy, are possible follow-ups.
 //
 // NewServerCodec separately limits rows and proofs before decoding allocates
-// memory for them.
+// memory for them, and rejects oversized DownloadShard requests before copying
+// them.
 const (
 	maxConnections       = 16
 	maxConcurrentStreams = 13

--- a/fibre/server_download_test.go
+++ b/fibre/server_download_test.go
@@ -1,14 +1,18 @@
 package fibre_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/celestiaorg/celestia-app/v10/fibre"
+	grpcfibre "github.com/celestiaorg/celestia-app/v10/fibre/internal/grpc"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d/rlc"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // TestServerDownloadShard unit tests the [Server.DownloadShard].
@@ -142,4 +146,32 @@ func storeTestShard(t *testing.T, server *fibre.Server, blob *fibre.Blob) {
 
 	err = server.Store().Put(t.Context(), promise, shard, promise.CreationTimestamp.Add(time.Second))
 	require.NoError(t, err)
+}
+
+// TestDownloadShardOversizedRequestRejected checks that the server rejects a
+// DownloadShard request far larger than a blob ID with a gRPC status before the
+// handler runs, and keeps serving afterwards.
+func TestDownloadShardOversizedRequestRejected(t *testing.T) {
+	validators, privKeys := makeTestValidators(t, 1)
+	valSetGetter := newShufflingValidatorSetGetter(validators, 1)
+	servers, _, addresses := makeTestServers(t, validators, privKeys, fibre.DefaultProtocolParams, valSetGetter, nil)
+	t.Cleanup(func() { _ = servers[0].Stop(context.Background()) })
+
+	newClient := grpcfibre.DefaultNewClientFn(
+		&testHostRegistry{addresses: addresses},
+		func() string { return "celestia" },
+		fibre.DefaultProtocolParams.MaxMessageSize(),
+		nil,
+	)
+	client, err := newClient(t.Context(), validators[0])
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.DownloadShard(t.Context(), &types.DownloadShardRequest{BlobId: make([]byte, 1<<20)})
+	require.Equal(t, codes.Internal, status.Code(err))
+	require.ErrorContains(t, err, "download request exceeds")
+
+	// A well-formed request still reaches the handler.
+	_, err = client.DownloadShard(t.Context(), &types.DownloadShardRequest{BlobId: makeTestBlobV0(t, 256).ID()})
+	require.Equal(t, codes.NotFound, status.Code(err))
 }


### PR DESCRIPTION
Closes: PROTOCO-2630
Rejects a \`DownloadShardRequest\` larger than 1 KiB in the Fibre server codec before it is decoded. A valid request is 35 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)