### PR TITLE
feat(fibre): limit object shard reads

### DIFF
--- a/docs/architecture/adr-030-fibre-elastic-shard-storage.md
+++ b/docs/architecture/adr-030-fibre-elastic-shard-storage.md
@@ -11,6 +11,7 @@
 - 2026-09-02: Make conditional object writes idempotent
 - 2026-09-02: Define the shard-marker binary format
 - 2026-09-07: Route shard operations through `routedStorage`
+- 2026-09-09: Allow one retry per admitted object read
 
 ## Status
 
@@ -157,6 +158,15 @@ For each matching shard marker, `Store` will use this flow:
 Every read of an object-backed shard accesses object storage.
 
 The read flow keeps missing-file markers until pruning can release their recorded sizes.
+
+### Object-read rate limit and retries
+
+Object reads share one token bucket per object backend, with burst 1 and an explicit positive RPS value.
+Each `GetObject` call consumes one token and permits at most two SDK attempts: the initial attempt and one retry for transient errors.
+The retry does not consume another token, so admitted calls can generate up to two provider attempts each.
+Local reads remain unrestricted.
+
+Open question: do measured request costs and provider load require stricter limiting, such as charging each retry a token or disabling retries?
 
 ### Read latency concerns
 

--- a/fibre/server_download.go
+++ b/fibre/server_download.go
@@ -46,6 +46,11 @@ func (s *Server) DownloadShard(ctx context.Context, req *types.DownloadShardRequ
 	blobShard, err := s.store.Get(ctx, id.Commitment())
 	s.metrics.observeStoreOp(ctx, s.metrics.storeGetDuration, storeGetStart, err == nil)
 	if err != nil {
+		if errors.Is(err, ErrObjectReadRateLimited) {
+			s.log.WarnContext(ctx, "object read rate limit exceeded", "blob_commitment", id.Commitment().String())
+			span.SetStatus(codes.Error, "object read rate limit exceeded")
+			return nil, status.Error(grpccodes.ResourceExhausted, ErrObjectReadRateLimited.Error())
+		}
 		if errors.Is(err, ErrStoreNotFound) {
 			s.log.WarnContext(ctx, "no blob shard found for commitment", "blob_commitment", id.Commitment().String())
 			span.SetStatus(codes.Error, "no blob shard found")

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -124,8 +124,8 @@ func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseH
 		Bucket: aws.String(b.bucket),
 		Key:    aws.String(b.objectKey(commitment, promiseHash)),
 	}, func(options *s3.Options) {
-		// Each token permits one provider attempt.
-		options.RetryMaxAttempts = 1
+		// Each token permits an initial attempt and one retry for transient errors.
+		options.RetryMaxAttempts = 2
 	})
 	if isObjectNotFound(err) {
 		return nil, ErrStoreNotFound

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"path"
 	"strings"
 
@@ -15,9 +16,13 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"golang.org/x/time/rate"
 )
 
 const maxObjectDeleteBatchSize = 1000
+
+// ErrObjectReadRateLimited is returned when the object-read limit is exhausted.
+var ErrObjectReadRateLimited = errors.New("object read rate limit exceeded")
 
 type s3ObjectClient interface {
 	PutObject(context.Context, *s3.PutObjectInput, ...func(*s3.Options)) (*s3.PutObjectOutput, error)
@@ -39,6 +44,7 @@ type objectBackend struct {
 	prefix           string
 	chainID          string
 	validatorAddress string
+	readLimiter      *rate.Limiter
 }
 
 var _ shardBackend = (*objectBackend)(nil)
@@ -47,14 +53,19 @@ func (*objectBackend) backendTag() shardBackendTag {
 	return objectBackendTag
 }
 
-func newObjectBackend(client s3ObjectClient, bucket, prefix, chainID, validatorAddress string) *objectBackend {
+func newObjectBackend(client s3ObjectClient, bucket, prefix, chainID, validatorAddress string, readRPS float64) (*objectBackend, error) {
+	// rate.Inf is math.MaxFloat64, so that finite value must also be rejected.
+	if readRPS <= 0 || math.IsNaN(readRPS) || readRPS >= float64(rate.Inf) {
+		return nil, fmt.Errorf("object read RPS must be positive and below %g", rate.Inf)
+	}
 	return &objectBackend{
 		client:           client,
 		bucket:           bucket,
 		prefix:           strings.Trim(prefix, "/"),
 		chainID:          chainID,
 		validatorAddress: validatorAddress,
-	}
+		readLimiter:      rate.NewLimiter(rate.Limit(readRPS), 1),
+	}, nil
 }
 
 func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseHash []byte, shard *types.BlobShard) (bool, error) {
@@ -105,9 +116,16 @@ func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseH
 		return nil, err
 	}
 
+	if !b.readLimiter.Allow() {
+		return nil, ErrObjectReadRateLimited
+	}
+
 	output, err := b.client.GetObject(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(b.bucket),
 		Key:    aws.String(b.objectKey(commitment, promiseHash)),
+	}, func(options *s3.Options) {
+		// Each token permits one provider attempt.
+		options.RetryMaxAttempts = 1
 	})
 	if isObjectNotFound(err) {
 		return nil, ErrStoreNotFound

--- a/fibre/store_object_test.go
+++ b/fibre/store_object_test.go
@@ -8,8 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,8 +23,128 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	pebbledb "github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+func TestObjectBackendRejectsInvalidReadRPS(t *testing.T) {
+	for _, rps := range []float64{0, -1, math.NaN(), math.Inf(1), math.Inf(-1), math.MaxFloat64} {
+		t.Run(fmt.Sprint(rps), func(t *testing.T) {
+			backend, err := newObjectBackend(&s3ObjectClientStub{}, "bucket", "prefix", "chain", "validator", rps)
+			require.Error(t, err)
+			require.Nil(t, backend)
+		})
+	}
+}
+
+func TestObjectBackendGetRateLimit(t *testing.T) {
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: []byte("data")}}}
+	var encoded bytes.Buffer
+	require.NoError(t, writeShardBinary(&encoded, shard))
+	for _, providerErr := range []error{nil, errors.New("provider error"), &smithy.GenericAPIError{Code: "NoSuchKey"}} {
+		t.Run(fmt.Sprint(providerErr), func(t *testing.T) {
+			var calls atomic.Int32
+			client := &s3ObjectClientStub{
+				getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+					calls.Add(1)
+					if providerErr != nil {
+						return nil, providerErr
+					}
+					return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(encoded.Bytes()))}, nil
+				},
+			}
+			// One token, with no refill during the test.
+			backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1e-9)
+			require.NoError(t, err)
+			ctx, cancel := context.WithCancel(t.Context())
+			cancel()
+			_, err = backend.Get(ctx, Commitment{}, []byte{1})
+			require.ErrorIs(t, err, context.Canceled)
+			require.Zero(t, calls.Load())
+
+			const readers = 16
+			results := make(chan error, readers)
+			var wg sync.WaitGroup
+			for i := range readers {
+				wg.Go(func() {
+					_, err := backend.Get(t.Context(), Commitment{byte(i)}, []byte{byte(i)})
+					results <- err
+				})
+			}
+			wg.Wait()
+			close(results)
+			limited := 0
+			for err := range results {
+				switch {
+				case errors.Is(err, ErrObjectReadRateLimited):
+					limited++
+				case isObjectNotFound(providerErr):
+					require.ErrorIs(t, err, ErrStoreNotFound)
+				default:
+					require.ErrorIs(t, err, providerErr)
+				}
+			}
+			require.Equal(t, readers-1, limited)
+			require.Equal(t, int32(1), calls.Load())
+		})
+	}
+}
+
+func TestServerDownloadShardObjectReadLimit(t *testing.T) {
+	store := newMarkerTestStore(t)
+	var calls int
+	client := &s3ObjectClientStub{
+		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			calls++
+			return nil, errors.New("provider error")
+		},
+	}
+	object, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1e-9)
+	require.NoError(t, err)
+	store.shards = newRoutedStorage(object, store.shards.primary)
+	commitment := Commitment{1}
+	marker := encodeShardMarkerForBackend(objectBackendTag, 1)
+	for _, hash := range [][]byte{{1}, {2}} {
+		require.NoError(t, store.db.Set(shardKey(commitment, hash), marker, pebbledb.NoSync))
+	}
+	metrics, err := newServerMetrics(otel.Meter("test"), newOccupancy(0))
+	require.NoError(t, err)
+	server := &Server{
+		store:   store,
+		log:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		tracer:  otel.Tracer("test"),
+		metrics: metrics,
+	}
+	req := &types.DownloadShardRequest{BlobId: NewBlobID(0, commitment)}
+	response, err := server.DownloadShard(t.Context(), req)
+	require.Nil(t, response)
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Equal(t, 1, calls)
+
+	// An exhausted object backend must not prevent a local sibling from serving the read.
+	localHash := []byte{3}
+	size := writeMarkerTestShard(t, store, commitment, localHash)
+	require.NoError(t, store.db.Set(shardKey(commitment, localHash), encodeShardMarkerForBackend(localBackendTag, size), pebbledb.NoSync))
+	response, err = server.DownloadShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, []byte("data"), response.Shard.Rows[0].Data)
+	require.Equal(t, 1, calls)
+	for _, hash := range [][]byte{{1}, {2}} {
+		data, closer, err := store.db.Get(shardKey(commitment, hash))
+		require.NoError(t, err)
+		require.Equal(t, marker, data)
+		require.NoError(t, closer.Close())
+		require.NoError(t, store.db.Delete(shardKey(commitment, hash), pebbledb.NoSync))
+	}
+
+	response, err = server.DownloadShard(t.Context(), req)
+	require.NoError(t, err)
+	require.Equal(t, []byte("data"), response.Shard.Rows[0].Data)
+	require.Equal(t, 1, calls)
+}
 
 func TestObjectBackendPutContentLength(t *testing.T) {
 	shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: bytes.Repeat([]byte("data"), 1<<19)}}}
