### PR TITLE
refactor: remove the no-op blob tx cache pruning

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -604,23 +604,6 @@ func (app *App) Info(req *abci.RequestInfo) (*abci.ResponseInfo, error) {
 	return res, nil
 }
 
-// FinalizeBlock implements the abci interface. It overrides baseapp's FinalizeBlock method, essentially becoming a decorator
-// in order to add transaction pruning logic after normal finalize block processing.
-func (app *App) FinalizeBlock(req *abci.RequestFinalizeBlock) (*abci.ResponseFinalizeBlock, error) {
-	// Call the normal BaseApp FinalizeBlock first
-	res, err := app.BaseApp.FinalizeBlock(req)
-	if err != nil {
-		return nil, err
-	}
-
-	// Go through all the transactions that are getting executed and prune the tx tracker
-	for _, tx := range req.Txs {
-		app.txCache.RemoveTransaction(tx)
-	}
-
-	return res, nil
-}
-
 // PreBlocker application updates every pre block
 func (app *App) PreBlocker(ctx sdk.Context, _ *abci.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
 	return app.ModuleManager.PreBlock(ctx)

--- a/app/pfb_tx_cache.go
+++ b/app/pfb_tx_cache.go
@@ -63,12 +63,6 @@ func (c *TxCache) getBlobsHash(blobs []*share.Blob) string {
 	return string(sum)
 }
 
-// RemoveTransaction removes specific transactions from the cache
-func (c *TxCache) RemoveTransaction(tx []byte) {
-	key := c.getTxKey(tx)
-	c.entries.Remove(key)
-}
-
 // Size returns the current number of entries in the cache
 func (c *TxCache) Size() int {
 	return c.entries.Len()

--- a/app/pfb_tx_cache_bench_test.go
+++ b/app/pfb_tx_cache_bench_test.go
@@ -92,7 +92,7 @@ func BenchmarkTxCache_Operations(b *testing.B) {
 		}
 	})
 
