### PR TITLE
feat(fibre)!: configure object shard storage (small config break for `ServerConfig`)

### DIFF
--- a/docs/architecture/adr-030-fibre-elastic-shard-storage.md
+++ b/docs/architecture/adr-030-fibre-elastic-shard-storage.md
@@ -332,7 +332,6 @@ The first cache option to evaluate will be a bounded, write-through in-memory ca
 - Do not populate the cache after object-storage reads. This prevents arbitrary reads from displacing recent uploads.
 - Treat the cache as optional and non-durable. It will start empty after a restart.
 - Measure shard sizes, the hot-read window, cache hit rate, and memory use before selecting a default limit.
-- Include cache misses when evaluating the deferred object-read limit.
 
 ## References
 

--- a/docs/architecture/adr-030-fibre-elastic-shard-storage.md
+++ b/docs/architecture/adr-030-fibre-elastic-shard-storage.md
@@ -150,9 +150,9 @@ For each matching shard marker, `Store` will use this flow:
 3. For a local marker, `localBackend` reads the local flat file.
 4. For an object marker, `objectBackend` reads the object with `GetObject`.
 5. If local storage returns `NotFound`, keep the marker for occupancy accounting and try the next matching shard marker.
-6. If object storage returns `NotFound`, keep the marker, record an integrity error, and try the next matching shard marker.
+6. If object storage returns `NotFound`, keep the marker and try the next matching shard marker.
 7. If another durable-storage error occurs, record it and try the next matching shard marker.
-8. If no matching shard marker succeeds, return the recorded error.
+8. If no matching shard marker succeeds, return the recorded error, or `ErrStoreNotFound` if no other error occurred.
 
 Every read of an object-backed shard accesses object storage.
 
@@ -186,6 +186,8 @@ The `Store` API will not change. `Store` will contain `routedStorage` and delega
 `NewStore` will always open Pebble and `localBackend`.
 
 `NewStore` will open `objectBackend` in object mode. It will also open this backend while live markers record `object`.
+
+Startup fails if required object-storage settings are missing or invalid, including in local mode with object markers.
 
 In local mode, `routedStorage` will use `localBackend` as primary. It will use `objectBackend` as secondary when object access is configured.
 
@@ -314,7 +316,7 @@ This approach preserves the Pebble marker format. It adds backend requests and r
 | Write latency | An object upload can exceed the current upload timeout. | Measure the complete write path against the timeout. |
 | Provider availability | An outage stops new uploads and object-backed reads. | Fibre reports the provider error and keeps its Pebble markers. |
 | Read latency | Object storage adds latency to every object-backed read. | Measure object-read latency and define request limits. |