@@ -45,7 +169,8 @@ func TestObjectBackendPutContentLength(t *testing.T) {
 		UsePathStyle: true,
 		HTTPClient:   server.Client(),
 	})
-	backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+	require.NoError(t, err)
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 	created, err := backend.Put(ctx, Commitment{}, []byte{1}, shard)
@@ -85,7 +210,8 @@ func TestObjectBackendPut(t *testing.T) {
 				return &s3.PutObjectOutput{}, nil
 			},
 		}
-		backend := newObjectBackend(client, "bucket", "/fibre/", "test-chain", "celestiavalcons1validator")
+		backend, err := newObjectBackend(client, "bucket", "/fibre/", "test-chain", "celestiavalcons1validator", 1)
+		require.NoError(t, err)
 
 		created, err := backend.Put(t.Context(), commitment, promiseHash, shard)
 		require.NoError(t, err)
@@ -98,7 +224,8 @@ func TestObjectBackendPut(t *testing.T) {
 				return nil, &smithy.GenericAPIError{Code: "PreconditionFailed", Fault: smithy.FaultClient}
 			},
 		}
-		backend := newObjectBackend(client, "bucket", "fibre", "test-chain", "celestiavalcons1validator")
+		backend, err := newObjectBackend(client, "bucket", "fibre", "test-chain", "celestiavalcons1validator", 1)
+		require.NoError(t, err)
 
 		created, err := backend.Put(t.Context(), commitment, promiseHash, shard)
 		require.NoError(t, err)
