### PR TITLE
feat(fibre): add backend GET pressure metrics

### DIFF
--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -227,7 +227,7 @@ Resource attributes exported with every trace: `service.name=fibre`, `service.ve
 | `fibre.server.prune.entries` | Counter | — | Total entries pruned |
 | `fibre.server.prune.duration` | Histogram (s) | `success` | Prune cycle duration |
 
-Backend GET metrics use `backend=local|object`.
+Backend GET metrics record only the primary backend and use `backend=local|object`.
 The duration metric uses `outcome=success|not_found|timeout|canceled|throttled|error`.
 Each observation covers one backend call. Object GET duration includes SDK retries; the outcome describes the final result.
 

--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -188,7 +188,7 @@ W3C TraceContext and Baggage propagators are registered globally, enabling distr
 
 Resource attributes exported with every trace: `service.name=fibre`, `service.version`, `service.instance.id` (hostname).
 
-**Metrics** — Exported via a periodic OTLP reader. All duration histograms carry a `success` attribute for error rate derivation from `_count`. Exemplars are automatically attached to metric observations, linking metric datapoints to traces — in Grafana, clicking an exemplar on a metric panel opens the corresponding trace.
+**Metrics** — Exported via a periodic OTLP reader. Duration histograms carry a `success` or `outcome` attribute for error rate derivation from `_count`. Exemplars are automatically attached to metric observations, linking metric datapoints to traces — in Grafana, clicking an exemplar on a metric panel opens the corresponding trace.
 
 #### Client metrics
 
@@ -220,9 +220,16 @@ Resource attributes exported with every trace: `service.name=fibre`, `service.ve
 | `fibre.server.download_shard.bytes` | Counter (By) | — | Total bytes sent |
 | `fibre.server.store.put.duration` | Histogram (s) | `success` | Store write latency |
 | `fibre.server.store.get.duration` | Histogram (s) | `success` | Store read latency |
+| `fibre.server.backend.get.duration` | Histogram (s) | `backend`, `outcome` | Backend GET latency through payload reading, decoding and closing |
+| `fibre.server.backend.get.in_flight` | UpDownCounter | `backend` | Concurrent backend GET calls |
+| `fibre.server.backend.get.bytes` | Counter (By) | `backend` | Encoded bytes consumed, including partial failures and buffered reads |
 | `fibre.server.sign.duration` | Histogram (s) | `success` | Payment promise signing latency |
 | `fibre.server.prune.entries` | Counter | — | Total entries pruned |
 | `fibre.server.prune.duration` | Histogram (s) | `success` | Prune cycle duration |
+
+Backend GET metrics use `backend=local|object`.
+The duration metric uses `outcome=success|not_found|timeout|canceled|throttled|error`.
+Each observation covers one backend call. Object GET duration includes SDK retries; the outcome describes the final result.
 
 #### Grafana dashboard
 

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -152,6 +152,14 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("opening store: %w", err)
 	}
+	for _, backend := range []shardBackend{s.store.shards.primary, s.store.shards.secondary} {
+		switch backend := backend.(type) {
+		case *localBackend:
+			backend.metrics = s.metrics
+		case *objectBackend:
+			backend.metrics = s.metrics
+		}
+	}
 
 	if err := s.seedOccupancy(ctx); err != nil {
 		return err

--- a/fibre/server.go
+++ b/fibre/server.go
@@ -152,14 +152,7 @@ func (s *Server) Start(ctx context.Context) (err error) {
 	if err != nil {
 		return fmt.Errorf("opening store: %w", err)
 	}
-	for _, backend := range []shardBackend{s.store.shards.primary, s.store.shards.secondary} {
-		switch backend := backend.(type) {
-		case *localBackend:
-			backend.metrics = s.metrics
-		case *objectBackend:
-			backend.metrics = s.metrics
-		}
-	}
+	s.store.shards.setMetrics(s.metrics)
 
 	if err := s.seedOccupancy(ctx); err != nil {
 		return err

--- a/fibre/server_download_test.go
+++ b/fibre/server_download_test.go
@@ -1,6 +1,7 @@
 package fibre_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/secp256k1"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 // TestServerDownloadShard unit tests the [Server.DownloadShard].
@@ -100,6 +104,33 @@ func TestServerDownloadShard(t *testing.T) {
 			tt.check(t, resp, err)
 		})
 	}
+}
+
+func TestServerBackendGetMetrics(t *testing.T) {
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	server, _, _ := makeTestServerWithConfig(t, func(cfg *fibre.ServerConfig) {
+		cfg.Meter = provider.Meter("server-test")
+	})
+	blob := makeTestBlobV0(t, 256)
+	storeTestShard(t, server, blob)
+	_, err := server.DownloadShard(t.Context(), &types.DownloadShardRequest{BlobId: blob.ID()})
+	require.NoError(t, err)
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &data))
+	for _, scope := range data.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			if m.Name == "fibre.server.backend.get.duration" {
+				points := m.Data.(metricdata.Histogram[float64]).DataPoints
+				require.Len(t, points, 1)
+				require.Equal(t, uint64(1), points[0].Count)
+				require.Equal(t, attribute.NewSet(attribute.String("backend", "local"), attribute.String("outcome", "success")), points[0].Attributes)
+				return
+			}
+		}
+	}
+	t.Fatal("server did not record backend GET metrics")
 }
 
 // storeTestShard stores a test blob shard in the server's store for download testing.

