### PR TITLE
fix!: harden TxCache.getBlobsHash against blob hash collisions (backport #7398)

### DIFF
--- a/app/tx_cache.go
+++ b/app/tx_cache.go
@@ -49,13 +49,13 @@ func (c *TxCache) Set(tx []byte, blobs []*share.Blob) {
 	c.cache.Store(key, blobsHash)
 }
 
+// getBlobsHash hashes the domain-separated, length-prefixed hash of each blob.
+// Since each blob contributes a fixed-size digest, the boundaries between
+// adjacent blobs are unambiguous.
 func (c *TxCache) getBlobsHash(blobs []*share.Blob) string {
 	h := sha256.New()
 	for _, blob := range blobs {
-		h.Write(blob.Namespace().Bytes())
-		h.Write(blob.Data())
-		h.Write([]byte{blob.ShareVersion()})
-		h.Write(blob.Signer())
+		h.Write(blob.Hash())
 	}
 	sum := h.Sum(nil)
 	return string(sum)

--- a/app/tx_cache_test.go
+++ b/app/tx_cache_test.go
@@ -1,12 +1,14 @@
 package app
 
 import (
+	"bytes"
 	"fmt"
 	"sync"
 	"testing"
 
 	"github.com/celestiaorg/celestia-app/v9/test/util/blobfactory"
 	"github.com/celestiaorg/celestia-app/v9/test/util/random"
+	"github.com/celestiaorg/go-square/v4/share"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -154,6 +156,54 @@ func TestTxCache_GetBlobsHash(t *testing.T) {
 	blobs2 := blobfactory.ManyRandBlobs(random.New(), 1000)
 	blobsHash3 := cache.getBlobsHash(blobs2)
 	assert.NotEqual(t, blobsHash1, blobsHash3)
+}
+
+// TestTxCache_GetBlobsHashCrossVersionCollision is a regression test for the
+// collision pattern in GHSA-jv5p-xwcc-q8mf: without domain separation and
+// length prefixes, a v0 blob whose data embeds the v1 share version byte and
+// signer hashes identically to the v1 blob (when the signer ends in 0x00).
+func TestTxCache_GetBlobsHashCrossVersionCollision(t *testing.T) {
+	cache := NewTxCache()
+	ns := share.RandomNamespace()
+
+	victimData := []byte("victim payload")
+	victimSigner := append(bytes.Repeat([]byte{0xAA}, share.SignerSize-1), 0x00)
+	v1Blob, err := share.NewV1Blob(ns, victimData, victimSigner)
+	require.NoError(t, err)
+
+	attackerData := append([]byte{}, victimData...)
+	attackerData = append(attackerData, share.ShareVersionOne)
+	attackerData = append(attackerData, victimSigner[:share.SignerSize-1]...)
+	v0Blob, err := share.NewV0Blob(ns, attackerData)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, cache.getBlobsHash([]*share.Blob{v1Blob}), cache.getBlobsHash([]*share.Blob{v0Blob}),
+		"a v0 blob must not collide with a v1 blob's hash")
+}
+
+// TestTxCache_GetBlobsHashInterBlobBoundaryCollision asserts that the boundary
+// between adjacent blobs is pinned: two v0 blobs must not hash identically to
+// a single v0 blob whose data embeds the concatenation of both.
+func TestTxCache_GetBlobsHashInterBlobBoundaryCollision(t *testing.T) {
+	cache := NewTxCache()
+	ns := share.RandomNamespace()
+
+	blob1, err := share.NewV0Blob(ns, []byte("first blob"))
+	require.NoError(t, err)
+	blob2, err := share.NewV0Blob(ns, []byte("second blob"))
+	require.NoError(t, err)
+
+	// merged.data = blob1.data || v0 share version byte || ns || blob2.data, so
+	// the ambiguous concatenation produces the same byte stream as [blob1, blob2].
+	mergedData := append([]byte{}, blob1.Data()...)
+	mergedData = append(mergedData, share.ShareVersionZero)
+	mergedData = append(mergedData, ns.Bytes()...)
+	mergedData = append(mergedData, blob2.Data()...)
+	merged, err := share.NewV0Blob(ns, mergedData)
+	require.NoError(t, err)
+
+	assert.NotEqual(t, cache.getBlobsHash([]*share.Blob{blob1, blob2}), cache.getBlobsHash([]*share.Blob{merged}),
+		"adjacent blobs must not collide with a single merged blob")
 }
 
 func TestTxCache_GetTxKeyEmptyTx(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/bcp-innovations/hyperlane-cosmos v1.1.0
 	github.com/celestiaorg/go-square/v2 v2.3.3
 	github.com/celestiaorg/go-square/v3 v3.0.2
-	github.com/celestiaorg/go-square/v4 v4.0.0-rc4
+	github.com/celestiaorg/go-square/v4 v4.0.0-rc5
 	github.com/celestiaorg/nmt v0.24.3
 	github.com/celestiaorg/rsmt2d v0.15.2
 	github.com/cockroachdb/pebble/v2 v2.1.4

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1
 github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/celestiaorg/go-square/v3 v3.0.2 h1:eSQOgNII8inK9IhiBZ+6GADQeWbRq4HYY72BOgcduA4=
 github.com/celestiaorg/go-square/v3 v3.0.2/go.mod h1:oFReMLsSDMRs82ICFEeFQFCqNvwdsbIM1BzCcb0f7dM=
-github.com/celestiaorg/go-square/v4 v4.0.0-rc4 h1:bh7rney5lLq4Z9OpaSg9ckY9bt6BZUW0VYnFOi1RPwQ=
-github.com/celestiaorg/go-square/v4 v4.0.0-rc4/go.mod h1:7Vc4H3u3gvcfLFp84EqyMVT/9r0ZGUgZP4aYMOYXVsw=
+github.com/celestiaorg/go-square/v4 v4.0.0-rc5 h1:lMOPS73bz9vWz4XwiWiP/LfhiS2bA+dovMDITTv7KzU=
+github.com/celestiaorg/go-square/v4 v4.0.0-rc5/go.mod h1:2zbWIcy48bI1JYSIhrMSiI1Tq60Kv/7OiEvxCIdBe/k=
 github.com/celestiaorg/ibc-go/v8 v8.7.2 h1:AWae851fdX7pJWlGnUBKlKJzpr4c2t5m4TLs6vDfmAY=
 github.com/celestiaorg/ibc-go/v8 v8.7.2/go.mod h1:E3WTax+cfyDIehNRpwEI96/0E8GBtU1g9XWr18qUGZ8=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=

--- a/test/docker-e2e/go.mod
+++ b/test/docker-e2e/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bcp-innovations/hyperlane-cosmos v1.1.0
 	github.com/celestiaorg/celestia-app/v9 v9.0.0-rc0
 	github.com/celestiaorg/go-square/v3 v3.0.2
-	github.com/celestiaorg/go-square/v4 v4.0.0-rc4
+	github.com/celestiaorg/go-square/v4 v4.0.0-rc5
 	github.com/celestiaorg/tastora v0.19.0
 	github.com/cometbft/cometbft v1.0.1
 	github.com/cosmos/cosmos-sdk v0.50.13

--- a/test/docker-e2e/go.sum
+++ b/test/docker-e2e/go.sum
@@ -183,8 +183,8 @@ github.com/celestiaorg/go-square/v2 v2.3.3 h1:vhu6Lt39km19Q/Jk4nS3r2cuWJq6jFg+/1
 github.com/celestiaorg/go-square/v2 v2.3.3/go.mod h1:vY5RRv+qRmEVjPF6dAdr0dyLwKmTTDHHffENPQw8pUA=
 github.com/celestiaorg/go-square/v3 v3.0.2 h1:eSQOgNII8inK9IhiBZ+6GADQeWbRq4HYY72BOgcduA4=
 github.com/celestiaorg/go-square/v3 v3.0.2/go.mod h1:oFReMLsSDMRs82ICFEeFQFCqNvwdsbIM1BzCcb0f7dM=
-github.com/celestiaorg/go-square/v4 v4.0.0-rc4 h1:bh7rney5lLq4Z9OpaSg9ckY9bt6BZUW0VYnFOi1RPwQ=
-github.com/celestiaorg/go-square/v4 v4.0.0-rc4/go.mod h1:7Vc4H3u3gvcfLFp84EqyMVT/9r0ZGUgZP4aYMOYXVsw=
+github.com/celestiaorg/go-square/v4 v4.0.0-rc5 h1:lMOPS73bz9vWz4XwiWiP/LfhiS2bA+dovMDITTv7KzU=
+github.com/celestiaorg/go-square/v4 v4.0.0-rc5/go.mod h1:2zbWIcy48bI1JYSIhrMSiI1Tq60Kv/7OiEvxCIdBe/k=
 github.com/celestiaorg/ibc-go/v8 v8.7.2 h1:AWae851fdX7pJWlGnUBKlKJzpr4c2t5m4TLs6vDfmAY=
 github.com/celestiaorg/ibc-go/v8 v8.7.2/go.mod h1:E3WTax+cfyDIehNRpwEI96/0E8GBtU1g9XWr18qUGZ8=
 github.com/celestiaorg/merkletree v0.0.0-20210714075610-a84dc3ddbbe4 h1:CJdIpo8n5MFP2MwK0gSRcOVlDlFdQJO1p+FqdxYzmvc=


### PR DESCRIPTION
Closes [PROTOCO-1935](https://linear.app/celestia/issue/PROTOCO-1935/harden-celestia-app-txcachegetblobshash-against-the-blobhash-collision)

Backport of #7398 to `v9.x`.

`TxCache.getBlobsHash` concatenated `namespace || data || shareVersion || signer` per blob with no length prefixes or domain separation, so distinct blob lists could produce the same hash. This replaces the hand-rolled loop with `Blob.Hash()` and bumps go-square/v4 to `v4.0.0-rc5`, which carries the domain-separated, length-prefixed construction.

The two regression tests fail on the old construction and pass with the fix.

### Notes for review

The `!` is inherited from the original PR title. On `v9.x` the change looks consensus-inert:

- `Blob.Hash()` has no callers inside go-square and exactly one in this repo, the cache itself.
- The rest of the rc4 → rc5 delta is an additive `IsFibreBlob()`, a comment, and a slice capacity hint.
- The cache only decides whether `ProcessProposal` skips the share-commitment check; a miss falls back to full validation, so accept/reject is unchanged.

Happy to drop the `!` if reviewers agree.

`v4.0.0` (what `main` pins) is not a viable target here because it removes `tx/pay_for_fibre.go`; `rc5` is the minimal bump that carries the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)