### PR TITLE
fix(fibre): warn about retained object shards when switching storage

### DIFF
--- a/fibre/cmd/README.md
+++ b/fibre/cmd/README.md
@@ -88,6 +88,14 @@ The config file is at `$FIBRE_HOME/server_config.toml` (default `~/.celestia-fib
 
 Config precedence: **flag > config file > default**.
 
+### Switching shard storage backends
+
+Changing `storage_backend` between `local` and `object` only changes where new shards are stored. Existing shards stay on their original backend.
+
+**Warning:** After switching back to `local`, keep `[object_storage]` configured until all object shards are pruned. Keep access to the same bucket and prefix, with valid credentials, throughout the retention window. While these shards remain, do not remove the object data or change the configured bucket or prefix.
+
+Local mode still uses object storage to read and prune retained object shards. Missing object storage configuration or credentials prevents startup.
+
 ### Shard retention
 
 How long uploaded shards are kept locally before pruning is the `shard_retention` on-chain parameter of the `x/fibre` module (default `4h`), changeable by governance. It is independent of the chain's payment-promise timeout. The server reads the current value from the app node on every upload (returned by `ValidatePaymentPromise`), so there is no local setting to configure.

--- a/fibre/store_config.go
+++ b/fibre/store_config.go
@@ -59,8 +59,10 @@ func (s *Store) openObjectStorage(ctx context.Context, cfg StoreConfig) (shardBa
 	if !needsObject {
 		return nil, nil
 	}
+	s.log.Warn("Changing storage_backend only affects new shards. Keep object storage configured and accessible until all object shards are pruned.",
+		"storage_backend", cfg.StorageBackend)
 	if err := cfg.ObjectStorage.Validate(); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("object storage must remain configured until all object shards are pruned: %w", err)
 	}
 	if cfg.ObjectStorage.ChainID == "" || cfg.ObjectStorage.ValidatorAddress == "" {
 		return nil, fmt.Errorf("chain ID and validator address are required for object storage")

--- a/fibre/store_config_test.go
+++ b/fibre/store_config_test.go
@@ -1,10 +1,12 @@
 package fibre
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/xml"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -196,7 +198,9 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 		}
 	}))
 	defer server.Close()
+	var logs bytes.Buffer
 	cfg := DefaultStoreConfig()
+	cfg.Log = slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn}))
 	cfg.Path = t.TempDir()
 	cfg.ObjectStorage = testObjectStorageConfig()
 	cfg.ObjectStorage.Endpoint = server.URL
@@ -214,12 +218,16 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	localCommitment := promise.Commitment
 	store, err := NewStore(t.Context(), cfg)
 	require.NoError(t, err)
+	require.Empty(t, logs.String())
 	require.NoError(t, store.Put(t.Context(), promise, shard, pruneAt))
 	require.NoError(t, store.Close())
 
 	cfg.StorageBackend = "object"
 	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
+	require.Contains(t, logs.String(), "level=WARN")
+	require.Contains(t, logs.String(), "Changing storage_backend only affects new shards")
+	logs.Reset()
 	got, err := store.Get(t.Context(), localCommitment)
 	require.NoError(t, err)
 	require.Equal(t, shard, got)
@@ -237,9 +245,13 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	cfg.ObjectStorage = ObjectStorageConfig{}
 	_, err = NewStore(t.Context(), cfg)
 	require.ErrorContains(t, err, "object_storage.endpoint")
+	require.ErrorContains(t, err, "object storage must remain configured until all object shards are pruned")
+	logs.Reset()
 	cfg.ObjectStorage = retainedConfig
 	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
+	require.Contains(t, logs.String(), "level=WARN")
+	require.Contains(t, logs.String(), "Keep object storage configured and accessible until all object shards are pruned")
 	require.Equal(t, localBackendTag, store.shards.primary.backendTag())
 	got, err = store.Get(t.Context(), promise.Commitment)
 	require.NoError(t, err)
@@ -253,10 +265,12 @@ func TestStoreConfiguredBackendSwitch(t *testing.T) {
 	require.Equal(t, 2*shardBinarySize(shard), freed)
 	require.NoError(t, store.Close())
 
+	logs.Reset()
 	cfg.ObjectStorage = ObjectStorageConfig{}
 	store, err = NewStore(t.Context(), cfg)
 	require.NoError(t, err)
 	require.Nil(t, store.shards.secondary)
+	require.Empty(t, logs.String())
 	require.NoError(t, store.Close())
 }
 


### PR DESCRIPTION
Closes [PROTOCO-2675](https://linear.app/celestia/issue/PROTOCO-2675/add-clear-warnings-re-back-and-forth-migration)

Warn operators that switching storage backends only affects new shards. Object storage must stay configured and accessible until retained object shards are pruned. Add a clearer startup error, operator guidance and coverage in the existing backend-switch test.

Logs happen when: 
  - Object mode: always, even if the operator has never switched backends
  - Local mode: only if at least one object shard marker remains 

Stacked on [celestiaorg/celestia-app#7810](https://github.com/celestiaorg/celestia-app/pull/7810).
