### PR TITLE
test(fibre): cover object shard routing and replacement

### DIFF
--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -539,7 +539,7 @@ func TestStoreMissingObjectPreservesMetadata(t *testing.T) {
 
 	store.shards.secondary = &shardStorageStub{missing: true}
 	_, err = store.Get(t.Context(), commitment)
-	require.ErrorIs(t, err, ErrStoreIntegrity)
+	require.ErrorIs(t, err, ErrStoreNotFound)
 	has, err := store.Has(t.Context(), commitment, promiseHash)
 	require.NoError(t, err)
 	require.False(t, has)

--- a/fibre/store_marker_test.go
+++ b/fibre/store_marker_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	pebbledb "github.com/cockroachdb/pebble/v2"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/stretchr/testify/require"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 )
@@ -473,4 +474,137 @@ func storeLocalBackend(t *testing.T, store *Store) *localBackend {
 	local, err := store.shards.localBackend()
 	require.NoError(t, err)
 	return local
+}
+
+func TestStoreRoutesObjectShard(t *testing.T) {
+	store := newMarkerTestStore(t)
+	object := &shardStorageStub{}
+	store.shards = newRoutedStorage(object, store.shards.primary)
+
+	commitment := generateCommitment()
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}}}
+	promise := &PaymentPromise{
+		ChainID:           "test-chain",
+		SignerKey:         secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey),
+		Commitment:        commitment,
+		CreationTimestamp: time.Unix(1, 0),
+		Signature:         []byte{1},
+	}
+	require.NoError(t, store.Put(t.Context(), promise, shard, promise.CreationTimestamp))
+
+	promiseHash, err := promise.Hash()
+	require.NoError(t, err)
+	markerData, closer, err := store.db.Get(shardKey(promise.Commitment, promiseHash))
+	require.NoError(t, err)
+	require.Equal(t, byte(objectBackendTag), markerData[1])
+	require.NoError(t, closer.Close())
+	require.Equal(t, 1, object.puts)
+
+	got, err := store.Get(t.Context(), commitment)
+	require.NoError(t, err)
+	require.Equal(t, shard, got)
+	has, err := store.Has(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.True(t, has)
+	require.Equal(t, 1, object.gets)
+	require.Equal(t, 1, object.heads)
+
+	size, err := store.Size(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, shardBinarySize(shard), size)
+
+	object.missing = true
+	has, accounted, err := store.shardStatus(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
+	require.True(t, accounted)
+	require.NoError(t, store.Put(t.Context(), promise, shard, promise.CreationTimestamp))
+	got, err = store.Get(t.Context(), commitment)
+	require.NoError(t, err)
+	require.Equal(t, shard, got)
+	size, err = store.Size(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, shardBinarySize(shard), size)
+}
+
+func TestStoreMissingObjectPreservesMetadata(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	promiseHash := []byte{1}
+	marker := []byte{1, byte(objectBackendTag), 0, 0, 0, 0, 0, 0, 0, 1}
+	require.NoError(t, store.db.Set(shardKey(commitment, promiseHash), marker, pebbledb.NoSync))
+
+	_, err := store.Get(t.Context(), commitment)
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+
+	store.shards.secondary = &shardStorageStub{missing: true}
+	_, err = store.Get(t.Context(), commitment)
+	require.ErrorIs(t, err, ErrStoreIntegrity)
+	has, err := store.Has(t.Context(), commitment, promiseHash)
+	require.NoError(t, err)
+	require.False(t, has)
+
+	data, closer, err := store.db.Get(shardKey(commitment, promiseHash))
+	require.NoError(t, err)
+	require.Equal(t, marker, data)
+	require.NoError(t, closer.Close())
+}
+
+func TestStoreGetSkipsMissingObjectToLocalSibling(t *testing.T) {
+	store := newMarkerTestStore(t)
+	object := &shardStorageStub{missing: true}
+	store.shards.secondary = object
+	commitment := generateCommitment()
+	objectHash := []byte{1}
+	localHash := []byte{2}
+	wantSize := writeMarkerTestShard(t, store, commitment, localHash)
+	objectMarker := encodeShardMarkerForBackend(objectBackendTag, 1)
+	require.NoError(t, store.db.Set(shardKey(commitment, objectHash), objectMarker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(shardKey(commitment, localHash), encodeShardMarkerForBackend(localBackendTag, wantSize), pebbledb.NoSync))
+
+	shard, err := store.Get(t.Context(), commitment)
+	require.NoError(t, err)
+	require.Equal(t, []byte("data"), shard.Rows[0].Data)
+	require.Equal(t, 1, object.gets)
+
+	data, closer, err := store.db.Get(shardKey(commitment, objectHash))
+	require.NoError(t, err)
+	require.Equal(t, objectMarker, data)
+	require.NoError(t, closer.Close())
+}
+
+type shardStorageStub struct {
+	shard   *types.BlobShard
+	missing bool
+	puts    int
+	gets    int
+	heads   int
+}
+
+func (s *shardStorageStub) Put(_ context.Context, _ Commitment, _ []byte, shard *types.BlobShard) (bool, error) {
+	s.puts++
+	s.shard = shard
+	s.missing = false
+	return true, nil
+}
+
+func (s *shardStorageStub) Get(context.Context, Commitment, []byte) (*types.BlobShard, error) {
+	s.gets++
+	if s.missing {
+		return nil, ErrStoreNotFound
+	}
+	return s.shard, nil
+}
+
+func (s *shardStorageStub) Has(context.Context, Commitment, []byte) (bool, error) {
+	s.heads++
+	return !s.missing, nil
+}
+
+func (*shardStorageStub) Delete(context.Context, Commitment, []byte) error {
+	return nil
+}
+
+func (*shardStorageStub) backendTag() shardBackendTag {
+	return objectBackendTag
 }

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -2,6 +2,7 @@ package fibre
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
@@ -43,7 +44,11 @@ func (s *routedStorage) Get(ctx context.Context, marker []byte, commitment Commi
 	if err != nil {
 		return nil, err
 	}
-	return backend.Get(ctx, commitment, promiseHash)
+	shard, err := backend.Get(ctx, commitment, promiseHash)
+	if backend.backendTag() == objectBackendTag && errors.Is(err, ErrStoreNotFound) {
+		return nil, fmt.Errorf("%w: object shard payload is missing", ErrStoreIntegrity)
+	}
+	return shard, err
 }
 
 func (s *routedStorage) Has(ctx context.Context, marker []byte, commitment Commitment, promiseHash []byte) (bool, error) {

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -2,7 +2,6 @@ package fibre
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
@@ -44,11 +43,7 @@ func (s *routedStorage) Get(ctx context.Context, marker []byte, commitment Commi
 	if err != nil {
 		return nil, err
 	}
-	shard, err := backend.Get(ctx, commitment, promiseHash)
-	if backend.backendTag() == objectBackendTag && errors.Is(err, ErrStoreNotFound) {
-		return nil, fmt.Errorf("%w: object shard payload is missing", ErrStoreIntegrity)
-	}
-	return shard, err
+	return backend.Get(ctx, commitment, promiseHash)
 }
 
 func (s *routedStorage) Has(ctx context.Context, marker []byte, commitment Commitment, promiseHash []byte) (bool, error) {


### PR DESCRIPTION
Adds some additional tests: 

Test object shard routing, missing-payload marker retention, local sibling fallback, and replacement without counting storage twice. 