@@ -117,7 +244,8 @@ func TestObjectBackendGet(t *testing.T) {
 			return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data.Bytes()))}, nil
 		},
 	}
-	backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+	require.NoError(t, err)
 
 	got, err := backend.Get(t.Context(), Commitment{}, []byte{1})
 	require.NoError(t, err)
@@ -153,7 +281,8 @@ func TestObjectBackendGetChecksum(t *testing.T) {
 					HTTPClient:                 server.Client(),
 					ResponseChecksumValidation: aws.ResponseChecksumValidationWhenSupported,
 				})
-				backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+				backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+				require.NoError(t, err)
 				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 				defer cancel()
 				got, err := backend.Get(ctx, Commitment{}, []byte{1})
@@ -173,6 +302,32 @@ func TestObjectBackendGetChecksum(t *testing.T) {
 	}
 }
 
+func TestObjectBackendGetDoesNotRetry(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Content-Type", "application/xml")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, "<Error><Code>SlowDown</Code><Message>retry later</Message></Error>")
+	}))
+	defer server.Close()
+	client := s3.New(s3.Options{
+		Region:           "us-east-1",
+		Credentials:      credentials.NewStaticCredentialsProvider("test", "test", ""),
+		BaseEndpoint:     aws.String(server.URL),
+		UsePathStyle:     true,
+		HTTPClient:       server.Client(),
+		RetryMaxAttempts: 3,
+	})
+	backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+	require.NoError(t, err)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+	defer cancel()
+	_, err = backend.Get(ctx, Commitment{}, []byte{1})
+	require.ErrorContains(t, err, "SlowDown")
+	require.Equal(t, int32(1), calls.Load())
+}
+
 func TestObjectBackendNormalisesMissingObject(t *testing.T) {
 	missing := &smithy.GenericAPIError{Code: "NoSuchKey", Fault: smithy.FaultClient}
 	client := &s3ObjectClientStub{
@@ -186,9 +341,10 @@ func TestObjectBackendNormalisesMissingObject(t *testing.T) {
 			return nil, missing
 		},
 	}
-	backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+	require.NoError(t, err)
 
-	_, err := backend.Get(t.Context(), Commitment{}, []byte{1})
+	_, err = backend.Get(t.Context(), Commitment{}, []byte{1})
 	require.ErrorIs(t, err, ErrStoreNotFound)
 	has, err := backend.Has(t.Context(), Commitment{}, []byte{1})
 	require.NoError(t, err)
@@ -220,7 +376,8 @@ func TestObjectBackendDeleteObjects(t *testing.T) {
 				}}}, nil
 			},
 		}