--- a/fibre/server_metrics.go
+++ b/fibre/server_metrics.go
@@ -148,7 +148,7 @@ func newServerMetrics(m metric.Meter, occ *occupancy) (*serverMetrics, error) {
 	}
 
 	sm.backendGetDuration, err = m.Float64Histogram("fibre.server.backend.get.duration",
-		metric.WithDescription("Duration of backend GET calls through payload reading, decoding and closing, including SDK retries"),
+		metric.WithDescription("Duration of backend GET calls through payload reading, decoding and closing"),
 		metric.WithUnit("s"),
 		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
 	)
@@ -156,7 +156,7 @@ func newServerMetrics(m metric.Meter, occ *occupancy) (*serverMetrics, error) {
 		return nil, fmt.Errorf("creating backend get duration histogram: %w", err)
 	}
 	sm.backendGetInFlight, err = m.Int64UpDownCounter("fibre.server.backend.get.in_flight",
-		metric.WithDescription("Number of backend GET calls in progress, including SDK retries and payload reading"),
+		metric.WithDescription("Number of backend GET calls in progress"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating backend get in_flight counter: %w", err)
@@ -235,7 +235,7 @@ func (m *serverMetrics) observeStoreOp(ctx context.Context, h metric.Float64Hist
 }
 
 func (m *serverMetrics) observeBackendGet(ctx context.Context, backend string) func(error) {
-	if m == nil {
+	if m == nil || (!m.backendGetDuration.Enabled(ctx) && !m.backendGetInFlight.Enabled(ctx)) {
 		return func(error) {}
 	}
 	start := time.Now()
@@ -270,7 +270,7 @@ func backendGetOutcome(err error) string {
 }
 
 func (m *serverMetrics) backendReader(ctx context.Context, backend string, r io.Reader) io.Reader {
-	if m == nil {
+	if m == nil || !m.backendGetBytes.Enabled(ctx) {
 		return r
 	}
 	return &backendMetricReader{

--- a/fibre/server_metrics.go
+++ b/fibre/server_metrics.go
@@ -15,6 +15,15 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+const (
+	metricOutcomeSuccess   = "success"
+	metricOutcomeNotFound  = "not_found"
+	metricOutcomeTimeout   = "timeout"
+	metricOutcomeCanceled  = "canceled"
+	metricOutcomeThrottled = "throttled"
+	metricOutcomeError     = "error"
+)
+
 // serverMetrics holds OTel metric instruments for the Fibre [Server].
 type serverMetrics struct {
 	// UploadShard RPC
@@ -254,18 +263,18 @@ func backendGetOutcome(err error) string {
 	var response interface{ HTTPStatusCode() int }
 	switch {
 	case err == nil:
-		return "success"
+		return metricOutcomeSuccess
 	case errors.Is(err, ErrStoreNotFound):
-		return "not_found"
+		return metricOutcomeNotFound
 	case errors.Is(err, context.DeadlineExceeded), errors.As(err, &timeout) && timeout.Timeout():
-		return "timeout"
+		return metricOutcomeTimeout
 	case errors.Is(err, context.Canceled):
-		return "canceled"
+		return metricOutcomeCanceled
 	case (retry.ThrottleErrorCode{Codes: retry.DefaultThrottleErrorCodes}).IsErrorThrottle(err) == aws.TrueTernary,
 		errors.As(err, &response) && response.HTTPStatusCode() == http.StatusTooManyRequests:
-		return "throttled"
+		return metricOutcomeThrottled
 	default:
-		return "error"
+		return metricOutcomeError
 	}
 }
 

--- a/fibre/server_metrics.go
+++ b/fibre/server_metrics.go
@@ -2,9 +2,15 @@ package fibre
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
@@ -23,8 +29,11 @@ type serverMetrics struct {
 	downloadShardBytes    metric.Int64Counter
 
 	// Store operations
-	storePutDuration metric.Float64Histogram
-	storeGetDuration metric.Float64Histogram
+	storePutDuration   metric.Float64Histogram
+	storeGetDuration   metric.Float64Histogram
+	backendGetDuration metric.Float64Histogram
+	backendGetInFlight metric.Int64UpDownCounter
+	backendGetBytes    metric.Int64Counter
 
 	// Signing
 	signDuration metric.Float64Histogram
@@ -138,6 +147,28 @@ func newServerMetrics(m metric.Meter, occ *occupancy) (*serverMetrics, error) {
 		return nil, fmt.Errorf("creating store get duration histogram: %w", err)
 	}
 
+	sm.backendGetDuration, err = m.Float64Histogram("fibre.server.backend.get.duration",
+		metric.WithDescription("Duration of backend GET calls through payload reading, decoding and closing, including SDK retries"),
+		metric.WithUnit("s"),
+		metric.WithExplicitBucketBoundaries(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating backend get duration histogram: %w", err)
+	}
+	sm.backendGetInFlight, err = m.Int64UpDownCounter("fibre.server.backend.get.in_flight",
+		metric.WithDescription("Number of backend GET calls in progress, including SDK retries and payload reading"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating backend get in_flight counter: %w", err)
+	}
+	sm.backendGetBytes, err = m.Int64Counter("fibre.server.backend.get.bytes",
+		metric.WithDescription("Encoded bytes consumed from backend payload readers, including partial failures and buffered reads"),
+		metric.WithUnit("By"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("creating backend get bytes counter: %w", err)
+	}
+
 	// Signing metrics
 	sm.signDuration, err = m.Float64Histogram("fibre.server.sign.duration",
 		metric.WithDescription("Duration of payment promise signing in seconds"),
@@ -201,6 +232,68 @@ func (m *serverMetrics) observeDownloadShard(ctx context.Context) (done func(sha
 // observeStoreOp records store operation duration.
 func (m *serverMetrics) observeStoreOp(ctx context.Context, h metric.Float64Histogram, start time.Time, success bool) {
 	h.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(attribute.Bool("success", success)))
+}
+
+func (m *serverMetrics) observeBackendGet(ctx context.Context, backend string) func(error) {
+	if m == nil {
+		return func(error) {}
+	}
+	start := time.Now()
+	attrs := metric.WithAttributes(attribute.String("backend", backend))
+	m.backendGetInFlight.Add(ctx, 1, attrs)
+	return func(err error) {
+		m.backendGetInFlight.Add(ctx, -1, attrs)
+		m.backendGetDuration.Record(ctx, time.Since(start).Seconds(), metric.WithAttributes(
+			attribute.String("backend", backend), attribute.String("outcome", backendGetOutcome(err)),
+		))
+	}
+}
+
+func backendGetOutcome(err error) string {
+	var timeout net.Error
+	var response interface{ HTTPStatusCode() int }
+	switch {
+	case err == nil:
+		return "success"
+	case errors.Is(err, ErrStoreNotFound):
+		return "not_found"
+	case errors.Is(err, context.DeadlineExceeded), errors.As(err, &timeout) && timeout.Timeout():
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case (retry.ThrottleErrorCode{Codes: retry.DefaultThrottleErrorCodes}).IsErrorThrottle(err) == aws.TrueTernary,
+		errors.As(err, &response) && response.HTTPStatusCode() == http.StatusTooManyRequests:
+		return "throttled"
+	default:
+		return "error"
+	}
+}
+
+func (m *serverMetrics) backendReader(ctx context.Context, backend string, r io.Reader) io.Reader {
+	if m == nil {
+		return r
+	}
+	return &backendMetricReader{
+		Reader: r,
+		ctx:    ctx,
+		bytes:  m.backendGetBytes,
+		attrs:  metric.WithAttributes(attribute.String("backend", backend)),
+	}
+}
+
+type backendMetricReader struct {
+	io.Reader
+	ctx   context.Context
+	bytes metric.Int64Counter
+	attrs metric.MeasurementOption
+}
+
+func (r *backendMetricReader) Read(p []byte) (int, error) {
+	n, err := r.Reader.Read(p)
+	if n > 0 {
+		r.bytes.Add(r.ctx, int64(n), r.attrs)
+	}
+	return n, err
 }
 
 // observeSign records signing duration.

--- a/fibre/store_codec.go
+++ b/fibre/store_codec.go
@@ -1,15 +1,12 @@
 package fibre
 
 import (
-	"bufio"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
-	"github.com/cockroachdb/pebble/v2/vfs"
 )
 
 // On-disk shard format (custom binary, all big-endian):
@@ -204,19 +201,4 @@ func readShardBinary(r io.Reader) (*types.BlobShard, error) {
 	}
 
 	return shard, nil
-}
-
-// readShardFile returns [ErrStoreNotFound] when the file is missing.
-func readShardFile(filesystem vfs.FS, path string) (*types.BlobShard, error) {
-	f, err := filesystem.Open(path)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, ErrStoreNotFound
-		}
-		return nil, err
-	}
-	defer f.Close()
-	// Buffered so the many 4-byte length-prefix reads don't each become a
-	// syscall; bufio bypasses the buffer for large reads.
-	return readShardBinary(bufio.NewReaderSize(f, 1<<20))
 }

--- a/fibre/store_local.go
+++ b/fibre/store_local.go
@@ -21,8 +21,9 @@ const (
 
 // localBackend stores shard payloads as flat files.
 type localBackend struct {
-	path string
-	fs   vfs.FS
+	path    string
+	fs      vfs.FS
+	metrics *serverMetrics
 }
 
 // shardPayloadWriteCategory labels shard payload bytes in VFS disk-write metrics.
@@ -61,8 +62,19 @@ func (b *localBackend) Put(ctx context.Context, commitment Commitment, promiseHa
 	return true, nil
 }
 
-func (b *localBackend) Get(_ context.Context, commitment Commitment, promiseHash []byte) (*types.BlobShard, error) {
-	return readShardFile(b.fs, b.shardPath(commitment, promiseHash))
+func (b *localBackend) Get(ctx context.Context, commitment Commitment, promiseHash []byte) (_ *types.BlobShard, err error) {
+	done := b.metrics.observeBackendGet(ctx, storageBackendLocal)
+	defer func() { done(err) }()
+	f, err := b.fs.Open(b.shardPath(commitment, promiseHash))
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, ErrStoreNotFound
+		}
+		return nil, err
+	}
+	defer f.Close()
+	// Buffer small codec reads to avoid per-field file reads and metric updates.
+	return readShardBinary(bufio.NewReaderSize(b.metrics.backendReader(ctx, storageBackendLocal, f), 1<<20))
 }
 
 func (b *localBackend) Has(_ context.Context, commitment Commitment, promiseHash []byte) (bool, error) {

--- a/fibre/store_metrics_test.go
+++ b/fibre/store_metrics_test.go
@@ -1,0 +1,197 @@
+package fibre
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
+	"github.com/cockroachdb/pebble/v2/vfs"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func TestBackendGetMetrics(t *testing.T) {
+	shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: []byte("data")}}}
+	var encoded bytes.Buffer
+	require.NoError(t, writeShardBinary(&encoded, shard))
+	for _, backend := range []string{storageBackendLocal, storageBackendObject} {
+		for _, outcome := range []string{"success", "not_found", "error"} {
+			t.Run(backend+"/"+outcome, func(t *testing.T) {
+				metrics, reader := newBackendTestMetrics(t)
+				data := encoded.Bytes()
+				if outcome == "error" {
+					data = data[:len(data)-1]
+				}
+				var b shardBackend
+				if backend == storageBackendLocal {
+					local, err := newLocalBackend("/store", vfs.NewMem())
+					require.NoError(t, err)
+					local.metrics = metrics
+					if outcome != "not_found" {
+						f, err := local.fs.Create(local.shardPath(Commitment{}, nil), shardPayloadWriteCategory)
+						require.NoError(t, err)
+						_, err = f.Write(bytes.Clone(data))
+						require.NoError(t, err)
+						require.NoError(t, f.Close())
+					}
+					b = local
+				} else {
+					object := newObjectBackend(&s3ObjectClientStub{
+						getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+							if outcome == "not_found" {
+								return nil, &smithy.GenericAPIError{Code: "NoSuchKey"}
+							}
+							return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}, nil
+						},
+					}, "bucket", "prefix", "chain", "validator")
+					object.metrics = metrics
+					b = object
+				}
+				got, err := b.Get(t.Context(), Commitment{}, nil)
+				if outcome == "success" {
+					require.NoError(t, err)
+					require.Equal(t, shard, got)
+				} else {
+					require.Error(t, err)
+				}
+				wantBytes := int64(len(data))
+				if outcome == "not_found" {
+					wantBytes = 0
+				}
+				assertBackendGetMetrics(t, reader, backend, outcome, wantBytes)
+			})
+		}
+	}
+}
+
+func TestObjectBackendGetErrorMetrics(t *testing.T) {
+	for _, tc := range []struct {
+		name, outcome string
+		err           error
+	}{
+		{"deadline", "timeout", context.DeadlineExceeded},
+		{"canceled", "canceled", context.Canceled},
+		{"slow down", "throttled", &smithy.GenericAPIError{Code: "SlowDown"}},
+		{"429", "throttled", &smithyhttp.ResponseError{
+			Response: &smithyhttp.Response{Response: &http.Response{StatusCode: http.StatusTooManyRequests}},
+			Err:      errors.New("too many requests"),
+		}},
+		{"other", "error", errors.New("arbitrary error text")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			metrics, reader := newBackendTestMetrics(t)
+			object := newObjectBackend(&s3ObjectClientStub{
+				getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+					return nil, fmt.Errorf("request failed: %w", tc.err)
+				},
+			}, "bucket", "prefix", "chain", "validator")
+			object.metrics = metrics
+			_, err := object.Get(t.Context(), Commitment{}, nil)
+			require.ErrorIs(t, err, tc.err)
+			assertBackendGetMetrics(t, reader, storageBackendObject, tc.outcome, 0)
+		})
+	}
+}
+
+func TestObjectBackendGetMetricsDuringRead(t *testing.T) {
+	metrics, reader := newBackendTestMetrics(t)
+	reads := 0
+	body := &metricTestBody{
+		read: func(p []byte) (int, error) {
+			reads++
+			if reads == 1 {
+				return copy(p, []byte{0, 0, 0, 1}), nil
+			}
+			data := collectBackendMetrics(t, reader)
+			require.Equal(t, int64(1), data["in_flight"].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+			require.Equal(t, int64(4), data["bytes"].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+			_, recorded := data["duration"]
+			require.False(t, recorded)
+			return copy(p, []byte{0, 0}), context.DeadlineExceeded
+		},
+		close: func() error {
+			data := collectBackendMetrics(t, reader)
+			require.Equal(t, int64(1), data["in_flight"].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
+			_, recorded := data["duration"]
+			require.False(t, recorded, "duration must include closing the body")
+			return nil
+		},
+	}
+	object := newObjectBackend(&s3ObjectClientStub{
+		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
+			return &s3.GetObjectOutput{Body: body}, nil
+		},
+	}, "bucket", "prefix", "chain", "validator")
+	object.metrics = metrics
+	_, err := object.Get(t.Context(), Commitment{}, nil)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	assertBackendGetMetrics(t, reader, storageBackendObject, "timeout", 6)
+}
+
+type metricTestBody struct {
+	read  func([]byte) (int, error)
+	close func() error
+}
+
+func (b *metricTestBody) Read(p []byte) (int, error) { return b.read(p) }
+func (b *metricTestBody) Close() error               { return b.close() }
+
+func newBackendTestMetrics(t *testing.T) (*serverMetrics, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	metrics, err := newServerMetrics(provider.Meter("backend-test"), newOccupancy(0))
+	require.NoError(t, err)
+	return metrics, reader
+}
+
+func collectBackendMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
+	t.Helper()
+	var data metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &data))
+	result := make(map[string]metricdata.Metrics)
+	for _, scope := range data.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			for _, name := range []string{"duration", "in_flight", "bytes"} {
+				if m.Name == "fibre.server.backend.get."+name {
+					result[name] = m
+				}
+			}
+		}
+	}
+	return result
+}
+
+func assertBackendGetMetrics(t *testing.T, reader *sdkmetric.ManualReader, backend, outcome string, wantBytes int64) {
+	t.Helper()
+	data := collectBackendMetrics(t, reader)
+	duration := data["duration"].Data.(metricdata.Histogram[float64])
+	require.Len(t, duration.DataPoints, 1)
+	require.Equal(t, uint64(1), duration.DataPoints[0].Count)
+	require.Positive(t, duration.DataPoints[0].Sum)
+	require.Equal(t, attribute.NewSet(attribute.String("backend", backend), attribute.String("outcome", outcome)), duration.DataPoints[0].Attributes)
+	inFlight := data["in_flight"].Data.(metricdata.Sum[int64])
+	require.Len(t, inFlight.DataPoints, 1)
+	require.Equal(t, int64(0), inFlight.DataPoints[0].Value)
+	require.Equal(t, attribute.NewSet(attribute.String("backend", backend)), inFlight.DataPoints[0].Attributes)
+	if wantBytes == 0 {
+		_, recorded := data["bytes"]
+		require.False(t, recorded)
+	} else {
+		readBytes := data["bytes"].Data.(metricdata.Sum[int64])
+		require.Len(t, readBytes.DataPoints, 1)
+		require.Equal(t, wantBytes, readBytes.DataPoints[0].Value)
+		require.Equal(t, attribute.NewSet(attribute.String("backend", backend)), readBytes.DataPoints[0].Attributes)
+	}
+}

--- a/fibre/store_metrics_test.go
+++ b/fibre/store_metrics_test.go
@@ -100,3 +100,22 @@ func TestBackendMetricsDisabled(t *testing.T) {
 		metrics.observeBackendGet(t.Context(), storageBackendLocal)(nil)
 	}
 }
+
+func TestRoutedStorageMetricsPrimaryOnly(t *testing.T) {
+	for _, objectPrimary := range []bool{false, true} {
+		local, object := &localBackend{}, &objectBackend{}
+		primary, secondary := shardBackend(local), shardBackend(object)
+		if objectPrimary {
+			primary, secondary = secondary, primary
+		}
+		metrics := &serverMetrics{}
+		newRoutedStorage(primary, secondary).setMetrics(metrics)
+		if objectPrimary {
+			require.Same(t, metrics, object.metrics)
+			require.Nil(t, local.metrics)
+		} else {
+			require.Same(t, metrics, local.metrics)
+			require.Nil(t, object.metrics)
+		}
+	}
+}

--- a/fibre/store_metrics_test.go
+++ b/fibre/store_metrics_test.go
@@ -6,80 +6,73 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"os"
 	"testing"
+	"testing/iotest"
 
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/celestiaorg/celestia-app/v10/x/fibre/types"
-	"github.com/cockroachdb/pebble/v2/vfs"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric/noop"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
 func TestBackendGetMetrics(t *testing.T) {
-	shard := &types.BlobShard{Rows: []*types.BlobRow{{Data: []byte("data")}}}
-	var encoded bytes.Buffer
-	require.NoError(t, writeShardBinary(&encoded, shard))
-	for _, backend := range []string{storageBackendLocal, storageBackendObject} {
-		for _, outcome := range []string{"success", "not_found", "error"} {
-			t.Run(backend+"/"+outcome, func(t *testing.T) {
-				metrics, reader := newBackendTestMetrics(t)
-				data := encoded.Bytes()
-				if outcome == "error" {
-					data = data[:len(data)-1]
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	metrics, err := newServerMetrics(provider.Meter("test"), newOccupancy(0))
+	require.NoError(t, err)
+	done := metrics.observeBackendGet(t.Context(), storageBackendObject)
+	source := io.MultiReader(bytes.NewBufferString("data"), iotest.ErrReader(context.DeadlineExceeded))
+	data, err := io.ReadAll(metrics.backendReader(t.Context(), storageBackendObject, source))
+	require.Equal(t, "data", string(data))
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	done(err)
+
+	var collected metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(t.Context(), &collected))
+	seen := 0
+	for _, scope := range collected.ScopeMetrics {
+		for _, m := range scope.Metrics {
+			switch m.Name {
+			case "fibre.server.backend.get.duration":
+				points := m.Data.(metricdata.Histogram[float64]).DataPoints
+				require.Len(t, points, 1)
+				require.Equal(t, uint64(1), points[0].Count)
+				require.Positive(t, points[0].Sum)
+				require.Equal(t, attribute.NewSet(attribute.String("backend", "object"), attribute.String("outcome", "timeout")), points[0].Attributes)
+			case "fibre.server.backend.get.in_flight", "fibre.server.backend.get.bytes":
+				points := m.Data.(metricdata.Sum[int64]).DataPoints
+				require.Len(t, points, 1)
+				want := int64(0)
+				if m.Name == "fibre.server.backend.get.bytes" {
+					want = 4
 				}
-				var b shardBackend
-				if backend == storageBackendLocal {
-					local, err := newLocalBackend("/store", vfs.NewMem())
-					require.NoError(t, err)
-					local.metrics = metrics
-					if outcome != "not_found" {
-						f, err := local.fs.Create(local.shardPath(Commitment{}, nil), shardPayloadWriteCategory)
-						require.NoError(t, err)
-						_, err = f.Write(bytes.Clone(data))
-						require.NoError(t, err)
-						require.NoError(t, f.Close())
-					}
-					b = local
-				} else {
-					object := newObjectBackend(&s3ObjectClientStub{
-						getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-							if outcome == "not_found" {
-								return nil, &smithy.GenericAPIError{Code: "NoSuchKey"}
-							}
-							return &s3.GetObjectOutput{Body: io.NopCloser(bytes.NewReader(data))}, nil
-						},
-					}, "bucket", "prefix", "chain", "validator")
-					object.metrics = metrics
-					b = object
-				}
-				got, err := b.Get(t.Context(), Commitment{}, nil)
-				if outcome == "success" {
-					require.NoError(t, err)
-					require.Equal(t, shard, got)
-				} else {
-					require.Error(t, err)
-				}
-				wantBytes := int64(len(data))
-				if outcome == "not_found" {
-					wantBytes = 0
-				}
-				assertBackendGetMetrics(t, reader, backend, outcome, wantBytes)
-			})
+				require.Equal(t, want, points[0].Value)
+				require.Equal(t, attribute.NewSet(attribute.String("backend", "object")), points[0].Attributes)
+			default:
+				continue
+			}
+			seen++
 		}
 	}
+	require.Equal(t, 3, seen)
 }
 
-func TestObjectBackendGetErrorMetrics(t *testing.T) {
+func TestBackendGetOutcome(t *testing.T) {
 	for _, tc := range []struct {
 		name, outcome string
 		err           error
 	}{
+		{"success", "success", nil},
+		{"missing", "not_found", ErrStoreNotFound},
 		{"deadline", "timeout", context.DeadlineExceeded},
+		{"network timeout", "timeout", &net.OpError{Err: os.ErrDeadlineExceeded}},
 		{"canceled", "canceled", context.Canceled},
 		{"slow down", "throttled", &smithy.GenericAPIError{Code: "SlowDown"}},
 		{"429", "throttled", &smithyhttp.ResponseError{
@@ -89,109 +82,21 @@ func TestObjectBackendGetErrorMetrics(t *testing.T) {
 		{"other", "error", errors.New("arbitrary error text")},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			metrics, reader := newBackendTestMetrics(t)
-			object := newObjectBackend(&s3ObjectClientStub{
-				getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-					return nil, fmt.Errorf("request failed: %w", tc.err)
-				},
-			}, "bucket", "prefix", "chain", "validator")
-			object.metrics = metrics
-			_, err := object.Get(t.Context(), Commitment{}, nil)
-			require.ErrorIs(t, err, tc.err)
-			assertBackendGetMetrics(t, reader, storageBackendObject, tc.outcome, 0)
+			err := tc.err
+			if err != nil {
+				err = fmt.Errorf("wrapped: %w", err)
+			}
+			require.Equal(t, tc.outcome, backendGetOutcome(err))
 		})
 	}
 }
 
-func TestObjectBackendGetMetricsDuringRead(t *testing.T) {
-	metrics, reader := newBackendTestMetrics(t)
-	reads := 0
-	body := &metricTestBody{
-		read: func(p []byte) (int, error) {
-			reads++
-			if reads == 1 {
-				return copy(p, []byte{0, 0, 0, 1}), nil
-			}
-			data := collectBackendMetrics(t, reader)
-			require.Equal(t, int64(1), data["in_flight"].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-			require.Equal(t, int64(4), data["bytes"].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-			_, recorded := data["duration"]
-			require.False(t, recorded)
-			return copy(p, []byte{0, 0}), context.DeadlineExceeded
-		},
-		close: func() error {
-			data := collectBackendMetrics(t, reader)
-			require.Equal(t, int64(1), data["in_flight"].Data.(metricdata.Sum[int64]).DataPoints[0].Value)
-			_, recorded := data["duration"]
-			require.False(t, recorded, "duration must include closing the body")
-			return nil
-		},
-	}
-	object := newObjectBackend(&s3ObjectClientStub{
-		getObject: func(context.Context, *s3.GetObjectInput, ...func(*s3.Options)) (*s3.GetObjectOutput, error) {
-			return &s3.GetObjectOutput{Body: body}, nil
-		},
-	}, "bucket", "prefix", "chain", "validator")
-	object.metrics = metrics
-	_, err := object.Get(t.Context(), Commitment{}, nil)
-	require.ErrorIs(t, err, context.DeadlineExceeded)
-	assertBackendGetMetrics(t, reader, storageBackendObject, "timeout", 6)
-}
-
-type metricTestBody struct {
-	read  func([]byte) (int, error)
-	close func() error
-}
-
-func (b *metricTestBody) Read(p []byte) (int, error) { return b.read(p) }
-func (b *metricTestBody) Close() error               { return b.close() }
-
-func newBackendTestMetrics(t *testing.T) (*serverMetrics, *sdkmetric.ManualReader) {
-	t.Helper()
-	reader := sdkmetric.NewManualReader()
-	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
-	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
-	metrics, err := newServerMetrics(provider.Meter("backend-test"), newOccupancy(0))
+func TestBackendMetricsDisabled(t *testing.T) {
+	disabled, err := newServerMetrics(noop.NewMeterProvider().Meter("test"), newOccupancy(0))
 	require.NoError(t, err)
-	return metrics, reader
-}
-
-func collectBackendMetrics(t *testing.T, reader *sdkmetric.ManualReader) map[string]metricdata.Metrics {
-	t.Helper()
-	var data metricdata.ResourceMetrics
-	require.NoError(t, reader.Collect(t.Context(), &data))
-	result := make(map[string]metricdata.Metrics)
-	for _, scope := range data.ScopeMetrics {
-		for _, m := range scope.Metrics {
-			for _, name := range []string{"duration", "in_flight", "bytes"} {
-				if m.Name == "fibre.server.backend.get."+name {
-					result[name] = m
-				}
-			}
-		}
-	}
-	return result
-}
-
-func assertBackendGetMetrics(t *testing.T, reader *sdkmetric.ManualReader, backend, outcome string, wantBytes int64) {
-	t.Helper()
-	data := collectBackendMetrics(t, reader)
-	duration := data["duration"].Data.(metricdata.Histogram[float64])
-	require.Len(t, duration.DataPoints, 1)
-	require.Equal(t, uint64(1), duration.DataPoints[0].Count)
-	require.Positive(t, duration.DataPoints[0].Sum)
-	require.Equal(t, attribute.NewSet(attribute.String("backend", backend), attribute.String("outcome", outcome)), duration.DataPoints[0].Attributes)
-	inFlight := data["in_flight"].Data.(metricdata.Sum[int64])
-	require.Len(t, inFlight.DataPoints, 1)
-	require.Equal(t, int64(0), inFlight.DataPoints[0].Value)
-	require.Equal(t, attribute.NewSet(attribute.String("backend", backend)), inFlight.DataPoints[0].Attributes)
-	if wantBytes == 0 {
-		_, recorded := data["bytes"]
-		require.False(t, recorded)
-	} else {
-		readBytes := data["bytes"].Data.(metricdata.Sum[int64])
-		require.Len(t, readBytes.DataPoints, 1)
-		require.Equal(t, wantBytes, readBytes.DataPoints[0].Value)
-		require.Equal(t, attribute.NewSet(attribute.String("backend", backend)), readBytes.DataPoints[0].Attributes)
+	for _, metrics := range []*serverMetrics{nil, disabled} {
+		r := bytes.NewReader([]byte("data"))
+		require.Same(t, r, metrics.backendReader(t.Context(), storageBackendLocal, r))
+		metrics.observeBackendGet(t.Context(), storageBackendLocal)(nil)
 	}
 }

--- a/fibre/store_object.go
+++ b/fibre/store_object.go
@@ -40,6 +40,7 @@ type objectBackend struct {
 	prefix           string
 	chainID          string
 	validatorAddress string
+	metrics          *serverMetrics
 }
 
 var _ shardBackend = (*objectBackend)(nil)
@@ -103,7 +104,9 @@ func (b *objectBackend) Put(ctx context.Context, commitment Commitment, promiseH
 	return true, nil
 }
 
-func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseHash []byte) (*types.BlobShard, error) {
+func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseHash []byte) (_ *types.BlobShard, err error) {
+	done := b.metrics.observeBackendGet(ctx, storageBackendObject)
+	defer func() { done(err) }()
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -120,7 +123,7 @@ func (b *objectBackend) Get(ctx context.Context, commitment Commitment, promiseH
 	}
 	defer output.Body.Close()
 
-	reader := bufio.NewReaderSize(output.Body, 1<<20)
+	reader := bufio.NewReaderSize(b.metrics.backendReader(ctx, storageBackendObject, output.Body), 1<<20)
 	shard, err := readShardBinary(reader)
 	if err != nil {
 		return nil, fmt.Errorf("decoding shard object: %w", err)

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -29,13 +29,11 @@ func newRoutedStorage(primary, secondary shardBackend) *routedStorage {
 }
 
 func (s *routedStorage) setMetrics(metrics *serverMetrics) {
-	for _, backend := range []shardBackend{s.primary, s.secondary} {
-		switch backend := backend.(type) {
-		case *localBackend:
-			backend.metrics = metrics
-		case *objectBackend:
-			backend.metrics = metrics
-		}
+	switch backend := s.primary.(type) {
+	case *localBackend:
+		backend.metrics = metrics
+	case *objectBackend:
+		backend.metrics = metrics
 	}
 }
 

--- a/fibre/store_shard.go
+++ b/fibre/store_shard.go
@@ -28,6 +28,17 @@ func newRoutedStorage(primary, secondary shardBackend) *routedStorage {
 	return &routedStorage{primary: primary, secondary: secondary}
 }
 
+func (s *routedStorage) setMetrics(metrics *serverMetrics) {
+	for _, backend := range []shardBackend{s.primary, s.secondary} {
+		switch backend := backend.(type) {
+		case *localBackend:
+			backend.metrics = metrics
+		case *objectBackend:
+			backend.metrics = metrics
+		}
+	}
+}
+
 func (s *routedStorage) marker(size int64) []byte {
 	return encodeShardMarkerForBackend(s.primary.backendTag(), size)
 }

--- a/specs/src/fibre_server.md
+++ b/specs/src/fibre_server.md
@@ -237,6 +237,14 @@ The server records OpenTelemetry metrics for:
 - `fibre.server.download_shard.bytes`
 - `fibre.server.store.put.duration`
 - `fibre.server.store.get.duration`
+- `fibre.server.backend.get.duration`
+- `fibre.server.backend.get.in_flight`
+- `fibre.server.backend.get.bytes`
 - `fibre.server.sign.duration`
 - `fibre.server.prune.entries`
 - `fibre.server.prune.duration`
+
+Backend GET metrics use `backend=local|object`.
+Duration is measured in seconds through payload reading, decoding and closing, with `outcome=success|not_found|timeout|canceled|throttled|error`.
+The in-flight metric counts concurrent backend GET calls. The byte counter records encoded bytes consumed, including partial failures and buffered reads.
+Each observation covers one backend call. Object GET duration includes SDK retries; the outcome describes the final result.

--- a/specs/src/fibre_server.md
+++ b/specs/src/fibre_server.md
@@ -244,7 +244,7 @@ The server records OpenTelemetry metrics for:
 - `fibre.server.prune.entries`
 - `fibre.server.prune.duration`
 
-Backend GET metrics use `backend=local|object`.
+Backend GET metrics record only the primary backend and use `backend=local|object`.
 Duration is measured in seconds through payload reading, decoding and closing, with `outcome=success|not_found|timeout|canceled|throttled|error`.
 The in-flight metric counts concurrent backend GET calls. The byte counter records encoded bytes consumed, including partial failures and buffered reads.
 Each observation covers one backend call. Object GET duration includes SDK retries; the outcome describes the final result.


### PR DESCRIPTION
Closes [PROTOCO-2674](https://linear.app/celestia/issue/PROTOCO-2674)

Add primary backend GET duration, in-flight reads, and consumed-byte metrics using the existing server OTel meter. These compare local and object read pressure to show whether read limits are needed.

Duration includes payload reading, decoding, and closing. Object GET timing also includes SDK retries. Outcomes distinguish success, missing payloads, timeouts, cancellation, throttling, and other errors. Bytes include partial failures. Metrics count logical GET calls; they do not expose individual SDK retry attempts.

Metric setup stays inside routedStorage and instruments only the primary backend. Nil or disabled metrics leave the payload reader unchanged. Both metric lists document the instruments and their labels.

Validation: `make build`, `make test-short`, focused backend and server metric tests with `-race -count=3`, and two clean invariant review rounds. `make lint` passes in a clean checkout; ignored local planning notes prevent it from passing in the working checkout.