-| Request cost | Repeated downloads can create unbounded object-read charges. | Before object mode ships, define a configurable global limit for object-read requests and measure its effect on legitimate downloads. |
+| Request cost | Repeated downloads can create unbounded object-read charges. | Object-read limiting is deferred to [PROTOCO-2621](https://linear.app/celestia/issue/PROTOCO-2621). Measure traffic and costs before selecting a policy. |
 | Binary downgrade | Old Fibre cannot read live object-backed shards. | Copy live objects to legacy local paths before downgrade. |
 | Disaster recovery | Loss of Pebble removes the object index. | Complete disaster recovery is outside this ADR. |
 | Provider lifecycle rules | A short lifecycle can delete a promised shard. | Use at least 30 days as a safety net and review this period when protocol retention limits change. |
@@ -330,7 +332,7 @@ The first cache option to evaluate will be a bounded, write-through in-memory ca
 - Do not populate the cache after object-storage reads. This prevents arbitrary reads from displacing recent uploads.
 - Treat the cache as optional and non-durable. It will start empty after a restart.
 - Measure shard sizes, the hot-read window, cache hit rate, and memory use before selecting a default limit.
-- Keep the global object-read limit because cache misses still access object storage.
+- Include cache misses when evaluating the deferred object-read limit.
 
 ## References
 

--- a/fibre/client_server_test.go
+++ b/fibre/client_server_test.go
@@ -365,7 +365,7 @@ func makeTestServers(
 			modifyServerConfig(&serverCfg)
 		}
 
-		serverCfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+		serverCfg.StoreFn = func(_ context.Context, scfg fibre.StoreConfig) (*fibre.Store, error) {
 			return fibre.NewMemoryStore(scfg), nil
 		}
 		srv, err := fibre.NewServer(serverCfg)

--- a/fibre/cmd/start_cmd_test.go
+++ b/fibre/cmd/start_cmd_test.go
@@ -125,7 +125,7 @@ func TestStartCmdNilLog(t *testing.T) {
 		cfg.SignerFn = func(string) (core.PrivValidator, error) {
 			return &mockPV, nil
 		}
-		cfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+		cfg.StoreFn = func(_ context.Context, scfg fibre.StoreConfig) (*fibre.Store, error) {
 			return fibre.NewMemoryStore(scfg), nil
 		}
 		return startServer(ctx, cfg)

--- a/fibre/internal/e2e/fibre_e2e_test.go
+++ b/fibre/internal/e2e/fibre_e2e_test.go
@@ -77,7 +77,7 @@ func (s *FibreE2ETestSuite) SetupSuite() {
 		return filePV, nil
 	}
 
-	serverCfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+	serverCfg.StoreFn = func(_ context.Context, scfg fibre.StoreConfig) (*fibre.Store, error) {
 		return fibre.NewMemoryStore(scfg), nil
 	}
 	s.fibreServer, err = fibre.NewServer(serverCfg)

--- a/fibre/internal/e2e/fibre_stack_test.go
+++ b/fibre/internal/e2e/fibre_stack_test.go
@@ -1,6 +1,7 @@
 package e2e_test
 
 import (
+	"context"
 	"encoding/json"
 	"path/filepath"
 	"testing"
@@ -40,7 +41,7 @@ func startFibreStack(t *testing.T, cctx testnode.Context, ecfg encoding.Config, 
 	serverCfg.AppGRPCAddress = grpcAddr
 	serverCfg.ServerListenAddress = "127.0.0.1:0"
 	serverCfg.SignerFn = func(_ string) (core.PrivValidator, error) { return filePV, nil }
-	serverCfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+	serverCfg.StoreFn = func(_ context.Context, scfg fibre.StoreConfig) (*fibre.Store, error) {
 		return fibre.NewMemoryStore(scfg), nil
 	}
 	server, err := fibre.NewServer(serverCfg)

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/fibre/state"
 	"github.com/celestiaorg/celestia-app/v10/pkg/rsema1d"
 	core "github.com/cometbft/cometbft/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"go.opentelemetry.io/otel/trace"
 	grpclib "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -141,6 +142,12 @@ func (s *Server) Start(ctx context.Context) (err error) {
 		grpclib.Creds(creds),
 	)
 
+	pubKey, err := s.signer.GetPubKey()
+	if err != nil {
+		return fmt.Errorf("getting validator public key: %w", err)
+	}
+	s.Config.ChainID = s.state.ChainID()
+	s.Config.ValidatorAddress = sdk.ConsAddress(pubKey.Address()).String()
 	s.store, err = s.Config.StoreFn(s.Config.StoreConfig)
 	if err != nil {
 		return fmt.Errorf("opening store: %w", err)

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -146,8 +146,8 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("getting validator public key: %w", err)
 	}
-	s.Config.ChainID = s.state.ChainID()
-	s.Config.ValidatorAddress = sdk.ConsAddress(pubKey.Address()).String()
+	s.Config.ObjectStorage.ChainID = s.state.ChainID()
+	s.Config.ObjectStorage.ValidatorAddress = sdk.ConsAddress(pubKey.Address()).String()
 	s.store, err = s.Config.StoreFn(s.Config.StoreConfig)
 	if err != nil {
 		return fmt.Errorf("opening store: %w", err)

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -148,7 +148,7 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	}
 	s.Config.ObjectStorage.ChainID = s.state.ChainID()
 	s.Config.ObjectStorage.ValidatorAddress = sdk.ConsAddress(pubKey.Address()).String()
-	s.store, err = s.Config.StoreFn(s.Config.StoreConfig)
+	s.store, err = s.Config.StoreFn(ctx, s.Config.StoreConfig)
 	if err != nil {
 		return fmt.Errorf("opening store: %w", err)
 	}

--- a/fibre/server_config.go
+++ b/fibre/server_config.go
@@ -37,7 +37,7 @@ type ServerConfig struct {
 	// UploadVerifyWorkers caps concurrent shard verifications. Defaults to GOMAXPROCS.
 	UploadVerifyWorkers int `toml:"upload_verify_workers" comment:"UploadVerifyWorkers caps concurrent shard verifications. Defaults to GOMAXPROCS."`
 
-	StoreConfig `toml:"-"`
+	StoreConfig
 
 	// LivenessThreshold is the fraction of stake needed for reconstruction (typically 1/3).
 	LivenessThreshold cmtmath.Fraction `toml:"-"`

--- a/fibre/server_config.go
+++ b/fibre/server_config.go
@@ -1,6 +1,7 @@
 package fibre
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -54,7 +55,7 @@ type ServerConfig struct {
 
 	// StoreFn creates the persistent [Store] for the server.
 	// If nil, defaults to [NewStore].
-	StoreFn func(StoreConfig) (*Store, error) `toml:"-"`
+	StoreFn func(context.Context, StoreConfig) (*Store, error) `toml:"-"`
 	// StateClientFn creates a [StateClient] for communicating with a celestia-app node.
 	// It is called during server construction.
 	StateClientFn func() (state.Client, error) `toml:"-"`

--- a/fibre/server_config_test.go
+++ b/fibre/server_config_test.go
@@ -92,3 +92,31 @@ func TestServerConfigValidateNoSigner(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "signer_grpc_address is required")
 }
+
+func TestServerConfigObjectStorageRoundTrip(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret-key")
+	var (
+		cfg        = DefaultServerConfig()
+		loaded     = DefaultServerConfig()
+		configPath = DefaultConfigPath(t.TempDir())
+	)
+	cfg.StorageBackend = "object"
+	cfg.ObjectStorage = testObjectStorageConfig()
+	cfg.Path = "runtime-store-path"
+	cfg.ChainID = "runtime-chain"
+	cfg.ValidatorAddress = "runtime-validator"
+	require.NoError(t, cfg.Save(configPath))
+	require.NoError(t, loaded.Load(configPath))
+	require.Equal(t, "object", loaded.StorageBackend)
+	require.Equal(t, cfg.ObjectStorage, loaded.ObjectStorage)
+	require.Empty(t, loaded.Path)
+	require.Empty(t, loaded.ChainID)
+	require.Empty(t, loaded.ValidatorAddress)
+	data, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+	for _, excluded := range []string{"test-access-key", "test-secret-key", "runtime-store-path", "runtime-chain", "runtime-validator", "access_key", "secret_key"} {
+		require.NotContains(t, string(data), excluded)
+	}
+	require.Contains(t, string(data), "[object_storage]")
+}

--- a/fibre/server_config_test.go
+++ b/fibre/server_config_test.go
@@ -104,19 +104,20 @@ func TestServerConfigObjectStorageRoundTrip(t *testing.T) {
 	cfg.StorageBackend = "object"
 	cfg.ObjectStorage = testObjectStorageConfig()
 	cfg.Path = "runtime-store-path"
-	cfg.ChainID = "runtime-chain"
-	cfg.ValidatorAddress = "runtime-validator"
+	cfg.ObjectStorage.ChainID = "runtime-chain"
+	cfg.ObjectStorage.ValidatorAddress = "runtime-validator"
 	require.NoError(t, cfg.Save(configPath))
 	require.NoError(t, loaded.Load(configPath))
 	require.Equal(t, "object", loaded.StorageBackend)
-	require.Equal(t, cfg.ObjectStorage, loaded.ObjectStorage)
+	require.Equal(t, testObjectStorageConfig(), loaded.ObjectStorage)
 	require.Empty(t, loaded.Path)
-	require.Empty(t, loaded.ChainID)
-	require.Empty(t, loaded.ValidatorAddress)
+	require.Empty(t, loaded.ObjectStorage.ChainID)
+	require.Empty(t, loaded.ObjectStorage.ValidatorAddress)
 	data, err := os.ReadFile(configPath)
 	require.NoError(t, err)
 	for _, excluded := range []string{"test-access-key", "test-secret-key", "runtime-store-path", "runtime-chain", "runtime-validator", "access_key", "secret_key"} {
 		require.NotContains(t, string(data), excluded)
 	}
 	require.Contains(t, string(data), "[object_storage]")
+	require.Contains(t, string(data), "# Use auto for Cloudflare R2.")
 }

--- a/fibre/server_test.go
+++ b/fibre/server_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cometbft/cometbft/crypto"
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	core "github.com/cometbft/cometbft/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -157,3 +158,35 @@ func (m *testPrivValidator) SignProposal(chainID string, proposal *cmtproto.Prop
 func (m *testPrivValidator) GetAddress() core.Address {
 	return m.privKey.PubKey().Address()
 }
+
+func TestServerStartDerivesStoreIdentity(t *testing.T) {
+	var got fibre.StoreConfig
+	_, _, validator := makeTestServerWithConfig(t, func(cfg *fibre.ServerConfig) {
+		newState := cfg.StateClientFn
+		cfg.StateClientFn = func() (state.Client, error) {
+			client, err := newState()
+			return &startChainStateClient{Client: client}, err
+		}
+		cfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+			got = scfg
+			return fibre.NewMemoryStore(scfg), nil
+		}
+	})
+	require.Equal(t, "started-chain", got.ChainID)
+	require.Equal(t, sdk.ConsAddress(validator.Address).String(), got.ValidatorAddress)
+}
+
+type startChainStateClient struct {
+	state.Client
+	chainID string
+}
+
+func (s *startChainStateClient) Start(ctx context.Context) error {
+	if err := s.Client.Start(ctx); err != nil {
+		return err
+	}
+	s.chainID = "started-chain"
+	return nil
+}
+
+func (s *startChainStateClient) ChainID() string { return s.chainID }

--- a/fibre/server_test.go
+++ b/fibre/server_test.go
@@ -65,7 +65,7 @@ func makeTestServerWithConfig(t *testing.T, modify func(*fibre.ServerConfig)) (*
 		return privVal, nil
 	}
 
-	cfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+	cfg.StoreFn = func(_ context.Context, scfg fibre.StoreConfig) (*fibre.Store, error) {
 		return fibre.NewMemoryStore(scfg), nil
 	}
 	if modify != nil {
@@ -168,7 +168,8 @@ func TestServerStartDerivesStoreIdentity(t *testing.T) {
 			client, err := newState()
 			return &startChainStateClient{Client: client}, err
 		}
-		cfg.StoreFn = func(scfg fibre.StoreConfig) (*fibre.Store, error) {
+		cfg.StoreFn = func(ctx context.Context, scfg fibre.StoreConfig) (*fibre.Store, error) {
+			require.Same(t, t.Context(), ctx)
 			got = scfg
 			return fibre.NewMemoryStore(scfg), nil
 		}
@@ -202,7 +203,7 @@ func TestServerStartFailsWhenStoreCannotOpen(t *testing.T) {
 		return core.NewMockPV(), nil
 	}
 	wantErr := errors.New("cannot open store")
-	cfg.StoreFn = func(fibre.StoreConfig) (*fibre.Store, error) { return nil, wantErr }
+	cfg.StoreFn = func(context.Context, fibre.StoreConfig) (*fibre.Store, error) { return nil, wantErr }
 	server, err := fibre.NewServer(cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, server.Stop(context.Background())) })

--- a/fibre/server_test.go
+++ b/fibre/server_test.go
@@ -2,6 +2,7 @@ package fibre_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -172,8 +173,8 @@ func TestServerStartDerivesStoreIdentity(t *testing.T) {
 			return fibre.NewMemoryStore(scfg), nil
 		}
 	})
-	require.Equal(t, "started-chain", got.ChainID)
-	require.Equal(t, sdk.ConsAddress(validator.Address).String(), got.ValidatorAddress)
+	require.Equal(t, "started-chain", got.ObjectStorage.ChainID)
+	require.Equal(t, sdk.ConsAddress(validator.Address).String(), got.ObjectStorage.ValidatorAddress)
 }
 
 type startChainStateClient struct {
@@ -190,3 +191,21 @@ func (s *startChainStateClient) Start(ctx context.Context) error {
 }
 
 func (s *startChainStateClient) ChainID() string { return s.chainID }
+
+func TestServerStartFailsWhenStoreCannotOpen(t *testing.T) {
+	cfg := fibre.DefaultServerConfig()
+	cfg.ServerListenAddress = "127.0.0.1:0"
+	cfg.StateClientFn = func() (state.Client, error) {
+		return &mockStateClient{chainID: "test-chain"}, nil
+	}
+	cfg.SignerFn = func(string) (core.PrivValidator, error) {
+		return core.NewMockPV(), nil
+	}
+	wantErr := errors.New("cannot open store")
+	cfg.StoreFn = func(fibre.StoreConfig) (*fibre.Store, error) { return nil, wantErr }
+	server, err := fibre.NewServer(cfg)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, server.Stop(context.Background())) })
+	require.ErrorIs(t, server.Start(t.Context()), wantErr)
+	require.Nil(t, server.Store())
+}

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -39,9 +39,6 @@ type StoreConfig struct {
 	StorageBackend string `toml:"storage_backend"`
 	// ObjectStorage must remain configured until all object shards are pruned.
 	ObjectStorage ObjectStorageConfig `toml:"object_storage"`
-	// ChainID and ValidatorAddress are derived by the server at startup.
-	ChainID          string `toml:"-"`
-	ValidatorAddress string `toml:"-"`
 	// Path is the path to the store directory.
 	Path string `toml:"-"`
 	// Log defaults to [slog.Default] when nil.
@@ -131,13 +128,19 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 		return nil, fmt.Errorf("opening pebble database: %w", err)
 	}
 