-		backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+		backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+		require.NoError(t, err)
 
 		errs, err := backend.DeleteObjects(t.Context(), ids)
 		require.NoError(t, err)
@@ -235,7 +392,8 @@ func TestObjectBackendDeleteObjects(t *testing.T) {
 				return nil, requestErr
 			},
 		}
-		backend := newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+		backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
+		require.NoError(t, err)
 
 		errs, err := backend.DeleteObjects(t.Context(), ids)
 		require.ErrorIs(t, err, requestErr)
@@ -243,8 +401,9 @@ func TestObjectBackendDeleteObjects(t *testing.T) {
 	})
 
 	t.Run("batch limit", func(t *testing.T) {
-		backend := newObjectBackend(&s3ObjectClientStub{}, "bucket", "prefix", "chain", "validator")
-		_, err := backend.DeleteObjects(t.Context(), make([]shardID, maxObjectDeleteBatchSize+1))
+		backend, err := newObjectBackend(&s3ObjectClientStub{}, "bucket", "prefix", "chain", "validator", 1)
+		require.NoError(t, err)
+		_, err = backend.DeleteObjects(t.Context(), make([]shardID, maxObjectDeleteBatchSize+1))
 		require.ErrorContains(t, err, "maximum is 1000")
 	})
 }

--- a/fibre/store_object_test.go
+++ b/fibre/store_object_test.go
@@ -302,30 +302,48 @@ func TestObjectBackendGetChecksum(t *testing.T) {
 	}
 }
 
