### PR TITLE
feat(fibre): batch object shard pruning

### DIFF
--- a/fibre/store.go
+++ b/fibre/store.go
@@ -410,12 +410,12 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 // PruneBefore deletes all shards and payment promises with pruneAt before the given time
 // and returns the number of pruned entries and the freed bytes.
 //
-// It deletes at most [maxPruneBatchSize] expired entries per call. If invalid
+// It selects at most [maxPruneBatchSize] expired entries per call. If invalid
 // markers are skipped, it commits valid deletions and returns their count and
 // freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
 // do not consume deletion capacity. Fatal errors return no uncommitted counts.
 // If a payload deletion fails, completed cleanup is committed and returned
-// with the deletion error.
+// with the deletion error. Object deletions use batches; failed keys remain for retry.
 func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{
@@ -430,13 +430,19 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 	batch := s.db.NewBatch()
 	defer batch.Close()
 	var (
+		selectedBytes  int64
+		local          []pruneCandidate
+		objects        []pruneCandidate
 		pruned         int
 		prunedBytes    int64
 		integrityErr   error
 		corruptMarkers int
 	)
 	beforeStr := formatTimestamp(before.UTC())
-	for valid := iter.First(); valid && pruned < maxPruneBatchSize; valid = iter.Next() {
+	for valid := iter.First(); valid && len(local)+len(objects) < maxPruneBatchSize; valid = iter.Next() {
+		if err := ctx.Err(); err != nil {
+			return 0, 0, err
+		}
 		key := iter.Key()
 
 		// Keys are sorted; once the timestamp reaches the cutoff we're done.
@@ -474,41 +480,87 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 			}
 			continue
 		}
-		if size > math.MaxInt64-prunedBytes {
+		if size > math.MaxInt64-selectedBytes {
 			return 0, 0, errors.New("pruned shard size overflows int64")
 		}
-
-		// Missing file is fine (orphan marker from a crashed Put).
-		if err := s.shards.Delete(ctx, markerData, commitment, promiseHash); err != nil {
-			if commitErr := batch.Commit(pebbledb.NoSync); commitErr != nil {
-				return 0, 0, errors.Join(err, fmt.Errorf("committing batch: %w", commitErr))
-			}
-			return pruned, prunedBytes, err
+		selectedBytes += size
+		candidate := pruneCandidate{
+			id:  shardID{commitment: commitment, promiseHash: promiseHash},
+			key: slices.Clone(key), marker: markerData, size: size,
 		}
-		if err := batch.Delete(key, pebbledb.NoSync); err != nil {
-			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
+		// size already validated the marker and its backend.
+		tag, _, _ := decodeShardMarkerBackend(markerData)
+		if tag == objectBackendTag {
+			objects = append(objects, candidate)
+		} else {
+			local = append(local, candidate)
 		}
-		if err := batch.Delete(shardKey(commitment, promiseHash), pebbledb.NoSync); err != nil {
-			return 0, 0, fmt.Errorf("deleting shard marker: %w", err)
-		}
-		if err := batch.Delete(promiseKey(promiseHash), pebbledb.NoSync); err != nil {
-			return 0, 0, fmt.Errorf("deleting payment promise: %w", err)
-		}
-		pruned++
-		prunedBytes += size
 	}
 
 	if err := iter.Error(); err != nil {
 		return 0, 0, fmt.Errorf("iterating prune index: %w", err)
 	}
 
+	var deleteErr error
+	var successful []pruneCandidate
+	for _, candidate := range local {
+		if err := s.shards.Delete(ctx, candidate.marker, candidate.id.commitment, candidate.id.promiseHash); err != nil {
+			deleteErr = err
+			break
+		}
+		successful = append(successful, candidate)
+	}
+	if len(objects) > 0 {
+		ids := make([]shardID, len(objects))
+		for i, candidate := range objects {
+			ids[i] = candidate.id
+		}
+		results, err := s.shards.DeleteObjects(ctx, ids)
+		if err != nil {
+			deleteErr = errors.Join(deleteErr, err)
+		} else {
+			for i, err := range results {
+				if err != nil {
+					if deleteErr == nil {
+						deleteErr = err
+					}
+					continue
+				}
+				successful = append(successful, objects[i])
+			}
+		}
+	}
+	for _, candidate := range successful {
+		if err := batch.Delete(candidate.key, pebbledb.NoSync); err != nil {
+			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
+		}
+		if err := batch.Delete(shardKey(candidate.id.commitment, candidate.id.promiseHash), pebbledb.NoSync); err != nil {
+			return 0, 0, fmt.Errorf("deleting shard marker: %w", err)
+		}
+		if err := batch.Delete(promiseKey(candidate.id.promiseHash), pebbledb.NoSync); err != nil {
+			return 0, 0, fmt.Errorf("deleting payment promise: %w", err)
+		}
+		pruned++
+		prunedBytes += candidate.size
+	}
+
 	if err := batch.Commit(pebbledb.NoSync); err != nil {
-		return 0, 0, fmt.Errorf("committing batch: %w", err)
+		return 0, 0, errors.Join(deleteErr, fmt.Errorf("committing batch: %w", err))
+	}
+	if deleteErr != nil {
+		return pruned, prunedBytes, deleteErr
 	}
 	if corruptMarkers > 1 {
 		integrityErr = fmt.Errorf("%w (%d corrupt shard markers)", integrityErr, corruptMarkers)
 	}
 	return pruned, prunedBytes, integrityErr
+}
+
+type pruneCandidate struct {
+	id     shardID
+	key    []byte
+	marker []byte
+	size   int64
 }
 
 // reconcile drops everything under <store>/staging/. Anything there at open

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -407,15 +407,8 @@ func (s *Store) GetPaymentPromise(_ context.Context, promiseHash []byte) (*Payme
 	return &promise, nil
 }
 
-// PruneBefore deletes all shards and payment promises with pruneAt before the given time
-// and returns the number of pruned entries and the freed bytes.
-//
-// It selects at most [maxPruneBatchSize] expired entries per call. If invalid
-// markers are skipped, it commits valid deletions and returns their count and
-// freed bytes with [ErrStoreIntegrity]. Invalid markers remain unchanged and
-// do not consume deletion capacity. Fatal errors return no uncommitted counts.
-// If a payload deletion fails, completed cleanup is committed and returned
-// with the deletion error. Object deletions use batches; failed keys remain for retry.
+// PruneBefore deletes up to [maxPruneBatchSize] shards and payment promises that expire before the given time.
+// It returns the committed deletion count and freed bytes, retaining failed or invalid entries for retry.
 func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, error) {
 	prefix := []byte("/prune/")
 	iter, err := s.db.NewIter(&pebbledb.IterOptions{

--- a/fibre/store.go
+++ b/fibre/store.go
@@ -431,15 +431,14 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 	defer batch.Close()
 	var (
 		selectedBytes  int64
-		local          []pruneCandidate
-		objects        []pruneCandidate
+		candidates     []pruneCandidate
 		pruned         int
 		prunedBytes    int64
 		integrityErr   error
 		corruptMarkers int
 	)
 	beforeStr := formatTimestamp(before.UTC())
-	for valid := iter.First(); valid && len(local)+len(objects) < maxPruneBatchSize; valid = iter.Next() {
+	for valid := iter.First(); valid && len(candidates) < maxPruneBatchSize; valid = iter.Next() {
 		if err := ctx.Err(); err != nil {
 			return 0, 0, err
 		}
@@ -484,53 +483,25 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 			return 0, 0, errors.New("pruned shard size overflows int64")
 		}
 		selectedBytes += size
-		candidate := pruneCandidate{
-			id:  shardID{commitment: commitment, promiseHash: promiseHash},
-			key: slices.Clone(key), marker: markerData, size: size,
-		}
-		// size already validated the marker and its backend.
-		tag, _, _ := decodeShardMarkerBackend(markerData)
-		if tag == objectBackendTag {
-			objects = append(objects, candidate)
-		} else {
-			local = append(local, candidate)
-		}
+		candidates = append(candidates, pruneCandidate{
+			markedShard: markedShard{
+				id: shardID{commitment: commitment, promiseHash: promiseHash}, marker: markerData,
+			},
+			key: slices.Clone(key), size: size,
+		})
 	}
 
 	if err := iter.Error(); err != nil {
 		return 0, 0, fmt.Errorf("iterating prune index: %w", err)
 	}
 
-	var deleteErr error
-	var successful []pruneCandidate
-	for _, candidate := range local {
-		if err := s.shards.Delete(ctx, candidate.marker, candidate.id.commitment, candidate.id.promiseHash); err != nil {
-			deleteErr = err
-			break
-		}
-		successful = append(successful, candidate)
+	shards := make([]markedShard, len(candidates))
+	for i, candidate := range candidates {
+		shards[i] = candidate.markedShard
 	}
-	if len(objects) > 0 {
-		ids := make([]shardID, len(objects))
-		for i, candidate := range objects {
-			ids[i] = candidate.id
-		}
-		results, err := s.shards.DeleteObjects(ctx, ids)
-		if err != nil {
-			deleteErr = errors.Join(deleteErr, err)
-		} else {
-			for i, err := range results {
-				if err != nil {
-					if deleteErr == nil {
-						deleteErr = err
-					}
-					continue
-				}
-				successful = append(successful, objects[i])
-			}
-		}
-	}
-	for _, candidate := range successful {
+	successful, deleteErr := s.shards.DeleteBatch(ctx, shards)
+	for _, i := range successful {
+		candidate := candidates[i]
 		if err := batch.Delete(candidate.key, pebbledb.NoSync); err != nil {
 			return 0, 0, fmt.Errorf("deleting prune index: %w", err)
 		}
@@ -557,10 +528,9 @@ func (s *Store) PruneBefore(ctx context.Context, before time.Time) (int, int64, 
 }
 
 type pruneCandidate struct {
-	id     shardID
-	key    []byte
-	marker []byte
-	size   int64
+	markedShard
+	key  []byte
+	size int64
 }
 
 // reconcile drops everything under <store>/staging/. Anything there at open

--- a/fibre/store_config_test.go
+++ b/fibre/store_config_test.go
@@ -3,6 +3,7 @@ package fibre
 import (
 	"context"
 	"encoding/hex"
+	"encoding/xml"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -176,8 +177,19 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 			if r.Method == http.MethodGet {
 				_, _ = w.Write(data)
 			}
-		case http.MethodDelete:
-			delete(objects, r.URL.Path)
+		case http.MethodPost:
+			assert.True(t, r.URL.Query().Has("delete"))
+			var request struct {
+				Keys []string `xml:"Object>Key"`
+			}
+			if err := xml.NewDecoder(r.Body).Decode(&request); !assert.NoError(t, err) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			for _, key := range request.Keys {
+				delete(objects, r.URL.Path+"/"+key)
+			}
+			_, _ = w.Write([]byte("<DeleteResult/>"))
 		default:
 			t.Errorf("unexpected method %s", r.Method)
 			w.WriteHeader(http.StatusBadRequest)

--- a/fibre/store_prune_object_test.go
+++ b/fibre/store_prune_object_test.go
@@ -1,0 +1,158 @@
+package fibre
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	pebbledb "github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+)
+
+func TestPruneObjectPartialFailureRecovery(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	fail := true
+	var batches []int
+	client := &s3ObjectClientStub{
+		deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+			return nil, errors.New("expected batch deletion")
+		},
+		deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+			batches = append(batches, len(input.Delete.Objects))
+			if fail {
+				return &s3.DeleteObjectsOutput{Errors: []s3types.Error{
+					{Key: input.Delete.Objects[0].Key, Code: aws.String("AccessDenied")},
+					{Key: input.Delete.Objects[1].Key, Code: aws.String("NoSuchKey")},
+				}}, nil
+			}
+			return &s3.DeleteObjectsOutput{}, nil
+		},
+	}
+	store.shards.secondary = newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	for _, hash := range []byte{1, 2, 3} {
+		setPruneEntry(t, store, pruneAt, commitment, []byte{hash}, encodeShardMarkerForBackend(objectBackendTag, 7))
+	}
+	localHash := []byte{4}
+	localSize := writeMarkerTestShard(t, store, commitment, localHash)
+	setPruneEntry(t, store, pruneAt, commitment, localHash, encodeShardMarkerForBackend(localBackendTag, localSize))
+	occ := newOccupancy(0)
+	occ.seed(21 + localSize)
+	provider := sdkmetric.NewMeterProvider()
+	metrics, err := newServerMetrics(provider.Meter("prune-test"), occ)
+	require.NoError(t, err)
+	server := &Server{store: store, occ: occ, metrics: metrics, log: slog.Default()}
+	server.prune(t.Context())
+	require.Equal(t, int64(7), occ.usage())
+	for _, hash := range []byte{1, 2, 3, 4} {
+		requirePruneEntry(t, store, pruneAt, commitment, []byte{hash}, hash == 1)
+	}
+	has, err := storeLocalBackend(t, store).Has(t.Context(), commitment, localHash)
+	require.NoError(t, err)
+	require.False(t, has)
+	fail = false
+	server.prune(t.Context())
+	server.prune(t.Context())
+	require.Zero(t, occ.usage())
+	require.Equal(t, []int{3, 1}, batches)
+	requirePruneEntry(t, store, pruneAt, commitment, []byte{1}, false)
+}
+
+func TestPruneObjectRequestFailure(t *testing.T) {
+	for _, cancelled := range []bool{false, true} {
+		t.Run(map[bool]string{false: "request", true: "cancelled"}[cancelled], func(t *testing.T) {
+			store := newMarkerTestStore(t)
+			commitment := generateCommitment()
+			pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+			requestErr := errors.New("request failed")
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			client := &s3ObjectClientStub{
+				deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+					return nil, errors.New("expected batch deletion")
+				},
+				deleteObjects: func(context.Context, *s3.DeleteObjectsInput, ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+					if cancelled {
+						cancel()
+						return nil, ctx.Err()
+					}
+					return nil, requestErr
+				},
+			}
+			store.shards = newRoutedStorage(newObjectBackend(client, "bucket", "prefix", "chain", "validator"), store.shards.primary)
+			localHash := []byte{2}
+			size := writeMarkerTestShard(t, store, commitment, localHash)
+			setPruneEntry(t, store, pruneAt, commitment, localHash, nil)
+			setPruneEntry(t, store, pruneAt, commitment, []byte{1}, encodeShardMarkerForBackend(objectBackendTag, 7))
+			pruned, freed, err := store.PruneBefore(ctx, pruneAt.Add(time.Hour))
+			if cancelled {
+				require.ErrorIs(t, err, context.Canceled)
+			} else {
+				require.ErrorIs(t, err, requestErr)
+			}
+			require.Equal(t, 1, pruned)
+			require.Equal(t, size, freed)
+			requirePruneEntry(t, store, pruneAt, commitment, localHash, false)
+			requirePruneEntry(t, store, pruneAt, commitment, []byte{1}, true)
+		})
+	}
+}
+
+func TestPruneObjectBatchLimit(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	pruneAt := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	var batches []int
+	client := &s3ObjectClientStub{
+		deleteObject: func(context.Context, *s3.DeleteObjectInput, ...func(*s3.Options)) (*s3.DeleteObjectOutput, error) {
+			return nil, errors.New("expected batch deletion")
+		},
+		deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+			batches = append(batches, len(input.Delete.Objects))
+			return &s3.DeleteObjectsOutput{}, nil
+		},
+	}
+	store.shards.secondary = newObjectBackend(client, "bucket", "prefix", "chain", "validator")
+	for i := range maxObjectDeleteBatchSize + 1 {
+		hash := binary.BigEndian.AppendUint64(nil, uint64(i))
+		setPruneEntry(t, store, pruneAt, commitment, hash, encodeShardMarkerForBackend(objectBackendTag, 1))
+	}
+	setPruneEntry(t, store, pruneAt.Add(time.Hour), commitment, []byte{255}, encodeShardMarkerForBackend(objectBackendTag, 1))
+	for _, want := range []int{maxObjectDeleteBatchSize, 1, 0} {
+		pruned, freed, err := store.PruneBefore(t.Context(), pruneAt.Add(time.Hour))
+		require.NoError(t, err)
+		require.Equal(t, want, pruned)
+		require.Equal(t, int64(want), freed)
+	}
+	require.Equal(t, []int{maxObjectDeleteBatchSize, 1}, batches)
+	requirePruneEntry(t, store, pruneAt.Add(time.Hour), commitment, []byte{255}, true)
+}
+
+func setPruneEntry(t *testing.T, store *Store, pruneAt time.Time, commitment Commitment, hash, marker []byte) {
+	t.Helper()
+	require.NoError(t, store.db.Set(shardKey(commitment, hash), marker, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(pruneKey(pruneAt, commitment, hash), nil, pebbledb.NoSync))
+	require.NoError(t, store.db.Set(promiseKey(hash), []byte("promise"), pebbledb.NoSync))
+}
+
+func requirePruneEntry(t *testing.T, store *Store, pruneAt time.Time, commitment Commitment, hash []byte, present bool) {
+	t.Helper()
+	for _, key := range [][]byte{shardKey(commitment, hash), pruneKey(pruneAt, commitment, hash), promiseKey(hash)} {
+		_, closer, err := store.db.Get(key)
+		if present {
+			require.NoError(t, err)
+			require.NoError(t, closer.Close())
+		} else {
+			require.ErrorIs(t, err, pebbledb.ErrNotFound)
+			require.Nil(t, closer)
+		}
+	}
+}

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -73,6 +73,7 @@ type markedShard struct {
 // Local deletes stop on failure. Object requests contain at most 1,000 keys; per-key failures remain for retry.
 func (s *routedStorage) DeleteBatch(ctx context.Context, shards []markedShard) ([]int, error) {
 	var local, objects []int
+	var object *objectBackend
 	for i, shard := range shards {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -82,6 +83,11 @@ func (s *routedStorage) DeleteBatch(ctx context.Context, shards []markedShard) (
 			return nil, err
 		}
 		if backend.backendTag() == objectBackendTag {
+			var ok bool
+			object, ok = backend.(*objectBackend)
+			if !ok {
+				return nil, fmt.Errorf("%w: object backend does not support batch deletion", ErrStoreIntegrity)
+			}
 			objects = append(objects, i)
 		} else {
 			local = append(local, i)
@@ -100,14 +106,6 @@ func (s *routedStorage) DeleteBatch(ctx context.Context, shards []markedShard) (
 	}
 	if len(objects) == 0 {
 		return successful, deleteErr
-	}
-	backend, err := s.backend(objectBackendTag)
-	if err != nil {
-		return successful, errors.Join(deleteErr, err)
-	}
-	object, ok := backend.(*objectBackend)
-	if !ok {
-		return successful, errors.Join(deleteErr, fmt.Errorf("%w: object backend does not support batch deletion", ErrStoreIntegrity))
 	}
 	for indices := range slices.Chunk(objects, maxObjectDeleteBatchSize) {
 		ids := make([]shardID, len(indices))

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -2,7 +2,9 @@ package fibre
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 )
@@ -62,17 +64,71 @@ func (s *routedStorage) Delete(ctx context.Context, marker []byte, commitment Co
 	return backend.Delete(ctx, commitment, promiseHash)
 }
 
-// DeleteObjects routes a batch of object shards to the object backend.
-func (s *routedStorage) DeleteObjects(ctx context.Context, ids []shardID) ([]error, error) {
+type markedShard struct {
+	id     shardID
+	marker []byte
+}
+
+// DeleteBatch deletes payloads by marker and returns their successful input positions.
+// Local deletes stop on failure. Object requests contain at most 1,000 keys; per-key failures remain for retry.
+func (s *routedStorage) DeleteBatch(ctx context.Context, shards []markedShard) ([]int, error) {
+	var local, objects []int
+	for i, shard := range shards {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		backend, err := s.backendForMarker(shard.marker)
+		if err != nil {
+			return nil, err
+		}
+		if backend.backendTag() == objectBackendTag {
+			objects = append(objects, i)
+		} else {
+			local = append(local, i)
+		}
+	}
+
+	var successful []int
+	var deleteErr error
+	for _, i := range local {
+		shard := shards[i]
+		if err := s.Delete(ctx, shard.marker, shard.id.commitment, shard.id.promiseHash); err != nil {
+			deleteErr = err
+			break
+		}
+		successful = append(successful, i)
+	}
+	if len(objects) == 0 {
+		return successful, deleteErr
+	}
 	backend, err := s.backend(objectBackendTag)
 	if err != nil {
-		return nil, err
+		return successful, errors.Join(deleteErr, err)
 	}
 	object, ok := backend.(*objectBackend)
 	if !ok {
-		return nil, fmt.Errorf("%w: object backend does not support batch deletion", ErrStoreIntegrity)
+		return successful, errors.Join(deleteErr, fmt.Errorf("%w: object backend does not support batch deletion", ErrStoreIntegrity))
 	}
-	return object.DeleteObjects(ctx, ids)
+	for indices := range slices.Chunk(objects, maxObjectDeleteBatchSize) {
+		ids := make([]shardID, len(indices))
+		for i, index := range indices {
+			ids[i] = shards[index].id
+		}
+		results, err := object.DeleteObjects(ctx, ids)
+		if err != nil {
+			return successful, errors.Join(deleteErr, err)
+		}
+		for i, err := range results {
+			if err != nil {
+				if deleteErr == nil {
+					deleteErr = err
+				}
+				continue
+			}
+			successful = append(successful, indices[i])
+		}
+	}
+	return successful, deleteErr
 }
 
 func (s *routedStorage) size(marker []byte, commitment Commitment, promiseHash []byte) (int64, error) {

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -62,6 +62,19 @@ func (s *routedStorage) Delete(ctx context.Context, marker []byte, commitment Co
 	return backend.Delete(ctx, commitment, promiseHash)
 }
 
+// DeleteObjects routes a batch of object shards to the object backend.
+func (s *routedStorage) DeleteObjects(ctx context.Context, ids []shardID) ([]error, error) {
+	backend, err := s.backend(objectBackendTag)
+	if err != nil {
+		return nil, err
+	}
+	object, ok := backend.(*objectBackend)
+	if !ok {
+		return nil, fmt.Errorf("%w: object backend does not support batch deletion", ErrStoreIntegrity)
+	}
+	return object.DeleteObjects(ctx, ids)
+}
+
 func (s *routedStorage) size(marker []byte, commitment Commitment, promiseHash []byte) (int64, error) {
 	tag, size, err := decodeShardMarkerBackend(marker)
 	if err != nil {

--- a/fibre/store_shard_test.go
+++ b/fibre/store_shard_test.go
@@ -1,8 +1,15 @@
 package fibre
 
 import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"slices"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -40,4 +47,92 @@ type taggedShardBackend struct {
 
 func (b *taggedShardBackend) backendTag() shardBackendTag {
 	return b.tag
+}
+
+func TestRoutedStorageDeleteBatchLocal(t *testing.T) {
+	store := newMarkerTestStore(t)
+	commitment := generateCommitment()
+	hash := []byte{1}
+	size := writeMarkerTestShard(t, store, commitment, hash)
+	shards := []markedShard{
+		{id: shardID{commitment: commitment, promiseHash: hash}, marker: encodeShardMarkerForBackend(localBackendTag, size)},
+		{id: shardID{commitment: commitment, promiseHash: []byte{2}}},
+	}
+	successful, err := store.shards.DeleteBatch(t.Context(), shards)
+	require.NoError(t, err)
+	require.Equal(t, []int{0, 1}, successful)
+	has, err := storeLocalBackend(t, store).Has(t.Context(), commitment, hash)
+	require.NoError(t, err)
+	require.False(t, has)
+}
+
+func TestRoutedStorageChunksObjectDeletes(t *testing.T) {
+	for _, outcome := range []string{"success", "per-key failure", "request failure", "cancelled"} {
+		t.Run(outcome, func(t *testing.T) {
+			store := newMarkerTestStore(t)
+			commitment := generateCommitment()
+			ctx, cancel := context.WithCancel(t.Context())
+			defer cancel()
+			requestErr := errors.New("request failed")
+			var batches []int
+			object := newObjectBackend(&s3ObjectClientStub{
+				deleteObjects: func(_ context.Context, input *s3.DeleteObjectsInput, _ ...func(*s3.Options)) (*s3.DeleteObjectsOutput, error) {
+					batches = append(batches, len(input.Delete.Objects))
+					if len(batches) == 1 {
+						switch outcome {
+						case "per-key failure":
+							return &s3.DeleteObjectsOutput{Errors: []s3types.Error{{
+								Key: input.Delete.Objects[0].Key, Code: aws.String("AccessDenied"),
+							}}}, nil
+						case "cancelled":
+							cancel()
+						}
+					} else if outcome == "request failure" {
+						return nil, requestErr
+					}
+					return &s3.DeleteObjectsOutput{}, nil
+				},
+			}, "bucket", "prefix", "chain", "validator")
+			store.shards.secondary = object
+			shards := make([]markedShard, maxObjectDeleteBatchSize+2)
+			localIndex := maxObjectDeleteBatchSize / 2
+			want := []int{localIndex}
+			for i := range shards {
+				hash := binary.BigEndian.AppendUint64(nil, uint64(i))
+				shards[i] = markedShard{
+					id:     shardID{commitment: commitment, promiseHash: hash},
+					marker: encodeShardMarkerForBackend(objectBackendTag, 1),
+				}
+				if i == localIndex {
+					size := writeMarkerTestShard(t, store, commitment, hash)
+					shards[i].marker = encodeShardMarkerForBackend(localBackendTag, size)
+					continue
+				}
+				want = append(want, i)
+			}
+			successful, err := store.shards.DeleteBatch(ctx, shards)
+			switch outcome {
+			case "success":
+				require.NoError(t, err)
+			case "per-key failure":
+				require.ErrorContains(t, err, "AccessDenied")
+				want = slices.Delete(want, 1, 2)
+			case "request failure":
+				require.ErrorIs(t, err, requestErr)
+				want = want[:len(want)-1]
+			case "cancelled":
+				require.ErrorIs(t, err, context.Canceled)
+				want = want[:len(want)-1]
+			}
+			require.Equal(t, want, successful)
+			if outcome == "cancelled" {
+				require.Equal(t, []int{maxObjectDeleteBatchSize}, batches)
+			} else {
+				require.Equal(t, []int{maxObjectDeleteBatchSize, 1}, batches)
+			}
+			has, err := storeLocalBackend(t, store).Has(t.Context(), commitment, shards[localIndex].id.promiseHash)
+			require.NoError(t, err)
+			require.False(t, has)
+		})
+	}
 }


### PR DESCRIPTION
Closes [PROTOCO-2620](https://linear.app/celestia/issue/PROTOCO-2620)

Batch expired object shards in groups of at most 1,000 keys. Delete local payloads individually, retain failed entries for retry, and release marker-accounted capacity only after metadata cleanup commits.

Stacked on #7797
