### PR TITLE
ci: disable mergify queue control comments

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -80,3 +80,4 @@ pull_request_rules:
           - main
 merge_queue:
   status_comments: none
+  queue_controls_comment: false


### PR DESCRIPTION
Motivation: https://github.com/celestiaorg/celestia-app/pull/7832#issuecomment-5635361187

Mergify still posts a "Tick the box to add this pull request to the merge queue" comment on every PR, even though status comments were disabled in #7660. That checkbox is a separate feature controlled by `queue_controls_comment` (default `true`). We only use Mergify for backports, so this turns it off.

Ref: https://docs.mergify.com/configuration/file-format/

🤖 Generated with [Claude Code](https://claude.com/claude-code)