-func TestObjectBackendGetDoesNotRetry(t *testing.T) {
-	var calls atomic.Int32
-	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		calls.Add(1)
-		w.Header().Set("Content-Type", "application/xml")
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = io.WriteString(w, "<Error><Code>SlowDown</Code><Message>retry later</Message></Error>")
-	}))
-	defer server.Close()
-	client := s3.New(s3.Options{
-		Region:           "us-east-1",
-		Credentials:      credentials.NewStaticCredentialsProvider("test", "test", ""),
-		BaseEndpoint:     aws.String(server.URL),
-		UsePathStyle:     true,
-		HTTPClient:       server.Client(),
-		RetryMaxAttempts: 3,
-	})
-	backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1)
-	require.NoError(t, err)
-	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-	defer cancel()
-	_, err = backend.Get(ctx, Commitment{}, []byte{1})
-	require.ErrorContains(t, err, "SlowDown")
-	require.Equal(t, int32(1), calls.Load())
+func TestObjectBackendGetRetriesOnce(t *testing.T) {
+	for _, recovers := range []bool{false, true} {
+		t.Run(fmt.Sprintf("recovers=%t", recovers), func(t *testing.T) {
+			shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: []byte("data")}}}
+			var encoded bytes.Buffer
+			require.NoError(t, writeShardBinary(&encoded, shard))
+			var calls atomic.Int32
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				if calls.Add(1) == 2 && recovers {
+					_, _ = w.Write(encoded.Bytes())
+					return
+				}
+				w.Header().Set("Content-Type", "application/xml")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, _ = io.WriteString(w, "<Error><Code>SlowDown</Code><Message>retry later</Message></Error>")
+			}))
+			defer server.Close()
+			client := s3.New(s3.Options{
+				Region:           "us-east-1",
+				Credentials:      credentials.NewStaticCredentialsProvider("test", "test", ""),
+				BaseEndpoint:     aws.String(server.URL),
+				UsePathStyle:     true,
+				HTTPClient:       server.Client(),
+				RetryMaxAttempts: 3,
+			})
+			backend, err := newObjectBackend(client, "bucket", "prefix", "chain", "validator", 1e-9)
+			require.NoError(t, err)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+			defer cancel()
+			got, err := backend.Get(ctx, Commitment{}, []byte{1})
+			if recovers {
+				require.NoError(t, err)
+				require.Equal(t, shard, got)
+			} else {
+				require.ErrorContains(t, err, "SlowDown")
+			}
+			require.Equal(t, int32(2), calls.Load())
+			_, err = backend.Get(ctx, Commitment{}, []byte{1})
+			require.ErrorIs(t, err, ErrObjectReadRateLimited)
+			require.Equal(t, int32(2), calls.Load())
+		})
+	}
 }
 
 func TestObjectBackendNormalisesMissingObject(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -83,6 +83,7 @@ require (
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.294.0
 	google.golang.org/genproto/googleapis/api v0.0.0-20260819154853-08b0e4226688
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260825221802-da73d73af1c5
@@ -438,7 +439,6 @@ require (
 	golang.org/x/exp/typeparams v0.0.0-20251125195548-87e1e737ad39 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
-	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto v0.0.0-20260715232425-e75dac1f907d // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
Closes [PROTOCO-2621](https://linear.app/celestia/issue/PROTOCO-2621)

Limit object reads with one shared token bucket and return `ResourceExhausted` when it rejects a read. Require an explicit positive RPS value, use burst 1, and allow one SDK retry so each token permits up to two attempts. Local reads and sibling fallback remain available.

The ADR leaves stricter limiting as an open question based on measured request costs and provider load.