-	s := &Store{db: db, log: cfg.Log, shards: newRoutedStorage(local, nil)}
-	if err := s.openObjectStorage(cfg); err != nil {
-		_ = db.Close()
+	s := &Store{db: db, log: cfg.Log}
+	object, err := s.openObjectStorage(cfg)
+	if err != nil {
+		_ = s.Close()
 		return nil, fmt.Errorf("opening object shard storage: %w", err)
 	}
+	if cfg.StorageBackend == "object" {
+		s.shards = newRoutedStorage(object, local)
+	} else {
+		s.shards = newRoutedStorage(local, object)
+	}
 	if err := s.reconcile(); err != nil {
-		_ = s.db.Close()
+		_ = s.Close()
 		return nil, fmt.Errorf("reconciling store: %w", err)
 	}
 	return s, nil

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -47,18 +47,18 @@ type StoreConfig struct {
 
 // DefaultStoreConfig returns a [StoreConfig] with default values.
 func DefaultStoreConfig() StoreConfig {
-	return StoreConfig{StorageBackend: "local"}
+	return StoreConfig{StorageBackend: storageBackendLocal}
 }
 
 // Validate checks that the StoreConfig is valid and fills in defaults for
 // unset fields.
 func (cfg *StoreConfig) Validate() error {
 	if cfg.StorageBackend == "" {
-		cfg.StorageBackend = "local"
+		cfg.StorageBackend = storageBackendLocal
 	}
 	switch cfg.StorageBackend {
-	case "local":
-	case "object":
+	case storageBackendLocal:
+	case storageBackendObject:
 		if err := cfg.ObjectStorage.Validate(); err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ const memStorePath = "/store"
 // when the Store is garbage collected.
 func NewMemoryStore(cfg StoreConfig) *Store {
 	cfg.Path = memStorePath
-	cfg.StorageBackend = "local"
+	cfg.StorageBackend = storageBackendLocal
 	s, err := openStore(context.Background(), cfg, vfs.NewMem())
 	if err != nil {
 		panic(fmt.Sprintf("opening in-memory store: %v", err))
@@ -137,7 +137,7 @@ func openStore(ctx context.Context, cfg StoreConfig, filesystem vfs.FS) (*Store,
 		_ = s.Close()
 		return nil, fmt.Errorf("opening object shard storage: %w", err)
 	}
-	if cfg.StorageBackend == "object" {
+	if cfg.StorageBackend == storageBackendObject {
 		s.shards = newRoutedStorage(object, local)
 	} else {
 		s.shards = newRoutedStorage(local, object)

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -407,15 +407,8 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 	return &promise, nil
 }
 
-// PruneBefore deletes all shards and payment promises with pruneAt before the given time
-// and returns the number of pruned entries and the freed bytes.
-//
-// It deletes at most [maxPruneBatchSize] expired entries per call. If invalid
-// markers are skipped, it commits valid deletions and returns their count and
-// freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
-// do not consume deletion capacity. Fatal errors return no uncommitted counts.
-// If a payload deletion fails, completed cleanup is committed and returned
-// with the deletion error.
+// PruneBefore deletes up to [maxPruneBatchSize] shards and payment promises that expire before the given time.
+// It returns the committed deletion count and freed bytes, retaining failed or invalid entries for retry.
 func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -430,13 +423,18 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 	batch := s.db.NewBatch()
 	defer batch.Close()
 	var (
+		selectedBytes  int64
+		candidates     []pruneCandidate
 		pruned         int
 		prunedBytes    int64
 		integrityErr   error
 		corruptMarkers int
 	)
 	beforeStr := formatTimestamp(before.UTC())
-	for valid := iter.First(); valid && pruned < maxPruneBatchSize; valid = iter.Next() {
+	for valid := iter.First(); valid && len(candidates) < maxPruneBatchSize; valid = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
 		key := iter.Key()
 
 		// Keys are sorted; once the timestamp reaches the cutoff we're done.
@@ -474,41 +472,58 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 			}
 			continue
 		}
-		if size > math.MaxInt64-prunedBytes {
+		if size > math.MaxInt64-selectedBytes {
 			return 0, 0, errors.New("pruned shard size overflows int64")
 		}
-
-		// Missing file is fine (orphan marker from a crashed Put).
-		if err := s.shards.Delete(ctx, markerData, commitment, promiseHash); err != nil {
-			if commitErr := batch.Commit(pebbledb.NoSync); commitErr != nil {
-				return 0, 0, errors.Join(err, fmt.Errorf("committing batch: %w", commitErr))
-			}
-			return pruned, prunedBytes, err
-		}
-		if err := batch.Delete(key, pebbledb.NoSync); err != nil {
-			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
-		}
-		if err := batch.Delete(shardKey(commitment, promiseHash), pebbledb.NoSync); err != nil {
-			return 0, 0, fmt.Errorf("deleting shard marker: %w", err)
-		}
-		if err := batch.Delete(promiseKey(promiseHash), pebbledb.NoSync); err != nil {
-			return 0, 0, fmt.Errorf("deleting payment promise: %w", err)
-		}
-		pruned++
-		prunedBytes += size
+		selectedBytes += size
+		candidates = append(candidates, pruneCandidate{
+			markedShard: markedShard{
+				id: shardID{commitment: commitment, promiseHash: promiseHash}, marker: markerData,
+			},
+			key: slices.Clone(key), size: size,
+		})
 	}
 
 	if err := iter.Error(); err != nil {
 		return 0, 0, fmt.Errorf("iterating prune index: %w", err)
 	}
 
+	shards := make([]markedShard, len(candidates))
+	for i, candidate := range candidates {
+		shards[i] = candidate.markedShard
+	}
+	successful, deleteErr := s.shards.DeleteBatch(ctx, shards)
+	for _, i := range successful {
+		candidate := candidates[i]
+		if err := batch.Delete(candidate.key, pebbledb.NoSync); err != nil {
+			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
+		}
+		if err := batch.Delete(shardKey(candidate.id.commitment, candidate.id.promiseHash), pebbledb.NoSync); err != nil {
+			return 0, 0, fmt.Errorf("deleting shard marker: %w", err)
+		}
+		if err := batch.Delete(promiseKey(candidate.id.promiseHash), pebbledb.NoSync); err != nil {
+			return 0, 0, fmt.Errorf("deleting payment promise: %w", err)
+		}
+		pruned++
+		prunedBytes += candidate.size
+	}
+
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
-		return 0, 0, fmt.Errorf("committing batch: %w", err)
+		return 0, 0, errors.Join(deleteErr, fmt.Errorf("committing batch: %w", err))
+	}
+	if deleteErr != nil {
+		return pruned, prunedBytes, deleteErr
 	}
 	if corruptMarkers > 1 {
 		integrityErr = fmt.Errorf("%w (%d corrupt shard markers)", integrityErr, corruptMarkers)
 	}
 	return pruned, prunedBytes, integrityErr
+}
+
+type pruneCandidate struct {
+	markedShard
+	key  []byte
+	size int64
 }
 
 // reconcile drops everything under <store>/staging/. Anything there at open

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -35,6 +35,13 @@ var ErrStoreIntegrity = errors.New("store integrity error")
 
 // StoreConfig contains configuration options for the [Store].
 type StoreConfig struct {
+	// StorageBackend selects the backend for new shards: local or object.
+	StorageBackend string `toml:"storage_backend"`
+	// ObjectStorage must remain configured until all object shards are pruned.
+	ObjectStorage ObjectStorageConfig `toml:"object_storage"`
+	// ChainID and ValidatorAddress are derived by the server at startup.
+	ChainID          string `toml:"-"`
+	ValidatorAddress string `toml:"-"`
 	// Path is the path to the store directory.
 	Path string `toml:"-"`
 	// Log defaults to [slog.Default] when nil.
@@ -43,12 +50,24 @@ type StoreConfig struct {
 
 // DefaultStoreConfig returns a [StoreConfig] with default values.
 func DefaultStoreConfig() StoreConfig {
-	return StoreConfig{}
+	return StoreConfig{StorageBackend: "local"}
 }
 
 // Validate checks that the StoreConfig is valid and fills in defaults for
 // unset fields.
 func (cfg *StoreConfig) Validate() error {
+	if cfg.StorageBackend == "" {
+		cfg.StorageBackend = "local"
+	}
+	switch cfg.StorageBackend {
+	case "local":
+	case "object":
+		if err := cfg.ObjectStorage.Validate(); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("storage_backend must be local or object")
+	}
 	if cfg.Path == "" {
 		return fmt.Errorf("store path is required")
 	}
@@ -76,6 +95,7 @@ const memStorePath = "/store"
 // when the Store is garbage collected.
 func NewMemoryStore(cfg StoreConfig) *Store {
 	cfg.Path = memStorePath
+	cfg.StorageBackend = "local"
 	s, err := openStore(cfg, vfs.NewMem())
 	if err != nil {
 		panic(fmt.Sprintf("opening in-memory store: %v", err))
@@ -83,9 +103,8 @@ func NewMemoryStore(cfg StoreConfig) *Store {
 	return s
 }
 
-// NewStore opens a [Store] backed by an on-disk pebble database and flat
-// shard files at cfg.Path. On open, [Store.reconcile] drops leftover staging
-// files from a previous crash.
+// NewStore opens Pebble and the configured shard backends at cfg.Path.
+// It removes leftover staging files from a previous crash.
 func NewStore(cfg StoreConfig) (*Store, error) {
 	return openStore(cfg, vfs.Default)
 }
@@ -113,6 +132,10 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 	}
 
 	s := &Store{db: db, log: cfg.Log, shards: newRoutedStorage(local, nil)}
+	if err := s.openObjectStorage(cfg); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("opening object shard storage: %w", err)
+	}
 	if err := s.reconcile(); err != nil {
 		_ = s.db.Close()
 		return nil, fmt.Errorf("reconciling store: %w", err)

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -93,7 +93,7 @@ const memStorePath = "/store"
 func NewMemoryStore(cfg StoreConfig) *Store {
 	cfg.Path = memStorePath
 	cfg.StorageBackend = "local"
-	s, err := openStore(cfg, vfs.NewMem())
+	s, err := openStore(context.Background(), cfg, vfs.NewMem())
 	if err != nil {
 		panic(fmt.Sprintf("opening in-memory store: %v", err))
 	}
@@ -102,11 +102,14 @@ func NewMemoryStore(cfg StoreConfig) *Store {
 
 // NewStore opens Pebble and the configured shard backends at cfg.Path.
 // It removes leftover staging files from a previous crash.
-func NewStore(cfg StoreConfig) (*Store, error) {
-	return openStore(cfg, vfs.Default)
+func NewStore(ctx context.Context, cfg StoreConfig) (*Store, error) {
+	return openStore(ctx, cfg, vfs.Default)
 }
 
-func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
+func openStore(ctx context.Context, cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("validating store config: %w", err)
 	}
@@ -129,7 +132,7 @@ func openStore(cfg StoreConfig, filesystem vfs.FS) (*Store, error) {
 	}
 
 	s := &Store{db: db, log: cfg.Log}
-	object, err := s.openObjectStorage(cfg)
+	object, err := s.openObjectStorage(ctx, cfg)
 	if err != nil {
 		_ = s.Close()
 		return nil, fmt.Errorf("opening object shard storage: %w", err)

--- a/fibre/store_bench_test.go
+++ b/fibre/store_bench_test.go
@@ -75,7 +75,7 @@ func benchmarkPruneBefore(b *testing.B, totalEntries, prunePercent int) {
 func makeBenchStore(b *testing.B) *fibre.Store {
 	cfg := fibre.DefaultStoreConfig()
 	cfg.Path = b.TempDir()
-	store, err := fibre.NewStore(cfg)
+	store, err := fibre.NewStore(b.Context(), cfg)
 	if err != nil {
 		b.Fatalf("failed to create store: %v", err)
 	}

--- a/fibre/store_config.go
+++ b/fibre/store_config.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -18,61 +19,70 @@ type ObjectStorageConfig struct {
 	Region   string `toml:"region" comment:"Use auto for Cloudflare R2."`
 	Bucket   string `toml:"bucket"`
 	Prefix   string `toml:"prefix"`
+	// ChainID and ValidatorAddress are derived by the server at startup.
+	ChainID          string `toml:"-"`
+	ValidatorAddress string `toml:"-"`
 }
 
-// Validate checks the settings required to access object storage.
-func (cfg ObjectStorageConfig) Validate() error {
+// Validate removes surrounding whitespace and checks the settings required to access object storage.
+func (cfg *ObjectStorageConfig) Validate() error {
+	cfg.Region = strings.TrimSpace(cfg.Region)
+	cfg.Bucket = strings.TrimSpace(cfg.Bucket)
+	cfg.Prefix = strings.TrimSpace(cfg.Prefix)
 	u, err := url.Parse(cfg.Endpoint)
 	if err != nil || u.Hostname() == "" || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
 		return fmt.Errorf("object_storage.endpoint must be an absolute HTTP or HTTPS URL without credentials, query, or fragment")
 	}
-	if strings.TrimSpace(cfg.Region) == "" {
+	if cfg.Region == "" {
 		return fmt.Errorf("object_storage.region is required")
 	}
-	if strings.TrimSpace(cfg.Bucket) == "" {
+	if cfg.Bucket == "" {
 		return fmt.Errorf("object_storage.bucket is required")
 	}
-	if strings.Trim(strings.TrimSpace(cfg.Prefix), "/") == "" {
+	if strings.Trim(cfg.Prefix, "/") == "" {
 		return fmt.Errorf("object_storage.prefix is required")
 	}
 	return nil
 }
 
-func (s *Store) openObjectStorage(cfg StoreConfig) error {
+// openObjectStorage opens the backend for object mode or existing object markers.
+// Local mode still needs it to read and prune shards written before a mode change.
+func (s *Store) openObjectStorage(cfg StoreConfig) (shardBackend, error) {
 	needsObject := cfg.StorageBackend == "object"
 	if !needsObject {
 		var err error
 		needsObject, err = s.hasObjectMarkers()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 	if !needsObject {
-		return nil
+		return nil, nil
 	}
 	if err := cfg.ObjectStorage.Validate(); err != nil {
-		return err
+		return nil, err
 	}
-	if cfg.ChainID == "" || cfg.ValidatorAddress == "" {
-		return fmt.Errorf("chain ID and validator address are required for object storage")
+	if cfg.ObjectStorage.ChainID == "" || cfg.ObjectStorage.ValidatorAddress == "" {
+		return nil, fmt.Errorf("chain ID and validator address are required for object storage")
 	}
 
-	awsConfig, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(cfg.ObjectStorage.Region))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.ObjectStorage.Region))
 	if err != nil {
-		return fmt.Errorf("loading AWS configuration: %w", err)
+		return nil, fmt.Errorf("loading AWS configuration: %w", err)
+	}
+	// The SDK resolves credentials lazily; fail startup if none can be retrieved.
+	if _, err := awsConfig.Credentials.Retrieve(ctx); err != nil {
+		return nil, fmt.Errorf("loading object storage credentials: %w", err)
 	}
 	client := s3.NewFromConfig(awsConfig, func(options *s3.Options) {
 		options.BaseEndpoint = aws.String(cfg.ObjectStorage.Endpoint)
 	})
-	object := newObjectBackend(client, cfg.ObjectStorage.Bucket, cfg.ObjectStorage.Prefix, cfg.ChainID, cfg.ValidatorAddress)
-	if cfg.StorageBackend == "object" {
-		s.shards = newRoutedStorage(object, s.shards.primary)
-	} else {
-		s.shards.secondary = object
-	}
-	return nil
+	return newObjectBackend(client, cfg.ObjectStorage.Bucket, cfg.ObjectStorage.Prefix, cfg.ObjectStorage.ChainID, cfg.ObjectStorage.ValidatorAddress), nil
 }
 
+// hasObjectMarkers stops at the first valid object marker without reading payloads.
 func (s *Store) hasObjectMarkers() (bool, error) {
 	prefix := []byte(shardKeyPrefix)
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{

--- a/fibre/store_config.go
+++ b/fibre/store_config.go
@@ -1,0 +1,94 @@
+package fibre
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	pebbledb "github.com/cockroachdb/pebble/v2"
+)
+
+// ObjectStorageConfig configures S3-compatible storage. Credentials use the AWS SDK credential chain.
+type ObjectStorageConfig struct {
+	Endpoint string `toml:"endpoint"`
+	Region   string `toml:"region" comment:"Use auto for Cloudflare R2."`
+	Bucket   string `toml:"bucket"`
+	Prefix   string `toml:"prefix"`
+}
+
+// Validate checks the settings required to access object storage.
+func (cfg ObjectStorageConfig) Validate() error {
+	u, err := url.Parse(cfg.Endpoint)
+	if err != nil || u.Hostname() == "" || (u.Scheme != "http" && u.Scheme != "https") || u.User != nil || u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("object_storage.endpoint must be an absolute HTTP or HTTPS URL without credentials, query, or fragment")
+	}
+	if strings.TrimSpace(cfg.Region) == "" {
+		return fmt.Errorf("object_storage.region is required")
+	}
+	if strings.TrimSpace(cfg.Bucket) == "" {
+		return fmt.Errorf("object_storage.bucket is required")
+	}
+	if strings.Trim(strings.TrimSpace(cfg.Prefix), "/") == "" {
+		return fmt.Errorf("object_storage.prefix is required")
+	}
+	return nil
+}
+
+func (s *Store) openObjectStorage(cfg StoreConfig) error {
+	needsObject := cfg.StorageBackend == "object"
+	if !needsObject {
+		var err error
+		needsObject, err = s.hasObjectMarkers()
+		if err != nil {
+			return err
+		}
+	}
+	if !needsObject {
+		return nil
+	}
+	if err := cfg.ObjectStorage.Validate(); err != nil {
+		return err
+	}
+	if cfg.ChainID == "" || cfg.ValidatorAddress == "" {
+		return fmt.Errorf("chain ID and validator address are required for object storage")
+	}
+
+	awsConfig, err := config.LoadDefaultConfig(context.Background(), config.WithRegion(cfg.ObjectStorage.Region))
+	if err != nil {
+		return fmt.Errorf("loading AWS configuration: %w", err)
+	}
+	client := s3.NewFromConfig(awsConfig, func(options *s3.Options) {
+		options.BaseEndpoint = aws.String(cfg.ObjectStorage.Endpoint)
+	})
+	object := newObjectBackend(client, cfg.ObjectStorage.Bucket, cfg.ObjectStorage.Prefix, cfg.ChainID, cfg.ValidatorAddress)
+	if cfg.StorageBackend == "object" {
+		s.shards = newRoutedStorage(object, s.shards.primary)
+	} else {
+		s.shards.secondary = object
+	}
+	return nil
+}
+
+func (s *Store) hasObjectMarkers() (bool, error) {
+	prefix := []byte(shardKeyPrefix)
+	iter, err := s.db.NewIter(&pebbledb.IterOptions{
+		LowerBound: prefix,
+		UpperBound: prefixUpperBound(prefix),
+	})
+	if err != nil {
+		return false, fmt.Errorf("creating shard iterator: %w", err)
+	}
+	defer iter.Close()
+
+	for valid := iter.First(); valid; valid = iter.Next() {
+		backend, _, err := decodeShardMarkerBackend(iter.Value())
+		if err == nil && backend == objectBackendTag {
+			return true, nil
+		}
+	}
+	return false, iter.Error()
+}

--- a/fibre/store_config.go
+++ b/fibre/store_config.go
@@ -48,7 +48,7 @@ func (cfg *ObjectStorageConfig) Validate() error {
 // openObjectStorage opens the backend for object mode or existing object markers.
 // Local mode still needs it to read and prune shards written before a mode change.
 func (s *Store) openObjectStorage(ctx context.Context, cfg StoreConfig) (shardBackend, error) {
-	needsObject := cfg.StorageBackend == "object"
+	needsObject := cfg.StorageBackend == storageBackendObject
 	if !needsObject {
 		var err error
 		needsObject, err = s.hasObjectMarkers(ctx)

--- a/fibre/store_config.go
+++ b/fibre/store_config.go
@@ -47,11 +47,11 @@ func (cfg *ObjectStorageConfig) Validate() error {
 
 // openObjectStorage opens the backend for object mode or existing object markers.
 // Local mode still needs it to read and prune shards written before a mode change.
-func (s *Store) openObjectStorage(cfg StoreConfig) (shardBackend, error) {
+func (s *Store) openObjectStorage(ctx context.Context, cfg StoreConfig) (shardBackend, error) {
 	needsObject := cfg.StorageBackend == "object"
 	if !needsObject {
 		var err error
-		needsObject, err = s.hasObjectMarkers()
+		needsObject, err = s.hasObjectMarkers(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -66,7 +66,7 @@ func (s *Store) openObjectStorage(cfg StoreConfig) (shardBackend, error) {
 		return nil, fmt.Errorf("chain ID and validator address are required for object storage")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 	awsConfig, err := config.LoadDefaultConfig(ctx, config.WithRegion(cfg.ObjectStorage.Region))
 	if err != nil {
@@ -83,7 +83,7 @@ func (s *Store) openObjectStorage(cfg StoreConfig) (shardBackend, error) {
 }
 
 // hasObjectMarkers stops at the first valid object marker without reading payloads.
-func (s *Store) hasObjectMarkers() (bool, error) {
+func (s *Store) hasObjectMarkers(ctx context.Context) (bool, error) {
 	prefix := []byte(shardKeyPrefix)
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
 		LowerBound: prefix,
@@ -95,6 +95,9 @@ func (s *Store) hasObjectMarkers() (bool, error) {
 	defer iter.Close()
 
 	for valid := iter.First(); valid; valid = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return false, err
+		}
 		backend, _, err := decodeShardMarkerBackend(iter.Value())
 		if err == nil && backend == objectBackendTag {
 			return true, nil

--- a/fibre/store_config_test.go
+++ b/fibre/store_config_test.go
@@ -3,6 +3,7 @@ package fibre
 import (
 	"context"
 	"encoding/hex"
+	"encoding/xml"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -176,8 +177,19 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 			if r.Method == http.MethodGet {
 				_, _ = w.Write(data)
 			}
-		case http.MethodDelete:
-			delete(objects, r.URL.Path)
+		case http.MethodPost:
+			assert.True(t, r.URL.Query().Has("delete"))
+			var request struct {
+				Keys []string `xml:"Object>Key"`
+			}
+			if err := xml.NewDecoder(r.Body).Decode(&request); !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			for _, key := range request.Keys {
+				delete(objects, r.URL.Path+"/"+key)
+			}
+			_, _ = w.Write([]byte("<DeleteResult/>"))
 		default:
 			t.Errorf("unexpected method %s", r.Method)
 			w.WriteHeader(http.StatusBadRequest)

--- a/fibre/store_config_test.go
+++ b/fibre/store_config_test.go
@@ -55,6 +55,46 @@ func TestObjectStorageConfigValidate(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 }
 
+func TestObjectStorageConfigNormalisesWhitespace(t *testing.T) {
+	cfg := testObjectStorageConfig()
+	want := cfg
+	cfg.Region = " \tauto\n"
+	cfg.Bucket = " fibre-shards "
+	cfg.Prefix = " fibre "
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, want, cfg)
+}
+
+func TestStoreRejectsMissingObjectCredentials(t *testing.T) {
+	for _, name := range []string{
+		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE", "AWS_DEFAULT_PROFILE",
+		"AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+	} {
+		t.Setenv(name, "")
+	}
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "missing"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "missing"))
+	cfg := DefaultStoreConfig()
+	cfg.Path = t.TempDir()
+	store, err := NewStore(cfg)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{1}), encodeShardMarkerForBackend(objectBackendTag, 1), pebbledb.Sync))
+	require.NoError(t, store.Close())
+	cfg.ObjectStorage = testObjectStorageConfig()
+	cfg.ObjectStorage.ChainID, cfg.ObjectStorage.ValidatorAddress = "test-chain", "test-validator"
+	for _, mode := range []string{"local", "object"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg.StorageBackend = mode
+			store, err := NewStore(cfg)
+			if store != nil {
+				require.NoError(t, store.Close())
+			}
+			require.ErrorContains(t, err, "credentials")
+		})
+	}
+}
+
 func TestStoreConfigValidateBackend(t *testing.T) {
 	cfg := StoreConfig{Path: t.TempDir()}
 	require.NoError(t, cfg.Validate())
@@ -67,11 +107,13 @@ func TestStoreConfigValidateBackend(t *testing.T) {
 	require.NoError(t, cfg.Validate())
 	_, err := NewStore(cfg)
 	require.ErrorContains(t, err, "chain ID and validator address")
-	cfg.ChainID = "test-chain"
+	cfg.ObjectStorage.ChainID = "test-chain"
 	_, err = NewStore(cfg)
 	require.ErrorContains(t, err, "chain ID and validator address")
 }
 
+// TestStoreConfiguredBackendSwitch checks reads and pruning across local-to-object-to-local restarts.
+// It also checks SDK signing, object keys, and the required configuration for retained object markers.
 func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	t.Setenv("AWS_ACCESS_KEY_ID", "test-key")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
@@ -113,12 +155,15 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	cfg.Path = t.TempDir()
 	cfg.ObjectStorage = testObjectStorageConfig()
 	cfg.ObjectStorage.Endpoint = server.URL
-	cfg.ChainID = "test-chain"
-	cfg.ValidatorAddress = "test-validator"
+	cfg.ObjectStorage.Region = " auto "
+	cfg.ObjectStorage.Bucket = " fibre-shards "
+	cfg.ObjectStorage.Prefix = " fibre "
+	cfg.ObjectStorage.ChainID = "test-chain"
+	cfg.ObjectStorage.ValidatorAddress = "test-validator"
 	shard := &types.BlobShard{Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}}}
 	pruneAt := time.Unix(60, 0)
 	promise := &PaymentPromise{
-		ChainID: cfg.ChainID, SignerKey: secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey),
+		ChainID: cfg.ObjectStorage.ChainID, SignerKey: secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey),
 		Commitment: generateCommitment(), CreationTimestamp: pruneAt, Signature: []byte{1},
 	}
 	localCommitment := promise.Commitment
@@ -170,6 +215,8 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	require.NoError(t, store.Close())
 }
 
+// TestStoreLocalDoesNotLoadAWSConfig checks that local stores without object markers ignore an invalid AWS profile.
+// Object mode must load the profile and report its error.
 func TestStoreLocalDoesNotLoadAWSConfig(t *testing.T) {
 	t.Setenv("AWS_PROFILE", "missing-profile")
 	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "missing"))
@@ -188,7 +235,7 @@ func TestStoreLocalDoesNotLoadAWSConfig(t *testing.T) {
 	require.NoError(t, store.Close())
 	cfg.StorageBackend = "object"
 	cfg.ObjectStorage = testObjectStorageConfig()
-	cfg.ChainID, cfg.ValidatorAddress = "test-chain", "test-validator"
+	cfg.ObjectStorage.ChainID, cfg.ObjectStorage.ValidatorAddress = "test-chain", "test-validator"
 	_, err = NewStore(cfg)
 	require.ErrorContains(t, err, "loading AWS configuration")
 }

--- a/fibre/store_config_test.go
+++ b/fibre/store_config_test.go
@@ -1,6 +1,7 @@
 package fibre
 
 import (
+	"context"
 	"encoding/hex"
 	"io"
 	"net/http"
@@ -66,6 +67,29 @@ func TestObjectStorageConfigNormalisesWhitespace(t *testing.T) {
 }
 
 func TestStoreRejectsMissingObjectCredentials(t *testing.T) {
+	clearAWSCredentials(t)
+	cfg := DefaultStoreConfig()
+	cfg.Path = t.TempDir()
+	store, err := NewStore(t.Context(), cfg)
+	require.NoError(t, err)
+	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{1}), encodeShardMarkerForBackend(objectBackendTag, 1), pebbledb.Sync))
+	require.NoError(t, store.Close())
+	cfg.ObjectStorage = testObjectStorageConfig()
+	cfg.ObjectStorage.ChainID, cfg.ObjectStorage.ValidatorAddress = "test-chain", "test-validator"
+	for _, mode := range []string{"local", "object"} {
+		t.Run(mode, func(t *testing.T) {
+			cfg.StorageBackend = mode
+			store, err := NewStore(t.Context(), cfg)
+			if store != nil {
+				require.NoError(t, store.Close())
+			}
+			require.ErrorContains(t, err, "credentials")
+		})
+	}
+}
+
+func clearAWSCredentials(t *testing.T) {
+	t.Helper()
 	for _, name := range []string{
 		"AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_ACCESS_KEY", "AWS_SECRET_KEY", "AWS_SESSION_TOKEN", "AWS_PROFILE", "AWS_DEFAULT_PROFILE",
 		"AWS_WEB_IDENTITY_TOKEN_FILE", "AWS_ROLE_ARN", "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "AWS_CONTAINER_CREDENTIALS_FULL_URI",
@@ -75,24 +99,33 @@ func TestStoreRejectsMissingObjectCredentials(t *testing.T) {
 	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
 	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "missing"))
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "missing"))
+}
+
+// TestStoreCancelsCredentialLookup cancels startup while the credential provider is still waiting.
+func TestStoreCancelsCredentialLookup(t *testing.T) {
+	clearAWSCredentials(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	release := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		cancel()
+		<-release
+		_, _ = io.WriteString(w, `{"AccessKeyId":"test-key","SecretAccessKey":"test-secret","Token":"test-token","Expiration":"2100-01-01T00:00:00Z"}`)
+	}))
+	defer server.Close()
+	defer close(release)
+	t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", server.URL)
 	cfg := DefaultStoreConfig()
 	cfg.Path = t.TempDir()
-	store, err := NewStore(cfg)
-	require.NoError(t, err)
-	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{1}), encodeShardMarkerForBackend(objectBackendTag, 1), pebbledb.Sync))
-	require.NoError(t, store.Close())
+	cfg.StorageBackend = "object"
 	cfg.ObjectStorage = testObjectStorageConfig()
 	cfg.ObjectStorage.ChainID, cfg.ObjectStorage.ValidatorAddress = "test-chain", "test-validator"
-	for _, mode := range []string{"local", "object"} {
-		t.Run(mode, func(t *testing.T) {
-			cfg.StorageBackend = mode
-			store, err := NewStore(cfg)
-			if store != nil {
-				require.NoError(t, store.Close())
-			}
-			require.ErrorContains(t, err, "credentials")
-		})
+	store, err := NewStore(ctx, cfg)
+	if store != nil {
+		require.NoError(t, store.Close())
 	}
+	require.ErrorIs(t, ctx.Err(), context.Canceled)
+	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestStoreConfigValidateBackend(t *testing.T) {
@@ -105,10 +138,10 @@ func TestStoreConfigValidateBackend(t *testing.T) {
 	require.ErrorContains(t, cfg.Validate(), "object_storage.endpoint")
 	cfg.ObjectStorage = testObjectStorageConfig()
 	require.NoError(t, cfg.Validate())
-	_, err := NewStore(cfg)
+	_, err := NewStore(t.Context(), cfg)
 	require.ErrorContains(t, err, "chain ID and validator address")
 	cfg.ObjectStorage.ChainID = "test-chain"
-	_, err = NewStore(cfg)
+	_, err = NewStore(t.Context(), cfg)
 	require.ErrorContains(t, err, "chain ID and validator address")
 }
 
@@ -167,13 +200,13 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 		Commitment: generateCommitment(), CreationTimestamp: pruneAt, Signature: []byte{1},
 	}
 	localCommitment := promise.Commitment
-	store, err := NewStore(cfg)
+	store, err := NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.NoError(t, store.Put(t.Context(), promise, shard, pruneAt))
 	require.NoError(t, store.Close())
 
 	cfg.StorageBackend = "object"
-	store, err = NewStore(cfg)
+	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	got, err := store.Get(t.Context(), localCommitment)
 	require.NoError(t, err)
@@ -190,10 +223,10 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	cfg.StorageBackend = "local"
 	retainedConfig := cfg.ObjectStorage
 	cfg.ObjectStorage = ObjectStorageConfig{}
-	_, err = NewStore(cfg)
+	_, err = NewStore(t.Context(), cfg)
 	require.ErrorContains(t, err, "object_storage.endpoint")
 	cfg.ObjectStorage = retainedConfig
-	store, err = NewStore(cfg)
+	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.Equal(t, localBackendTag, store.shards.primary.backendTag())
 	got, err = store.Get(t.Context(), promise.Commitment)
@@ -209,7 +242,7 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	require.NoError(t, store.Close())
 
 	cfg.ObjectStorage = ObjectStorageConfig{}
-	store, err = NewStore(cfg)
+	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.Nil(t, store.shards.secondary)
 	require.NoError(t, store.Close())
@@ -223,19 +256,19 @@ func TestStoreLocalDoesNotLoadAWSConfig(t *testing.T) {
 	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "missing"))
 	cfg := DefaultStoreConfig()
 	cfg.Path = t.TempDir()
-	store, err := NewStore(cfg)
+	store, err := NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.Nil(t, store.shards.secondary)
 	// Legacy and invalid markers do not identify an object backend.
 	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{1}), nil, pebbledb.Sync))
 	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{2}), []byte{1}, pebbledb.Sync))
 	require.NoError(t, store.Close())
-	store, err = NewStore(cfg)
+	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.NoError(t, store.Close())
 	cfg.StorageBackend = "object"
 	cfg.ObjectStorage = testObjectStorageConfig()
 	cfg.ObjectStorage.ChainID, cfg.ObjectStorage.ValidatorAddress = "test-chain", "test-validator"
-	_, err = NewStore(cfg)
+	_, err = NewStore(t.Context(), cfg)
 	require.ErrorContains(t, err, "loading AWS configuration")
 }

--- a/fibre/store_config_test.go
+++ b/fibre/store_config_test.go
@@ -1,0 +1,194 @@
+package fibre
+
+import (
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	pebbledb "github.com/cockroachdb/pebble/v2"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testObjectStorageConfig() ObjectStorageConfig {
+	return ObjectStorageConfig{
+		Endpoint: "https://account.r2.cloudflarestorage.com",
+		Region:   "auto",
+		Bucket:   "fibre-shards",
+		Prefix:   "fibre",
+	}
+}
+
+func TestObjectStorageConfigValidate(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		modify func(*ObjectStorageConfig)
+	}{
+		{"endpoint missing", func(c *ObjectStorageConfig) { c.Endpoint = "" }},
+		{"endpoint relative", func(c *ObjectStorageConfig) { c.Endpoint = "/r2" }},
+		{"endpoint scheme", func(c *ObjectStorageConfig) { c.Endpoint = "ftp://r2.example" }},
+		{"endpoint malformed", func(c *ObjectStorageConfig) { c.Endpoint = "https://%" }},
+		{"endpoint credentials", func(c *ObjectStorageConfig) { c.Endpoint = "https://user:secret@r2.example" }},
+		{"endpoint query", func(c *ObjectStorageConfig) { c.Endpoint += "?query=1" }},
+		{"endpoint fragment", func(c *ObjectStorageConfig) { c.Endpoint += "#fragment" }},
+		{"region", func(c *ObjectStorageConfig) { c.Region = " " }},
+		{"bucket", func(c *ObjectStorageConfig) { c.Bucket = " " }},
+		{"prefix", func(c *ObjectStorageConfig) { c.Prefix = " " }},
+		{"prefix slashes", func(c *ObjectStorageConfig) { c.Prefix = "///" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := testObjectStorageConfig()
+			tc.modify(&cfg)
+			require.Error(t, cfg.Validate())
+		})
+	}
+	cfg := testObjectStorageConfig()
+	require.NoError(t, cfg.Validate())
+	cfg.Endpoint = "http://localhost:9000"
+	require.NoError(t, cfg.Validate())
+}
+
+func TestStoreConfigValidateBackend(t *testing.T) {
+	cfg := StoreConfig{Path: t.TempDir()}
+	require.NoError(t, cfg.Validate())
+	require.Equal(t, "local", cfg.StorageBackend)
+	cfg.StorageBackend = "unknown"
+	require.ErrorContains(t, cfg.Validate(), "storage_backend")
+	cfg.StorageBackend = "object"
+	require.ErrorContains(t, cfg.Validate(), "object_storage.endpoint")
+	cfg.ObjectStorage = testObjectStorageConfig()
+	require.NoError(t, cfg.Validate())
+	_, err := NewStore(cfg)
+	require.ErrorContains(t, err, "chain ID and validator address")
+	cfg.ChainID = "test-chain"
+	_, err = NewStore(cfg)
+	require.ErrorContains(t, err, "chain ID and validator address")
+}
+
+func TestStoreConfiguredBackendSwitch(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "test-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test-secret")
+	t.Setenv("AWS_SESSION_TOKEN", "")
+	t.Setenv("AWS_PROFILE", "")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "config"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "credentials"))
+	var mu sync.Mutex
+	objects := make(map[string][]byte)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		assert.Contains(t, r.Header.Get("Authorization"), "Credential=test-key/")
+		switch r.Method {
+		case http.MethodPut:
+			assert.Equal(t, "*", r.Header.Get("If-None-Match"))
+			data, err := io.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, int64(len(data)), r.ContentLength)
+			objects[r.URL.Path] = data
+		case http.MethodGet, http.MethodHead:
+			data, ok := objects[r.URL.Path]
+			if !ok {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if r.Method == http.MethodGet {
+				_, _ = w.Write(data)
+			}
+		case http.MethodDelete:
+			delete(objects, r.URL.Path)
+		default:
+			t.Errorf("unexpected method %s", r.Method)
+			w.WriteHeader(http.StatusBadRequest)
+		}
+	}))
+	defer server.Close()
+	cfg := DefaultStoreConfig()
+	cfg.Path = t.TempDir()
+	cfg.ObjectStorage = testObjectStorageConfig()
+	cfg.ObjectStorage.Endpoint = server.URL
+	cfg.ChainID = "test-chain"
+	cfg.ValidatorAddress = "test-validator"
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Index: 1, Data: []byte("data")}}}
+	pruneAt := time.Unix(60, 0)
+	promise := &PaymentPromise{
+		ChainID: cfg.ChainID, SignerKey: secp256k1.GenPrivKey().PubKey().(*secp256k1.PubKey),
+		Commitment: generateCommitment(), CreationTimestamp: pruneAt, Signature: []byte{1},
+	}
+	localCommitment := promise.Commitment
+	store, err := NewStore(cfg)
+	require.NoError(t, err)
+	require.NoError(t, store.Put(t.Context(), promise, shard, pruneAt))
+	require.NoError(t, store.Close())
+
+	cfg.StorageBackend = "object"
+	store, err = NewStore(cfg)
+	require.NoError(t, err)
+	got, err := store.Get(t.Context(), localCommitment)
+	require.NoError(t, err)
+	require.Equal(t, shard, got)
+	promise.Commitment[0]++
+	require.NoError(t, store.Put(t.Context(), promise, shard, pruneAt))
+	promiseHash, err := promise.Hash()
+	require.NoError(t, err)
+	mu.Lock()
+	assert.Contains(t, objects, "/fibre-shards/fibre/test-chain/test-validator/shards/"+promise.Commitment.String()+"-"+hex.EncodeToString(promiseHash))
+	mu.Unlock()
+	require.NoError(t, store.Close())
+
+	cfg.StorageBackend = "local"
+	retainedConfig := cfg.ObjectStorage
+	cfg.ObjectStorage = ObjectStorageConfig{}
+	_, err = NewStore(cfg)
+	require.ErrorContains(t, err, "object_storage.endpoint")
+	cfg.ObjectStorage = retainedConfig
+	store, err = NewStore(cfg)
+	require.NoError(t, err)
+	require.Equal(t, localBackendTag, store.shards.primary.backendTag())
+	got, err = store.Get(t.Context(), promise.Commitment)
+	require.NoError(t, err)
+	require.Equal(t, shard, got)
+	has, err := store.Has(t.Context(), promise.Commitment, promiseHash)
+	require.NoError(t, err)
+	require.True(t, has)
+	pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Minute))
+	require.NoError(t, err)
+	require.Equal(t, 2, pruned)
+	require.Equal(t, 2*shardBinarySize(shard), freed)
+	require.NoError(t, store.Close())
+
+	cfg.ObjectStorage = ObjectStorageConfig{}
+	store, err = NewStore(cfg)
+	require.NoError(t, err)
+	require.Nil(t, store.shards.secondary)
+	require.NoError(t, store.Close())
+}
+
+func TestStoreLocalDoesNotLoadAWSConfig(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "missing-profile")
+	t.Setenv("AWS_CONFIG_FILE", filepath.Join(t.TempDir(), "missing"))
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.Join(t.TempDir(), "missing"))
+	cfg := DefaultStoreConfig()
+	cfg.Path = t.TempDir()
+	store, err := NewStore(cfg)
+	require.NoError(t, err)
+	require.Nil(t, store.shards.secondary)
+	// Legacy and invalid markers do not identify an object backend.
+	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{1}), nil, pebbledb.Sync))
+	require.NoError(t, store.db.Set(shardKey(Commitment{}, []byte{2}), []byte{1}, pebbledb.Sync))
+	require.NoError(t, store.Close())
+	store, err = NewStore(cfg)
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+	cfg.StorageBackend = "object"
+	cfg.ObjectStorage = testObjectStorageConfig()
+	cfg.ChainID, cfg.ValidatorAddress = "test-chain", "test-validator"
+	_, err = NewStore(cfg)
+	require.ErrorContains(t, err, "loading AWS configuration")
+}