-	b.Run("All operations (set, exists, remove)", func(b *testing.B) {
+	b.Run("All operations (set, exists)", func(b *testing.B) {
 		for _, tc := range testCases {
 			b.Run(tc.name, func(b *testing.B) {
 				b.ReportAllocs()
@@ -107,10 +107,6 @@ func BenchmarkTxCache_Operations(b *testing.B) {
 
 					for i, tx := range txs {
 						cache.Exists(tx, blobs[i])
-					}
-
-					for _, tx := range txs {
-						cache.RemoveTransaction(tx)
 					}
 				}
 			})

--- a/app/pfb_tx_cache_test.go
+++ b/app/pfb_tx_cache_test.go
@@ -86,48 +86,6 @@ func TestTxCache_ExistsEmpty(t *testing.T) {
 	assert.False(t, exists)
 }
 
-func TestTxCache_RemoveTransaction(t *testing.T) {
-	cache := NewTxCache()
-	tx1 := []byte("tx1")
-	tx2 := []byte("tx2")
-	tx3 := []byte("tx3")
-	blobs1 := blobfactory.ManyRandBlobs(random.New(), 1000)
-	blobs2 := blobfactory.ManyRandBlobs(random.New(), 1000)
-	blobs3 := blobfactory.ManyRandBlobs(random.New(), 1000)
-
-	cache.Set(tx1, blobs1)
-	cache.Set(tx2, blobs2)
-	cache.Set(tx3, blobs3)
-	assert.Equal(t, 3, cache.Size())
-
-	cache.RemoveTransaction(tx2)
-
-	assert.Equal(t, 2, cache.Size())
-	exists := cache.Exists(tx1, blobs1)
-	assert.True(t, exists)
-
-	exists = cache.Exists(tx2, blobs2)
-	assert.False(t, exists)
-
-	exists = cache.Exists(tx3, blobs3)
-	assert.True(t, exists)
-}
-
-func TestTxCache_RemoveTransactionNonExistent(t *testing.T) {
-	cache := NewTxCache()
-	tx := []byte("tx1")
-	blobs := blobfactory.ManyRandBlobs(random.New(), 1000)
-	nonExistentTx := []byte("non existent")
-
-	cache.Set(tx, blobs)
-	assert.Equal(t, 1, cache.Size())
-
-	cache.RemoveTransaction(nonExistentTx)
-	assert.Equal(t, 1, cache.Size())
-	exists := cache.Exists(tx, blobs)
-	assert.True(t, exists)
-}
-
 func TestTxCache_Eviction(t *testing.T) {
 	cache := NewTxCache()
 	blobs := blobfactory.ManyRandBlobs(random.New(), 100)
@@ -311,13 +269,13 @@ func TestTxCache_ConcurrentBatches(t *testing.T) {
 	expectedSize := len(batch1) + len(batch2)
 	require.Equal(t, expectedSize, cache.Size())
 
-	// phase 3: Concurrently remove batch 2 and add batch 3
-	// remove batch 2
+	// phase 3: Concurrently read batch 2 and add batch 3
+	// read batch 2
 	for _, tx := range batch2 {
 		wg.Add(1)
 		go func(transaction []byte) {
 			defer wg.Done()
-			cache.RemoveTransaction(transaction)
+			require.True(t, cache.Exists(transaction, blobs))
 		}(tx)
 	}
 

--- a/x/blob/types/blob_tx_test.go
+++ b/x/blob/types/blob_tx_test.go
@@ -3,7 +3,6 @@ package types_test
 import (
 	"bytes"
 	"testing"
-	"time"
 
 	"cosmossdk.io/math"
 	"github.com/celestiaorg/celestia-app/v10/app"
@@ -409,42 +408,6 @@ func TestValidateBlobTxWithCache(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "namespace of blob and its respective MsgPayForBlobs differ")
 		assert.False(t, fromCache, "blobs changed so cache miss, full validation used")
-	})
-
-	t.Run("cache is cleaned after FinalizeBlock", func(t *testing.T) {
-		blobTxBytes := blobfactory.RandBlobTxsWithNamespacesAndSigner(
-			signers[3],
-			[]share.Namespace{namespace1},
-			[]int{100},
-		)[0]
-
-		blobTx, isBlobTx, err := tx.UnmarshalBlobTx(blobTxBytes)
-		require.NoError(t, err)
-		require.True(t, isBlobTx)
-
-		resp, err := testApp.CheckTx(&abci.RequestCheckTx{
-			Type: abci.CheckTxType_New,
-			Tx:   blobTxBytes,
-		})
-		require.NoError(t, err)
-		require.Equal(t, abci.CodeTypeOK, resp.Code)
-
-		fromCache, err := testApp.ValidateBlobTxWithCache(blobTx)
-		require.NoError(t, err)
-		assert.True(t, fromCache, "expected validation from cache before FinalizeBlock")
-
-		// finalize block to clean the cache
-		_, err = testApp.FinalizeBlock(&abci.RequestFinalizeBlock{
-			Txs:    [][]byte{blobTx.Tx},
-			Time:   time.Now(),
-			Height: 2,
-		})
-		require.NoError(t, err)
-
-		// verify transaction is no longer in cache
-		fromCache, err = testApp.ValidateBlobTxWithCache(blobTx)
-		require.NoError(t, err)
-		assert.False(t, fromCache, "expected validation without cache after FinalizeBlock")
 	})
 }
 


### PR DESCRIPTION
Closes [PROTOCO-2665](https://linear.app/celestia/issue/PROTOCO-2665) https://github.com/celestiaorg/celestia-app/issues/7805

`FinalizeBlock` pruned the blob tx cache with `RemoveTransaction`, but it never removed anything: blocks carry wrapped `BlobTx` bytes while the cache is keyed on the inner tx, so the hashes never matched.

Rather than fix it, this removes it. #7778 bounded the cache with an LRU, which was the only reason to prune. Fixing the pruning would have added an `UnmarshalBlobTx` over every tx in every block for a marginal hit-rate gain.

With the loop gone the `FinalizeBlock` override only delegated to `BaseApp`, so it goes too — ABCI now calls the promoted `BaseApp.FinalizeBlock`. `RemoveTransaction` has no callers left and is removed with it.

No behavior change: the loop was already a no-op for blob txs, and only blob txs are cached.