--- a/fibre/store_marker.go
+++ b/fibre/store_marker.go
@@ -16,6 +16,9 @@ type shardBackendTag byte
 const (
 	localBackendTag  shardBackendTag = 0x01
 	objectBackendTag shardBackendTag = 0x02
+
+	storageBackendLocal  = "local"
+	storageBackendObject = "object"
 )
 
 // encodeShardMarkerForBackend encodes a backend and shard size in a versioned marker.

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -83,6 +83,7 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 		IfNoneMatch:   aws.String("*"),
 	}, func(options *s3.Options) {
 		options.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		// The pipe cannot rewind for SigV4 payload hashing; sign the request with UNSIGNED-PAYLOAD instead.
 		options.APIOptions = append(options.APIOptions, v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware)
 	})
 	_ = reader.CloseWithError(putErr)

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/signer/v4"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
@@ -82,6 +83,7 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 		IfNoneMatch:   aws.String("*"),
 	}, func(options *s3.Options) {
 		options.RequestChecksumCalculation = aws.RequestChecksumCalculationWhenRequired
+		options.APIOptions = append(options.APIOptions, v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware)
 	})
 	_ = reader.CloseWithError(putErr)
 	writeErr := <-writeDone

--- a/fibre/store_prune_object_test.go
+++ b/fibre/store_prune_object_test.go
@@ -1,0 +1,158 @@
+package fibre
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	pebbledb "github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestPruneObjectPartialFailureRecovery(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	fail := true
+	var batches []int
+	client := &s3ObjectClientStub{
+		deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+			return nil, errors.New("expected batch deletion")
+		},
+		deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+			batches = append(batches, len(input.Delete.Objects))
+			if fail {
+				return &s3.DeleteObjectsOutput{Errors: []s3types.Error{
+					{Key: input.Delete.Objects[0].Key, Code: aws.String("AccessDenied")},
+					{Key: input.Delete.Objects[1].Key, Code: aws.String("NoSuchKey")},
+				}}, nil
+			}
+			return &s3.DeleteObjectsOutput{}, nil
+		},
+	}
+	store.shards.secondary = newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	for _, hash := range []byte{1, 2, 3} {
+		setPruneEntry(t, store, pruneAt, commitment, []byte{hash}, encodeShardMarkerForBackend(objectBackendTag, 7))
+	}
+	localHash := []byte{4}
+	localSize := writeMarkerTestShard(t, store, commitment, localHash)
+	setPruneEntry(t, store, pruneAt, commitment, localHash, encodeShardMarkerForBackend(localBackendTag, localSize))
+	occ := newOccupancy(0)
+	occ.seed(21 + localSize)
+	provider := sdkmetric.NewMeterProvider()
+	metrics, err := newServerMetrics(provider.Meter("prune-test"), occ)
+	require.NoError(t, err)
+	server := &Server{store: store, occ: occ, metrics: metrics, log: slog.Default()}
+	server.prune(t.Context())
+	require.Equal(t, int64(7), occ.usage())
+	for _, hash := range []byte{1, 2, 3, 4} {
+		requirePruneEntry(t, store, pruneAt, commitment, []byte{hash}, hash == 1)
+	}
+	has, err := storeLocalBackend(t, store).Has(t.Context(), commitment, localHash)
+	require.NoError(t, err)
+	require.False(t, has)
+	fail = false
+	server.prune(t.Context())
+	server.prune(t.Context())
+	require.Zero(t, occ.usage())
+	require.Equal(t, []int{3, 1}, batches)
+	requirePruneEntry(t, store, pruneAt, commitment, []byte{1}, false)
+}
+
+func TestPruneObjectRequestFailure(t *testing.T) {
+	for _, cancelled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "request", true: "cancelled"}[cancelled], func(t *testing.T) {
+			store := newMarkerTestStore(t)
+			commitment := generateCommitment()
+			pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+			requestErr := errors.New("request failed")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			client := &s3ObjectClientStub{
+				deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+					return nil, errors.New("expected batch deletion")
+				},
+				deleteObjects: func(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+					if cancelled {
+						cancel()
+						return nil, ctx.Err()
+					}
+					return nil, requestErr
+				},
+			}
+			store.shards = newRoutedStorage(newObjectBackend(client, "bucket", "prefix", "chain", "validator"), store.shards.primary)
+			localHash := []byte{2}
+			size := writeMarkerTestShard(t, store, commitment, localHash)
+			setPruneEntry(t, store, pruneAt, commitment, localHash, nil)
+			setPruneEntry(t, store, pruneAt, commitment, []byte{1}, encodeShardMarkerForBackend(objectBackendTag, 7))
+			pruned, freed, err := store.PruneBefore(ctx, pruneAt.Add(time.Hour))
+			if cancelled {
+				require.ErrorIs(t, err, context.Canceled)
+			} else {
+				require.ErrorIs(t, err, requestErr)
+			}
+			require.Equal(t, 1, pruned)
+			require.Equal(t, size, freed)
+			requirePruneEntry(t, store, pruneAt, commitment, localHash, false)
+			requirePruneEntry(t, store, pruneAt, commitment, []byte{1}, true)
+		})
+	}
+}
+
+func TestPruneObjectBatchLimit(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	var batches []int
+	client := &s3ObjectClientStub{
+		deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+			return nil, errors.New("expected batch deletion")
+		},
+		deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+			batches = append(batches, len(input.Delete.Objects))
+			return &s3.DeleteObjectsOutput{}, nil
+		},
+	}
+	store.shards.secondary = newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	for i := range maxObjectDeleteBatchSize + 1 {
+		hash := binary.BigEndian.AppendUint64(nil, uint64(i))
+		setPruneEntry(t, store, pruneAt, commitment, hash, encodeShardMarkerForBackend(objectBackendTag, 1))
+	}
+	setPruneEntry(t, store, pruneAt.Add(time.Hour), commitment, []byte{255}, encodeShardMarkerForBackend(objectBackendTag, 1))
+	for _, want := range []int{maxObjectDeleteBatchSize, 1, 0} {
+		pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+		require.NoError(t, err)
+		require.Equal(t, want, pruned)
+		require.Equal(t, int64(want), freed)
+	}
+	require.Equal(t, []int{maxObjectDeleteBatchSize, 1}, batches)
+	requirePruneEntry(t, store, pruneAt.Add(time.Hour), commitment, []byte{255}, true)
+}
+
+func setPruneEntry(t *testing.T, store *Store, pruneAt time.Time, commitment Commitment, hash, marker []byte) {
+	t.Helper()
+	require.NoError(t, store.db.Set(shardKey(commitment, hash), marker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, hash), nil, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(promiseKey(hash), []byte("promise"), pebbledb.NoSync))
+}
+
+func requirePruneEntry(t *testing.T, store *Store, pruneAt time.Time, commitment Commitment, hash []byte, present bool) {
+	t.Helper()
+	for _, key := range [][]byte{shardKey(commitment, hash), pruneKey(pruneAt, commitment, hash), promiseKey(hash)} {
+		_, closer, err := store.db.Get(key)
+		if present {
+			require.NoError(t, err)
+			require.NoError(t, closer.Close())
+		} else {
+			require.ErrorIs(t, err, pebbledb.ErrNotFound)
+			require.Nil(t, closer)
+		}
+	}
+}

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -2,7 +2,9 @@ package fibre
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 )
@@ -60,6 +62,71 @@ func (s *routedStorage) Delete(ctx context.Context, marker []byte, commitment Co
 		return err
 	}
 	return backend.Delete(ctx, commitment, promiseHash)
+}
+
+type markedShard struct {
+	id     shardID
+	marker []byte
+}
+
+// DeleteBatch deletes payloads by marker and returns their successful input positions.
+// Local deletes stop on failure. Object requests contain at most 1,000 keys; per-key failures remain for retry.
+func (s *routedStorage) DeleteBatch(ctx context.Context, shards []markedShard) ([]int, error) {
+	var local, objects []int
+	var object *objectBackend
+	for i, shard := range shards {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		backend, err := s.backendForMarker(shard.marker)
+		if err != nil {
+			return nil, err
+		}
+		if backend.backendTag() == objectBackendTag {
+			var ok bool
+			object, ok = backend.(*objectBackend)
+			if !ok {
+				return nil, fmt.Errorf("%w: object backend does not support batch deletion", ErrStoreIntegrity)
+			}
+			objects = append(objects, i)
+		} else {
+			local = append(local, i)
+		}
+	}
+
+	var successful []int
+	var deleteErr error
+	for _, i := range local {
+		shard := shards[i]
+		if err := s.Delete(ctx, shard.marker, shard.id.commitment, shard.id.promiseHash); err != nil {
+			deleteErr = err
+			break
+		}
+		successful = append(successful, i)
+	}
+	if len(objects) == 0 {
+		return successful, deleteErr
+	}
+	for indices := range slices.Chunk(objects, maxObjectDeleteBatchSize) {
+		ids := make([]shardID, len(indices))
+		for i, index := range indices {
+			ids[i] = shards[index].id
+		}
+		results, err := object.DeleteObjects(ctx, ids)
+		if err != nil {
+			return successful, errors.Join(deleteErr, err)
+		}
+		for i, err := range results {
+			if err != nil {
+				if deleteErr == nil {
+					deleteErr = err
+				}
+				continue
+			}
+			successful = append(successful, indices[i])
+		}
+	}
+	return successful, deleteErr
 }
 
 func (s *routedStorage) size(marker []byte, commitment Commitment, promiseHash []byte) (int64, error) {

--- a/fibre/store_shard_test.go
+++ b/fibre/store_shard_test.go
@@ -1,8 +1,15 @@
 package fibre
 
 import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"slices"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +47,92 @@ type taggedShardBackend struct {
 
 func (b *taggedShardBackend) backendTag() shardBackendTag {
 	return b.tag
+}
+
+func TestRoutedStorageDeleteBatchLocal(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	hash := []byte{1}
+	size := writeMarkerTestShard(t, store, commitment, hash)
+	shards := []markedShard{
+		{id: shardID{commitment: commitment, promiseHash: hash}, marker: encodeShardMarkerForBackend(localBackendTag, size)},
+		{id: shardID{commitment: commitment, promiseHash: []byte{2}}},
+	}
+	successful, err := store.shards.DeleteBatch(t.Context(), shards)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, successful)
+	has, err := storeLocalBackend(t, store).Has(t.Context(), commitment, hash)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestRoutedStorageChunksObjectDeletes(t *testing.T) {
+	for _, outcome := range []string{"success", "per-key failure", "request failure", "cancelled"} {
+		t.Run(outcome, func(t *testing.T) {
+			store := newMarkerTestStore(t)
+			commitment := generateCommitment()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			requestErr := errors.New("request failed")
+			var batches []int
+			object := newObjectBackend(&s3ObjectClientStub{
+				deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+					batches = append(batches, len(input.Delete.Objects))
+					if len(batches) == 1 {
+						switch outcome {
+						case "per-key failure":
+							return &s3.DeleteObjectsOutput{Errors: []s3types.Error{{
+								Key: input.Delete.Objects[0].Key, Code: aws.String("AccessDenied"),
+							}}}, nil
+						case "cancelled":
+							cancel()
+						}
+					} else if outcome == "request failure" {
+						return nil, requestErr
+					}
+					return &s3.DeleteObjectsOutput{}, nil
+				},
+			}, "bucket", "prefix", "chain", "validator")
+			store.shards.secondary = object
+			shards := make([]markedShard, maxObjectDeleteBatchSize+2)
+			localIndex := maxObjectDeleteBatchSize / 2
+			want := []int{localIndex}
+			for i := range shards {
+				hash := binary.BigEndian.AppendUint64(nil, uint64(i))
+				shards[i] = markedShard{
+					id:     shardID{commitment: commitment, promiseHash: hash},
+					marker: encodeShardMarkerForBackend(objectBackendTag, 1),
+				}
+				if i == localIndex {
+					size := writeMarkerTestShard(t, store, commitment, hash)
+					shards[i].marker = encodeShardMarkerForBackend(localBackendTag, size)
+					continue
+				}
+				want = append(want, i)
+			}
+			successful, err := store.shards.DeleteBatch(ctx, shards)
+			switch outcome {
+			case "success":
+				require.NoError(t, err)
+			case "per-key failure":
+				require.ErrorContains(t, err, "AccessDenied")
+				want = slices.Delete(want, 1, 2)
+			case "request failure":
+				require.ErrorIs(t, err, requestErr)
+				want = want[:len(want)-1]
+			case "cancelled":
+				require.ErrorIs(t, err, context.Canceled)
+				want = want[:len(want)-1]
+			}
+			require.Equal(t, want, successful)
+			if outcome == "cancelled" {
+				require.Equal(t, []int{maxObjectDeleteBatchSize}, batches)
+			} else {
+				require.Equal(t, []int{maxObjectDeleteBatchSize, 1}, batches)
+			}
+			has, err := storeLocalBackend(t, store).Has(t.Context(), commitment, shards[localIndex].id.promiseHash)
+			require.NoError(t, err)
+			require.False(t, has)
+		})
+	}
 }

--- a/fibre/store_test.go
+++ b/fibre/store_test.go
@@ -360,7 +360,7 @@ func testStoreGetDeterministicOrdering(t *testing.T, store *fibre.Store, _ strin
 func TestStoreReconcileStaging(t *testing.T) {
 	cfg := fibre.DefaultStoreConfig()
 	cfg.Path = t.TempDir()
-	store, err := fibre.NewStore(cfg)
+	store, err := fibre.NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 
 	blob := makeTestBlobV0(t, 256)
@@ -379,7 +379,7 @@ func TestStoreReconcileStaging(t *testing.T) {
 	var buf strings.Builder
 	cfg.Log = slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	store, err = fibre.NewStore(cfg)
+	store, err = fibre.NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 
@@ -610,7 +610,7 @@ func makeTestStore(t *testing.T) (*fibre.Store, string) {
 	t.Helper()
 	cfg := fibre.DefaultStoreConfig()
 	cfg.Path = t.TempDir()
-	store, err := fibre.NewStore(cfg)
+	store, err := fibre.NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	t.Cleanup(func() { store.Close() })
 	return store, cfg.Path


### PR DESCRIPTION
Closes [PROTOCO-2622](https://linear.app/celestia/issue/PROTOCO-2622)

Expose object storage through server TOML configuration, using the current storage router and AWS credential chain. Local storage remains the default. Startup fails if object markers require missing or invalid object-storage settings.

## Very small config break! 

Changed the function signature for StoreFn in the store config

-----------------

**Open question:** 

how should available capacity be reported when object storage is primary? `DiskAvailable` and the existing disk-budget warning remain unchanged.
